### PR TITLE
Use interaction.companies instead of interaction.company field

### DIFF
--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -20,6 +20,7 @@ async function getCommon(req, res, next) {
       req,
       contact.company.id
     )
+    res.locals.companies = [res.locals.company]
     res.locals.id = req.params.contactId
     res.locals.reasonForArchiveOptions = reasonForArchiveOptions
     res.locals.reasonForArchiveOptionsPrefix = reasonForArchiveOptionsPrefix

--- a/src/apps/events/attendees/__test__/transformers.test.js
+++ b/src/apps/events/attendees/__test__/transformers.test.js
@@ -12,10 +12,12 @@ describe('#transformEventToAttendeeListItem', () => {
 
   context('when the contact is missing', () => {
     beforeEach(() => {
-      this.serviceDelivery.company = {
-        id: '2222',
-        name: 'Test company',
-      }
+      this.serviceDelivery.companies = [
+        {
+          id: '2222',
+          name: 'Test company',
+        },
+      ]
       this.result = transformServiceDeliveryToAttendeeListItem(
         this.serviceDelivery
       )
@@ -60,10 +62,12 @@ describe('#transformEventToAttendeeListItem', () => {
 
   context('when a valid company is provided', () => {
     beforeEach(() => {
-      this.serviceDelivery.company = {
-        id: '2222',
-        name: 'Test company',
-      }
+      this.serviceDelivery.companies = [
+        {
+          id: '2222',
+          name: 'Test company',
+        },
+      ]
     })
 
     context('when a valid contact is provided without a job title', () => {

--- a/src/apps/events/attendees/controllers/__test__/create.test.js
+++ b/src/apps/events/attendees/controllers/__test__/create.test.js
@@ -51,7 +51,7 @@ describe('Create attendee controller', () => {
           .reply(200, contact)
           .post('/v3/interaction', {
             contacts: ['59c815d1-91d0-4d1f-b980-1d04157a298f'],
-            company: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+            companies: ['0fb3379c-341c-4da4-b825-bf8d47b26baa'],
             date: '2017-11-10',
             dit_participants: [{ adviser: '999' }],
             event: '31a9f8bd-7796-4af4-8f8c-25450860e2d1',

--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -32,7 +32,7 @@ async function createAttendee(req, res, next) {
 
     const serviceDelivery = {
       contacts: [contact.id],
-      company: get(contact, 'company.id'),
+      companies: [get(contact, 'company.id')],
       date: event.start_date,
       dit_participants: [
         {

--- a/src/apps/events/attendees/repos.js
+++ b/src/apps/events/attendees/repos.js
@@ -30,7 +30,6 @@ async function fetchEventAttendees({
       (value) => !isNil(value)
     ),
   })
-
   return eventAttendees
 }
 

--- a/src/apps/events/attendees/transformers.js
+++ b/src/apps/events/attendees/transformers.js
@@ -6,15 +6,15 @@ const { fetchEventAttendees } = require('./repos')
 
 function transformServiceDeliveryToAttendeeListItem({
   contacts = [],
-  company,
+  companies = [],
   date,
   id,
 }) {
   const metaItems = [
     {
       key: 'company',
-      value: get(company, 'name'),
-      url: `/companies/${get(company, 'id')}`,
+      value: get(companies[0], 'name'),
+      url: `/companies/${get(companies[0], 'id')}`,
     },
     {
       key: 'job_title',
@@ -46,7 +46,6 @@ function transformServiceDeliveryToAttendeeListItem({
         name: 'No contact assigned',
         meta: compact(metaItems),
       }
-
   return listItem
 }
 

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -91,7 +91,7 @@ const InteractionDetailsForm = ({
       {(getTask) => {
         const saveInteractionTask = getTask(TASK_SAVE_INTERACTION, STATE_ID)
         const openContactFormTask = getTask(TASK_OPEN_CONTACT_FORM, STATE_ID)
-
+        const companyIds = [companyId]
         return (
           <Analytics>
             {(pushAnalytics) => (
@@ -103,7 +103,7 @@ const InteractionDetailsForm = ({
                   saveInteractionTask.start({
                     payload: {
                       values,
-                      companyId,
+                      companyIds,
                       referralId,
                     },
                     onSuccessDispatch: ADD_INTERACTION_FORM__SUBMIT,

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -94,7 +94,7 @@ export function restoreState() {
   return JSON.parse(stateFromStorage)
 }
 
-export function saveInteraction({ values, companyId, referralId }) {
+export function saveInteraction({ values, companyIds, referralId }) {
   window.sessionStorage.removeItem(STORE_ID)
 
   const endpoint = referralId
@@ -105,9 +105,7 @@ export function saveInteraction({ values, companyId, referralId }) {
 
   const commonPayload = {
     status: INTERACTION_STATUS.COMPLETE,
-    company: {
-      id: companyId,
-    },
+    companies: companyIds,
     service: values.service_2nd_level || values.service,
     service_answers: transformServiceAnswers(values),
     contacts: transformArrayOfOptions(values.contacts),

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -140,7 +140,7 @@ const getInitialFormValues = (req, res) => {
   return {
     theme,
     kind,
-    company: company.id,
+    companies: [company.id],
     investment_project: investmentId,
     date: {
       day: formatWithoutParsing(date, 'dd'),

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -46,7 +46,7 @@ export const transformInteractionToListItem = ({
   subject,
   dit_participants,
   service,
-  company,
+  companies,
   id,
   contacts,
   kind,
@@ -59,7 +59,10 @@ export const transformInteractionToListItem = ({
       label: 'Contact(s)',
       value: contacts && formatContacts(contacts),
     },
-    { label: 'Company', value: company?.name },
+    {
+      label: 'Company',
+      value: companies && (companies.length ? companies[0].name : null),
+    },
     {
       label: 'Adviser(s)',
       value: dit_participants && formatParticipants(dit_participants),

--- a/src/apps/interactions/controllers/__test__/complete.test.js
+++ b/src/apps/interactions/controllers/__test__/complete.test.js
@@ -163,7 +163,7 @@ describe('Interaction details controller', () => {
 
       it('should redirect to the interactions', () => {
         expect(middlewareParameters.resMock.redirect).calledOnceWithExactly(
-          urls.companies.interactions.index(draftPastMeeting.company.id)
+          urls.companies.interactions.index(draftPastMeeting.companies[0].id)
         )
       })
 
@@ -342,7 +342,7 @@ describe('Interaction details controller', () => {
 
         it('should redirect to the interactions', () => {
           expect(middlewareParameters.resMock.redirect).calledOnceWithExactly(
-            urls.companies.interactions.index(draftPastMeeting.company.id)
+            urls.companies.interactions.index(draftPastMeeting.companies[0].id)
           )
         })
 
@@ -453,7 +453,7 @@ describe('Interaction details controller', () => {
 
       it('should redirect to the interaction create journey', () => {
         const expectedPath = urls.companies.interactions.edit(
-          draftPastMeeting.company.id,
+          draftPastMeeting.companies[0].id,
           draftPastMeeting.id
         )
         expect(middlewareParameters.resMock.redirect).calledOnceWithExactly(

--- a/src/apps/interactions/controllers/__test__/details.test.js
+++ b/src/apps/interactions/controllers/__test__/details.test.js
@@ -2,6 +2,7 @@ const buildMiddlewareParameters = require('../../../../../test/unit/helpers/midd
 const draftFutureMeeting = require('../../../../../test/unit/data/interactions/draft-future-meeting.json')
 const draftPastMeeting = require('../../../../../test/unit/data/interactions/draft-past-meeting.json')
 const interaction = require('../../../../../test/unit/data/interactions/interaction.json')
+const interactionWithReferral = require('../../../../../test/unit/data/interactions/interaction-with-referral.json')
 const serviceDelivery = require('../../../../../test/unit/data/interactions/service-delivery.json')
 
 const { detailsController } = require('../index')
@@ -58,6 +59,67 @@ describe('Interaction details controller', () => {
       it('should render the template with canEdit as true', () => {
         expect(middlewareParameters.resMock.render.firstCall.args[1].canEdit).to
           .be.true
+      })
+    })
+
+    context('when rendering a complete company referral interaction', () => {
+      beforeEach(() => {
+        middlewareParameters = buildMiddlewareParameters({
+          interaction: interactionWithReferral,
+          requestParams: {
+            id: '1234',
+          },
+        })
+
+        detailsController.renderDetailsPage(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should set the breadcrumb', () => {
+        expect(middlewareParameters.resMock.breadcrumb).to.be.calledWithExactly(
+          'Interaction'
+        )
+        expect(middlewareParameters.resMock.breadcrumb).to.have.been.calledOnce
+      })
+
+      it('should set the title', () => {
+        expect(middlewareParameters.resMock.title).to.be.calledWith(
+          'This is an automated interaction'
+        )
+      })
+
+      it('should render the interaction details template', () => {
+        expect(middlewareParameters.resMock.render).to.be.calledWith(
+          'interactions/views/details'
+        )
+      })
+
+      it('should render the template with interaction data', () => {
+        expect(
+          middlewareParameters.resMock.render.firstCall.args[1]
+            .interactionViewRecord
+        ).to.exist
+      })
+
+      it('should render the template with canComplete as false', () => {
+        expect(
+          middlewareParameters.resMock.render.firstCall.args[1].canComplete
+        ).to.be.false
+      })
+
+      it('should render the template with canEdit as true', () => {
+        expect(middlewareParameters.resMock.render.firstCall.args[1].canEdit).to
+          .be.true
+      })
+
+      it('should render the template with a referral', () => {
+        expect(
+          middlewareParameters.resMock.render.firstCall.args[1].referral
+            .companyId
+        ).to.equal('0f5216e0-849f-11e6-ae22-56b6b6499611')
       })
     })
 

--- a/src/apps/interactions/controllers/complete.js
+++ b/src/apps/interactions/controllers/complete.js
@@ -64,7 +64,7 @@ async function postComplete(req, res, next) {
 
       req.flash('success', 'The interaction has been updated')
       return res.redirect(
-        urls.companies.interactions.index(interaction.company.id)
+        urls.companies.interactions.index(interaction.companies[0].id)
       )
     } catch (e) {
       return next(e)
@@ -73,7 +73,10 @@ async function postComplete(req, res, next) {
 
   if (req.body.meeting_happen === 'true') {
     return res.redirect(
-      urls.companies.interactions.edit(interaction.company.id, interaction.id)
+      urls.companies.interactions.edit(
+        interaction.companies[0].id,
+        interaction.id
+      )
     )
   }
 }

--- a/src/apps/interactions/controllers/details.js
+++ b/src/apps/interactions/controllers/details.js
@@ -13,8 +13,9 @@ function renderDetailsPage(req, res, next) {
       isComplete
     )
     const referral = interaction.company_referral
-    if (referral) {
-      referral.companyId = interaction.company.id
+    const hasCompany = interaction.companies && interaction.companies.length
+    if (referral && hasCompany) {
+      referral.companyId = interaction.companies[0].id
     }
     const canComplete =
       interaction.status === INTERACTION_STATUS.DRAFT &&

--- a/src/apps/interactions/middleware/__test__/details.test.js
+++ b/src/apps/interactions/middleware/__test__/details.test.js
@@ -1,7 +1,7 @@
 const proxyquire = require('proxyquire')
 
 const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
-const interactionData = require('../../../../../test/unit/data/interactions/new-interaction')
+const interactionData = require('../../../../../test/unit/data/interactions/interaction.json')
 
 const modulePath = '../details'
 
@@ -40,10 +40,10 @@ describe('Interaction details middleware', () => {
 
     context('when provided an interaction with a company associated', () => {
       before(async () => {
-        this.company = sinon.mock()
+        this.companies = sinon.mock()
         this.interaction = {
           ...interactionData,
-          company: this.company,
+          companies: [this.company],
         }
         this.fetchInteractionStub.resolves(this.interaction)
 
@@ -60,13 +60,18 @@ describe('Interaction details middleware', () => {
           this.middlewareParameters.resMock.locals.interaction
         ).to.deep.equal(this.interaction)
       })
+      it('should set interaction company data on locals', () => {
+        expect(this.middlewareParameters.resMock.locals.company).to.deep.equal(
+          this.interaction.companies[0]
+        )
+      })
     })
 
     context('when provided an investment interaction with no company', () => {
       before(async () => {
         this.interaction = {
           ...interactionData,
-          company: null,
+          companies: null,
           contact: {
             id: '4444',
           },
@@ -75,9 +80,11 @@ describe('Interaction details middleware', () => {
         this.fetchInteractionStub.resolves(this.interaction)
 
         this.getContactStub.resolves({
-          company: {
-            id: '1234',
-          },
+          companies: [
+            {
+              id: '1234',
+            },
+          ],
         })
 
         this.company = sinon.mock()

--- a/src/apps/interactions/middleware/details.js
+++ b/src/apps/interactions/middleware/details.js
@@ -7,7 +7,10 @@ async function getInteractionDetails(req, res, next, interactionId) {
     res.locals.interaction = interaction
 
     if (!res.locals.company) {
-      res.locals.company = await getDitCompany(req, interaction.company.id)
+      const companies = await Promise.all(
+        interaction.companies.map((company) => getDitCompany(req, company.id))
+      )
+      res.locals.company = companies[0]
     }
 
     next()

--- a/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
@@ -409,7 +409,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
       this.transformed = transformInteractionResponseToViewRecord(
         {
           ...mockInteraction,
-          company: null,
+          companies: null,
         },
         true
       )

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -77,7 +77,7 @@ function getExportCountries(countries) {
 
 function transformInteractionResponseToViewRecord(
   {
-    company,
+    companies,
     notes,
     date,
     dit_participants,
@@ -103,7 +103,11 @@ function transformInteractionResponseToViewRecord(
   const kindLabels = labels[camelCase(kind)]
 
   const viewRecord = {
-    company: transformEntityLink(company, 'companies'),
+    // TODO: currently only a single company is displayed
+    company:
+      companies &&
+      companies.length &&
+      transformEntityLink(companies[0], 'companies'),
     contacts: contacts.map((contact) =>
       transformEntityLink(contact, 'contacts')
     ),

--- a/src/apps/interactions/transformers/interaction-to-list-item.js
+++ b/src/apps/interactions/transformers/interaction-to-list-item.js
@@ -10,7 +10,7 @@ function transformInteractionToListItem(showCompany = true) {
     subject,
     kind,
     contacts,
-    company,
+    companies,
     date,
     dit_participants,
     service,
@@ -55,7 +55,11 @@ function transformInteractionToListItem(showCompany = true) {
         label: labels.metaItems.contacts,
         value: contacts && formatContacts(contacts),
       },
-      { label: labels.metaItems.company, value: showCompany && company },
+      // TODO: currently only one company is supported
+      showCompany && {
+        label: labels.metaItems.company,
+        value: companies && (companies.length ? companies[0] : null),
+      },
       {
         label: labels.metaItems.dit_participants,
         value: dit_participants && formatParticipants(dit_participants),

--- a/test/api-schema.json
+++ b/test/api-schema.json
@@ -7042,8 +7042,11 @@
             "type": "string",
             "format": "uuid"
           },
-          "company": {
-            "type": "string"
+          "companies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "contacts": {
             "type": "array",
@@ -7245,7 +7248,7 @@
           }
         },
         "required": [
-          "company",
+          "companies",
           "contacts",
           "kind",
           "date",

--- a/test/end-to-end/cypress/fixtures/contact/create-contact.js
+++ b/test/end-to-end/cypress/fixtures/contact/create-contact.js
@@ -1,12 +1,14 @@
 const { v4: uuidv4 } = require('uuid')
 
-function create(companyId) {
+function create(companyId, _first_name, _last_name) {
+  const first_name = typeof _first_name === 'undefined' ? 'Johnny' : _first_name
+  const last_name = typeof _last_name === 'undefined' ? 'Cakeman' : _last_name
   return {
     model: 'company.contact',
     pk: uuidv4(),
     fields: {
-      first_name: 'Johnny',
-      last_name: 'Cakeman',
+      first_name: first_name,
+      last_name: last_name,
       company: companyId,
       primary: 'False',
       telephone_countrycode: '+44',

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -159,25 +159,29 @@ describe('Event', () => {
   })
 
   describe('Add attendee', () => {
+    const event = fixtures.event.create.defaultEvent()
+    const company = fixtures.company.create.defaultCompany('attendee testing')
+    const contact = fixtures.contact.create(company.pk, 'Joe', 'Attendee')
+
     before(() => {
-      const event = fixtures.event.create.defaultEvent()
-      cy.loadFixture([event])
-      cy.visit(urls.events.details(event.pk))
+      cy.loadFixture([event, company, contact])
     })
     it('Should add an interaction with the attendee', () => {
+      cy.visit(urls.events.details(event.pk))
       cy.contains('a', 'Attendees').click()
       cy.contains('Add attendee').click()
-      cy.get('input').type('John')
+      cy.get('input').type('Attendee')
       cy.contains('button', 'Search').click()
       cy.get('[data-test="item-contact-0"] a')
-        .should('contain', 'Johnny Cakeman')
+        .should('contain', 'Joe Attendee')
         .click()
       cy.contains('Event attendee added')
     })
     it('Should not be able to add a duplicate attendee', () => {
+      cy.visit(urls.events.details(event.pk))
       cy.contains('a', 'Attendees').click()
       cy.contains('Add attendee').click()
-      cy.get('input').type('John')
+      cy.get('input').type('Attendee')
       cy.contains('button', 'Search').click()
       cy.get('main li a').should('not.exist')
       cy.get('main li').should('contain', 'Existing attendee')

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -46,7 +46,7 @@ describe('Interaction', () => {
       cy.get('[data-test="collection-item"]')
         .should('contain', 'Some interesting interaction')
         .and('contain', 'Johnny Cakeman')
-        .and('contain', 'Venus Ltd')
+        .and('contain', 'interaction testing')
         .and(
           'contain',
           'DIT Staff, UKTI Team East Midlands - International Trade Team'
@@ -189,7 +189,7 @@ describe('Service delivery', () => {
     cy.get('[data-test="collection-item"]')
       .should('contain', 'Some interesting service delivery')
       .and('contain', 'Johnny Cakeman')
-      .and('contain', 'Venus Ltd')
+      .and('contain', 'interaction testing')
       .and(
         'contain',
         'DIT Staff, UKTI Team East Midlands - International Trade Team'

--- a/test/functional/cypress/fakers/interactions.js
+++ b/test/functional/cypress/fakers/interactions.js
@@ -8,11 +8,13 @@ import teamFaker from './team'
 
 const interactionFaker = (overrides = {}) => ({
   ...jsf.generate(apiSchema.components.schemas.Interaction),
-  company: {
-    trading_names: [],
-    name: faker.company.companyName(),
-    id: faker.datatype.uuid(),
-  },
+  companies: [
+    {
+      trading_names: [],
+      name: faker.company.companyName(),
+      id: faker.datatype.uuid(),
+    },
+  ],
   contacts: [userFaker()],
   dit_participants: [
     {

--- a/test/functional/cypress/specs/interaction/collection-spec.js
+++ b/test/functional/cypress/specs/interaction/collection-spec.js
@@ -122,7 +122,7 @@ const assertInteractionDetails = ({
       .eq(listItemNumber)
       .find('[data-test="metadata-item"]')
       .eq(2)
-      .should('have.text', `Company ${listType.company.name}`)
+      .should('have.text', `Company ${listType.companies[0].name}`)
   })
   it('should display adviser details', () => {
     cy.get('@collectionItems')

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -164,7 +164,7 @@ const COMMON_REQUEST_BODY = {
   policy_issue_types: ['688ac22e-89d4-4d1f-bf0b-013588bf63a7'],
   policy_areas: ['583c0bb6-d3c5-4e4b-8f25-e861c1e8d9c9'],
   policy_feedback_notes: 'Some policy feedback notes',
-  company: { id: '0f5216e0-849f-11e6-ae22-56b6b6499611' },
+  companies: ['0f5216e0-849f-11e6-ae22-56b6b6499611'],
   service_answers: {},
   status: 'complete',
   has_related_trade_agreements: 'yes',
@@ -842,9 +842,7 @@ describe('Adding an interaction from a referral', () => {
     assertRequestBody(
       {
         ...COMMON_REQUEST_BODY,
-        company: {
-          id: referral.company.id,
-        },
+        companies: [referral.company.id],
         contacts: [referral.contact.id], // Was prepopulated
         theme: 'export',
         service: 'e64d7719-0bd9-65df-55a9-f08d328bc467',

--- a/test/functional/cypress/specs/interaction/details-spec.js
+++ b/test/functional/cypress/specs/interaction/details-spec.js
@@ -382,7 +382,7 @@ describe('Interaction details', () => {
       cy.url().should(
         'contain',
         companies.referrals.details(
-          interactionWithReferral.company.id,
+          interactionWithReferral.companies[0].id,
           interactionWithReferral.company_referral.id
         )
       )

--- a/test/sandbox/fixtures/v3/interaction/interaction-by-company-id.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-by-company-id.json
@@ -1,9 +1,11 @@
 {
   "id": "9eb0b11d-384a-4225-9ee1-1ea79efd695f",
-  "company": {
+  "companies": [
+    {
       "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
       "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+    }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v3/interaction/interaction-by-contact-id.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-by-contact-id.json
@@ -5,10 +5,12 @@
   "results": [
       {
           "id": "9719eed5-5f1c-4894-a72b-1dceeff3d8d3",
-          "company": {
+          "companies": [
+            {
               "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
               "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+            }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -76,10 +78,12 @@
       },
       {
           "id": "65e984ad-1ad5-4d89-9b12-71cdff5f412d",
-          "company": {
+          "companies": [
+            {
               "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
               "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+            }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -147,10 +151,12 @@
       },
       {
           "id": "9dca679b-098b-47a7-bf52-e77f3cdbbe8e",
-          "company": {
+          "companies": [
+            {
               "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
               "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+            }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -218,10 +224,12 @@
       },
       {
           "id": "1f40f9b3-2730-42c3-a0ab-b6ce0c4c05d2",
-          "company": {
+          "companies": [
+            {
               "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
               "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+            }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",

--- a/test/sandbox/fixtures/v3/interaction/interaction-by-investment-project-id.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-by-investment-project-id.json
@@ -1,9 +1,11 @@
 {
   "id": "29f20b89-e037-4a8b-8536-2fee1d8c715d",
-  "company": {
+  "companies": [
+    {
       "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
       "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+    }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v3/interaction/interaction-cancelled-meeting.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-cancelled-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "57a0b5ea-ad56-49c9-b70e-0542153ea673",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Tyson Morar",

--- a/test/sandbox/fixtures/v3/interaction/interaction-create.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-create.json
@@ -1,9 +1,11 @@
 {
   "id": "ab3b8067-e1c7-4559-9c73-c0ee76d6e14b",
-  "company": {
+  "companies": [
+    {
       "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
       "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+    }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v3/interaction/interaction-draft-future-meeting.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-draft-future-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "999c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/sandbox/fixtures/v3/interaction/interaction-draft-past-meeting.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-draft-past-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "888c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/sandbox/fixtures/v3/interaction/interaction-with-document-link.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-with-document-link.json
@@ -1,11 +1,13 @@
-{  
+{
   "id":"ec4a46ef-6e50-4a5c-bba0-e311f0471312",
-  "company":{  
-     "name":"Venus Ltd",
-     "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
-  "contacts":[  
-     {  
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
+  "contacts":[
+     {
         "name":"Johnny Cakeman",
         "first_name":"Johnny",
         "last_name":"Cakeman",
@@ -14,20 +16,20 @@
      }
   ],
   "created_on":"2017-06-05T00:00:00Z",
-  "created_by":{  
+  "created_by":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
      "id":"e83a608e-84a4-11e6-ae22-56b6b6499611"
   },
-  "event":{  
+  "event":{
      "name":"Grand exhibition",
      "id":"bda12a57-433c-4a0c-a7ce-5ebd080e09e8"
   },
   "is_event":true,
   "status": "complete",
   "kind":"service_delivery",
-  "modified_by":{  
+  "modified_by":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
@@ -35,13 +37,13 @@
   },
   "modified_on":"2017-06-05T00:00:00Z",
   "date":"2017-09-05",
-  "dit_adviser":{  
+  "dit_adviser":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
      "id":"e83a608e-84a4-11e6-ae22-56b6b6499611"
   },
-  "dit_team":{  
+  "dit_team":{
      "name":"CBBC North EAST",
      "id":"602b971d-5df6-e511-888e-e4115bead28a"
   },
@@ -49,7 +51,7 @@
   "grant_amount_offered":null,
   "investment_project":null,
   "net_company_receipt":null,
-  "service":{  
+  "service":{
      "name":"Events - UK Based",
      "id":"9584b82b-3499-e211-a939-e4115bead28a"
   },
@@ -57,11 +59,11 @@
   "subject":"Link to a document",
   "notes":"This is a dummy service delivery for testing",
   "archived_documents_url_path":"/documents/123",
-  "policy_areas":[  
+  "policy_areas":[
 
   ],
   "policy_feedback_notes":"",
-  "policy_issue_types":[  
+  "policy_issue_types":[
 
   ],
   "was_policy_feedback_provided":false

--- a/test/sandbox/fixtures/v3/interaction/interaction-with-referral.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-with-referral.json
@@ -1,18 +1,20 @@
-{  
+{
     "id":"65e984ad-1ad5-4d89-9b12-71cdff5f412d",
-    "company":{  
-       "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-       "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-    },
-    "contact":{  
+    "companies": [
+      {
+       "name": "Venus Ltd",
+       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      }
+    ],
+    "contact":{
        "name":"Bob lawson",
        "first_name":"Bob",
        "last_name":"lawson",
        "job_title":"Magician",
        "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce"
     },
-    "contacts":[  
-       {  
+    "contacts":[
+       {
           "name":"Bob lawson",
           "first_name":"Bob",
           "last_name":"lawson",
@@ -21,7 +23,7 @@
        }
     ],
     "created_on":"2019-02-07T15:54:01.435652Z",
-    "created_by":{  
+    "created_by":{
        "name":"DIT Staff",
        "first_name":"DIT",
        "last_name":"Staff",
@@ -31,7 +33,7 @@
     "is_event":null,
     "status": "complete",
     "kind":"interaction",
-    "modified_by":{  
+    "modified_by":{
        "name":"DIT Staff",
        "first_name":"DIT",
        "last_name":"Staff",
@@ -100,14 +102,14 @@
           "id":"9010dd28-9798-e211-a939-e4115bead28a"
         }
       }],
-    "communication_channel":{  
+    "communication_channel":{
        "name":"Social Media",
        "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
     },
     "grant_amount_offered":null,
     "investment_project":null,
     "net_company_receipt":null,
-    "service":{  
+    "service":{
        "name":"Account Managment: Northern Powerhouse",
        "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
     },
@@ -115,12 +117,12 @@
     "subject":"This is an automated interaction",
     "notes":"Sandbox",
     "archived_documents_url_path":"",
-    "policy_areas":[  
-  
+    "policy_areas":[
+
     ],
     "policy_feedback_notes":"",
-    "policy_issue_types":[  
-  
+    "policy_issue_types":[
+
     ],
     "was_policy_feedback_provided":false
   }

--- a/test/sandbox/fixtures/v3/interaction/interaction-without-document-link.json
+++ b/test/sandbox/fixtures/v3/interaction/interaction-without-document-link.json
@@ -1,9 +1,11 @@
 {
   "id": "0dcb3748-c097-4f20-b84f-0114bbb1a8e0",
-  "company": {
+  "companies": [
+    {
       "name": "Venus Ltd",
       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+    }
+  ],
   "contacts": [
       {
           "name": "Dean Cox",

--- a/test/sandbox/fixtures/v3/interaction/interactions.json
+++ b/test/sandbox/fixtures/v3/interaction/interactions.json
@@ -1,37 +1,39 @@
-{  
+{
   "count":1233,
   "next":"https://api.datahub.dev.uktrade.io/v3/interaction?limit=100&offset=100",
   "previous":null,
-  "results":[  
-     {  
+  "results":[
+     {
         "id":"d14abf23-7f07-4640-8908-cb6b40dc3ce3",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "first_name":"Sheila",
            "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "job_title":"Direct Research Assistant",
            "id":"0e92dab2-84af-405c-8d32-95e46568f9a7"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Katrine Block|80d2a6ea-de8f-45a3-ae89-ac4616fa0f39",
               "first_name":"Katrine",
               "last_name":"Block|80d2a6ea-de8f-45a3-ae89-ac4616fa0f39",
               "job_title":"Customer Assurance Analyst",
               "id":"708584a1-dd4b-4625-856f-72cc4aee49f8"
            },
-           {  
+           {
               "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "first_name":"Meda",
               "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "job_title":"Legacy Interactions Engineer",
               "id":"76ca9ab8-a6da-4103-a707-6974db2091e4"
            },
-           {  
+           {
               "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
               "first_name":"Sheila",
               "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
@@ -40,7 +42,7 @@
            }
         ],
         "created_on":"2019-01-07T16:26:56.363999Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -49,7 +51,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -57,24 +59,24 @@
         },
         "modified_on":"2019-02-01T09:51:23.355225Z",
         "date":"2060-11-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Coastal West Sussex",
            "id":"dc2e7f67-0653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"DSO Interaction",
            "id":"0796b92b-3499-e211-a939-e4115bead28a"
         },
@@ -82,30 +84,32 @@
         "subject":"totam|f19f5014-8bb1-4645-a224-27a4c8db5336",
         "notes":"<Spacein Leeds (Andrew lives in Leeds). EE also offered to explore interest from D4D MIC as SerenusAI considers orthopaedics to be a key strength. <h1> </h1>\r\n\r\n The company engages clinicians to develop artificial case studies (scenarios) in particular clinical areas and uses these in conjunction with 1.5 million [Israeli] patient records to develop algorithms which indicate the best pathway for a patient on the interface from primary care to secondary care based on clinical information and patient feedback.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e58f0ef4-6181-4558-a79a-8ff896012de9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Matteo Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
            "first_name":"Matteo",
            "last_name":"Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
            "job_title":"District Configuration Consultant",
            "id":"8ce58f47-1064-4a4f-888c-6a5b7eda768e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Matteo Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
               "first_name":"Matteo",
               "last_name":"Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
@@ -114,7 +118,7 @@
            }
         ],
         "created_on":"2019-01-07T15:44:32.688381Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -123,7 +127,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -131,24 +135,24 @@
         },
         "modified_on":"2019-01-07T15:44:32.688410Z",
         "date":"2059-11-26",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Financial & Professional Sector",
            "id":"ac93bb45-6e6b-e411-a72b-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -156,30 +160,32 @@
         "subject":"porro|20811eb2-0ca5-4f5a-9889-ab0f84716b83",
         "notes":"Nihil deserunt nihil ut nostrum consequatur aut culpa.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"80149410-813f-41c6-b1d8-c922870cb798",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -188,19 +194,19 @@
            }
         ],
         "created_on":"2018-12-07T16:24:55.271846Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Schoen Group",
            "id":"5cf26bb8-9453-4b16-ad3a-ec878859d54f"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -208,13 +214,13 @@
         },
         "modified_on":"2018-12-31T10:12:51.560134Z",
         "date":"2059-10-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Julie Brown",
            "first_name":"Julie",
            "last_name":"Brown",
            "id":"6086c0f0-2700-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Tel Aviv Israel",
            "id":"136e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -222,7 +228,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -230,30 +236,32 @@
         "subject":"earum|171ef6c0-1a2b-457c-b425-804a5fffba41",
         "notes":"Fuga sunt aspernatur veritatis quia iste eum at cumque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2a6f7bc6-8b17-4d1f-9cdc-d3fab05b3376",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -262,7 +270,7 @@
            }
         ],
         "created_on":"2018-11-23T08:11:25.241167Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -271,7 +279,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -279,24 +287,24 @@
         },
         "modified_on":"2018-11-23T08:11:25.241196Z",
         "date":"2059-09-12",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mandeep Channa",
            "first_name":"Mandeep",
            "last_name":"Channa",
            "id":"075ea5b0-1f01-e411-8a2b-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Paris France",
            "id":"077e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Client Proposal (IST use only)",
            "id":"d03cce05-f9f7-e511-888e-e4115bead28a"
         },
@@ -304,30 +312,32 @@
         "subject":"vero|709065cf-2509-42e1-8e1d-b8d01d7976f3",
         "notes":"Consequatur est ut deserunt iste nesciunt enim nemo.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b101f06e-b566-4f04-9bfa-23c369548b33",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Murl Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
            "first_name":"Murl",
            "last_name":"Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
            "job_title":"Investor Configuration Representative",
            "id":"eebd88a2-5da3-4762-88a4-31784830988b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Murl Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
               "first_name":"Murl",
               "last_name":"Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
@@ -336,19 +346,19 @@
            }
         ],
         "created_on":"2018-12-07T14:10:19.087967Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"est corrupti et illo",
            "id":"af46b1a6-4cc0-4c7c-964a-68464a904c02"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -356,13 +366,13 @@
         },
         "modified_on":"2018-12-07T14:10:19.087997Z",
         "date":"2059-08-18",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Chris Wall",
            "first_name":"Chris",
            "last_name":"Wall",
            "id":"20fdb970-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Northampton Borough Council",
            "id":"85c88c98-1153-e611-af02-e4115bead28a"
         },
@@ -370,7 +380,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Onward Referral",
            "id":"c4f9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -378,30 +388,32 @@
         "subject":"excepturi|0a6a0e56-cc22-4277-8a91-e4dc11f9a8ce",
         "notes":"Doloribus perferendis adipisci possimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7d5d1530-96e6-439f-b8ea-d2aa659066b8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "first_name":"Aletha",
            "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "job_title":"Product Division Executive",
            "id":"4f10d5a3-a86f-4dc9-811c-473660d8b80a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
               "first_name":"Aletha",
               "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
@@ -410,7 +422,7 @@
            }
         ],
         "created_on":"2018-11-22T22:08:57.790899Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -419,7 +431,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -427,24 +439,24 @@
         },
         "modified_on":"2018-11-22T22:08:57.790929Z",
         "date":"2059-08-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Jeremy Attree",
            "first_name":"Jeremy",
            "last_name":"Attree",
            "id":"bf5d6d3a-5151-e511-9d3c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ITFG - ICT & Data Policy and Support",
            "id":"3748318c-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -452,30 +464,32 @@
         "subject":"explicabo|224f6e55-26c6-440b-9daa-513372475cf8",
         "notes":"Qui facere velit nulla corporis praesentium.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5c981b7c-f002-4293-bd8e-5e0278081ffb",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -484,7 +498,7 @@
            }
         ],
         "created_on":"2018-12-05T19:19:36.155291Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -493,7 +507,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -501,24 +515,24 @@
         },
         "modified_on":"2018-12-05T19:19:36.155321Z",
         "date":"2059-04-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Divia Patel",
            "first_name":"Divia",
            "last_name":"Patel",
            "id":"4a35eedc-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Abuja Nigeria",
            "id":"48d616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -526,30 +540,32 @@
         "subject":"magnam|5935b9b9-6290-41f8-9252-a1535d6761dc",
         "notes":"Cum illum est sapiente quia voluptatem quod rerum magni.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"07f729e5-f040-4aff-b3cf-0edf49d2d43a",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "first_name":"Melvina",
            "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "job_title":"Future Data Technician",
            "id":"aeaa2cad-52de-492e-93e8-89fbf51cc03d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
               "first_name":"Melvina",
               "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
@@ -558,19 +574,19 @@
            }
         ],
         "created_on":"2019-01-11T16:11:38.996226Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hermiston - Okuneva",
            "id":"c4b39477-1d24-43b8-b25e-11ea96e80e0d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -578,13 +594,13 @@
         },
         "modified_on":"2019-01-11T16:11:38.996258Z",
         "date":"2059-03-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Campaigns and Special Programmes",
            "id":"4b4049e6-9698-e211-a939-e4115bead28a"
         },
@@ -592,7 +608,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -600,30 +616,32 @@
         "subject":"sed|f6f83b7a-ef19-484b-8aed-5afe06e8c43b",
         "notes":"Omnis explicabo eum et ut et voluptas quibusdam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2418e882-b02d-41e2-b60c-8cb22aa563ea",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -632,19 +650,19 @@
            }
         ],
         "created_on":"2019-01-10T11:43:53.339042Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hermiston - Hills",
            "id":"00e48876-39fd-4718-8039-69b82cf21074"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -652,13 +670,13 @@
         },
         "modified_on":"2019-01-29T13:24:10.255958Z",
         "date":"2058-12-02",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Wellington New Zealand",
            "id":"197c51d4-9698-e211-a939-e4115bead28a"
         },
@@ -666,7 +684,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -674,30 +692,32 @@
         "subject":"placeat|ef6e12ee-0751-4dd2-bade-ef40c5cf9bb2",
         "notes":"Odit minima eum est.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"af4aac84-4d6a-47df-a733-5a54e3008c32",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -706,7 +726,7 @@
            }
         ],
         "created_on":"2018-01-23T10:39:18.220321Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -715,7 +735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -723,24 +743,24 @@
         },
         "modified_on":"2018-10-04T12:44:57.950073Z",
         "date":"2058-11-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Priyanka Karunan",
            "first_name":"Priyanka",
            "last_name":"Karunan",
            "id":"537df876-5062-e311-8255-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Chief Executive's Office",
            "id":"16362a92-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -748,30 +768,32 @@
         "subject":"ad",
         "notes":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur vel mauris metus. Vestibulum quis suscipit diam. Nullam euismod lectus porta, sollicitudin erat ut, congue lectus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec orci neque, sodales sit amet metus eu, lacinia tristique quam. Proin quis feugiat turpis. Nulla aliquam nunc sit amet vehicula malesuada. Fusce nulla sem, finibus ut eros scelerisque, dignissim pellentesque est. Donec a tortor eget nisi viverra suscipit eget ut sem. Cras ante eros, pellentesque tincidunt purus quis, pretium iaculis nibh. Nullam pulvinar dapibus malesuada. Suspendisse convallis nisi id massa vestibulum, id porttitor tellus vestibulum. Maecenas non dolor dolor. Etiam non neque lacinia, eleifend ante ac, aliquet ante.\r\n\r\nSed rhoncus eros ut tortor pharetra scelerisque. Maecenas id ultrices tellus. Mauris sed rutrum dolor. Pellentesque in dolor non sapien gravida aliquam. Vestibulum tempor laoreet lacus in lobortis. Nullam pellentesque augue elementum, vestibulum metus laoreet, pretium metus. Phasellus lacus mauris, aliquam eget fermentum nec, rhoncus at leo. Suspendisse pellentesque lacus purus, ac imperdiet purus maximus ac. Cras quis metus eget felis accumsan finibus nec porta leo. Nullam eget sem eu metus rhoncus vehicula. Aliquam neque ligula, eleifend et elit nec, congue aliquet tellus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In ultricies ac ipsum sed dapibus. Maecenas tempus lacus nec convallis rutrum.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque at nibh eu nulla blandit dignissim et quis justo. Fusce nec neque ut quam condimentum pretium. Donec vulputate, purus ut mattis porttitor, purus lorem auctor velit, ac maximus lorem arcu at neque. Etiam tincidunt mauris varius, condimentum ex at, congue dolor. Vestibulum eu mi quis elit pellentesque pharetra. Praesent augue nisi, faucibus tincidunt lacinia eget, dapibus eget arcu. Mauris ut fermentum turpis. Donec pretium nulla et urna dictum, pretium pulvinar risus viverra. Quisque leo arcu, tristique sed condimentum rhoncus, dictum in ipsum.\r\n\r\nAenean leo velit, commodo nec rhoncus fermentum, ornare ut ipsum. Donec a dolor et massa pharetra feugiat nec a enim. Aliquam sit amet nibh et sapien interdum faucibus. Donec volutpat nunc sit amet tempus tristique. Fusce tempus eros vitae fermentum dignissim. Nullam vestibulum fermentum lobortis. Praesent ac risus dolor. Vivamus in lectus lobortis, ultrices nulla eget, pellentesque dolor. Donec urna eros, fermentum id odio quis, commodo fermentum ex. Proin non purus ut arcu vulputate varius.\r\n\r\nMauris aliquam quam sodales porta feugiat. In fringilla, odio ut tristique sagittis, odio libero gravida tortor, finibus tincidunt nisl erat eu nunc. Proin hendrerit dictum erat sed posuere. Praesent placerat nulla ut ullamcorper tincidunt. Cras ultricies vitae orci sed porttitor. Curabitur viverra, turpis vestibulum euismod interdum, sem leo varius ligula, eget cursus nisi mauris ac leo. Nullam ut odio vel eros pretium congue. Donec felis nunc, placerat sit amet urna nec, mattis vestibulum ipsum. Suspendisse ultricies nunc ut vehicula pharetra.\r\n\r\nInteger ut rhoncus lorem, vel blandit lorem. Sed accumsan at massa ac aliquam. Maecenas in nisi quis leo convallis condimentum at et metus. Nunc quis dictum risus, ut scelerisque ligula. Proin euismod mattis risus, sit amet cursus ante pretium nec. Sed euismod dapibus massa, vitae pulvinar felis elementum a. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam ultricies lorem dapibus metus lobortis, eu vulputate sem varius. Maecenas tincidunt mi a velit placerat rhoncus. Nunc pharetra metus dolor, sed molestie justo dignissim in. Vestibulum interdum ligula in interdum pharetra. Etiam imperdiet interdum pretium. Proin quis nisl egestas, rhoncus quam sit amet, tristique nulla. Fusce mollis lacus vitae nisi convallis, quis efficitur arcu tincidunt.\r\n\r\nPraesent sollicitudin laoreet blandit. Donec eu sem purus. Curabitur pulvinar tortor quis diam consequat, ac pretium velit faucibus. Sed blandit sapien eu nulla posuere suscipit. Ut sed nisi dui. Phasellus sed lectus porta, auctor velit sed, egestas eros. Nullam porta nisl quis ullamcorper cursus. Aenean elementum at lorem sit amet elementum. Aliquam vitae aliquet lacus. Vestibulum lacinia diam quis libero euismod ultricies. Integer eget consectetur neque. Praesent vel orci accumsan, dapibus nisl a, consequat tellus. Quisque eu porttitor felis. Quisque scelerisque velit metus, non semper libero dictum et.\r\n\r\nNullam sed tincidunt sapien. Duis fringilla, mauris eu pharetra venenatis, enim ex cursus lorem, eu pretium lorem neque id orci. Sed sit amet sem quis erat iaculis luctus. Vestibulum tincidunt euismod arcu, eu ornare sem. In hac habitasse platea dictumst. Pellentesque eros metus, feugiat vel luctus non, dictum quis risus. Phasellus nulla leo, dapibus non lectus at, convallis mollis lectus.\r\n\r\nQuisque et pretium enim. Fusce nulla libero, semper quis condimentum sit amet, efficitur vel magna. Sed efficitur nulla quis mauris iaculis ultrices. Donec mattis sodales lacus. Suspendisse porta pellentesque ultricies. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi convallis fringilla tellus, pretium aliquam metus rhoncus a. Praesent enim erat, pharetra sed purus vel, rutrum convallis odio. Ut scelerisque efficitur neque, ac dignissim enim cursus id. Fusce ac suscipit quam, non porttitor nibh. Integer pharetra risus vitae leo tincidunt rhoncus. Proin ac turpis ac arcu sodales imperdiet nec at enim.\r\n\r\nMauris tristique vitae arcu vel fringilla. Maecenas commodo mi euismod eleifend semper. Donec sollicitudin, erat eget pretium mollis, nulla nisi vehicula nisl, sit amet ullamcorper dolor enim ac lorem. Cras nibh turpis, convallis convallis dolor et, cursus laoreet ex. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur lectus massa, aliquet in quam vel, tempus sodales quam. Vestibulum consectetur, tellus sit amet efficitur faucibus, lorem nibh fringilla nisi, at efficitur mauris dui ac orci. Etiam dictum venenatis accumsan.\r\n\r\nCurabitur aliquam purus ligula, eget vestibulum lectus eleifend vitae. Donec sagittis, nisi non imperdiet posuere, eros velit scelerisque ante, varius fermentum diam neque non justo. Aenean facilisis vitae mi feugiat mollis. Etiam vehicula sem a blandit bibendum. Vivamus sodales luctus magna id aliquet. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris ac pulvinar nunc. Donec convallis ligula non felis aliquet, eget ultrices lorem egestas. Quisque sed libero id enim elementum ultrices non mattis urna. Vestibulum eros nisl, pharetra eu consequat vitae, varius sed tellus.\r\n\r\nNam cursus dolor ut sapien cursus tempor. Etiam suscipit nec enim in eleifend. Nulla sem nulla, commodo sit amet lorem ac, maximus dictum tellus. Vivamus in eleifend tortor. Sed eu eros ac velit molestie vestibulum. Nunc congue nisl erat, non dictum mi finibus vel. Proin velit mi, rhoncus vitae enim vel, commodo varius neque. Integer rutrum tempor purus mollis sagittis. Integer arcu ante, ultrices in lacinia at, varius ac velit. Maecenas volutpat ipsum sed vulputate iaculis. Aenean et aliquet lacus. Donec nisl odio, congue quis ipsum vel, volutpat auctor elit. Aliquam ultricies hendrerit fermentum. Curabitur id dui dictum, euismod eros in, tincidunt erat.\r\n\r\nEtiam feugiat sapien sit amet nisl pellentesque dictum. Nam posuere ac nulla at porttitor. Phasellus elit magna, elementum non rutrum vitae, vehicula nec enim. Phasellus risus orci, ultrices quis vestibulum sed, bibendum quis urna. Proin pretium sit amet purus nec ultrices. Curabitur euismod ipsum et interdum blandit. Donec porttitor porttitor eros, a aliquam nisi mattis vel. Vestibulum rutrum sapien sit amet turpis vulputate, quis tristique neque aliquet. Nunc molestie convallis sem ultrices commodo. Curabitur aliquam vel sapien nec vehicula. Morbi eget sagittis velit. Nulla aliquet dictum nisl nec euismod. Aliquam ultricies nunc sed turpis dictum, vitae ultricies orci pulvinar. Sed cursus magna sapien, id sollicitudin diam tempus et. Nulla convallis turpis in egestas sodales.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sit amet pharetra dui, at lacinia ex. Sed finibus massa vel metus hendrerit, sed consequat nulla elementum. Vivamus auctor dolor ut blandit malesuada. Curabitur ultrices erat eu cursus pellentesque. Fusce luctus vulputate posuere. Aenean ac hendrerit lectus, id feugiat augue. Cras hendrerit iaculis erat quis porttitor. Phasellus eget diam ac justo rutrum dignissim vel a tellus. In hac habitasse platea dictumst. Donec ullamcorper tortor ut posuere interdum. Pellentesque ullamcorper metus in velit lacinia, mollis ultrices ipsum ullamcorper. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer sed sagittis odio metus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"f3055aaf-2423-4288-963c-d49e149bcb0b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -780,7 +802,7 @@
            }
         ],
         "created_on":"2018-11-22T21:06:02.054748Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -789,7 +811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -797,24 +819,24 @@
         },
         "modified_on":"2018-12-18T16:51:04.388817Z",
         "date":"2058-09-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Christopher Hatton",
            "first_name":"Christopher",
            "last_name":"Hatton",
            "id":"20994bb2-6224-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Dir - Group Resources",
            "id":"15374ae0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -822,30 +844,32 @@
         "subject":"enim|6aa4ed37-a7a0-468d-b5ce-839c68c93166",
         "notes":"Quas et dolor eum non doloremque ut ex.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0629623d-3f64-46d0-abf0-5236e66b54b1",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
            "first_name":"Meda",
            "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
            "job_title":"Legacy Interactions Engineer",
            "id":"76ca9ab8-a6da-4103-a707-6974db2091e4"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "first_name":"Meda",
               "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
@@ -854,7 +878,7 @@
            }
         ],
         "created_on":"2019-01-11T17:03:27.923953Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -863,7 +887,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -871,24 +895,24 @@
         },
         "modified_on":"2019-01-11T17:03:27.923987Z",
         "date":"2058-08-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Inactive Advisor Service Provider",
            "id":"0242ce6a-d9be-e211-a646-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -896,36 +920,38 @@
         "subject":"aut|18658cbd-4d40-4cbe-9000-c74133a064bb",
         "notes":"Adipisci fugiat aut vero sunt.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Local Growth",
               "id":"01861666-4150-4aaf-b659-31f84e459612"
            }
         ],
         "policy_feedback_notes":"Odio illum ea vero ut sed et quod repellat cumque.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"9e55bfe6-12c6-47be-9e84-35e5cf10ac4f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "first_name":"Shanel",
            "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "job_title":"Forward Security Planner",
            "id":"3d196f6b-62ab-444b-9c35-e60d8daaca9e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
               "first_name":"Shanel",
               "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
@@ -934,19 +960,19 @@
            }
         ],
         "created_on":"2018-12-10T11:28:07.530276Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Larkin - Glover",
            "id":"6f2fd0c6-fd2b-41a7-9224-ee0d336a094a"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -954,13 +980,13 @@
         },
         "modified_on":"2018-12-10T11:28:07.530314Z",
         "date":"2058-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Nicholls",
            "first_name":"Andrew",
            "last_name":"Nicholls",
            "id":"815bb7e0-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Vientiane Laos",
            "id":"ea8333c8-9698-e211-a939-e4115bead28a"
         },
@@ -968,7 +994,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"OBN Chargeable Services",
            "id":"0b94cd30-e5eb-e311-8a2b-e4115bead28a"
         },
@@ -976,30 +1002,32 @@
         "subject":"dolorum|6308cc8b-0439-4ca5-872d-afceb560eaec",
         "notes":"Eius delectus neque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4093f571-63bc-4400-b9ee-46048e8ec3d7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -1008,19 +1036,19 @@
            }
         ],
         "created_on":"2019-01-11T16:35:34.480243Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Mante, Quitzon and Rodriguez",
            "id":"0be4a431-5668-438e-92ef-74901fe86d23"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1028,13 +1056,13 @@
         },
         "modified_on":"2019-01-11T16:35:34.480277Z",
         "date":"2058-06-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UK - India Business Council (UK IBC) - UK",
            "id":"298433c8-9698-e211-a939-e4115bead28a"
         },
@@ -1042,7 +1070,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1050,30 +1078,32 @@
         "subject":"quis|804d8566-4bb1-4e0e-8e38-516634e6d394",
         "notes":"Beatae vel dolor quaerat et quia eum nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"32cee8ad-dd72-45be-b7ac-3c7d6f81c50c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "first_name":"Melvina",
            "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "job_title":"Future Data Technician",
            "id":"aeaa2cad-52de-492e-93e8-89fbf51cc03d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
               "first_name":"Melvina",
               "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
@@ -1082,19 +1112,19 @@
            }
         ],
         "created_on":"2018-12-07T10:04:19.544433Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Koepp, Ward and Wyman",
            "id":"dccfa7dd-2401-43f5-a0e9-9e5cd0dd2424"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1102,13 +1132,13 @@
         },
         "modified_on":"2018-12-07T10:04:19.544464Z",
         "date":"2058-05-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Dawn Ross",
            "first_name":"Dawn",
            "last_name":"Ross",
            "id":"4bc1dfc4-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Renewable UK",
            "id":"0ef12898-9698-e211-a939-e4115bead28a"
         },
@@ -1116,7 +1146,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"OBN Chargeable Services",
            "id":"0b94cd30-e5eb-e311-8a2b-e4115bead28a"
         },
@@ -1124,30 +1154,32 @@
         "subject":"aut|3d7674bd-c300-4cfc-b309-9f7295c6e7b3",
         "notes":"Dicta numquam soluta.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c15cc8b9-7602-4cee-bef2-3d40a10d05f4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "first_name":"Sheila",
            "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "job_title":"Direct Research Assistant",
            "id":"0e92dab2-84af-405c-8d32-95e46568f9a7"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
               "first_name":"Sheila",
               "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
@@ -1156,19 +1188,19 @@
            }
         ],
         "created_on":"2019-01-11T16:22:32.142350Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ward, Rau and Labadie",
            "id":"113cbf82-8831-4470-aca6-ff84a96b3e66"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1176,13 +1208,13 @@
         },
         "modified_on":"2019-01-11T16:22:32.142400Z",
         "date":"2058-03-20",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Association of Professional Recording Services Ltd",
            "id":"3bf12898-9698-e211-a939-e4115bead28a"
         },
@@ -1190,7 +1222,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1198,30 +1230,32 @@
         "subject":"rerum|5425981f-130f-4e48-a9e4-9dc00483505e",
         "notes":"Dolore quidem tempore optio et eligendi assumenda incidunt.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c2c9279e-968f-47fe-b016-147188bc0273",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "first_name":"Garrick",
            "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "job_title":"Dynamic Interactions Designer",
            "id":"684b242a-c9b6-4cc6-98a8-4b6b4dd37e7f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
               "first_name":"Garrick",
               "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
@@ -1230,7 +1264,7 @@
            }
         ],
         "created_on":"2018-12-05T19:49:12.964124Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1239,7 +1273,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1247,24 +1281,24 @@
         },
         "modified_on":"2018-12-05T19:49:12.964155Z",
         "date":"2058-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Sarah Carter",
            "first_name":"Sarah",
            "last_name":"Carter",
            "id":"cf84236c-d707-e611-888e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - China",
            "id":"814d24c2-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -1272,30 +1306,32 @@
         "subject":"ab|7f7c8a66-8d65-41cd-a0c6-e96b29ead060",
         "notes":"Quod veritatis molestiae iure voluptas qui officia sint et nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6d6c1f1a-4852-4c4d-8b01-8659268deede",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Gilberto Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
            "first_name":"Gilberto",
            "last_name":"Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
            "job_title":"Lead Factors Supervisor",
            "id":"7a834b12-5978-4f52-9724-2cd43c53de7e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Gilberto Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
               "first_name":"Gilberto",
               "last_name":"Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
@@ -1304,7 +1340,7 @@
            }
         ],
         "created_on":"2018-11-23T09:19:43.410914Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1313,7 +1349,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1321,24 +1357,24 @@
         },
         "modified_on":"2018-11-23T09:19:43.410943Z",
         "date":"2057-11-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anthony Cowburn",
            "first_name":"Anthony",
            "last_name":"Cowburn",
            "id":"0626bcfe-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Kinematograph Sound and Television Society â€“ The Moving Image Society",
            "id":"f0f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -1346,30 +1382,32 @@
         "subject":"quasi|5139d60f-c178-43cc-a08c-61678ed6e1b8",
         "notes":"Architecto dolores sit quia non voluptatem fugit nesciunt non assumenda.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b3410d4b-9195-4ca8-a5a8-a1728c4586e8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -1378,7 +1416,7 @@
            }
         ],
         "created_on":"2018-11-22T17:50:28.238468Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1387,7 +1425,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1395,24 +1433,24 @@
         },
         "modified_on":"2018-11-22T17:50:28.238497Z",
         "date":"2057-10-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Willy Putra",
            "first_name":"Willy",
            "last_name":"Putra",
            "id":"7883452d-ee34-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Kyiv Ukraine",
            "id":"4f7e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1420,30 +1458,32 @@
         "subject":"eos|7a10cf5e-41b5-46c7-8dfa-3a86763d33fc",
         "notes":"Fugit quos aut veritatis odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0e0e6642-048d-413b-aa12-034f6a2d5cf7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "first_name":"Ashlee",
            "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "job_title":"Investor Assurance Technician",
            "id":"8d7fcf31-043a-43c2-baf8-58fc5fbb0689"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
               "first_name":"Ashlee",
               "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
@@ -1452,19 +1492,19 @@
            }
         ],
         "created_on":"2019-02-04T12:04:13.922396Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Goyette - Leuschke",
            "id":"00a5da1a-44ad-4b7a-a9f1-74965f4aa6aa"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1472,13 +1512,13 @@
         },
         "modified_on":"2019-02-04T12:04:13.922429Z",
         "date":"2057-10-17",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Paris France",
            "id":"077e43ce-9698-e211-a939-e4115bead28a"
         },
@@ -1486,7 +1526,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1494,36 +1534,38 @@
         "subject":"rerum|b602c4c0-e58b-4fcf-b442-62e1fa71e565",
         "notes":"Ab ab dolore ipsa at veniam autem ut et ducimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Government Communications",
               "id":"4fb8c6c6-d3aa-4b36-a954-7578e0337f4d"
            }
         ],
         "policy_feedback_notes":"Sed ratione nemo nisi tenetur magni repudiandae repellat provident.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"619639c9-92e9-4992-961d-e7359eb6e509",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -1532,7 +1574,7 @@
            }
         ],
         "created_on":"2019-01-07T16:15:30.583369Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1541,7 +1583,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1549,24 +1591,24 @@
         },
         "modified_on":"2019-01-07T16:15:30.583399Z",
         "date":"2057-07-17",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"OBN - British Chamber of Commerce in Hungary",
            "id":"daf91c3d-1c63-e311-8255-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Managment: Northern Powerhouse",
            "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
         },
@@ -1574,30 +1616,32 @@
         "subject":"nesciunt|8721c832-faff-409a-8cda-d15bfda7c3a1",
         "notes":"At rerum tempore harum eveniet veniam qui totam at.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2aabb068-4aab-4d5b-82da-5173015298e4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -1606,7 +1650,7 @@
            }
         ],
         "created_on":"2018-11-22T22:07:30.054033Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1615,7 +1659,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1623,24 +1667,24 @@
         },
         "modified_on":"2018-11-22T22:07:30.054063Z",
         "date":"2057-07-13",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alyson Beermann",
            "first_name":"Alyson",
            "last_name":"Beermann",
            "id":"17134cbe-f6ed-e211-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Winchester Council",
            "id":"2f4a754c-0753-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Overseas Market Introduction Service (OMIS)",
            "id":"360bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1648,30 +1692,32 @@
         "subject":"laborum|21faf3a7-16d1-40ac-95be-e074c62c9374",
         "notes":"Ipsa quia aspernatur dolores qui sit atque itaque ut minima.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fe861b92-ba93-4cce-a67a-72426149c8a0",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "first_name":"Abdiel",
            "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "job_title":"District Implementation Officer",
            "id":"1a36fa15-68b0-4627-8020-914f6f715d43"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
               "first_name":"Abdiel",
               "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
@@ -1680,7 +1726,7 @@
            }
         ],
         "created_on":"2018-11-22T13:47:59.113788Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1689,7 +1735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1697,24 +1743,24 @@
         },
         "modified_on":"2018-11-22T13:47:59.113847Z",
         "date":"2057-06-19",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Jones",
            "first_name":"Andrew",
            "last_name":"Jones",
            "id":"9f37a9da-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Textile Machinery Association",
            "id":"d965239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -1722,30 +1768,32 @@
         "subject":"aspernatur|1b0cb4bc-4d52-4227-9d42-ffa9f4bf41a4",
         "notes":"Quam quia sit vero quod.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"705a59dd-9c0a-4ccd-a15d-71317a334e09",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Nathaniel Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
            "first_name":"Nathaniel",
            "last_name":"Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
            "job_title":"Direct Directives Agent",
            "id":"39754dd3-a076-43da-9073-445d088e76ed"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Nathaniel Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
               "first_name":"Nathaniel",
               "last_name":"Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
@@ -1754,7 +1802,7 @@
            }
         ],
         "created_on":"2018-12-05T17:35:03.437828Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1763,7 +1811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1771,24 +1819,24 @@
         },
         "modified_on":"2018-12-05T17:35:03.437875Z",
         "date":"2057-06-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Lorraine Greene",
            "first_name":"Lorraine",
            "last_name":"Greene",
            "id":"2389d575-eecb-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"OBN - British Chamber of Commerce - Qatar",
            "id":"05321f01-0217-e311-a78e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1796,30 +1844,32 @@
         "subject":"sed|331875f9-beea-4efe-b964-ae6fba2471fb",
         "notes":"Nihil dolore ducimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4787165d-ae9e-4b16-9522-b31663aea344",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -1828,7 +1878,7 @@
            }
         ],
         "created_on":"2018-11-22T21:34:28.494478Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1837,7 +1887,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1845,24 +1895,24 @@
         },
         "modified_on":"2018-11-22T21:34:28.494509Z",
         "date":"2057-02-26",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"James Cushing",
            "first_name":"James",
            "last_name":"Cushing",
            "id":"1ff25c4d-ceae-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Chamber of Commerce - UK India Business Council",
            "id":"6873a5b3-ff16-e311-a78e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -1870,30 +1920,32 @@
         "subject":"libero|cda99c7a-7944-41c7-99a1-f12491d35d88",
         "notes":"Eum rerum alias ipsa nostrum ullam rerum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2c1f9ba3-9d33-41a7-90d0-cac775edf739",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "first_name":"Margaret",
            "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "job_title":"Chief Identity Orchestrator",
            "id":"e2b88408-57ef-4bb6-8103-1a2709f59d08"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
               "first_name":"Margaret",
               "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
@@ -1902,7 +1954,7 @@
            }
         ],
         "created_on":"2018-11-22T17:07:49.464659Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1911,7 +1963,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1919,24 +1971,24 @@
         },
         "modified_on":"2018-11-22T17:07:49.464687Z",
         "date":"2056-11-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Glen Wells",
            "first_name":"Glen",
            "last_name":"Wells",
            "id":"0a1c0f32-a005-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Markets",
            "id":"b4f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Tradeshow Access Programme (TAP)",
            "id":"f76eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1944,30 +1996,32 @@
         "subject":"blanditiis|72a1bbd8-74e9-40de-99cc-30b3a2166e47",
         "notes":"Eum quo in quia porro est.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8f9c2735-ece8-4b43-a4ee-73ec7df627a7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -1976,7 +2030,7 @@
            }
         ],
         "created_on":"2019-01-07T15:22:10.550417Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1985,7 +2039,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1993,24 +2047,24 @@
         },
         "modified_on":"2019-01-07T15:22:10.550446Z",
         "date":"2056-10-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Fluid Power Association",
            "id":"d5f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -2018,30 +2072,32 @@
         "subject":"minima|ac5f917e-b2b1-443a-a45d-2e6a494746a9",
         "notes":"Sit corrupti corrupti totam est quidem dignissimos consequatur placeat.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"72d44234-e78a-4e47-82b5-35f9a42ae8df",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -2050,19 +2106,19 @@
            }
         ],
         "created_on":"2018-01-22T17:15:48.874339Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Herzog LLC",
            "id":"cf3bd842-b18f-4c96-8a51-1eb7350faf87"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Marco Fucci",
            "first_name":"Marco",
            "last_name":"Fucci",
@@ -2070,13 +2126,13 @@
         },
         "modified_on":"2018-04-19T10:59:23.405646Z",
         "date":"2056-09-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Zeynep Oztekbas",
            "first_name":"Zeynep",
            "last_name":"Oztekbas",
            "id":"891df7e3-5c33-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Olympics Influenced Decision",
            "id":"bd2b032f-9798-e211-a939-e4115bead28a"
         },
@@ -2084,7 +2140,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2092,30 +2148,32 @@
         "subject":"sint",
         "notes":"Quo quae occaecati omnis quibusdam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7503e07c-e10f-4aed-9516-246507772e54",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pierre Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
            "first_name":"Pierre",
            "last_name":"Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
            "job_title":"Future Configuration Coordinator",
            "id":"bdc36be5-00f1-479c-882b-723c3a363b8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pierre Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
               "first_name":"Pierre",
               "last_name":"Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
@@ -2124,7 +2182,7 @@
            }
         ],
         "created_on":"2019-02-04T12:18:08.135234Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2133,7 +2191,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2141,24 +2199,24 @@
         },
         "modified_on":"2019-02-04T12:18:08.135264Z",
         "date":"2056-09-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Selby District Council",
            "id":"237b6d9c-0353-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -2166,30 +2224,32 @@
         "subject":"delectus|5278e0c6-48dc-47f9-b4a3-e5d5e6604432",
         "notes":"Sit et recusandae ipsa consequuntur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fee810e5-a95f-4a1e-ba64-0fbbe06bf588",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "first_name":"Shanel",
            "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "job_title":"Forward Security Planner",
            "id":"3d196f6b-62ab-444b-9c35-e60d8daaca9e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
               "first_name":"Shanel",
               "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
@@ -2198,19 +2258,19 @@
            }
         ],
         "created_on":"2018-12-07T13:49:50.421584Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Jacobi - Lockman",
            "id":"dcba3f74-25e5-4eb6-8005-0793c6da5c39"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2218,13 +2278,13 @@
         },
         "modified_on":"2018-12-07T13:49:50.421615Z",
         "date":"2056-08-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Cillian Cousins",
            "first_name":"Cillian",
            "last_name":"Cousins",
            "id":"3e576544-6e63-e511-9d3c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Opportunity Peterborough",
            "id":"5b0ba029-0653-e611-af02-e4115bead28a"
         },
@@ -2232,7 +2292,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -2240,30 +2300,32 @@
         "subject":"et|c9e996de-8e60-4af1-8a8b-ea1de3c5dcca",
         "notes":"Vero distinctio velit eum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8c365d3b-22a6-4aa1-b402-af7055d5e91b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Brandy Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
            "first_name":"Brandy",
            "last_name":"Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
            "job_title":"Human Paradigm Consultant",
            "id":"dac0bb0f-46e4-49ea-8228-e933d6b54392"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Brandy Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
               "first_name":"Brandy",
               "last_name":"Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
@@ -2272,7 +2334,7 @@
            }
         ],
         "created_on":"2019-01-11T16:59:31.479925Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2281,7 +2343,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2289,24 +2351,24 @@
         },
         "modified_on":"2019-01-11T16:59:31.479970Z",
         "date":"2056-06-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Dublin Ireland",
            "id":"587c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2314,36 +2376,38 @@
         "subject":"distinctio|ef21323e-a784-4bb5-8ffa-42d4a6d52082",
         "notes":"Nihil repudiandae sit est qui ab deserunt tempora.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Movement of Services",
               "id":"2ca6322b-27e4-4ed9-95d4-342989d98022"
            }
         ],
         "policy_feedback_notes":"Reiciendis in necessitatibus recusandae culpa reprehenderit voluptas ut.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"2a7d830c-e27b-4355-a4de-204099c88bf9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "first_name":"Lydia",
            "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "job_title":"Product Markets Strategist",
            "id":"d82cfc39-42df-46de-9787-856a41652c8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
               "first_name":"Lydia",
               "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
@@ -2352,19 +2416,19 @@
            }
         ],
         "created_on":"2018-12-04T10:43:31.517269Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Gulgowski LLC",
            "id":"8a25ff79-62bd-4fa0-b184-4cfebd5cefea"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2372,13 +2436,13 @@
         },
         "modified_on":"2018-12-04T10:43:31.517302Z",
         "date":"2056-03-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Syed Rizwan Haider",
            "first_name":"Syed Rizwan",
            "last_name":"Haider",
            "id":"357e3575-9c98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ITS United Kingdom",
            "id":"9ef924aa-9698-e211-a939-e4115bead28a"
         },
@@ -2386,7 +2450,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Market Visit Support (MVS)",
            "id":"340bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2394,30 +2458,32 @@
         "subject":"qui|b824eb89-9a80-4d80-bc36-1476f8163eba",
         "notes":"Qui et quod dolorum ullam et tenetur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"33762b51-d626-4da0-ac81-e30e9d8c0311",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -2426,7 +2492,7 @@
            }
         ],
         "created_on":"2019-01-11T16:57:04.160456Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2435,7 +2501,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2443,24 +2509,24 @@
         },
         "modified_on":"2019-01-11T16:57:04.160488Z",
         "date":"2056-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General Auckland New Zealand",
            "id":"167c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Tradeshow Access Programme (TAP)",
            "id":"f76eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -2468,36 +2534,38 @@
         "subject":"commodi|ad487ca8-a500-430e-a943-0ce9eee62855",
         "notes":"Nam cumque et voluptas atque harum dolor rem reiciendis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Imports",
               "id":"0da4abf1-6344-48bc-85cf-1834b5fb26e1"
            }
         ],
         "policy_feedback_notes":"Ratione itaque dolore.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"85f59ca9-2685-4fec-9b38-13b73fbb56a5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "first_name":"Ashlee",
            "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "job_title":"Investor Assurance Technician",
            "id":"8d7fcf31-043a-43c2-baf8-58fc5fbb0689"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
               "first_name":"Ashlee",
               "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
@@ -2506,7 +2574,7 @@
            }
         ],
         "created_on":"2018-12-05T16:16:54.580972Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2515,7 +2583,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2523,24 +2591,24 @@
         },
         "modified_on":"2018-12-05T16:16:54.581004Z",
         "date":"2056-03-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Monica Moorthy",
            "first_name":"Monica",
            "last_name":"Moorthy",
            "id":"05346184-9b98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of British Aerospace Companies Ltd",
            "id":"4a7b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2548,30 +2616,32 @@
         "subject":"eum|705a6e08-d246-410c-a996-2a266d650bbd",
         "notes":"Dolores sit iure alias accusantium vero et enim.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"1a3a6b70-ba17-4031-be2e-2a56ca437d2d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -2580,7 +2650,7 @@
            }
         ],
         "created_on":"2019-01-07T20:17:02.394878Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2589,7 +2659,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2597,24 +2667,24 @@
         },
         "modified_on":"2019-01-07T20:17:02.394910Z",
         "date":"2056-02-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC North EAST",
            "id":"602b971d-5df6-e511-888e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Managment: Northern Powerhouse",
            "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
         },
@@ -2622,30 +2692,32 @@
         "subject":"doloremque|09056026-ab8e-4725-8605-39097976f42b",
         "notes":"Perspiciatis consequatur quasi maiores et illum exercitationem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5f1b15f7-cbbc-4381-a89f-3dd07c36ddf1",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -2654,7 +2726,7 @@
            }
         ],
         "created_on":"2019-01-07T15:55:28.676317Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2663,7 +2735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2671,24 +2743,24 @@
         },
         "modified_on":"2019-01-07T15:55:28.676347Z",
         "date":"2056-02-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of British Gas Industries",
            "id":"3b7b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Client Proposal (IST use only)",
            "id":"d03cce05-f9f7-e511-888e-e4115bead28a"
         },
@@ -2696,30 +2768,32 @@
         "subject":"qui|820cab4e-7266-4974-b336-06afa6f1302f",
         "notes":"Ut qui aliquid aut.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c4dcd4b4-764f-48c4-bc84-019b6caf2dc5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "first_name":"Shanna",
            "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "job_title":"Lead Quality Coordinator",
            "id":"2c0ea5e0-9741-4f9e-8bfb-c749e14be1c9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
               "first_name":"Shanna",
               "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
@@ -2728,7 +2802,7 @@
            }
         ],
         "created_on":"2019-01-11T17:09:48.069840Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2737,7 +2811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2745,24 +2819,24 @@
         },
         "modified_on":"2019-01-11T17:09:48.069872Z",
         "date":"2055-12-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Strategy/Policy/Local Engagement - Strategy",
            "id":"32f671f0-094e-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -2770,30 +2844,32 @@
         "subject":"voluptas|32af86be-a602-4714-a829-1d9ddf33a7f8",
         "notes":"Aperiam fuga distinctio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"956680a2-b5b5-4b6a-8d57-21c6d878eb15",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -2802,19 +2878,19 @@
            }
         ],
         "created_on":"2018-12-06T12:41:58.288891Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ward, Rau and Labadie",
            "id":"113cbf82-8831-4470-aca6-ff84a96b3e66"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2822,13 +2898,13 @@
         },
         "modified_on":"2018-12-06T12:41:58.288921Z",
         "date":"2055-12-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mariko McTier",
            "first_name":"Mariko",
            "last_name":"McTier",
            "id":"be3f03eb-ea5d-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General Belo Horizonte Brazil",
            "id":"29cd87be-c191-e511-a84e-e4115bead28a"
         },
@@ -2836,7 +2912,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Opportunities",
            "id":"d520b92b-3499-e211-a939-e4115bead28a"
         },
@@ -2844,30 +2920,32 @@
         "subject":"est|1467c474-2df6-4739-ac14-46411a2280bc",
         "notes":"Labore cupiditate qui neque voluptas qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5371c428-c2f0-4761-b3ac-0a5913a51de5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "first_name":"Lydia",
            "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "job_title":"Product Markets Strategist",
            "id":"d82cfc39-42df-46de-9787-856a41652c8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
               "first_name":"Lydia",
               "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
@@ -2876,7 +2954,7 @@
            }
         ],
         "created_on":"2018-11-22T17:36:38.104092Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2885,7 +2963,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2893,24 +2971,24 @@
         },
         "modified_on":"2018-11-22T17:36:38.104120Z",
         "date":"2055-11-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Pippa Russo",
            "first_name":"Pippa",
            "last_name":"Russo",
            "id":"c9826157-d30a-e611-9bdc-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Athens Greece",
            "id":"3b8433c8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2918,30 +2996,32 @@
         "subject":"qui|69be5213-027a-42de-85de-fb36b3bbb7a8",
         "notes":"Ratione soluta est molestiae commodi necessitatibus nisi sit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b8936187-da15-441a-8cdb-b24bc0978659",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -2950,7 +3030,7 @@
            }
         ],
         "created_on":"2018-12-05T16:18:10.309765Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2959,7 +3039,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2967,24 +3047,24 @@
         },
         "modified_on":"2018-12-05T16:18:10.309794Z",
         "date":"2055-10-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Laura Campbell",
            "first_name":"Laura",
            "last_name":"Campbell",
            "id":"66205f64-2800-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Yorkshire and Humber Regional Sector Specialists",
            "id":"a52b032f-9798-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -2992,30 +3072,32 @@
         "subject":"iusto|9a567ff9-54c4-4a3a-a14f-b603056c8d1e",
         "notes":"Esse non et consequatur debitis et enim recusandae quod optio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4d46a1b1-4e6d-48a8-a9ce-e587fa0a5faf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -3024,7 +3106,7 @@
            }
         ],
         "created_on":"2018-05-24T22:23:45.256153Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3033,7 +3115,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3041,24 +3123,24 @@
         },
         "modified_on":"2018-05-24T22:23:45.256186Z",
         "date":"2055-10-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Kemenia McLean",
            "first_name":"Kemenia",
            "last_name":"McLean",
            "id":"eee0f538-c29d-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - TAP - Deputy Director",
            "id":"fd65239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -3066,30 +3148,32 @@
         "subject":"temporibus|66d29d1c-0cdd-4e3d-b86b-ed8fbb39c2ad",
         "notes":"Aut maiores vel non adipisci.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"491d0161-a72d-4bc7-8358-5f5fae2f14a4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -3098,19 +3182,19 @@
            }
         ],
         "created_on":"2018-12-05T17:47:07.766574Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Event event",
            "id":"9ca1147d-c855-47bb-86fb-b75265e13e32"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3118,13 +3202,13 @@
         },
         "modified_on":"2018-12-05T17:47:07.766604Z",
         "date":"2055-08-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anya Greaves",
            "first_name":"Anya",
            "last_name":"Greaves",
            "id":"6d93c233-1800-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Changsha",
            "id":"b483c1a0-d7df-e211-a78e-e4115bead28a"
         },
@@ -3132,7 +3216,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Overseas",
            "id":"ccf9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3140,30 +3224,32 @@
         "subject":"architecto|5e6c9e7a-5ae6-491e-bf8e-2559b82da6f9",
         "notes":"Sit id iusto provident.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"abf6cf32-0106-4007-a8b6-cc4ef41c28ac",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "first_name":"Shanna",
            "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "job_title":"Lead Quality Coordinator",
            "id":"2c0ea5e0-9741-4f9e-8bfb-c749e14be1c9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
               "first_name":"Shanna",
               "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
@@ -3172,7 +3258,7 @@
            }
         ],
         "created_on":"2018-11-23T09:17:49.460754Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3181,7 +3267,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3189,24 +3275,24 @@
         },
         "modified_on":"2018-11-23T09:17:49.460784Z",
         "date":"2055-07-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Test DSO2 Handler Test",
            "first_name":"Test",
            "last_name":"DSO2 Handler Test",
            "id":"a2e0f0d4-fe2e-e611-a7ac-e4115bed50dc"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Doncaster Council",
            "id":"78ac4641-1653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3214,30 +3300,32 @@
         "subject":"et|76f43296-90fc-46f4-9a3c-3c5fa46b7330",
         "notes":"At sit omnis minima sint est perspiciatis incidunt maiores.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"66daa610-ef51-474f-a0f6-4bbb07710317",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "first_name":"Aletha",
            "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "job_title":"Product Division Executive",
            "id":"4f10d5a3-a86f-4dc9-811c-473660d8b80a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
               "first_name":"Aletha",
               "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
@@ -3246,7 +3334,7 @@
            }
         ],
         "created_on":"2019-01-07T16:28:07.648153Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3255,7 +3343,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3263,24 +3351,24 @@
         },
         "modified_on":"2019-01-07T16:28:07.648183Z",
         "date":"2055-06-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Shenzhen",
            "id":"664d24c2-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3288,30 +3376,32 @@
         "subject":"iste|4f36ab15-c0ac-4712-810e-98201718020a",
         "notes":"Dicta assumenda et est sapiente consequatur fugit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"73d891b5-59cc-4535-8eff-9733c55d23ac",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -3320,19 +3410,19 @@
            }
         ],
         "created_on":"2018-12-07T09:50:46.773966Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Price Inc",
            "id":"ec4256eb-00db-4744-ae6e-4611fc1de7a5"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3340,13 +3430,13 @@
         },
         "modified_on":"2018-12-07T09:50:46.773995Z",
         "date":"2055-06-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mohammed Sharif",
            "first_name":"Mohammed",
            "last_name":"Sharif",
            "id":"a09d93bd-5453-e311-a56a-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"London Development Agency",
            "id":"c43ade1c-9798-e211-a939-e4115bead28a"
         },
@@ -3354,7 +3444,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Market Visit Support (MVS)",
            "id":"340bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -3362,30 +3452,32 @@
         "subject":"odit|de613e3e-52c7-4ff4-bb83-47a567a224a9",
         "notes":"Harum nostrum accusantium ea dolores incidunt deserunt quo ullam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"a3f56ba5-9743-41c0-9b3c-145b48953fba",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -3394,7 +3486,7 @@
            }
         ],
         "created_on":"2019-02-04T12:03:18.416826Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3403,7 +3495,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3411,24 +3503,24 @@
         },
         "modified_on":"2019-02-04T12:03:18.416857Z",
         "date":"2055-05-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Managing Director & PA",
            "id":"2a374ae0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -3436,30 +3528,32 @@
         "subject":"et|5ee92777-c6de-4a57-807a-c99c38534951",
         "notes":"Tempora sit reiciendis fugit ipsam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"20b3e670-86ce-480e-8dec-28c339584022",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -3468,19 +3562,19 @@
            }
         ],
         "created_on":"2018-12-06T15:00:25.536950Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"O'Connell - Conroy|f596a57c-2762-4010-8f36-b8bf585d9bb1",
            "id":"254bb413-30b5-4097-880b-b6ae8e1dcf16"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3488,13 +3582,13 @@
         },
         "modified_on":"2018-12-06T15:00:25.536978Z",
         "date":"2055-04-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Teresa Rosinski",
            "first_name":"Teresa",
            "last_name":"Rosinski",
            "id":"b647074c-8954-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Cambridge Cleantech Ltd",
            "id":"0379b20f-271a-e311-a78e-e4115bead28a"
         },
@@ -3502,7 +3596,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Webinars",
            "id":"510a4016-4bb9-e211-a646-e4115bead28a"
         },
@@ -3510,30 +3604,32 @@
         "subject":"reiciendis|97c3a6b2-0ef7-4d64-8529-ed0aeb168128",
         "notes":"Quod et nobis molestias.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"302ad5c7-0e99-47f3-8c41-d6910c46d296",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -3542,7 +3638,7 @@
            }
         ],
         "created_on":"2018-11-23T11:27:06.195146Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3551,7 +3647,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3559,24 +3655,24 @@
         },
         "modified_on":"2018-11-23T11:27:06.195177Z",
         "date":"2055-03-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Katarzyna Zwolak",
            "first_name":"Katarzyna",
            "last_name":"Zwolak",
            "id":"3b7257fd-cc94-e411-a839-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IST - Business and Partnerships",
            "id":"d64f1c8a-cfe9-e511-8ffa-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -3584,30 +3680,32 @@
         "subject":"aliquid|8c6391c7-b6b4-48ab-a3bc-f537befb4725",
         "notes":"Voluptatem voluptatem voluptatem ipsum sapiente eum id ipsum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"233d3edc-5d50-4e45-a4d4-b33037fedb80",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -3616,19 +3714,19 @@
            }
         ],
         "created_on":"2018-12-05T17:41:33.251589Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Wuckert and Sons",
            "id":"43a6d08d-c6a4-425d-889b-c7061b448cbb"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3636,13 +3734,13 @@
         },
         "modified_on":"2018-12-05T17:41:33.251619Z",
         "date":"2055-01-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Jennifer Hunter",
            "first_name":"Jennifer",
            "last_name":"Hunter",
            "id":"7e364f28-54c8-e211-a646-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General San Francisco USA",
            "id":"017e43ce-9698-e211-a939-e4115bead28a"
         },
@@ -3650,7 +3748,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) Non Funded",
            "id":"f46eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -3658,30 +3756,32 @@
         "subject":"perspiciatis|a1980d61-ca31-4d91-8f2b-2d762f33e8b9",
         "notes":"Aut cum qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e5d81b84-af59-4877-924c-72735649771b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -3690,19 +3790,19 @@
            }
         ],
         "created_on":"2018-12-07T13:26:34.815515Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Kerluke Inc",
            "id":"09c94086-ef82-4814-94f4-251977715046"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3710,13 +3810,13 @@
         },
         "modified_on":"2018-12-07T13:26:34.815557Z",
         "date":"2054-12-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Michael Reid",
            "first_name":"Michael",
            "last_name":"Reid",
            "id":"21eb8bf5-dbeb-e311-8a2b-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"West Oxfordshire District Council",
            "id":"5e2f39ac-1953-e611-af02-e4115bead28a"
         },
@@ -3724,7 +3824,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"UK Region Local",
            "id":"9a84b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3732,30 +3832,32 @@
         "subject":"sint|e7652f96-01b6-433e-807a-44b1d2383f39",
         "notes":"Facere voluptas voluptas dolores.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"46141a83-3217-4ec2-bfe8-dfa7181fa08c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -3764,19 +3866,19 @@
            }
         ],
         "created_on":"2019-02-04T12:19:09.104775Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Smith and Sons",
            "id":"636f171c-c602-4f89-81b2-d5d6a19db3d7"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3784,13 +3886,13 @@
         },
         "modified_on":"2019-02-04T12:19:09.104808Z",
         "date":"2054-10-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Yorkshire and Humber Regional Sector Specialists",
            "id":"a52b032f-9798-e211-a939-e4115bead28a"
         },
@@ -3798,7 +3900,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -3806,30 +3908,32 @@
         "subject":"ab|7aeb2646-9d6b-433a-a014-bcbaf28cc014",
         "notes":"Soluta et non recusandae.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"ff4c84b4-d225-40aa-96fb-0d398e3c6230",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Alexandre Morissette|b697da75-4804-4868-8886-e8df2219d89f",
            "first_name":"Alexandre",
            "last_name":"Morissette|b697da75-4804-4868-8886-e8df2219d89f",
            "job_title":"National Operations Associate",
            "id":"d795c064-8202-42d1-a21f-e4f7ae35589a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Alexandre Morissette|b697da75-4804-4868-8886-e8df2219d89f",
               "first_name":"Alexandre",
               "last_name":"Morissette|b697da75-4804-4868-8886-e8df2219d89f",
@@ -3838,7 +3942,7 @@
            }
         ],
         "created_on":"2018-11-22T20:10:56.029435Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3847,7 +3951,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3855,24 +3959,24 @@
         },
         "modified_on":"2018-11-22T20:10:56.029464Z",
         "date":"2054-10-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Thomas Ackroyd",
            "first_name":"Thomas",
            "last_name":"Ackroyd",
            "id":"639e1b6e-1dcc-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Aberdeen City Council",
            "id":"cff02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -3880,30 +3984,32 @@
         "subject":"aut|45021fa6-75d6-4c65-971d-ffd3f8d81a9a",
         "notes":"Eveniet in quam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0df6527d-eed4-4c57-9939-4b9f4c663dfd",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -3912,7 +4018,7 @@
            }
         ],
         "created_on":"2019-01-07T15:58:59.909739Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3921,7 +4027,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3929,24 +4035,24 @@
         },
         "modified_on":"2019-01-07T15:58:59.909773Z",
         "date":"2054-06-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Guatemala City Guatemala",
            "id":"40841eb0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -3954,30 +4060,32 @@
         "subject":"amet|530e7a94-5e44-4c54-877f-da7f95757859",
         "notes":"Cumque ducimus tempore consectetur aut quos distinctio tempore dignissimos qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"748bfee9-b901-467b-8bfc-2b0fb07bbb9a",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "first_name":"Abdiel",
            "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "job_title":"District Implementation Officer",
            "id":"1a36fa15-68b0-4627-8020-914f6f715d43"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
               "first_name":"Abdiel",
               "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
@@ -3986,7 +4094,7 @@
            }
         ],
         "created_on":"2019-01-11T16:36:19.515702Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3995,7 +4103,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4003,24 +4111,24 @@
         },
         "modified_on":"2019-01-11T16:36:19.515737Z",
         "date":"2054-06-05",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Havant Borough Council",
            "id":"259199aa-0653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -4028,36 +4136,38 @@
         "subject":"explicabo|56f8ed81-a8d8-429e-a199-05fe354c9a28",
         "notes":"Sed dolore sed voluptas error aspernatur repudiandae quasi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Returnships",
               "id":"276b98bc-d12e-42e2-b506-27c3f36083a4"
            }
         ],
         "policy_feedback_notes":"At distinctio odio est optio et.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"d0d723e3-6252-412b-880e-846fbd0f7d0c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carli Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
            "first_name":"Carli",
            "last_name":"Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
            "job_title":"Principal Metrics Officer",
            "id":"69bc7dbd-d62b-461f-9bbc-57fd2a5bc8f3"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carli Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
               "first_name":"Carli",
               "last_name":"Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
@@ -4066,7 +4176,7 @@
            }
         ],
         "created_on":"2018-11-23T11:23:33.045029Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4075,7 +4185,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4083,24 +4193,24 @@
         },
         "modified_on":"2018-11-23T11:23:33.045073Z",
         "date":"2054-01-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Gabriela Kramarova",
            "first_name":"Gabriela",
            "last_name":"Kramarova",
            "id":"5f01f330-9998-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Accra Ghana",
            "id":"1c6e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4108,30 +4218,32 @@
         "subject":"fugiat|ee7043a1-b3a1-4db3-842c-a33f17185bee",
         "notes":"Voluptas velit et ducimus eveniet.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2776253a-b1ad-42b3-a811-e6dce3e0acb3",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "first_name":"Unique",
            "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "job_title":"Direct Intranet Assistant",
            "id":"f6b8ca61-915c-4df1-8379-d3d9a8b99195"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
               "first_name":"Unique",
               "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
@@ -4140,19 +4252,19 @@
            }
         ],
         "created_on":"2019-01-11T16:12:26.637249Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"5fcbe01d-402f-4bff-93c7-bf3f03c7c6df",
            "id":"ed1f8c74-23e5-4043-806d-a899c7ebea83"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4160,13 +4272,13 @@
         },
         "modified_on":"2019-01-11T16:12:26.637299Z",
         "date":"2053-12-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Gateshead Council",
            "id":"4b3d36c4-6025-e511-b6bc-e4115bead28a"
         },
@@ -4174,7 +4286,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4182,30 +4294,32 @@
         "subject":"aliquam|b8278491-8cde-4a3a-9161-f9ad97b881c9",
         "notes":"Velit soluta excepturi eius quam non quasi reiciendis architecto.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"1f42c879-8124-4fd4-b20b-ab27c070d5ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -4214,7 +4328,7 @@
            }
         ],
         "created_on":"2019-01-11T16:12:47.166367Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4223,7 +4337,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4231,24 +4345,24 @@
         },
         "modified_on":"2019-01-11T16:12:47.166415Z",
         "date":"2053-11-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Panama City Panama",
            "id":"2ad616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -4256,30 +4370,32 @@
         "subject":"repellendus|2cf4771a-3676-49ea-ab7b-0d249ccf3095",
         "notes":"Labore quisquam corrupti quia laudantium architecto animi est quidem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b0260ae8-a0ca-4ea4-a2ef-927e8cd7e49d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -4288,19 +4404,19 @@
            }
         ],
         "created_on":"2019-01-11T16:22:55.748627Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Gislason - Gerhold",
            "id":"de4f1dad-930e-4b79-a4d4-c5e22fd69e18"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4308,13 +4424,13 @@
         },
         "modified_on":"2019-01-11T16:22:55.748658Z",
         "date":"2053-10-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of Motor Manufacturers & Traders Ltd",
            "id":"447b1ca4-9698-e211-a939-e4115bead28a"
         },
@@ -4322,41 +4438,43 @@
         "grant_amount_offered":"100000.00",
         "investment_project":null,
         "net_company_receipt":"50000.00",
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
-        "service_delivery_status":{  
+        "service_delivery_status":{
            "name":"Completed",
            "id":"47329c18-6095-e211-a939-e4115bead28a"
         },
         "subject":"vel|72fb9b38-4a3c-48dc-bdbc-373929c37329",
         "notes":"Placeat reprehenderit architecto ut non.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c4d33303-0387-4bc2-bb2d-6f3e2e8d8f25",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ressie Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
            "first_name":"Ressie",
            "last_name":"Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
            "job_title":"Internal Data Liaison",
            "id":"3df98941-fca6-4a7a-b8ce-05f571746aea"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ressie Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
               "first_name":"Ressie",
               "last_name":"Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
@@ -4365,7 +4483,7 @@
            }
         ],
         "created_on":"2018-11-22T18:02:06.747670Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4374,7 +4492,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4382,24 +4500,24 @@
         },
         "modified_on":"2018-11-22T18:02:06.747719Z",
         "date":"2053-08-14",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Kieran Mercer",
            "first_name":"Kieran",
            "last_name":"Mercer",
            "id":"0638a051-9a98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Leicester City Council",
            "id":"88c26d29-4f4e-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4407,30 +4525,32 @@
         "subject":"soluta|609368a6-83fa-4071-b37e-3e28a725d90b",
         "notes":"Autem ut itaque consequatur autem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b0344227-def7-4b11-b175-2bb2fa3081f4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -4439,7 +4559,7 @@
            }
         ],
         "created_on":"2018-11-22T14:21:34.231519Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4448,7 +4568,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4456,24 +4576,24 @@
         },
         "modified_on":"2018-11-22T14:21:34.231567Z",
         "date":"2053-08-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Akoto Agyeman",
            "first_name":"Akoto",
            "last_name":"Agyeman",
            "id":"ba05b3b0-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Wales",
            "id":"826e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -4481,30 +4601,32 @@
         "subject":"architecto|8db6621a-dd60-4008-9ae3-211d2f468c90",
         "notes":"Animi adipisci sed sed dolore beatae nisi repudiandae inventore dolorem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"10e95320-bbe1-4a13-bddc-4db4bc108965",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -4513,7 +4635,7 @@
            }
         ],
         "created_on":"2018-08-31T13:14:50.083309Z",
-        "created_by":{  
+        "created_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -4522,7 +4644,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -4530,24 +4652,24 @@
         },
         "modified_on":"2018-08-31T13:14:50.083339Z",
         "date":"2053-08-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anastasia Badina",
            "first_name":"Anastasia",
            "last_name":"Badina",
            "id":"0ccaaad4-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Sport",
            "id":"b9f924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Business Proposition",
            "id":"9384b82b-3499-e211-a939-e4115bead28a"
         },
@@ -4555,30 +4677,32 @@
         "subject":"rerum|68a20887-8f30-488b-a0ac-e29e0fda151c",
         "notes":"Praesentium odit omnis fuga ut reprehenderit quia sed odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"90eecb26-0c11-4d2c-8efb-97ac51c31770",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Frances Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
            "first_name":"Frances",
            "last_name":"Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
            "job_title":"Senior Accounts Executive",
            "id":"ba66c8bd-5787-4ded-a351-dc5273a0543d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Frances Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
               "first_name":"Frances",
               "last_name":"Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
@@ -4587,7 +4711,7 @@
            }
         ],
         "created_on":"2018-11-22T22:16:54.428620Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4596,7 +4720,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4604,24 +4728,24 @@
         },
         "modified_on":"2018-11-22T22:16:54.428665Z",
         "date":"2053-06-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Algar",
            "first_name":"Andrew",
            "last_name":"Algar",
            "id":"bacaaad4-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Sunderland Council",
            "id":"492aca01-8425-e511-b6bc-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -4629,30 +4753,32 @@
         "subject":"ut|4463109c-6f92-4563-b60f-e9a806eeb21f",
         "notes":"Dolorum porro at nihil sequi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0f7549c4-1236-48ee-a9a0-019ef8ad9a9b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "first_name":"Eddie",
            "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "job_title":"Senior Brand Coordinator",
            "id":"afbf7f18-dcb1-41a6-b754-983c752a49d9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
               "first_name":"Eddie",
               "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
@@ -4661,7 +4787,7 @@
            }
         ],
         "created_on":"2018-11-22T18:01:01.202865Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4670,7 +4796,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4678,24 +4804,24 @@
         },
         "modified_on":"2018-11-22T18:01:01.202894Z",
         "date":"2053-05-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Eleanor Butterwick",
            "first_name":"Eleanor",
            "last_name":"Butterwick",
            "id":"b8c204cc-d000-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Food From Britain",
            "id":"8cf924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4703,30 +4829,32 @@
         "subject":"numquam|994e12fa-2f34-4522-b199-c0248265e1a5",
         "notes":"Dolores unde quo pariatur laboriosam voluptates.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"79b956ab-b749-4d7d-890b-52bf89b3cf5c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -4735,7 +4863,7 @@
            }
         ],
         "created_on":"2018-11-22T13:33:53.892415Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4744,7 +4872,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4752,24 +4880,24 @@
         },
         "modified_on":"2018-11-22T13:33:53.892448Z",
         "date":"2053-03-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Antonio Santos",
            "first_name":"Antonio",
            "last_name":"Santos",
            "id":"e740c504-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Glass and Glazing Federation",
            "id":"8ff924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4777,30 +4905,32 @@
         "subject":"voluptates|28503fe5-e62a-45bc-8816-7e0a82f32fc9",
         "notes":"Eligendi recusandae cum sequi itaque et nam odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8072ad3f-dbd6-42d5-917e-7e8c9607c785",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -4809,19 +4939,19 @@
            }
         ],
         "created_on":"2018-04-17T11:12:11.261654Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hyatt LLC",
            "id":"2213391b-599c-4274-b0d9-72e5f45cafe6"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4829,13 +4959,13 @@
         },
         "modified_on":"2018-04-17T11:12:11.261689Z",
         "date":"2053-02-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Demosthenous",
            "first_name":"Andrew",
            "last_name":"Demosthenous",
            "id":"b5954ce6-a3d1-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - SR - Director &  PA",
            "id":"1b374ae0-9698-e211-a939-e4115bead28a"
         },
@@ -4843,7 +4973,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -4851,30 +4981,32 @@
         "subject":"aut|5c2726d1-87cb-4e07-8ee7-825e943289c9",
         "notes":"Deserunt amet explicabo assumenda quia aut enim dolor.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6b0b3f86-442b-4a90-a534-ed42d897c00e",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -4883,19 +5015,19 @@
            }
         ],
         "created_on":"2018-12-04T10:54:47.685361Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"My third event",
            "id":"08989891-e768-4f43-b431-dd28d7025768"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4903,13 +5035,13 @@
         },
         "modified_on":"2018-12-04T10:54:47.685409Z",
         "date":"2053-02-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Atma Panray",
            "first_name":"Atma",
            "last_name":"Panray",
            "id":"fff75dc5-bf9d-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - South East Asia",
            "id":"238433c8-9698-e211-a939-e4115bead28a"
         },
@@ -4917,7 +5049,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4925,30 +5057,32 @@
         "subject":"nihil|6272f9e8-0f1b-47fb-bbf3-cde8023952fc",
         "notes":"Quibusdam cum alias fuga.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"481d8ae5-e7ce-4cef-a984-7a62b035e9b8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -4957,7 +5091,7 @@
            }
         ],
         "created_on":"2018-01-30T16:28:00.502237Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4966,7 +5100,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4974,24 +5108,24 @@
         },
         "modified_on":"2018-01-30T16:28:00.502286Z",
         "date":"2053-01-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Ana Barragan",
            "first_name":"Ana",
            "last_name":"Barragan",
            "id":"0b3cb3ce-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Riyadh Saudi Arabia",
            "id":"51d616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Webinars",
            "id":"510a4016-4bb9-e211-a646-e4115bead28a"
         },
@@ -4999,30 +5133,32 @@
         "subject":"voluptas",
         "notes":"Consequatur quam quos aut temporibus ad.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"bc4fba97-d45e-443c-8660-0dbf4198b4cb",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -5031,7 +5167,7 @@
            }
         ],
         "created_on":"2018-08-31T14:59:43.118995Z",
-        "created_by":{  
+        "created_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -5040,7 +5176,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -5048,24 +5184,24 @@
         },
         "modified_on":"2018-08-31T14:59:43.119025Z",
         "date":"2052-11-05",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alan Roden",
            "first_name":"Alan",
            "last_name":"Roden",
            "id":"f4e8c3b6-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"SG4 - SG 4 International Business Schemes Directorate",
            "id":"73a963f8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -5073,30 +5209,32 @@
         "subject":"magnam|a9a7a91a-f953-4aad-9a2f-9a58ee1fa3f8",
         "notes":"Eveniet est optio ipsum esse officiis eos.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8be1cb46-13ce-4d99-9d0e-5cda88fb0d21",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -5105,19 +5243,19 @@
            }
         ],
         "created_on":"2018-03-21T13:34:29.490810Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Tillman - Eichmann",
            "id":"6ef89384-1bb2-4dc5-9ebd-cfe5532aac26"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5125,13 +5263,13 @@
         },
         "modified_on":"2018-03-21T13:34:29.490866Z",
         "date":"2052-08-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"David Edmondson",
            "first_name":"David",
            "last_name":"Edmondson",
            "id":"a566eeb2-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - TAP Team",
            "id":"0066239e-9698-e211-a939-e4115bead28a"
         },
@@ -5139,7 +5277,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -5147,30 +5285,32 @@
         "subject":"at|936ef003-6d09-49fa-ab09-0bd30b005f62",
         "notes":"Similique qui libero ipsum possimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8d30ff46-4304-45f8-ac29-2c38d2ade193",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "first_name":"Eddie",
            "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "job_title":"Senior Brand Coordinator",
            "id":"afbf7f18-dcb1-41a6-b754-983c752a49d9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
               "first_name":"Eddie",
               "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
@@ -5179,7 +5319,7 @@
            }
         ],
         "created_on":"2019-01-07T15:20:11.586885Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5188,7 +5328,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5196,24 +5336,24 @@
         },
         "modified_on":"2019-01-07T15:20:11.586916Z",
         "date":"2052-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Welsh Government (Investment)",
            "id":"bc85aa17-fabd-e511-88b6-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Services",
            "id":"0596b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5221,30 +5361,32 @@
         "subject":"minus|c9088305-1e16-4787-b1a7-7d90c4cc7551",
         "notes":"Quos ea architecto et eaque laudantium quia fugit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c1a0d89c-a4e7-4923-b2fb-1fea7b5c7586",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -5253,7 +5395,7 @@
            }
         ],
         "created_on":"2019-01-07T16:08:05.517751Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5262,7 +5404,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5270,24 +5412,24 @@
         },
         "modified_on":"2019-01-07T16:08:05.517782Z",
         "date":"2052-07-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"North East LEP.",
            "id":"483a3271-8825-e511-b6bc-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -5295,30 +5437,32 @@
         "subject":"nihil|4eb6dd0d-7398-44ca-80f2-18fac2875474",
         "notes":"Quod hic voluptates placeat sint.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"ef3d9929-b13a-4c3e-a01c-3f599237bccf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Angie Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
            "first_name":"Angie",
            "last_name":"Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
            "job_title":"Direct Branding Coordinator",
            "id":"fb434ee2-e723-468b-a0f2-20ea9a196728"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Angie Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
               "first_name":"Angie",
               "last_name":"Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
@@ -5327,19 +5471,19 @@
            }
         ],
         "created_on":"2018-12-07T16:23:41.875215Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Greenfelder and Sons",
            "id":"3c482095-da33-4aff-9a40-02d922ef4025"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5347,13 +5491,13 @@
         },
         "modified_on":"2018-12-07T16:23:41.875246Z",
         "date":"2052-05-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Bob Manning",
            "first_name":"Bob",
            "last_name":"Manning",
            "id":"54b8bc28-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Rabat Morocco",
            "id":"2e6e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -5361,7 +5505,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - UK Based",
            "id":"9584b82b-3499-e211-a939-e4115bead28a"
         },
@@ -5369,30 +5513,32 @@
         "subject":"at|095eae01-ce9d-40b5-a69e-f65ccfa00147",
         "notes":"Itaque beatae qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0df938cf-c94a-4726-b29c-668a02d6f543",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "first_name":"Margaret",
            "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "job_title":"Chief Identity Orchestrator",
            "id":"e2b88408-57ef-4bb6-8103-1a2709f59d08"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
               "first_name":"Margaret",
               "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
@@ -5401,7 +5547,7 @@
            }
         ],
         "created_on":"2018-11-22T17:06:38.897456Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5410,7 +5556,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5418,24 +5564,24 @@
         },
         "modified_on":"2018-11-22T17:06:38.897485Z",
         "date":"2052-01-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Francesca Varasano-Mitchell",
            "first_name":"Francesca",
            "last_name":"Varasano-Mitchell",
            "id":"579f25c4-ed97-e411-a839-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - Infrastructure & Life Sciences",
            "id":"c8f924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5443,30 +5589,32 @@
         "subject":"asperiores|8e21e6d0-5d11-4841-930c-0bc520708303",
         "notes":"Illo exercitationem accusamus quod et consequatur sunt eligendi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8347696c-3423-4b36-8ec2-c1f6389268ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abelardo Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
            "first_name":"Abelardo",
            "last_name":"Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
            "job_title":"Central Accountability Developer",
            "id":"911db4c4-94de-4716-bd1b-6bef5cc81a49"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abelardo Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
               "first_name":"Abelardo",
               "last_name":"Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
@@ -5475,7 +5623,7 @@
            }
         ],
         "created_on":"2018-11-23T08:34:41.925998Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5484,7 +5632,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5492,24 +5640,24 @@
         },
         "modified_on":"2018-11-23T08:34:41.926031Z",
         "date":"2051-11-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Audrianna Sibiski",
            "first_name":"Audrianna",
            "last_name":"Sibiski",
            "id":"6b4b0cae-c6be-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Bandar Seri Begawan Brunei",
            "id":"148433c8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"A",
            "id":"1783ae93-b78f-e611-8c55-e4115bed50dc"
         },
@@ -5517,30 +5665,32 @@
         "subject":"quo|cc32cc25-95a6-43bd-9b57-31ea3e88ea13",
         "notes":"Nobis autem commodi at sequi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3fa7e4b0-6ea7-4808-8a34-64c1c952dedf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Isom Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
            "first_name":"Isom",
            "last_name":"Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
            "job_title":"Regional Optimization Administrator",
            "id":"d0372ad4-aee4-4152-844e-105be0f27beb"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Isom Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
               "first_name":"Isom",
               "last_name":"Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
@@ -5549,7 +5699,7 @@
            }
         ],
         "created_on":"2019-01-07T15:18:05.413548Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5558,7 +5708,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5566,24 +5716,24 @@
         },
         "modified_on":"2019-01-07T15:18:05.413578Z",
         "date":"2051-11-02",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Association of Independent Music Ltd",
            "id":"35f12898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -5591,30 +5741,32 @@
         "subject":"reprehenderit|8f512bb9-aae9-440b-902d-76734e6c9b30",
         "notes":"Voluptatem reprehenderit facilis voluptatibus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"be6eb6cb-f90d-42d3-b905-5546530ec1c0",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -5623,19 +5775,19 @@
            }
         ],
         "created_on":"2019-01-11T16:26:10.542231Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Flatley and Sons",
            "id":"5fbf2978-f8f5-458e-9976-24ba4e20eb28"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5643,13 +5795,13 @@
         },
         "modified_on":"2019-01-11T16:26:10.542260Z",
         "date":"2051-09-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Asmara Eritria",
            "id":"4c841eb0-9698-e211-a939-e4115bead28a"
         },
@@ -5657,7 +5809,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Opportunities",
            "id":"d520b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5665,30 +5817,32 @@
         "subject":"aspernatur|fc310eb3-1d03-4458-9a37-49ac76f88f33",
         "notes":"Id quos consequuntur soluta et.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"293cd3d8-8596-413e-ae2e-006ed4e7f03f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -5697,19 +5851,19 @@
            }
         ],
         "created_on":"2018-01-22T16:56:15.228497Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"McKenzie Group",
            "id":"db16b72d-6590-44de-9cd9-61fc6c34b06d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5717,13 +5871,13 @@
         },
         "modified_on":"2018-01-22T16:56:15.228527Z",
         "date":"2051-09-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Babita Shahjahan",
            "first_name":"Babita",
            "last_name":"Shahjahan",
            "id":"b434bf10-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Belgrade Serbia",
            "id":"377c51d4-9698-e211-a939-e4115bead28a"
         },
@@ -5731,7 +5885,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5739,30 +5893,32 @@
         "subject":"atque",
         "notes":"Et veritatis et culpa est sit voluptates nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b9a42042-14a7-448d-8462-f62f6fbb44f9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -5771,19 +5927,19 @@
            }
         ],
         "created_on":"2018-11-22T12:29:59.735863Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Tillman - Kuhic",
            "id":"da32f3c9-580e-4811-a560-a5e5a93e3c3b"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5791,13 +5947,13 @@
         },
         "modified_on":"2018-11-22T12:29:59.735893Z",
         "date":"2051-07-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Antoinette Oliver",
            "first_name":"Antoinette",
            "last_name":"Oliver",
            "id":"3d26bcfe-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Accra Ghana",
            "id":"1c6e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -5805,7 +5961,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Overseas",
            "id":"ccf9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -5813,30 +5969,32 @@
         "subject":"commodi|5ff49bed-71c0-4cd6-a750-3179575afaa8",
         "notes":"Ab iusto adipisci error consequatur non aut earum aut.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c1b4830f-7ee8-4b9c-9ebf-688b5dc6d948",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -5845,7 +6003,7 @@
            }
         ],
         "created_on":"2019-01-07T15:13:11.126514Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5854,7 +6012,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5862,24 +6020,24 @@
         },
         "modified_on":"2019-01-07T15:13:11.126548Z",
         "date":"2051-06-14",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Rolands Kumpins",
            "first_name":"Rolands",
            "last_name":"Kumpins",
            "id":"6a5e518d-9c98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Safety Industry Federation",
            "id":"d365239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5887,30 +6045,32 @@
         "subject":"voluptas|03d995ff-79d0-49d3-813e-4b7d5bd07e5f",
         "notes":"Explicabo sequi ullam eos sed neque consequatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4777e0a1-66ad-43ad-8512-c87e9a6e91ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eryn Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
            "first_name":"Eryn",
            "last_name":"Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
            "job_title":"Central Interactions Coordinator",
            "id":"ea85433e-8a1b-4319-bddb-d210596f493e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eryn Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
               "first_name":"Eryn",
               "last_name":"Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
@@ -5919,7 +6079,7 @@
            }
         ],
         "created_on":"2019-01-07T15:02:28.520574Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5928,7 +6088,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5936,24 +6096,24 @@
         },
         "modified_on":"2019-01-07T15:02:28.520606Z",
         "date":"2051-06-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"DSO Senior Management Team",
            "id":"e9ad674d-16ad-e211-a646-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -5961,30 +6121,32 @@
         "subject":"voluptatibus|0532b107-3079-4f8a-a742-c0df07cdfc25",
         "notes":"Reiciendis sint totam odit itaque dolor.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"d240bf42-51d2-40fa-a1cd-32f1839f927c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "first_name":"Lavina",
            "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "job_title":"Regional Usability Liaison",
            "id":"70275f9d-f432-4531-95ed-3b1891759ff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
               "first_name":"Lavina",
               "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
@@ -5993,19 +6155,19 @@
            }
         ],
         "created_on":"2018-12-07T14:02:59.118453Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Altenwerth LLC",
            "id":"7c9bc972-2158-464b-8045-7e99736ded08"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6013,13 +6175,13 @@
         },
         "modified_on":"2018-12-07T14:02:59.118481Z",
         "date":"2051-04-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Fabio Alves",
            "first_name":"Fabio",
            "last_name":"Alves",
            "id":"6f1c4b33-ab5e-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Portsmouth City Council",
            "id":"afabc904-f04d-e611-af02-e4115bead28a"
         },
@@ -6027,7 +6189,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Inbound Referral",
            "id":"9984b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6035,30 +6197,32 @@
         "subject":"natus|c041edcd-c482-4d18-a1be-372b5f1c9e15",
         "notes":"Rerum temporibus repudiandae quis dolore omnis enim.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6bf50a7f-29b8-4312-be8a-f2aaacefd236",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -6067,19 +6231,19 @@
            }
         ],
         "created_on":"2018-02-02T14:56:40.940368Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Reichel - Lebsack",
            "id":"d25dbfef-544b-4307-8778-b43e7ce6b45e"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6087,13 +6251,13 @@
         },
         "modified_on":"2018-02-02T14:56:40.940413Z",
         "date":"2051-02-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alastair Roberts",
            "first_name":"Alastair",
            "last_name":"Roberts",
            "id":"48e9c3b6-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC North EAST",
            "id":"602b971d-5df6-e511-888e-e4115bead28a"
         },
@@ -6101,7 +6265,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Bank Referral",
            "id":"632b8708-28b6-e611-984a-e4115bead28a"
         },
@@ -6109,30 +6273,32 @@
         "subject":"aperiam",
         "notes":"Non mollitia culpa et voluptates maiores numquam ad aut corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2ea59aac-4763-4d1a-84b8-ea0c872a15ba",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Russ Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
            "first_name":"Russ",
            "last_name":"Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
            "job_title":"Senior Operations Manager",
            "id":"3c09ad7f-1ab9-40da-a014-7bc526be3a89"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Russ Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
               "first_name":"Russ",
               "last_name":"Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
@@ -6141,7 +6307,7 @@
            }
         ],
         "created_on":"2018-12-05T19:28:57.477438Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6150,7 +6316,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6158,24 +6324,24 @@
         },
         "modified_on":"2018-12-05T19:28:57.477471Z",
         "date":"2050-12-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"name 27 surname 27",
            "first_name":"name 27",
            "last_name":"surname 27",
            "id":"96488fac-0715-4b00-ae1a-751885abd41b"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Kinshasa Congo",
            "id":"73841eb0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -6183,30 +6349,32 @@
         "subject":"dicta|2875f319-ccf9-48bf-9800-ab54be1e9f5e",
         "notes":"Molestiae nam ut libero consequatur et eaque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"df351c54-14fb-4edf-93d3-44aa5f0085fe",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -6215,19 +6383,19 @@
            }
         ],
         "created_on":"2018-12-07T10:05:16.553507Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Cole LLC",
            "id":"9901b3f0-f48d-4143-a58f-e3fd792d5a38"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6235,13 +6403,13 @@
         },
         "modified_on":"2018-12-07T10:05:16.553536Z",
         "date":"2050-11-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Robert Cashmore",
            "first_name":"Robert",
            "last_name":"Cashmore",
            "id":"2fdae135-1d95-e511-a84e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Oxford City Council",
            "id":"2f958f3c-7f25-e511-b6bc-e4115bead28a"
         },
@@ -6249,7 +6417,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -6257,30 +6425,32 @@
         "subject":"beatae|4c6860f7-a230-4494-a682-fe07a6548358",
         "notes":"Amet in et.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"17eaecd4-ec91-4b05-82c1-9e6abbf8d3c2",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Favian Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
            "first_name":"Favian",
            "last_name":"Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
            "job_title":"Chief Solutions Strategist",
            "id":"8ba2e5a5-8c75-453c-b4b9-e3c0a324aa5f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Favian Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
               "first_name":"Favian",
               "last_name":"Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
@@ -6289,7 +6459,7 @@
            }
         ],
         "created_on":"2018-11-22T21:39:52.069157Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6298,7 +6468,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6306,24 +6476,24 @@
         },
         "modified_on":"2018-11-22T21:39:52.069199Z",
         "date":"2050-10-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Gary Underhill",
            "first_name":"Gary",
            "last_name":"Underhill",
            "id":"bddbf09e-c4b3-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Prague Czech Republic",
            "id":"467e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -6331,30 +6501,32 @@
         "subject":"placeat|ddf01d34-5bd7-4f2e-9e01-6bb6b69c8237",
         "notes":"Commodi numquam laborum aliquam aut iusto voluptate excepturi corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3485a6c5-fef4-48f7-9cdf-72aae0d95411",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
            "first_name":"Sheila",
            "last_name":"Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
            "job_title":"District Functionality Liaison",
            "id":"9be76d78-9df0-45b9-a233-f160e8ce5ed8"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Sheila Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
               "first_name":"Sheila",
               "last_name":"Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
@@ -6363,7 +6535,7 @@
            }
         ],
         "created_on":"2019-01-07T16:18:24.147438Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6372,7 +6544,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6380,24 +6552,24 @@
         },
         "modified_on":"2019-01-07T16:18:24.147470Z",
         "date":"2050-08-12",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Planning and Procurement",
            "id":"d0362a92-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -6405,30 +6577,32 @@
         "subject":"magnam|9677fa73-a2c1-47c4-b429-e708417f0e25",
         "notes":"Corporis vel beatae velit deleniti animi explicabo voluptate.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b1fab69f-e517-4557-8d72-5ba05d1a6d75",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "first_name":"Lavina",
            "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "job_title":"Regional Usability Liaison",
            "id":"70275f9d-f432-4531-95ed-3b1891759ff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
               "first_name":"Lavina",
               "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
@@ -6437,7 +6611,7 @@
            }
         ],
         "created_on":"2019-01-07T13:36:57.355634Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6446,7 +6620,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6454,24 +6628,24 @@
         },
         "modified_on":"2019-01-07T13:36:57.355667Z",
         "date":"2050-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"City of Lincoln Council",
            "id":"01688297-1353-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -6479,30 +6653,32 @@
         "subject":"qui|629d1aed-6060-4f86-a420-85e471a23723",
         "notes":"Quia sint voluptatibus et laborum qui beatae sint.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"827348a9-d059-4a94-b797-9c7d2025c06f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -6511,19 +6687,19 @@
            }
         ],
         "created_on":"2019-01-08T20:40:05.793282Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Mante, Quitzon and Rodriguez",
            "id":"0be4a431-5668-438e-92ef-74901fe86d23"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6531,13 +6707,13 @@
         },
         "modified_on":"2019-01-08T20:40:05.793312Z",
         "date":"2050-07-08",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Group Resources - Support Team",
            "id":"18374ae0-9698-e211-a939-e4115bead28a"
         },
@@ -6545,7 +6721,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Bank Referral",
            "id":"632b8708-28b6-e611-984a-e4115bead28a"
         },
@@ -6553,30 +6729,32 @@
         "subject":"architecto|ce89d3df-9034-4672-9e1c-bde051294600",
         "notes":"Optio inventore aspernatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"cb651667-b057-4fdd-8311-72b5bdffbf9a",
-        "company":{  
-           "name":"Krajcik - Johns|6e2bbd0e-b702-4a44-8621-7f30d38b5e14",
-           "id":"c5df0ca8-2471-425c-836e-4a733e74c29a"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Beatrice Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
            "first_name":"Beatrice",
            "last_name":"Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
            "job_title":"Dynamic Optimization Supervisor",
            "id":"91ba22cb-4bb8-4cd1-8316-7df8bf0bc535"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Beatrice Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
               "first_name":"Beatrice",
               "last_name":"Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
@@ -6585,19 +6763,19 @@
            }
         ],
         "created_on":"2017-12-14T16:09:28.280348Z",
-        "created_by":{  
+        "created_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
            "id":"5707c18a-454a-4bd2-b14b-218761a684bc"
         },
-        "event":{  
+        "event":{
            "name":"Rosenbaum - Keeling",
            "id":"a7b4bbfb-5377-453d-8048-6623f2e0042d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Venu Reddy",
            "first_name":"Venu",
            "last_name":"Reddy",
@@ -6605,13 +6783,13 @@
         },
         "modified_on":"2017-12-15T17:32:27.953282Z",
         "date":"2050-05-20",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Flavia Silva",
            "first_name":"Flavia",
            "last_name":"Silva",
            "id":"64d5ee24-9998-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Midlands Aerospace Alliance",
            "id":"b779fd34-9798-e211-a939-e4115bead28a"
         },
@@ -6619,7 +6797,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - G3 (07) - Revised Action Plans",
            "id":"1ec5548f-5c9a-e411-a839-e4115bead28a"
         },
@@ -6627,30 +6805,32 @@
         "subject":"et",
         "notes":"Fuga repudiandae similique laborum eos aut illum quis saepe.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2cdc2340-5818-4f10-a2f5-b7341df1786f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -6659,19 +6839,19 @@
            }
         ],
         "created_on":"2018-01-23T10:30:41.308391Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Goyette - Leuschke",
            "id":"00a5da1a-44ad-4b7a-a9f1-74965f4aa6aa"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6679,13 +6859,13 @@
         },
         "modified_on":"2018-01-23T10:30:41.308421Z",
         "date":"2050-05-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anna Faber",
            "first_name":"Anna",
            "last_name":"Faber",
            "id":"298624f8-5619-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Sarajevo Bosnia and Herzegovina",
            "id":"d7db4cda-9698-e211-a939-e4115bead28a"
         },
@@ -6693,7 +6873,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"UK Region Local",
            "id":"9a84b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6701,30 +6881,32 @@
         "subject":"sit",
         "notes":"Esse maiores quis blanditiis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"f6223a6e-16ff-4215-8670-7aecf26dc2db",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -6733,7 +6915,7 @@
            }
         ],
         "created_on":"2018-12-04T13:02:31.873298Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6742,7 +6924,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6750,24 +6932,24 @@
         },
         "modified_on":"2018-12-04T13:02:31.873327Z",
         "date":"2050-04-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"CDMSInstall Last name",
            "first_name":"CDMSInstall",
            "last_name":"Last name",
            "id":"419fe8a8-3e95-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Kingstown St Vincent",
            "id":"017c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -6775,30 +6957,32 @@
         "subject":"voluptates|b1dfd2e8-9993-49c9-b9cc-00fc0a504e8d",
         "notes":"Esse animi autem dicta et molestiae.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fd40eeca-5471-49c1-916e-a7d026695e0c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -6807,7 +6991,7 @@
            }
         ],
         "created_on":"2019-01-10T11:44:14.495015Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6816,7 +7000,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6824,24 +7008,24 @@
         },
         "modified_on":"2019-01-10T11:44:14.495044Z",
         "date":"2050-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Global Accounts - Adv Man - Aero, Space, Chem",
            "id":"27cab706-fb4d-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"A",
            "id":"1783ae93-b78f-e611-8c55-e4115bed50dc"
         },
@@ -6849,30 +7033,32 @@
         "subject":"aliquid|cb3e45e4-32c8-4aea-8dfd-dc230bdba06d",
         "notes":"At inventore veniam sed adipisci est aut et qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"cd6b82bf-99ba-4e41-9650-ec789dccde96",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "first_name":"Unique",
            "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "job_title":"Direct Intranet Assistant",
            "id":"f6b8ca61-915c-4df1-8379-d3d9a8b99195"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
               "first_name":"Unique",
               "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
@@ -6881,7 +7067,7 @@
            }
         ],
         "created_on":"2019-01-07T16:23:04.682375Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6890,7 +7076,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6898,24 +7084,24 @@
         },
         "modified_on":"2019-01-07T16:23:04.682405Z",
         "date":"2050-02-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Shipbuilders & Shiprepairer Association",
            "id":"26f12898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Business Proposition",
            "id":"9384b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6923,30 +7109,32 @@
         "subject":"et|e1d8124f-1cbf-4fcb-9ef2-72ac917e4b40",
         "notes":"Sit neque officia cum aliquam illum et optio voluptatibus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"626663d7-bcaa-4520-9566-ca6932c4665d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -6955,7 +7143,7 @@
            }
         ],
         "created_on":"2018-11-22T20:52:33.863204Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6964,7 +7152,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6972,24 +7160,24 @@
         },
         "modified_on":"2018-11-22T20:52:33.863233Z",
         "date":"2050-01-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Sarah Tyrrell",
            "first_name":"Sarah",
            "last_name":"Tyrrell",
            "id":"fcaf6ecd-9d2e-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Finance & Business Planning",
            "id":"481e03d9-3450-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -6997,30 +7185,32 @@
         "subject":"rerum|c1181c84-2e26-450b-bc20-e2e74eaf3368",
         "notes":"Sapiente adipisci alias eligendi esse nihil.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"448328c3-5d98-4d71-8d39-1d3f593daab8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -7029,7 +7219,7 @@
            }
         ],
         "created_on":"2018-03-14T15:46:50.927041Z",
-        "created_by":{  
+        "created_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
@@ -7038,7 +7228,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
@@ -7046,24 +7236,24 @@
         },
         "modified_on":"2018-03-14T15:46:50.927075Z",
         "date":"2050-01-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Amy Fitzgerald",
            "first_name":"Amy",
            "last_name":"Fitzgerald",
            "id":"dc3bb3ce-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"PS8 Ltd",
            "id":"717b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -7071,30 +7261,32 @@
         "subject":"incidunt|3ecea25c-6e9e-4492-bfc9-8ef5d0713271",
         "notes":"Consequatur enim mollitia rerum dolores et debitis repudiandae molestias consequatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3fb62ec7-17f3-437d-8056-36044accca2e",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "first_name":"Garrick",
            "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "job_title":"Dynamic Interactions Designer",
            "id":"684b242a-c9b6-4cc6-98a8-4b6b4dd37e7f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
               "first_name":"Garrick",
               "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
@@ -7103,19 +7295,19 @@
            }
         ],
         "created_on":"2018-12-07T13:40:39.932888Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ians event org",
            "id":"549b6feb-9745-47c8-8736-c5fa0713eb81"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7123,13 +7315,13 @@
         },
         "modified_on":"2018-12-07T13:40:39.932919Z",
         "date":"2049-12-31",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Ann Morrison",
            "first_name":"Ann",
            "last_name":"Morrison",
            "id":"dff9bdec-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Leicester City Council",
            "id":"88c26d29-4f4e-e611-af02-e4115bead28a"
         },
@@ -7137,7 +7329,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -7145,30 +7337,32 @@
         "subject":"animi|3160aac2-2598-47f6-a620-d690aacb7b7d",
         "notes":"Et mollitia illo quo sunt eius quaerat quos officia corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4cb9cc78-0ec2-4905-9192-a901f3cb049d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "first_name":"Reuben",
            "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "job_title":"International Directives Supervisor",
            "id":"2356a2a5-9451-49e4-b7eb-d1dcfc4ea40c"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
               "first_name":"Reuben",
               "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
@@ -7177,7 +7371,7 @@
            }
         ],
         "created_on":"2018-11-22T18:14:53.198511Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7186,7 +7380,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7194,24 +7388,24 @@
         },
         "modified_on":"2018-11-22T18:14:53.198561Z",
         "date":"2049-12-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anne Weir",
            "first_name":"Anne",
            "last_name":"Weir",
            "id":"7707bef8-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Technology, Innovation and Events",
            "id":"b7f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -7219,30 +7413,32 @@
         "subject":"harum|71ecdcc0-8ea9-4f64-ac5c-2e9076c10db0",
         "notes":"Architecto et et excepturi facilis aliquid dolores ipsa.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"841ad9f4-6fa8-413f-ace6-30e4ff6ad246",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -7251,7 +7447,7 @@
            }
         ],
         "created_on":"2018-11-23T08:09:40.370823Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7260,7 +7456,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7268,24 +7464,24 @@
         },
         "modified_on":"2018-11-23T08:09:40.370854Z",
         "date":"2049-12-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Davis",
            "first_name":"Andrew",
            "last_name":"Davis",
            "id":"d036a9da-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Central and Latin America",
            "id":"706e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -7293,30 +7489,32 @@
         "subject":"blanditiis|3756618c-2b3a-4715-9708-6ed68dd54c62",
         "notes":"Deserunt tempore porro.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7f96cfac-b3e5-4bfa-9ce2-06381b42c814",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -7325,7 +7523,7 @@
            }
         ],
         "created_on":"2018-11-23T11:22:32.283764Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7334,7 +7532,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7342,24 +7540,24 @@
         },
         "modified_on":"2018-11-23T11:22:32.283793Z",
         "date":"2049-09-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Tshegofatso Motaung",
            "first_name":"Tshegofatso",
            "last_name":"Motaung",
            "id":"cccabea2-9d98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IST - Shared Services",
            "id":"7bc40cdb-cfe9-e511-8ffa-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Services",
            "id":"0596b92b-3499-e211-a939-e4115bead28a"
         },
@@ -7367,30 +7565,32 @@
         "subject":"aliquid|c21e49da-a0c0-4c76-ba8d-813134476067",
         "notes":"Suscipit et magni.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e286e8e4-85b7-4ddc-a270-722002caf5cc",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "first_name":"Reuben",
            "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "job_title":"International Directives Supervisor",
            "id":"2356a2a5-9451-49e4-b7eb-d1dcfc4ea40c"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
               "first_name":"Reuben",
               "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
@@ -7399,7 +7599,7 @@
            }
         ],
         "created_on":"2018-11-22T22:06:38.439436Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7408,7 +7608,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7416,24 +7616,24 @@
         },
         "modified_on":"2018-11-22T22:06:38.439465Z",
         "date":"2049-05-18",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Peter Rippingale",
            "first_name":"Peter",
            "last_name":"Rippingale",
            "id":"611bbbcd-ccae-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Team West Midlands - Hereford and Worcester",
            "id":"9610dd28-9798-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -7441,11 +7641,11 @@
         "subject":"quis|f2ac81ee-041a-4438-b2da-4f44ee95d956",
         "notes":"Ratione rem consequatur non modi dolorem neque accusamus excepturi voluptatem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false

--- a/test/sandbox/fixtures/v3/search/interaction.json
+++ b/test/sandbox/fixtures/v3/search/interaction.json
@@ -2,11 +2,13 @@
     "count": 1332,
     "results": [
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -73,11 +75,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -142,11 +146,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -207,11 +213,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -266,11 +274,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -325,11 +335,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -408,11 +420,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -467,11 +481,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -526,11 +542,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -585,11 +603,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -644,11 +664,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -703,11 +725,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -762,11 +786,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -831,11 +857,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -890,11 +918,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -949,11 +979,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -1008,11 +1040,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -1067,11 +1101,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -1126,11 +1162,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -1185,11 +1223,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -1244,11 +1284,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -1303,11 +1345,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -1362,11 +1406,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -1431,11 +1477,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -1490,11 +1538,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -1549,11 +1599,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -1608,11 +1660,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -1667,11 +1721,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -1726,11 +1782,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -1785,11 +1843,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -1844,11 +1904,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -1903,11 +1965,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -1962,11 +2026,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2021,11 +2087,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2080,11 +2148,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -2149,11 +2219,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2208,11 +2280,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -2277,11 +2351,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -2336,11 +2412,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -2395,11 +2473,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -2454,11 +2534,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -2513,11 +2595,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2572,11 +2656,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -2631,11 +2717,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -2690,11 +2778,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -2749,11 +2839,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2808,11 +2900,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -2867,11 +2961,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -2926,11 +3022,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -2985,11 +3083,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -3044,11 +3144,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3103,11 +3205,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -3162,11 +3266,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3221,11 +3327,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3280,11 +3388,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3339,11 +3449,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3398,11 +3510,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -3457,11 +3571,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -3516,11 +3632,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -3585,11 +3703,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -3644,11 +3764,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3703,11 +3825,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -3762,11 +3886,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -3824,11 +3950,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -3883,11 +4011,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -3942,11 +4072,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -4001,11 +4133,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -4060,11 +4194,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -4119,11 +4255,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -4178,11 +4316,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+             "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -4237,11 +4377,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -4296,11 +4438,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -4355,11 +4499,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -4414,11 +4560,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -4473,11 +4621,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -4532,11 +4682,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -4591,11 +4743,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -4650,11 +4804,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -4709,11 +4865,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -4768,11 +4926,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -4827,11 +4987,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a7d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Video/Teleconf."
@@ -4886,11 +5048,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -4945,11 +5109,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5004,11 +5170,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5063,11 +5231,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5122,11 +5292,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -5181,11 +5353,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -5240,11 +5414,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5299,11 +5475,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -5358,11 +5536,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5417,11 +5597,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a8d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Social Media"
@@ -5476,11 +5658,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5535,11 +5719,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "72c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Telephone"
@@ -5594,11 +5780,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "a5d71fdd-5d95-e211-a939-e4115bead28a",
                 "name": "Face to Face"
@@ -5653,11 +5841,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"
@@ -5712,11 +5902,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5771,11 +5963,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "c5df0ca8-2471-425c-836e-4a733e74c29a",
-                "name": "Krajcik - Johns|6e2bbd0e-b702-4a44-8621-7f30d38b5e14",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "c5df0ca8-2471-425c-836e-4a733e74c29a",
+                  "name": "Krajcik - Johns|6e2bbd0e-b702-4a44-8621-7f30d38b5e14",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5834,11 +6028,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": null,
             "contacts": [
                 {
@@ -5893,11 +6089,13 @@
             "kind": "service_delivery"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "74c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Letter/Fax"
@@ -5952,11 +6150,13 @@
             "kind": "interaction"
         },
         {
-            "company": {
-                "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
-                "name": "Venus Ltd",
-                "trading_names": []
-            },
+            "companies": [
+                {
+                  "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+                  "name": "Venus Ltd",
+                  "trading_names": []
+                }
+            ],
             "communication_channel": {
                 "id": "70c226d7-5d95-e211-a939-e4115bead28a",
                 "name": "Email/Website"

--- a/test/sandbox/fixtures/v4/interaction/interaction-by-company-id.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-by-company-id.json
@@ -1,9 +1,11 @@
 {
   "id": "9eb0b11d-384a-4225-9ee1-1ea79efd695f",
-  "company": {
-      "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-      "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+  "companies": [
+      {
+        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+      }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v4/interaction/interaction-by-contact-id.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-by-contact-id.json
@@ -5,10 +5,12 @@
   "results": [
       {
           "id": "9719eed5-5f1c-4894-a72b-1dceeff3d8d3",
-          "company": {
-              "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-              "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+          "companies": [
+              {
+                "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+                "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+              }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -76,10 +78,12 @@
       },
       {
           "id": "65e984ad-1ad5-4d89-9b12-71cdff5f412d",
-          "company": {
+          "companies": [
+            {
               "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
               "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+            }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -147,10 +151,12 @@
       },
       {
           "id": "9dca679b-098b-47a7-bf52-e77f3cdbbe8e",
-          "company": {
-              "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-              "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+          "companies": [
+              {
+                "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+                "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+              }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",
@@ -218,10 +224,12 @@
       },
       {
           "id": "1f40f9b3-2730-42c3-a0ab-b6ce0c4c05d2",
-          "company": {
-              "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-              "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-          },
+          "companies": [
+              {
+                "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+                "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+              }
+          ],
           "contact": {
               "name": "Bob lawson",
               "first_name": "Bob",

--- a/test/sandbox/fixtures/v4/interaction/interaction-by-investment-project-id.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-by-investment-project-id.json
@@ -1,9 +1,11 @@
 {
   "id": "29f20b89-e037-4a8b-8536-2fee1d8c715d",
-  "company": {
-      "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-      "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+  "companies": [
+      {
+        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+      }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v4/interaction/interaction-cancelled-meeting.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-cancelled-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "57a0b5ea-ad56-49c9-b70e-0542153ea673",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+      {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      }
+  ],
   "contacts": [
     {
       "name": "Tyson Morar",

--- a/test/sandbox/fixtures/v4/interaction/interaction-create.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-create.json
@@ -1,9 +1,11 @@
 {
   "id": "ab3b8067-e1c7-4559-9c73-c0ee76d6e14b",
-  "company": {
-      "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-      "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
+  "companies": [
+      {
+        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+      }
+  ],
   "contact": {
       "name": "Bob lawson",
       "first_name": "Bob",

--- a/test/sandbox/fixtures/v4/interaction/interaction-draft-future-meeting.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-draft-future-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "999c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/sandbox/fixtures/v4/interaction/interaction-draft-past-meeting.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-draft-past-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "888c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/sandbox/fixtures/v4/interaction/interaction-with-document-link.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-with-document-link.json
@@ -1,11 +1,13 @@
-{  
+{
   "id":"ec4a46ef-6e50-4a5c-bba0-e311f0471312",
-  "company":{  
-     "name":"Venus Ltd",
-     "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
-  "contacts":[  
-     {  
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
+  "contacts":[
+     {
         "name":"Johnny Cakeman",
         "first_name":"Johnny",
         "last_name":"Cakeman",
@@ -14,20 +16,20 @@
      }
   ],
   "created_on":"2017-06-05T00:00:00Z",
-  "created_by":{  
+  "created_by":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
      "id":"e83a608e-84a4-11e6-ae22-56b6b6499611"
   },
-  "event":{  
+  "event":{
      "name":"Grand exhibition",
      "id":"bda12a57-433c-4a0c-a7ce-5ebd080e09e8"
   },
   "is_event":true,
   "status": "complete",
   "kind":"service_delivery",
-  "modified_by":{  
+  "modified_by":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
@@ -35,13 +37,13 @@
   },
   "modified_on":"2017-06-05T00:00:00Z",
   "date":"2017-09-05",
-  "dit_adviser":{  
+  "dit_adviser":{
      "name":"Puck Head",
      "first_name":"Puck",
      "last_name":"Head",
      "id":"e83a608e-84a4-11e6-ae22-56b6b6499611"
   },
-  "dit_team":{  
+  "dit_team":{
      "name":"CBBC North EAST",
      "id":"602b971d-5df6-e511-888e-e4115bead28a"
   },
@@ -49,7 +51,7 @@
   "grant_amount_offered":null,
   "investment_project":null,
   "net_company_receipt":null,
-  "service":{  
+  "service":{
      "name":"Events - UK Based",
      "id":"9584b82b-3499-e211-a939-e4115bead28a"
   },
@@ -57,11 +59,11 @@
   "subject":"Link to a document",
   "notes":"This is a dummy service delivery for testing",
   "archived_documents_url_path":"/documents/123",
-  "policy_areas":[  
+  "policy_areas":[
 
   ],
   "policy_feedback_notes":"",
-  "policy_issue_types":[  
+  "policy_issue_types":[
 
   ],
   "was_policy_feedback_provided":false

--- a/test/sandbox/fixtures/v4/interaction/interaction-with-referral.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-with-referral.json
@@ -1,18 +1,20 @@
-{  
+{
     "id":"65e984ad-1ad5-4d89-9b12-71cdff5f412d",
-    "company":{  
-       "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-       "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-    },
-    "contact":{  
+    "companies": [
+      {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      }
+    ],
+    "contact":{
        "name":"Bob lawson",
        "first_name":"Bob",
        "last_name":"lawson",
        "job_title":"Magician",
        "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce"
     },
-    "contacts":[  
-       {  
+    "contacts":[
+       {
           "name":"Bob lawson",
           "first_name":"Bob",
           "last_name":"lawson",
@@ -21,7 +23,7 @@
        }
     ],
     "created_on":"2019-02-07T15:54:01.435652Z",
-    "created_by":{  
+    "created_by":{
        "name":"DIT Staff",
        "first_name":"DIT",
        "last_name":"Staff",
@@ -31,7 +33,7 @@
     "is_event":null,
     "status": "complete",
     "kind":"interaction",
-    "modified_by":{  
+    "modified_by":{
        "name":"DIT Staff",
        "first_name":"DIT",
        "last_name":"Staff",
@@ -100,14 +102,14 @@
           "id":"9010dd28-9798-e211-a939-e4115bead28a"
         }
       }],
-    "communication_channel":{  
+    "communication_channel":{
        "name":"Social Media",
        "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
     },
     "grant_amount_offered":null,
     "investment_project":null,
     "net_company_receipt":null,
-    "service":{  
+    "service":{
        "name":"Account Managment: Northern Powerhouse",
        "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
     },
@@ -115,12 +117,12 @@
     "subject":"This is an automated interaction",
     "notes":"Sandbox",
     "archived_documents_url_path":"",
-    "policy_areas":[  
-  
+    "policy_areas":[
+
     ],
     "policy_feedback_notes":"",
-    "policy_issue_types":[  
-  
+    "policy_issue_types":[
+
     ],
     "was_policy_feedback_provided":false
   }

--- a/test/sandbox/fixtures/v4/interaction/interaction-without-document-link.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-without-document-link.json
@@ -1,9 +1,11 @@
 {
   "id": "0dcb3748-c097-4f20-b84f-0114bbb1a8e0",
-  "company": {
+  "companies": [
+    {
       "name": "Venus Ltd",
       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+    }
+  ],
   "contacts": [
       {
           "name": "Dean Cox",

--- a/test/sandbox/fixtures/v4/interaction/interaction.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction.json
@@ -1,18 +1,20 @@
-{  
+{
   "id":"65e984ad-1ad5-4d89-9b12-71cdff5f412d",
-  "company":{  
-     "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-     "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-  },
-  "contact":{  
+  "companies": [
+      {
+        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+      }
+  ],
+  "contact":{
      "name":"Bob lawson",
      "first_name":"Bob",
      "last_name":"lawson",
      "job_title":"Magician",
      "id":"0e75d636-1d24-416a-aaf0-3fb220d594ce"
   },
-  "contacts":[  
-     {  
+  "contacts":[
+     {
         "name":"Bob lawson",
         "first_name":"Bob",
         "last_name":"lawson",
@@ -21,7 +23,7 @@
      }
   ],
   "created_on":"2019-02-07T15:54:01.435652Z",
-  "created_by":{  
+  "created_by":{
      "name":"DIT Staff",
      "first_name":"DIT",
      "last_name":"Staff",
@@ -31,7 +33,7 @@
   "is_event":null,
   "status": "complete",
   "kind":"interaction",
-  "modified_by":{  
+  "modified_by":{
      "name":"DIT Staff",
      "first_name":"DIT",
      "last_name":"Staff",
@@ -62,14 +64,14 @@
         "id":"9010dd28-9798-e211-a939-e4115bead28a"
       }
     }],
-  "communication_channel":{  
+  "communication_channel":{
      "name":"Social Media",
      "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
   },
   "grant_amount_offered":null,
   "investment_project":null,
   "net_company_receipt":null,
-  "service":{  
+  "service":{
      "name":"Account Managment: Northern Powerhouse",
      "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
   },
@@ -77,11 +79,11 @@
   "subject":"This is an automated interaction",
   "notes":"Sandbox",
   "archived_documents_url_path":"",
-  "policy_areas":[  
+  "policy_areas":[
 
   ],
   "policy_feedback_notes":"",
-  "policy_issue_types":[  
+  "policy_issue_types":[
 
   ],
   "was_policy_feedback_provided":false

--- a/test/sandbox/fixtures/v4/interaction/interactions.json
+++ b/test/sandbox/fixtures/v4/interaction/interactions.json
@@ -1,37 +1,39 @@
-{  
+{
   "count":1233,
   "next":"https://api.datahub.dev.uktrade.io/v3/interaction?limit=100&offset=100",
   "previous":null,
-  "results":[  
-     {  
+  "results":[
+     {
         "id":"d14abf23-7f07-4640-8908-cb6b40dc3ce3",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "first_name":"Sheila",
            "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "job_title":"Direct Research Assistant",
            "id":"0e92dab2-84af-405c-8d32-95e46568f9a7"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Katrine Block|80d2a6ea-de8f-45a3-ae89-ac4616fa0f39",
               "first_name":"Katrine",
               "last_name":"Block|80d2a6ea-de8f-45a3-ae89-ac4616fa0f39",
               "job_title":"Customer Assurance Analyst",
               "id":"708584a1-dd4b-4625-856f-72cc4aee49f8"
            },
-           {  
+           {
               "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "first_name":"Meda",
               "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "job_title":"Legacy Interactions Engineer",
               "id":"76ca9ab8-a6da-4103-a707-6974db2091e4"
            },
-           {  
+           {
               "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
               "first_name":"Sheila",
               "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
@@ -40,7 +42,7 @@
            }
         ],
         "created_on":"2019-01-07T16:26:56.363999Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -49,7 +51,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -57,24 +59,24 @@
         },
         "modified_on":"2019-02-01T09:51:23.355225Z",
         "date":"2060-11-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Coastal West Sussex",
            "id":"dc2e7f67-0653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"DSO Interaction",
            "id":"0796b92b-3499-e211-a939-e4115bead28a"
         },
@@ -82,30 +84,32 @@
         "subject":"totam|f19f5014-8bb1-4645-a224-27a4c8db5336",
         "notes":"<Spacein Leeds (Andrew lives in Leeds). EE also offered to explore interest from D4D MIC as SerenusAI considers orthopaedics to be a key strength. <h1> </h1>\r\n\r\n The company engages clinicians to develop artificial case studies (scenarios) in particular clinical areas and uses these in conjunction with 1.5 million [Israeli] patient records to develop algorithms which indicate the best pathway for a patient on the interface from primary care to secondary care based on clinical information and patient feedback.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e58f0ef4-6181-4558-a79a-8ff896012de9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Matteo Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
            "first_name":"Matteo",
            "last_name":"Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
            "job_title":"District Configuration Consultant",
            "id":"8ce58f47-1064-4a4f-888c-6a5b7eda768e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Matteo Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
               "first_name":"Matteo",
               "last_name":"Renner|0fbd0b04-656f-4413-ae84-78fe2d81ea8f",
@@ -114,7 +118,7 @@
            }
         ],
         "created_on":"2019-01-07T15:44:32.688381Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -123,7 +127,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -131,24 +135,24 @@
         },
         "modified_on":"2019-01-07T15:44:32.688410Z",
         "date":"2059-11-26",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Financial & Professional Sector",
            "id":"ac93bb45-6e6b-e411-a72b-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -156,30 +160,32 @@
         "subject":"porro|20811eb2-0ca5-4f5a-9889-ab0f84716b83",
         "notes":"Nihil deserunt nihil ut nostrum consequatur aut culpa.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"80149410-813f-41c6-b1d8-c922870cb798",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -188,19 +194,19 @@
            }
         ],
         "created_on":"2018-12-07T16:24:55.271846Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Schoen Group",
            "id":"5cf26bb8-9453-4b16-ad3a-ec878859d54f"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -208,13 +214,13 @@
         },
         "modified_on":"2018-12-31T10:12:51.560134Z",
         "date":"2059-10-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Julie Brown",
            "first_name":"Julie",
            "last_name":"Brown",
            "id":"6086c0f0-2700-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Tel Aviv Israel",
            "id":"136e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -222,7 +228,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -230,30 +236,32 @@
         "subject":"earum|171ef6c0-1a2b-457c-b425-804a5fffba41",
         "notes":"Fuga sunt aspernatur veritatis quia iste eum at cumque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2a6f7bc6-8b17-4d1f-9cdc-d3fab05b3376",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -262,7 +270,7 @@
            }
         ],
         "created_on":"2018-11-23T08:11:25.241167Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -271,7 +279,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -279,24 +287,24 @@
         },
         "modified_on":"2018-11-23T08:11:25.241196Z",
         "date":"2059-09-12",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mandeep Channa",
            "first_name":"Mandeep",
            "last_name":"Channa",
            "id":"075ea5b0-1f01-e411-8a2b-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Paris France",
            "id":"077e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Client Proposal (IST use only)",
            "id":"d03cce05-f9f7-e511-888e-e4115bead28a"
         },
@@ -304,30 +312,32 @@
         "subject":"vero|709065cf-2509-42e1-8e1d-b8d01d7976f3",
         "notes":"Consequatur est ut deserunt iste nesciunt enim nemo.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b101f06e-b566-4f04-9bfa-23c369548b33",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Murl Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
            "first_name":"Murl",
            "last_name":"Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
            "job_title":"Investor Configuration Representative",
            "id":"eebd88a2-5da3-4762-88a4-31784830988b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Murl Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
               "first_name":"Murl",
               "last_name":"Hahn|9817807e-395d-4951-b3e7-769a20dd8558",
@@ -336,19 +346,19 @@
            }
         ],
         "created_on":"2018-12-07T14:10:19.087967Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"est corrupti et illo",
            "id":"af46b1a6-4cc0-4c7c-964a-68464a904c02"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -356,13 +366,13 @@
         },
         "modified_on":"2018-12-07T14:10:19.087997Z",
         "date":"2059-08-18",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Chris Wall",
            "first_name":"Chris",
            "last_name":"Wall",
            "id":"20fdb970-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Northampton Borough Council",
            "id":"85c88c98-1153-e611-af02-e4115bead28a"
         },
@@ -370,7 +380,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Onward Referral",
            "id":"c4f9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -378,30 +388,32 @@
         "subject":"excepturi|0a6a0e56-cc22-4277-8a91-e4dc11f9a8ce",
         "notes":"Doloribus perferendis adipisci possimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7d5d1530-96e6-439f-b8ea-d2aa659066b8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "first_name":"Aletha",
            "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "job_title":"Product Division Executive",
            "id":"4f10d5a3-a86f-4dc9-811c-473660d8b80a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
               "first_name":"Aletha",
               "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
@@ -410,7 +422,7 @@
            }
         ],
         "created_on":"2018-11-22T22:08:57.790899Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -419,7 +431,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -427,24 +439,24 @@
         },
         "modified_on":"2018-11-22T22:08:57.790929Z",
         "date":"2059-08-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Jeremy Attree",
            "first_name":"Jeremy",
            "last_name":"Attree",
            "id":"bf5d6d3a-5151-e511-9d3c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ITFG - ICT & Data Policy and Support",
            "id":"3748318c-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -452,30 +464,32 @@
         "subject":"explicabo|224f6e55-26c6-440b-9daa-513372475cf8",
         "notes":"Qui facere velit nulla corporis praesentium.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5c981b7c-f002-4293-bd8e-5e0278081ffb",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -484,7 +498,7 @@
            }
         ],
         "created_on":"2018-12-05T19:19:36.155291Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -493,7 +507,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -501,24 +515,24 @@
         },
         "modified_on":"2018-12-05T19:19:36.155321Z",
         "date":"2059-04-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Divia Patel",
            "first_name":"Divia",
            "last_name":"Patel",
            "id":"4a35eedc-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Abuja Nigeria",
            "id":"48d616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -526,30 +540,32 @@
         "subject":"magnam|5935b9b9-6290-41f8-9252-a1535d6761dc",
         "notes":"Cum illum est sapiente quia voluptatem quod rerum magni.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"07f729e5-f040-4aff-b3cf-0edf49d2d43a",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "first_name":"Melvina",
            "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "job_title":"Future Data Technician",
            "id":"aeaa2cad-52de-492e-93e8-89fbf51cc03d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
               "first_name":"Melvina",
               "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
@@ -558,19 +574,19 @@
            }
         ],
         "created_on":"2019-01-11T16:11:38.996226Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hermiston - Okuneva",
            "id":"c4b39477-1d24-43b8-b25e-11ea96e80e0d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -578,13 +594,13 @@
         },
         "modified_on":"2019-01-11T16:11:38.996258Z",
         "date":"2059-03-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Campaigns and Special Programmes",
            "id":"4b4049e6-9698-e211-a939-e4115bead28a"
         },
@@ -592,7 +608,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -600,30 +616,32 @@
         "subject":"sed|f6f83b7a-ef19-484b-8aed-5afe06e8c43b",
         "notes":"Omnis explicabo eum et ut et voluptas quibusdam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2418e882-b02d-41e2-b60c-8cb22aa563ea",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -632,19 +650,19 @@
            }
         ],
         "created_on":"2019-01-10T11:43:53.339042Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hermiston - Hills",
            "id":"00e48876-39fd-4718-8039-69b82cf21074"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -652,13 +670,13 @@
         },
         "modified_on":"2019-01-29T13:24:10.255958Z",
         "date":"2058-12-02",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Wellington New Zealand",
            "id":"197c51d4-9698-e211-a939-e4115bead28a"
         },
@@ -666,7 +684,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -674,30 +692,32 @@
         "subject":"placeat|ef6e12ee-0751-4dd2-bade-ef40c5cf9bb2",
         "notes":"Odit minima eum est.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"af4aac84-4d6a-47df-a733-5a54e3008c32",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -706,7 +726,7 @@
            }
         ],
         "created_on":"2018-01-23T10:39:18.220321Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -715,7 +735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -723,24 +743,24 @@
         },
         "modified_on":"2018-10-04T12:44:57.950073Z",
         "date":"2058-11-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Priyanka Karunan",
            "first_name":"Priyanka",
            "last_name":"Karunan",
            "id":"537df876-5062-e311-8255-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Chief Executive's Office",
            "id":"16362a92-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -748,30 +768,32 @@
         "subject":"ad",
         "notes":"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur vel mauris metus. Vestibulum quis suscipit diam. Nullam euismod lectus porta, sollicitudin erat ut, congue lectus. Interdum et malesuada fames ac ante ipsum primis in faucibus. Donec orci neque, sodales sit amet metus eu, lacinia tristique quam. Proin quis feugiat turpis. Nulla aliquam nunc sit amet vehicula malesuada. Fusce nulla sem, finibus ut eros scelerisque, dignissim pellentesque est. Donec a tortor eget nisi viverra suscipit eget ut sem. Cras ante eros, pellentesque tincidunt purus quis, pretium iaculis nibh. Nullam pulvinar dapibus malesuada. Suspendisse convallis nisi id massa vestibulum, id porttitor tellus vestibulum. Maecenas non dolor dolor. Etiam non neque lacinia, eleifend ante ac, aliquet ante.\r\n\r\nSed rhoncus eros ut tortor pharetra scelerisque. Maecenas id ultrices tellus. Mauris sed rutrum dolor. Pellentesque in dolor non sapien gravida aliquam. Vestibulum tempor laoreet lacus in lobortis. Nullam pellentesque augue elementum, vestibulum metus laoreet, pretium metus. Phasellus lacus mauris, aliquam eget fermentum nec, rhoncus at leo. Suspendisse pellentesque lacus purus, ac imperdiet purus maximus ac. Cras quis metus eget felis accumsan finibus nec porta leo. Nullam eget sem eu metus rhoncus vehicula. Aliquam neque ligula, eleifend et elit nec, congue aliquet tellus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In ultricies ac ipsum sed dapibus. Maecenas tempus lacus nec convallis rutrum.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque at nibh eu nulla blandit dignissim et quis justo. Fusce nec neque ut quam condimentum pretium. Donec vulputate, purus ut mattis porttitor, purus lorem auctor velit, ac maximus lorem arcu at neque. Etiam tincidunt mauris varius, condimentum ex at, congue dolor. Vestibulum eu mi quis elit pellentesque pharetra. Praesent augue nisi, faucibus tincidunt lacinia eget, dapibus eget arcu. Mauris ut fermentum turpis. Donec pretium nulla et urna dictum, pretium pulvinar risus viverra. Quisque leo arcu, tristique sed condimentum rhoncus, dictum in ipsum.\r\n\r\nAenean leo velit, commodo nec rhoncus fermentum, ornare ut ipsum. Donec a dolor et massa pharetra feugiat nec a enim. Aliquam sit amet nibh et sapien interdum faucibus. Donec volutpat nunc sit amet tempus tristique. Fusce tempus eros vitae fermentum dignissim. Nullam vestibulum fermentum lobortis. Praesent ac risus dolor. Vivamus in lectus lobortis, ultrices nulla eget, pellentesque dolor. Donec urna eros, fermentum id odio quis, commodo fermentum ex. Proin non purus ut arcu vulputate varius.\r\n\r\nMauris aliquam quam sodales porta feugiat. In fringilla, odio ut tristique sagittis, odio libero gravida tortor, finibus tincidunt nisl erat eu nunc. Proin hendrerit dictum erat sed posuere. Praesent placerat nulla ut ullamcorper tincidunt. Cras ultricies vitae orci sed porttitor. Curabitur viverra, turpis vestibulum euismod interdum, sem leo varius ligula, eget cursus nisi mauris ac leo. Nullam ut odio vel eros pretium congue. Donec felis nunc, placerat sit amet urna nec, mattis vestibulum ipsum. Suspendisse ultricies nunc ut vehicula pharetra.\r\n\r\nInteger ut rhoncus lorem, vel blandit lorem. Sed accumsan at massa ac aliquam. Maecenas in nisi quis leo convallis condimentum at et metus. Nunc quis dictum risus, ut scelerisque ligula. Proin euismod mattis risus, sit amet cursus ante pretium nec. Sed euismod dapibus massa, vitae pulvinar felis elementum a. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam ultricies lorem dapibus metus lobortis, eu vulputate sem varius. Maecenas tincidunt mi a velit placerat rhoncus. Nunc pharetra metus dolor, sed molestie justo dignissim in. Vestibulum interdum ligula in interdum pharetra. Etiam imperdiet interdum pretium. Proin quis nisl egestas, rhoncus quam sit amet, tristique nulla. Fusce mollis lacus vitae nisi convallis, quis efficitur arcu tincidunt.\r\n\r\nPraesent sollicitudin laoreet blandit. Donec eu sem purus. Curabitur pulvinar tortor quis diam consequat, ac pretium velit faucibus. Sed blandit sapien eu nulla posuere suscipit. Ut sed nisi dui. Phasellus sed lectus porta, auctor velit sed, egestas eros. Nullam porta nisl quis ullamcorper cursus. Aenean elementum at lorem sit amet elementum. Aliquam vitae aliquet lacus. Vestibulum lacinia diam quis libero euismod ultricies. Integer eget consectetur neque. Praesent vel orci accumsan, dapibus nisl a, consequat tellus. Quisque eu porttitor felis. Quisque scelerisque velit metus, non semper libero dictum et.\r\n\r\nNullam sed tincidunt sapien. Duis fringilla, mauris eu pharetra venenatis, enim ex cursus lorem, eu pretium lorem neque id orci. Sed sit amet sem quis erat iaculis luctus. Vestibulum tincidunt euismod arcu, eu ornare sem. In hac habitasse platea dictumst. Pellentesque eros metus, feugiat vel luctus non, dictum quis risus. Phasellus nulla leo, dapibus non lectus at, convallis mollis lectus.\r\n\r\nQuisque et pretium enim. Fusce nulla libero, semper quis condimentum sit amet, efficitur vel magna. Sed efficitur nulla quis mauris iaculis ultrices. Donec mattis sodales lacus. Suspendisse porta pellentesque ultricies. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi convallis fringilla tellus, pretium aliquam metus rhoncus a. Praesent enim erat, pharetra sed purus vel, rutrum convallis odio. Ut scelerisque efficitur neque, ac dignissim enim cursus id. Fusce ac suscipit quam, non porttitor nibh. Integer pharetra risus vitae leo tincidunt rhoncus. Proin ac turpis ac arcu sodales imperdiet nec at enim.\r\n\r\nMauris tristique vitae arcu vel fringilla. Maecenas commodo mi euismod eleifend semper. Donec sollicitudin, erat eget pretium mollis, nulla nisi vehicula nisl, sit amet ullamcorper dolor enim ac lorem. Cras nibh turpis, convallis convallis dolor et, cursus laoreet ex. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur lectus massa, aliquet in quam vel, tempus sodales quam. Vestibulum consectetur, tellus sit amet efficitur faucibus, lorem nibh fringilla nisi, at efficitur mauris dui ac orci. Etiam dictum venenatis accumsan.\r\n\r\nCurabitur aliquam purus ligula, eget vestibulum lectus eleifend vitae. Donec sagittis, nisi non imperdiet posuere, eros velit scelerisque ante, varius fermentum diam neque non justo. Aenean facilisis vitae mi feugiat mollis. Etiam vehicula sem a blandit bibendum. Vivamus sodales luctus magna id aliquet. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Mauris ac pulvinar nunc. Donec convallis ligula non felis aliquet, eget ultrices lorem egestas. Quisque sed libero id enim elementum ultrices non mattis urna. Vestibulum eros nisl, pharetra eu consequat vitae, varius sed tellus.\r\n\r\nNam cursus dolor ut sapien cursus tempor. Etiam suscipit nec enim in eleifend. Nulla sem nulla, commodo sit amet lorem ac, maximus dictum tellus. Vivamus in eleifend tortor. Sed eu eros ac velit molestie vestibulum. Nunc congue nisl erat, non dictum mi finibus vel. Proin velit mi, rhoncus vitae enim vel, commodo varius neque. Integer rutrum tempor purus mollis sagittis. Integer arcu ante, ultrices in lacinia at, varius ac velit. Maecenas volutpat ipsum sed vulputate iaculis. Aenean et aliquet lacus. Donec nisl odio, congue quis ipsum vel, volutpat auctor elit. Aliquam ultricies hendrerit fermentum. Curabitur id dui dictum, euismod eros in, tincidunt erat.\r\n\r\nEtiam feugiat sapien sit amet nisl pellentesque dictum. Nam posuere ac nulla at porttitor. Phasellus elit magna, elementum non rutrum vitae, vehicula nec enim. Phasellus risus orci, ultrices quis vestibulum sed, bibendum quis urna. Proin pretium sit amet purus nec ultrices. Curabitur euismod ipsum et interdum blandit. Donec porttitor porttitor eros, a aliquam nisi mattis vel. Vestibulum rutrum sapien sit amet turpis vulputate, quis tristique neque aliquet. Nunc molestie convallis sem ultrices commodo. Curabitur aliquam vel sapien nec vehicula. Morbi eget sagittis velit. Nulla aliquet dictum nisl nec euismod. Aliquam ultricies nunc sed turpis dictum, vitae ultricies orci pulvinar. Sed cursus magna sapien, id sollicitudin diam tempus et. Nulla convallis turpis in egestas sodales.\r\n\r\nLorem ipsum dolor sit amet, consectetur adipiscing elit. Nam sit amet pharetra dui, at lacinia ex. Sed finibus massa vel metus hendrerit, sed consequat nulla elementum. Vivamus auctor dolor ut blandit malesuada. Curabitur ultrices erat eu cursus pellentesque. Fusce luctus vulputate posuere. Aenean ac hendrerit lectus, id feugiat augue. Cras hendrerit iaculis erat quis porttitor. Phasellus eget diam ac justo rutrum dignissim vel a tellus. In hac habitasse platea dictumst. Donec ullamcorper tortor ut posuere interdum. Pellentesque ullamcorper metus in velit lacinia, mollis ultrices ipsum ullamcorper. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Integer sed sagittis odio metus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"f3055aaf-2423-4288-963c-d49e149bcb0b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -780,7 +802,7 @@
            }
         ],
         "created_on":"2018-11-22T21:06:02.054748Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -789,7 +811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Reupen Shah",
            "first_name":"Reupen",
            "last_name":"Shah",
@@ -797,24 +819,24 @@
         },
         "modified_on":"2018-12-18T16:51:04.388817Z",
         "date":"2058-09-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Christopher Hatton",
            "first_name":"Christopher",
            "last_name":"Hatton",
            "id":"20994bb2-6224-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Dir - Group Resources",
            "id":"15374ae0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -822,30 +844,32 @@
         "subject":"enim|6aa4ed37-a7a0-468d-b5ce-839c68c93166",
         "notes":"Quas et dolor eum non doloremque ut ex.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0629623d-3f64-46d0-abf0-5236e66b54b1",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
            "first_name":"Meda",
            "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
            "job_title":"Legacy Interactions Engineer",
            "id":"76ca9ab8-a6da-4103-a707-6974db2091e4"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Meda Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
               "first_name":"Meda",
               "last_name":"Rath|78c3e3e3-98ea-4d38-bfda-14750ba4766b",
@@ -854,7 +878,7 @@
            }
         ],
         "created_on":"2019-01-11T17:03:27.923953Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -863,7 +887,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -871,24 +895,24 @@
         },
         "modified_on":"2019-01-11T17:03:27.923987Z",
         "date":"2058-08-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Inactive Advisor Service Provider",
            "id":"0242ce6a-d9be-e211-a646-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -896,36 +920,38 @@
         "subject":"aut|18658cbd-4d40-4cbe-9000-c74133a064bb",
         "notes":"Adipisci fugiat aut vero sunt.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Local Growth",
               "id":"01861666-4150-4aaf-b659-31f84e459612"
            }
         ],
         "policy_feedback_notes":"Odio illum ea vero ut sed et quod repellat cumque.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"9e55bfe6-12c6-47be-9e84-35e5cf10ac4f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "first_name":"Shanel",
            "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "job_title":"Forward Security Planner",
            "id":"3d196f6b-62ab-444b-9c35-e60d8daaca9e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
               "first_name":"Shanel",
               "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
@@ -934,19 +960,19 @@
            }
         ],
         "created_on":"2018-12-10T11:28:07.530276Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Larkin - Glover",
            "id":"6f2fd0c6-fd2b-41a7-9224-ee0d336a094a"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -954,13 +980,13 @@
         },
         "modified_on":"2018-12-10T11:28:07.530314Z",
         "date":"2058-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Nicholls",
            "first_name":"Andrew",
            "last_name":"Nicholls",
            "id":"815bb7e0-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Vientiane Laos",
            "id":"ea8333c8-9698-e211-a939-e4115bead28a"
         },
@@ -968,7 +994,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"OBN Chargeable Services",
            "id":"0b94cd30-e5eb-e311-8a2b-e4115bead28a"
         },
@@ -976,30 +1002,32 @@
         "subject":"dolorum|6308cc8b-0439-4ca5-872d-afceb560eaec",
         "notes":"Eius delectus neque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4093f571-63bc-4400-b9ee-46048e8ec3d7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -1008,19 +1036,19 @@
            }
         ],
         "created_on":"2019-01-11T16:35:34.480243Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Mante, Quitzon and Rodriguez",
            "id":"0be4a431-5668-438e-92ef-74901fe86d23"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1028,13 +1056,13 @@
         },
         "modified_on":"2019-01-11T16:35:34.480277Z",
         "date":"2058-06-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UK - India Business Council (UK IBC) - UK",
            "id":"298433c8-9698-e211-a939-e4115bead28a"
         },
@@ -1042,7 +1070,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1050,30 +1078,32 @@
         "subject":"quis|804d8566-4bb1-4e0e-8e38-516634e6d394",
         "notes":"Beatae vel dolor quaerat et quia eum nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"32cee8ad-dd72-45be-b7ac-3c7d6f81c50c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "first_name":"Melvina",
            "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
            "job_title":"Future Data Technician",
            "id":"aeaa2cad-52de-492e-93e8-89fbf51cc03d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Melvina Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
               "first_name":"Melvina",
               "last_name":"Upton|4a1c69d3-7d71-48ad-a047-955650ff02f3",
@@ -1082,19 +1112,19 @@
            }
         ],
         "created_on":"2018-12-07T10:04:19.544433Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Koepp, Ward and Wyman",
            "id":"dccfa7dd-2401-43f5-a0e9-9e5cd0dd2424"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1102,13 +1132,13 @@
         },
         "modified_on":"2018-12-07T10:04:19.544464Z",
         "date":"2058-05-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Dawn Ross",
            "first_name":"Dawn",
            "last_name":"Ross",
            "id":"4bc1dfc4-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Renewable UK",
            "id":"0ef12898-9698-e211-a939-e4115bead28a"
         },
@@ -1116,7 +1146,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"OBN Chargeable Services",
            "id":"0b94cd30-e5eb-e311-8a2b-e4115bead28a"
         },
@@ -1124,30 +1154,32 @@
         "subject":"aut|3d7674bd-c300-4cfc-b309-9f7295c6e7b3",
         "notes":"Dicta numquam soluta.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c15cc8b9-7602-4cee-bef2-3d40a10d05f4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "first_name":"Sheila",
            "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
            "job_title":"Direct Research Assistant",
            "id":"0e92dab2-84af-405c-8d32-95e46568f9a7"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Sheila Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
               "first_name":"Sheila",
               "last_name":"Ondricka|10101423-4618-4fd2-96d0-4bc616b076ef",
@@ -1156,19 +1188,19 @@
            }
         ],
         "created_on":"2019-01-11T16:22:32.142350Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ward, Rau and Labadie",
            "id":"113cbf82-8831-4470-aca6-ff84a96b3e66"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1176,13 +1208,13 @@
         },
         "modified_on":"2019-01-11T16:22:32.142400Z",
         "date":"2058-03-20",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Association of Professional Recording Services Ltd",
            "id":"3bf12898-9698-e211-a939-e4115bead28a"
         },
@@ -1190,7 +1222,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1198,30 +1230,32 @@
         "subject":"rerum|5425981f-130f-4e48-a9e4-9dc00483505e",
         "notes":"Dolore quidem tempore optio et eligendi assumenda incidunt.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c2c9279e-968f-47fe-b016-147188bc0273",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "first_name":"Garrick",
            "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "job_title":"Dynamic Interactions Designer",
            "id":"684b242a-c9b6-4cc6-98a8-4b6b4dd37e7f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
               "first_name":"Garrick",
               "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
@@ -1230,7 +1264,7 @@
            }
         ],
         "created_on":"2018-12-05T19:49:12.964124Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1239,7 +1273,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1247,24 +1281,24 @@
         },
         "modified_on":"2018-12-05T19:49:12.964155Z",
         "date":"2058-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Sarah Carter",
            "first_name":"Sarah",
            "last_name":"Carter",
            "id":"cf84236c-d707-e611-888e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - China",
            "id":"814d24c2-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -1272,30 +1306,32 @@
         "subject":"ab|7f7c8a66-8d65-41cd-a0c6-e96b29ead060",
         "notes":"Quod veritatis molestiae iure voluptas qui officia sint et nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6d6c1f1a-4852-4c4d-8b01-8659268deede",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Gilberto Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
            "first_name":"Gilberto",
            "last_name":"Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
            "job_title":"Lead Factors Supervisor",
            "id":"7a834b12-5978-4f52-9724-2cd43c53de7e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Gilberto Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
               "first_name":"Gilberto",
               "last_name":"Huel|168f1d72-dbf8-4050-b7e1-eba0df153228",
@@ -1304,7 +1340,7 @@
            }
         ],
         "created_on":"2018-11-23T09:19:43.410914Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1313,7 +1349,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1321,24 +1357,24 @@
         },
         "modified_on":"2018-11-23T09:19:43.410943Z",
         "date":"2057-11-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anthony Cowburn",
            "first_name":"Anthony",
            "last_name":"Cowburn",
            "id":"0626bcfe-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Kinematograph Sound and Television Society â€“ The Moving Image Society",
            "id":"f0f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -1346,30 +1382,32 @@
         "subject":"quasi|5139d60f-c178-43cc-a08c-61678ed6e1b8",
         "notes":"Architecto dolores sit quia non voluptatem fugit nesciunt non assumenda.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b3410d4b-9195-4ca8-a5a8-a1728c4586e8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -1378,7 +1416,7 @@
            }
         ],
         "created_on":"2018-11-22T17:50:28.238468Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1387,7 +1425,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1395,24 +1433,24 @@
         },
         "modified_on":"2018-11-22T17:50:28.238497Z",
         "date":"2057-10-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Willy Putra",
            "first_name":"Willy",
            "last_name":"Putra",
            "id":"7883452d-ee34-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Kyiv Ukraine",
            "id":"4f7e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1420,30 +1458,32 @@
         "subject":"eos|7a10cf5e-41b5-46c7-8dfa-3a86763d33fc",
         "notes":"Fugit quos aut veritatis odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0e0e6642-048d-413b-aa12-034f6a2d5cf7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "first_name":"Ashlee",
            "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "job_title":"Investor Assurance Technician",
            "id":"8d7fcf31-043a-43c2-baf8-58fc5fbb0689"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
               "first_name":"Ashlee",
               "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
@@ -1452,19 +1492,19 @@
            }
         ],
         "created_on":"2019-02-04T12:04:13.922396Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Goyette - Leuschke",
            "id":"00a5da1a-44ad-4b7a-a9f1-74965f4aa6aa"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1472,13 +1512,13 @@
         },
         "modified_on":"2019-02-04T12:04:13.922429Z",
         "date":"2057-10-17",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Paris France",
            "id":"077e43ce-9698-e211-a939-e4115bead28a"
         },
@@ -1486,7 +1526,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1494,36 +1534,38 @@
         "subject":"rerum|b602c4c0-e58b-4fcf-b442-62e1fa71e565",
         "notes":"Ab ab dolore ipsa at veniam autem ut et ducimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Government Communications",
               "id":"4fb8c6c6-d3aa-4b36-a954-7578e0337f4d"
            }
         ],
         "policy_feedback_notes":"Sed ratione nemo nisi tenetur magni repudiandae repellat provident.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"619639c9-92e9-4992-961d-e7359eb6e509",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -1532,7 +1574,7 @@
            }
         ],
         "created_on":"2019-01-07T16:15:30.583369Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1541,7 +1583,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1549,24 +1591,24 @@
         },
         "modified_on":"2019-01-07T16:15:30.583399Z",
         "date":"2057-07-17",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"OBN - British Chamber of Commerce in Hungary",
            "id":"daf91c3d-1c63-e311-8255-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Managment: Northern Powerhouse",
            "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
         },
@@ -1574,30 +1616,32 @@
         "subject":"nesciunt|8721c832-faff-409a-8cda-d15bfda7c3a1",
         "notes":"At rerum tempore harum eveniet veniam qui totam at.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2aabb068-4aab-4d5b-82da-5173015298e4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -1606,7 +1650,7 @@
            }
         ],
         "created_on":"2018-11-22T22:07:30.054033Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1615,7 +1659,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1623,24 +1667,24 @@
         },
         "modified_on":"2018-11-22T22:07:30.054063Z",
         "date":"2057-07-13",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alyson Beermann",
            "first_name":"Alyson",
            "last_name":"Beermann",
            "id":"17134cbe-f6ed-e211-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Winchester Council",
            "id":"2f4a754c-0753-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Overseas Market Introduction Service (OMIS)",
            "id":"360bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -1648,30 +1692,32 @@
         "subject":"laborum|21faf3a7-16d1-40ac-95be-e074c62c9374",
         "notes":"Ipsa quia aspernatur dolores qui sit atque itaque ut minima.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fe861b92-ba93-4cce-a67a-72426149c8a0",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "first_name":"Abdiel",
            "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "job_title":"District Implementation Officer",
            "id":"1a36fa15-68b0-4627-8020-914f6f715d43"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
               "first_name":"Abdiel",
               "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
@@ -1680,7 +1726,7 @@
            }
         ],
         "created_on":"2018-11-22T13:47:59.113788Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1689,7 +1735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1697,24 +1743,24 @@
         },
         "modified_on":"2018-11-22T13:47:59.113847Z",
         "date":"2057-06-19",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Jones",
            "first_name":"Andrew",
            "last_name":"Jones",
            "id":"9f37a9da-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Textile Machinery Association",
            "id":"d965239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -1722,30 +1768,32 @@
         "subject":"aspernatur|1b0cb4bc-4d52-4227-9d42-ffa9f4bf41a4",
         "notes":"Quam quia sit vero quod.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"705a59dd-9c0a-4ccd-a15d-71317a334e09",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Nathaniel Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
            "first_name":"Nathaniel",
            "last_name":"Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
            "job_title":"Direct Directives Agent",
            "id":"39754dd3-a076-43da-9073-445d088e76ed"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Nathaniel Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
               "first_name":"Nathaniel",
               "last_name":"Wolf|66626ac6-9388-4ef4-a119-f7c5ba9b5ce9",
@@ -1754,7 +1802,7 @@
            }
         ],
         "created_on":"2018-12-05T17:35:03.437828Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1763,7 +1811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1771,24 +1819,24 @@
         },
         "modified_on":"2018-12-05T17:35:03.437875Z",
         "date":"2057-06-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Lorraine Greene",
            "first_name":"Lorraine",
            "last_name":"Greene",
            "id":"2389d575-eecb-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"OBN - British Chamber of Commerce - Qatar",
            "id":"05321f01-0217-e311-a78e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1796,30 +1844,32 @@
         "subject":"sed|331875f9-beea-4efe-b964-ae6fba2471fb",
         "notes":"Nihil dolore ducimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4787165d-ae9e-4b16-9522-b31663aea344",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -1828,7 +1878,7 @@
            }
         ],
         "created_on":"2018-11-22T21:34:28.494478Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1837,7 +1887,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1845,24 +1895,24 @@
         },
         "modified_on":"2018-11-22T21:34:28.494509Z",
         "date":"2057-02-26",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"James Cushing",
            "first_name":"James",
            "last_name":"Cushing",
            "id":"1ff25c4d-ceae-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Chamber of Commerce - UK India Business Council",
            "id":"6873a5b3-ff16-e311-a78e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -1870,30 +1920,32 @@
         "subject":"libero|cda99c7a-7944-41c7-99a1-f12491d35d88",
         "notes":"Eum rerum alias ipsa nostrum ullam rerum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2c1f9ba3-9d33-41a7-90d0-cac775edf739",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "first_name":"Margaret",
            "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "job_title":"Chief Identity Orchestrator",
            "id":"e2b88408-57ef-4bb6-8103-1a2709f59d08"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
               "first_name":"Margaret",
               "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
@@ -1902,7 +1954,7 @@
            }
         ],
         "created_on":"2018-11-22T17:07:49.464659Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1911,7 +1963,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1919,24 +1971,24 @@
         },
         "modified_on":"2018-11-22T17:07:49.464687Z",
         "date":"2056-11-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Glen Wells",
            "first_name":"Glen",
            "last_name":"Wells",
            "id":"0a1c0f32-a005-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Markets",
            "id":"b4f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Tradeshow Access Programme (TAP)",
            "id":"f76eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -1944,30 +1996,32 @@
         "subject":"blanditiis|72a1bbd8-74e9-40de-99cc-30b3a2166e47",
         "notes":"Eum quo in quia porro est.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8f9c2735-ece8-4b43-a4ee-73ec7df627a7",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -1976,7 +2030,7 @@
            }
         ],
         "created_on":"2019-01-07T15:22:10.550417Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1985,7 +2039,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -1993,24 +2047,24 @@
         },
         "modified_on":"2019-01-07T15:22:10.550446Z",
         "date":"2056-10-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Fluid Power Association",
            "id":"d5f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -2018,30 +2072,32 @@
         "subject":"minima|ac5f917e-b2b1-443a-a45d-2e6a494746a9",
         "notes":"Sit corrupti corrupti totam est quidem dignissimos consequatur placeat.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"72d44234-e78a-4e47-82b5-35f9a42ae8df",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -2050,19 +2106,19 @@
            }
         ],
         "created_on":"2018-01-22T17:15:48.874339Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Herzog LLC",
            "id":"cf3bd842-b18f-4c96-8a51-1eb7350faf87"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Marco Fucci",
            "first_name":"Marco",
            "last_name":"Fucci",
@@ -2070,13 +2126,13 @@
         },
         "modified_on":"2018-04-19T10:59:23.405646Z",
         "date":"2056-09-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Zeynep Oztekbas",
            "first_name":"Zeynep",
            "last_name":"Oztekbas",
            "id":"891df7e3-5c33-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Olympics Influenced Decision",
            "id":"bd2b032f-9798-e211-a939-e4115bead28a"
         },
@@ -2084,7 +2140,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2092,30 +2148,32 @@
         "subject":"sint",
         "notes":"Quo quae occaecati omnis quibusdam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7503e07c-e10f-4aed-9516-246507772e54",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pierre Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
            "first_name":"Pierre",
            "last_name":"Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
            "job_title":"Future Configuration Coordinator",
            "id":"bdc36be5-00f1-479c-882b-723c3a363b8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pierre Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
               "first_name":"Pierre",
               "last_name":"Leffler|e5b3dee9-6b53-45f2-bd30-8029bd5d2de5",
@@ -2124,7 +2182,7 @@
            }
         ],
         "created_on":"2019-02-04T12:18:08.135234Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2133,7 +2191,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2141,24 +2199,24 @@
         },
         "modified_on":"2019-02-04T12:18:08.135264Z",
         "date":"2056-09-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Selby District Council",
            "id":"237b6d9c-0353-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -2166,30 +2224,32 @@
         "subject":"delectus|5278e0c6-48dc-47f9-b4a3-e5d5e6604432",
         "notes":"Sit et recusandae ipsa consequuntur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fee810e5-a95f-4a1e-ba64-0fbbe06bf588",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "first_name":"Shanel",
            "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
            "job_title":"Forward Security Planner",
            "id":"3d196f6b-62ab-444b-9c35-e60d8daaca9e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanel Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
               "first_name":"Shanel",
               "last_name":"Kohler|abcfdec3-d2f4-4c66-b796-09c09740fc31",
@@ -2198,19 +2258,19 @@
            }
         ],
         "created_on":"2018-12-07T13:49:50.421584Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Jacobi - Lockman",
            "id":"dcba3f74-25e5-4eb6-8005-0793c6da5c39"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2218,13 +2278,13 @@
         },
         "modified_on":"2018-12-07T13:49:50.421615Z",
         "date":"2056-08-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Cillian Cousins",
            "first_name":"Cillian",
            "last_name":"Cousins",
            "id":"3e576544-6e63-e511-9d3c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Opportunity Peterborough",
            "id":"5b0ba029-0653-e611-af02-e4115bead28a"
         },
@@ -2232,7 +2292,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -2240,30 +2300,32 @@
         "subject":"et|c9e996de-8e60-4af1-8a8b-ea1de3c5dcca",
         "notes":"Vero distinctio velit eum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8c365d3b-22a6-4aa1-b402-af7055d5e91b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Brandy Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
            "first_name":"Brandy",
            "last_name":"Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
            "job_title":"Human Paradigm Consultant",
            "id":"dac0bb0f-46e4-49ea-8228-e933d6b54392"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Brandy Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
               "first_name":"Brandy",
               "last_name":"Marvin|d1153805-7361-4a5f-bb15-703e6e0f8e8a",
@@ -2272,7 +2334,7 @@
            }
         ],
         "created_on":"2019-01-11T16:59:31.479925Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2281,7 +2343,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2289,24 +2351,24 @@
         },
         "modified_on":"2019-01-11T16:59:31.479970Z",
         "date":"2056-06-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Dublin Ireland",
            "id":"587c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2314,36 +2376,38 @@
         "subject":"distinctio|ef21323e-a784-4bb5-8ffa-42d4a6d52082",
         "notes":"Nihil repudiandae sit est qui ab deserunt tempora.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Movement of Services",
               "id":"2ca6322b-27e4-4ed9-95d4-342989d98022"
            }
         ],
         "policy_feedback_notes":"Reiciendis in necessitatibus recusandae culpa reprehenderit voluptas ut.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"2a7d830c-e27b-4355-a4de-204099c88bf9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "first_name":"Lydia",
            "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "job_title":"Product Markets Strategist",
            "id":"d82cfc39-42df-46de-9787-856a41652c8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
               "first_name":"Lydia",
               "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
@@ -2352,19 +2416,19 @@
            }
         ],
         "created_on":"2018-12-04T10:43:31.517269Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Gulgowski LLC",
            "id":"8a25ff79-62bd-4fa0-b184-4cfebd5cefea"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2372,13 +2436,13 @@
         },
         "modified_on":"2018-12-04T10:43:31.517302Z",
         "date":"2056-03-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Syed Rizwan Haider",
            "first_name":"Syed Rizwan",
            "last_name":"Haider",
            "id":"357e3575-9c98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ITS United Kingdom",
            "id":"9ef924aa-9698-e211-a939-e4115bead28a"
         },
@@ -2386,7 +2450,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Market Visit Support (MVS)",
            "id":"340bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2394,30 +2458,32 @@
         "subject":"qui|b824eb89-9a80-4d80-bc36-1476f8163eba",
         "notes":"Qui et quod dolorum ullam et tenetur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"33762b51-d626-4da0-ac81-e30e9d8c0311",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -2426,7 +2492,7 @@
            }
         ],
         "created_on":"2019-01-11T16:57:04.160456Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2435,7 +2501,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2443,24 +2509,24 @@
         },
         "modified_on":"2019-01-11T16:57:04.160488Z",
         "date":"2056-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General Auckland New Zealand",
            "id":"167c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Tradeshow Access Programme (TAP)",
            "id":"f76eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -2468,36 +2534,38 @@
         "subject":"commodi|ad487ca8-a500-430e-a943-0ce9eee62855",
         "notes":"Nam cumque et voluptas atque harum dolor rem reiciendis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Imports",
               "id":"0da4abf1-6344-48bc-85cf-1834b5fb26e1"
            }
         ],
         "policy_feedback_notes":"Ratione itaque dolore.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"85f59ca9-2685-4fec-9b38-13b73fbb56a5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "first_name":"Ashlee",
            "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
            "job_title":"Investor Assurance Technician",
            "id":"8d7fcf31-043a-43c2-baf8-58fc5fbb0689"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ashlee Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
               "first_name":"Ashlee",
               "last_name":"Davis|b78a9080-33fe-4ff0-a878-334859ca87df",
@@ -2506,7 +2574,7 @@
            }
         ],
         "created_on":"2018-12-05T16:16:54.580972Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2515,7 +2583,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2523,24 +2591,24 @@
         },
         "modified_on":"2018-12-05T16:16:54.581004Z",
         "date":"2056-03-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Monica Moorthy",
            "first_name":"Monica",
            "last_name":"Moorthy",
            "id":"05346184-9b98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of British Aerospace Companies Ltd",
            "id":"4a7b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2548,30 +2616,32 @@
         "subject":"eum|705a6e08-d246-410c-a996-2a266d650bbd",
         "notes":"Dolores sit iure alias accusantium vero et enim.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"1a3a6b70-ba17-4031-be2e-2a56ca437d2d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -2580,7 +2650,7 @@
            }
         ],
         "created_on":"2019-01-07T20:17:02.394878Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2589,7 +2659,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2597,24 +2667,24 @@
         },
         "modified_on":"2019-01-07T20:17:02.394910Z",
         "date":"2056-02-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC North EAST",
            "id":"602b971d-5df6-e511-888e-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Managment: Northern Powerhouse",
            "id":"a4a733b6-eb95-e611-be23-e4115bead28a"
         },
@@ -2622,30 +2692,32 @@
         "subject":"doloremque|09056026-ab8e-4725-8605-39097976f42b",
         "notes":"Perspiciatis consequatur quasi maiores et illum exercitationem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5f1b15f7-cbbc-4381-a89f-3dd07c36ddf1",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -2654,7 +2726,7 @@
            }
         ],
         "created_on":"2019-01-07T15:55:28.676317Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2663,7 +2735,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2671,24 +2743,24 @@
         },
         "modified_on":"2019-01-07T15:55:28.676347Z",
         "date":"2056-02-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of British Gas Industries",
            "id":"3b7b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Client Proposal (IST use only)",
            "id":"d03cce05-f9f7-e511-888e-e4115bead28a"
         },
@@ -2696,30 +2768,32 @@
         "subject":"qui|820cab4e-7266-4974-b336-06afa6f1302f",
         "notes":"Ut qui aliquid aut.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c4dcd4b4-764f-48c4-bc84-019b6caf2dc5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "first_name":"Shanna",
            "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "job_title":"Lead Quality Coordinator",
            "id":"2c0ea5e0-9741-4f9e-8bfb-c749e14be1c9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
               "first_name":"Shanna",
               "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
@@ -2728,7 +2802,7 @@
            }
         ],
         "created_on":"2019-01-11T17:09:48.069840Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2737,7 +2811,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2745,24 +2819,24 @@
         },
         "modified_on":"2019-01-11T17:09:48.069872Z",
         "date":"2055-12-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Strategy/Policy/Local Engagement - Strategy",
            "id":"32f671f0-094e-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -2770,30 +2844,32 @@
         "subject":"voluptas|32af86be-a602-4714-a829-1d9ddf33a7f8",
         "notes":"Aperiam fuga distinctio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"956680a2-b5b5-4b6a-8d57-21c6d878eb15",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "first_name":"Edwin",
            "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
            "job_title":"Senior Quality Assistant",
            "id":"f2a57d5e-9a48-43fd-8154-296730992345"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Edwin Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
               "first_name":"Edwin",
               "last_name":"Harris|fd4fd08e-fa40-4c44-a696-16d38762dc00",
@@ -2802,19 +2878,19 @@
            }
         ],
         "created_on":"2018-12-06T12:41:58.288891Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ward, Rau and Labadie",
            "id":"113cbf82-8831-4470-aca6-ff84a96b3e66"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2822,13 +2898,13 @@
         },
         "modified_on":"2018-12-06T12:41:58.288921Z",
         "date":"2055-12-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mariko McTier",
            "first_name":"Mariko",
            "last_name":"McTier",
            "id":"be3f03eb-ea5d-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General Belo Horizonte Brazil",
            "id":"29cd87be-c191-e511-a84e-e4115bead28a"
         },
@@ -2836,7 +2912,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Opportunities",
            "id":"d520b92b-3499-e211-a939-e4115bead28a"
         },
@@ -2844,30 +2920,32 @@
         "subject":"est|1467c474-2df6-4739-ac14-46411a2280bc",
         "notes":"Labore cupiditate qui neque voluptas qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"5371c428-c2f0-4761-b3ac-0a5913a51de5",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "first_name":"Lydia",
            "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
            "job_title":"Product Markets Strategist",
            "id":"d82cfc39-42df-46de-9787-856a41652c8d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lydia Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
               "first_name":"Lydia",
               "last_name":"Hagenes|33a8567b-eaf4-4cbd-a34f-06191e790a1b",
@@ -2876,7 +2954,7 @@
            }
         ],
         "created_on":"2018-11-22T17:36:38.104092Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2885,7 +2963,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2893,24 +2971,24 @@
         },
         "modified_on":"2018-11-22T17:36:38.104120Z",
         "date":"2055-11-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Pippa Russo",
            "first_name":"Pippa",
            "last_name":"Russo",
            "id":"c9826157-d30a-e611-9bdc-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Athens Greece",
            "id":"3b8433c8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -2918,30 +2996,32 @@
         "subject":"qui|69be5213-027a-42de-85de-fb36b3bbb7a8",
         "notes":"Ratione soluta est molestiae commodi necessitatibus nisi sit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b8936187-da15-441a-8cdb-b24bc0978659",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -2950,7 +3030,7 @@
            }
         ],
         "created_on":"2018-12-05T16:18:10.309765Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2959,7 +3039,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -2967,24 +3047,24 @@
         },
         "modified_on":"2018-12-05T16:18:10.309794Z",
         "date":"2055-10-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Laura Campbell",
            "first_name":"Laura",
            "last_name":"Campbell",
            "id":"66205f64-2800-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Yorkshire and Humber Regional Sector Specialists",
            "id":"a52b032f-9798-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -2992,30 +3072,32 @@
         "subject":"iusto|9a567ff9-54c4-4a3a-a14f-b603056c8d1e",
         "notes":"Esse non et consequatur debitis et enim recusandae quod optio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4d46a1b1-4e6d-48a8-a9ce-e587fa0a5faf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -3024,7 +3106,7 @@
            }
         ],
         "created_on":"2018-05-24T22:23:45.256153Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3033,7 +3115,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3041,24 +3123,24 @@
         },
         "modified_on":"2018-05-24T22:23:45.256186Z",
         "date":"2055-10-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Kemenia McLean",
            "first_name":"Kemenia",
            "last_name":"McLean",
            "id":"eee0f538-c29d-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - TAP - Deputy Director",
            "id":"fd65239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -3066,30 +3148,32 @@
         "subject":"temporibus|66d29d1c-0cdd-4e3d-b86b-ed8fbb39c2ad",
         "notes":"Aut maiores vel non adipisci.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"491d0161-a72d-4bc7-8358-5f5fae2f14a4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -3098,19 +3182,19 @@
            }
         ],
         "created_on":"2018-12-05T17:47:07.766574Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Event event",
            "id":"9ca1147d-c855-47bb-86fb-b75265e13e32"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3118,13 +3202,13 @@
         },
         "modified_on":"2018-12-05T17:47:07.766604Z",
         "date":"2055-08-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anya Greaves",
            "first_name":"Anya",
            "last_name":"Greaves",
            "id":"6d93c233-1800-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Changsha",
            "id":"b483c1a0-d7df-e211-a78e-e4115bead28a"
         },
@@ -3132,7 +3216,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Overseas",
            "id":"ccf9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3140,30 +3224,32 @@
         "subject":"architecto|5e6c9e7a-5ae6-491e-bf8e-2559b82da6f9",
         "notes":"Sit id iusto provident.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"abf6cf32-0106-4007-a8b6-cc4ef41c28ac",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "first_name":"Shanna",
            "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
            "job_title":"Lead Quality Coordinator",
            "id":"2c0ea5e0-9741-4f9e-8bfb-c749e14be1c9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Shanna Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
               "first_name":"Shanna",
               "last_name":"Treutel|949bf2b5-f7b4-4f27-8419-44a2137983c8",
@@ -3172,7 +3258,7 @@
            }
         ],
         "created_on":"2018-11-23T09:17:49.460754Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3181,7 +3267,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3189,24 +3275,24 @@
         },
         "modified_on":"2018-11-23T09:17:49.460784Z",
         "date":"2055-07-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Test DSO2 Handler Test",
            "first_name":"Test",
            "last_name":"DSO2 Handler Test",
            "id":"a2e0f0d4-fe2e-e611-a7ac-e4115bed50dc"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Doncaster Council",
            "id":"78ac4641-1653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3214,30 +3300,32 @@
         "subject":"et|76f43296-90fc-46f4-9a3c-3c5fa46b7330",
         "notes":"At sit omnis minima sint est perspiciatis incidunt maiores.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"66daa610-ef51-474f-a0f6-4bbb07710317",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "first_name":"Aletha",
            "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
            "job_title":"Product Division Executive",
            "id":"4f10d5a3-a86f-4dc9-811c-473660d8b80a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Aletha Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
               "first_name":"Aletha",
               "last_name":"Bergstrom|59b623ec-81d3-4d94-b123-a35ca538005d",
@@ -3246,7 +3334,7 @@
            }
         ],
         "created_on":"2019-01-07T16:28:07.648153Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3255,7 +3343,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3263,24 +3351,24 @@
         },
         "modified_on":"2019-01-07T16:28:07.648183Z",
         "date":"2055-06-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Shenzhen",
            "id":"664d24c2-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Account Management",
            "id":"9484b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3288,30 +3376,32 @@
         "subject":"iste|4f36ab15-c0ac-4712-810e-98201718020a",
         "notes":"Dicta assumenda et est sapiente consequatur fugit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"73d891b5-59cc-4535-8eff-9733c55d23ac",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -3320,19 +3410,19 @@
            }
         ],
         "created_on":"2018-12-07T09:50:46.773966Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Price Inc",
            "id":"ec4256eb-00db-4744-ae6e-4611fc1de7a5"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3340,13 +3430,13 @@
         },
         "modified_on":"2018-12-07T09:50:46.773995Z",
         "date":"2055-06-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Mohammed Sharif",
            "first_name":"Mohammed",
            "last_name":"Sharif",
            "id":"a09d93bd-5453-e311-a56a-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"London Development Agency",
            "id":"c43ade1c-9798-e211-a939-e4115bead28a"
         },
@@ -3354,7 +3444,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Market Visit Support (MVS)",
            "id":"340bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -3362,30 +3452,32 @@
         "subject":"odit|de613e3e-52c7-4ff4-bb83-47a567a224a9",
         "notes":"Harum nostrum accusantium ea dolores incidunt deserunt quo ullam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"a3f56ba5-9743-41c0-9b3c-145b48953fba",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -3394,7 +3486,7 @@
            }
         ],
         "created_on":"2019-02-04T12:03:18.416826Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3403,7 +3495,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3411,24 +3503,24 @@
         },
         "modified_on":"2019-02-04T12:03:18.416857Z",
         "date":"2055-05-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Managing Director & PA",
            "id":"2a374ae0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -3436,30 +3528,32 @@
         "subject":"et|5ee92777-c6de-4a57-807a-c99c38534951",
         "notes":"Tempora sit reiciendis fugit ipsam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"20b3e670-86ce-480e-8dec-28c339584022",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "first_name":"Pasquale",
            "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
            "job_title":"Corporate Security Analyst",
            "id":"17fe3ff0-032c-42c5-b315-588a36b7208b"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Pasquale Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
               "first_name":"Pasquale",
               "last_name":"Lebsack|cba6fb53-46d8-409b-b86e-d478a444d641",
@@ -3468,19 +3562,19 @@
            }
         ],
         "created_on":"2018-12-06T15:00:25.536950Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"O'Connell - Conroy|f596a57c-2762-4010-8f36-b8bf585d9bb1",
            "id":"254bb413-30b5-4097-880b-b6ae8e1dcf16"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3488,13 +3582,13 @@
         },
         "modified_on":"2018-12-06T15:00:25.536978Z",
         "date":"2055-04-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Teresa Rosinski",
            "first_name":"Teresa",
            "last_name":"Rosinski",
            "id":"b647074c-8954-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Cambridge Cleantech Ltd",
            "id":"0379b20f-271a-e311-a78e-e4115bead28a"
         },
@@ -3502,7 +3596,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Webinars",
            "id":"510a4016-4bb9-e211-a646-e4115bead28a"
         },
@@ -3510,30 +3604,32 @@
         "subject":"reiciendis|97c3a6b2-0ef7-4d64-8529-ed0aeb168128",
         "notes":"Quod et nobis molestias.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"302ad5c7-0e99-47f3-8c41-d6910c46d296",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -3542,7 +3638,7 @@
            }
         ],
         "created_on":"2018-11-23T11:27:06.195146Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3551,7 +3647,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3559,24 +3655,24 @@
         },
         "modified_on":"2018-11-23T11:27:06.195177Z",
         "date":"2055-03-27",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Katarzyna Zwolak",
            "first_name":"Katarzyna",
            "last_name":"Zwolak",
            "id":"3b7257fd-cc94-e411-a839-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IST - Business and Partnerships",
            "id":"d64f1c8a-cfe9-e511-8ffa-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -3584,30 +3680,32 @@
         "subject":"aliquid|8c6391c7-b6b4-48ab-a3bc-f537befb4725",
         "notes":"Voluptatem voluptatem voluptatem ipsum sapiente eum id ipsum.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"233d3edc-5d50-4e45-a4d4-b33037fedb80",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -3616,19 +3714,19 @@
            }
         ],
         "created_on":"2018-12-05T17:41:33.251589Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Wuckert and Sons",
            "id":"43a6d08d-c6a4-425d-889b-c7061b448cbb"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3636,13 +3734,13 @@
         },
         "modified_on":"2018-12-05T17:41:33.251619Z",
         "date":"2055-01-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Jennifer Hunter",
            "first_name":"Jennifer",
            "last_name":"Hunter",
            "id":"7e364f28-54c8-e211-a646-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Consulate General San Francisco USA",
            "id":"017e43ce-9698-e211-a939-e4115bead28a"
         },
@@ -3650,7 +3748,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) Non Funded",
            "id":"f46eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -3658,30 +3756,32 @@
         "subject":"perspiciatis|a1980d61-ca31-4d91-8f2b-2d762f33e8b9",
         "notes":"Aut cum qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e5d81b84-af59-4877-924c-72735649771b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -3690,19 +3790,19 @@
            }
         ],
         "created_on":"2018-12-07T13:26:34.815515Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Kerluke Inc",
            "id":"09c94086-ef82-4814-94f4-251977715046"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3710,13 +3810,13 @@
         },
         "modified_on":"2018-12-07T13:26:34.815557Z",
         "date":"2054-12-15",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Michael Reid",
            "first_name":"Michael",
            "last_name":"Reid",
            "id":"21eb8bf5-dbeb-e311-8a2b-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"West Oxfordshire District Council",
            "id":"5e2f39ac-1953-e611-af02-e4115bead28a"
         },
@@ -3724,7 +3824,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"UK Region Local",
            "id":"9a84b82b-3499-e211-a939-e4115bead28a"
         },
@@ -3732,30 +3832,32 @@
         "subject":"sint|e7652f96-01b6-433e-807a-44b1d2383f39",
         "notes":"Facere voluptas voluptas dolores.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"46141a83-3217-4ec2-bfe8-dfa7181fa08c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -3764,19 +3866,19 @@
            }
         ],
         "created_on":"2019-02-04T12:19:09.104775Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Smith and Sons",
            "id":"636f171c-c602-4f89-81b2-d5d6a19db3d7"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3784,13 +3886,13 @@
         },
         "modified_on":"2019-02-04T12:19:09.104808Z",
         "date":"2054-10-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Yorkshire and Humber Regional Sector Specialists",
            "id":"a52b032f-9798-e211-a939-e4115bead28a"
         },
@@ -3798,7 +3900,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -3806,30 +3908,32 @@
         "subject":"ab|7aeb2646-9d6b-433a-a014-bcbaf28cc014",
         "notes":"Soluta et non recusandae.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"ff4c84b4-d225-40aa-96fb-0d398e3c6230",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Alexandre Morissette|b697da75-4804-4868-8886-e8df2219d89f",
            "first_name":"Alexandre",
            "last_name":"Morissette|b697da75-4804-4868-8886-e8df2219d89f",
            "job_title":"National Operations Associate",
            "id":"d795c064-8202-42d1-a21f-e4f7ae35589a"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Alexandre Morissette|b697da75-4804-4868-8886-e8df2219d89f",
               "first_name":"Alexandre",
               "last_name":"Morissette|b697da75-4804-4868-8886-e8df2219d89f",
@@ -3838,7 +3942,7 @@
            }
         ],
         "created_on":"2018-11-22T20:10:56.029435Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3847,7 +3951,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3855,24 +3959,24 @@
         },
         "modified_on":"2018-11-22T20:10:56.029464Z",
         "date":"2054-10-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Thomas Ackroyd",
            "first_name":"Thomas",
            "last_name":"Ackroyd",
            "id":"639e1b6e-1dcc-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Aberdeen City Council",
            "id":"cff02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -3880,30 +3984,32 @@
         "subject":"aut|45021fa6-75d6-4c65-971d-ffd3f8d81a9a",
         "notes":"Eveniet in quam.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0df6527d-eed4-4c57-9939-4b9f4c663dfd",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -3912,7 +4018,7 @@
            }
         ],
         "created_on":"2019-01-07T15:58:59.909739Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3921,7 +4027,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3929,24 +4035,24 @@
         },
         "modified_on":"2019-01-07T15:58:59.909773Z",
         "date":"2054-06-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Guatemala City Guatemala",
            "id":"40841eb0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -3954,30 +4060,32 @@
         "subject":"amet|530e7a94-5e44-4c54-877f-da7f95757859",
         "notes":"Cumque ducimus tempore consectetur aut quos distinctio tempore dignissimos qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"748bfee9-b901-467b-8bfc-2b0fb07bbb9a",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "first_name":"Abdiel",
            "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
            "job_title":"District Implementation Officer",
            "id":"1a36fa15-68b0-4627-8020-914f6f715d43"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abdiel McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
               "first_name":"Abdiel",
               "last_name":"McCullough|5468c4f5-bb42-4f49-b105-c46a9c95c2ca",
@@ -3986,7 +4094,7 @@
            }
         ],
         "created_on":"2019-01-11T16:36:19.515702Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -3995,7 +4103,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4003,24 +4111,24 @@
         },
         "modified_on":"2019-01-11T16:36:19.515737Z",
         "date":"2054-06-05",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Havant Borough Council",
            "id":"259199aa-0653-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -4028,36 +4136,38 @@
         "subject":"explicabo|56f8ed81-a8d8-429e-a199-05fe354c9a28",
         "notes":"Sed dolore sed voluptas error aspernatur repudiandae quasi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
-           {  
+        "policy_areas":[
+           {
               "name":"Returnships",
               "id":"276b98bc-d12e-42e2-b506-27c3f36083a4"
            }
         ],
         "policy_feedback_notes":"At distinctio odio est optio et.",
-        "policy_issue_types":[  
-           {  
+        "policy_issue_types":[
+           {
               "name":"Domestic",
               "id":"688ac22e-89d4-4d1f-bf0b-013588bf63a7"
            }
         ],
         "was_policy_feedback_provided":true
      },
-     {  
+     {
         "id":"d0d723e3-6252-412b-880e-846fbd0f7d0c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carli Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
            "first_name":"Carli",
            "last_name":"Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
            "job_title":"Principal Metrics Officer",
            "id":"69bc7dbd-d62b-461f-9bbc-57fd2a5bc8f3"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carli Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
               "first_name":"Carli",
               "last_name":"Rohan|4521768c-30fe-4cd3-bc8a-78fa259d7e03",
@@ -4066,7 +4176,7 @@
            }
         ],
         "created_on":"2018-11-23T11:23:33.045029Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4075,7 +4185,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4083,24 +4193,24 @@
         },
         "modified_on":"2018-11-23T11:23:33.045073Z",
         "date":"2054-01-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Gabriela Kramarova",
            "first_name":"Gabriela",
            "last_name":"Kramarova",
            "id":"5f01f330-9998-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Accra Ghana",
            "id":"1c6e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4108,30 +4218,32 @@
         "subject":"fugiat|ee7043a1-b3a1-4db3-842c-a33f17185bee",
         "notes":"Voluptas velit et ducimus eveniet.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2776253a-b1ad-42b3-a811-e6dce3e0acb3",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "first_name":"Unique",
            "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "job_title":"Direct Intranet Assistant",
            "id":"f6b8ca61-915c-4df1-8379-d3d9a8b99195"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
               "first_name":"Unique",
               "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
@@ -4140,19 +4252,19 @@
            }
         ],
         "created_on":"2019-01-11T16:12:26.637249Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"5fcbe01d-402f-4bff-93c7-bf3f03c7c6df",
            "id":"ed1f8c74-23e5-4043-806d-a899c7ebea83"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4160,13 +4272,13 @@
         },
         "modified_on":"2019-01-11T16:12:26.637299Z",
         "date":"2053-12-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Gateshead Council",
            "id":"4b3d36c4-6025-e511-b6bc-e4115bead28a"
         },
@@ -4174,7 +4286,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4182,30 +4294,32 @@
         "subject":"aliquam|b8278491-8cde-4a3a-9161-f9ad97b881c9",
         "notes":"Velit soluta excepturi eius quam non quasi reiciendis architecto.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"1f42c879-8124-4fd4-b20b-ab27c070d5ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -4214,7 +4328,7 @@
            }
         ],
         "created_on":"2019-01-11T16:12:47.166367Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4223,7 +4337,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4231,24 +4345,24 @@
         },
         "modified_on":"2019-01-11T16:12:47.166415Z",
         "date":"2053-11-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Panama City Panama",
            "id":"2ad616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -4256,30 +4370,32 @@
         "subject":"repellendus|2cf4771a-3676-49ea-ab7b-0d249ccf3095",
         "notes":"Labore quisquam corrupti quia laudantium architecto animi est quidem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b0260ae8-a0ca-4ea4-a2ef-927e8cd7e49d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -4288,19 +4404,19 @@
            }
         ],
         "created_on":"2019-01-11T16:22:55.748627Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Gislason - Gerhold",
            "id":"de4f1dad-930e-4b79-a4d4-c5e22fd69e18"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4308,13 +4424,13 @@
         },
         "modified_on":"2019-01-11T16:22:55.748658Z",
         "date":"2053-10-30",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Society of Motor Manufacturers & Traders Ltd",
            "id":"447b1ca4-9698-e211-a939-e4115bead28a"
         },
@@ -4322,41 +4438,43 @@
         "grant_amount_offered":"100000.00",
         "investment_project":null,
         "net_company_receipt":"50000.00",
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP)",
            "id":"380bba2b-3499-e211-a939-e4115bead28a"
         },
-        "service_delivery_status":{  
+        "service_delivery_status":{
            "name":"Completed",
            "id":"47329c18-6095-e211-a939-e4115bead28a"
         },
         "subject":"vel|72fb9b38-4a3c-48dc-bdbc-373929c37329",
         "notes":"Placeat reprehenderit architecto ut non.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c4d33303-0387-4bc2-bb2d-6f3e2e8d8f25",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Ressie Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
            "first_name":"Ressie",
            "last_name":"Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
            "job_title":"Internal Data Liaison",
            "id":"3df98941-fca6-4a7a-b8ce-05f571746aea"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Ressie Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
               "first_name":"Ressie",
               "last_name":"Williamson|5b1d0ac7-8f1d-46a6-844a-de7a0bdb6466",
@@ -4365,7 +4483,7 @@
            }
         ],
         "created_on":"2018-11-22T18:02:06.747670Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4374,7 +4492,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4382,24 +4500,24 @@
         },
         "modified_on":"2018-11-22T18:02:06.747719Z",
         "date":"2053-08-14",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Kieran Mercer",
            "first_name":"Kieran",
            "last_name":"Mercer",
            "id":"0638a051-9a98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Leicester City Council",
            "id":"88c26d29-4f4e-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4407,30 +4525,32 @@
         "subject":"soluta|609368a6-83fa-4071-b37e-3e28a725d90b",
         "notes":"Autem ut itaque consequatur autem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b0344227-def7-4b11-b175-2bb2fa3081f4",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -4439,7 +4559,7 @@
            }
         ],
         "created_on":"2018-11-22T14:21:34.231519Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4448,7 +4568,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4456,24 +4576,24 @@
         },
         "modified_on":"2018-11-22T14:21:34.231567Z",
         "date":"2053-08-06",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Akoto Agyeman",
            "first_name":"Akoto",
            "last_name":"Agyeman",
            "id":"ba05b3b0-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC Wales",
            "id":"826e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -4481,30 +4601,32 @@
         "subject":"architecto|8db6621a-dd60-4008-9ae3-211d2f468c90",
         "notes":"Animi adipisci sed sed dolore beatae nisi repudiandae inventore dolorem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"10e95320-bbe1-4a13-bddc-4db4bc108965",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -4513,7 +4635,7 @@
            }
         ],
         "created_on":"2018-08-31T13:14:50.083309Z",
-        "created_by":{  
+        "created_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -4522,7 +4644,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -4530,24 +4652,24 @@
         },
         "modified_on":"2018-08-31T13:14:50.083339Z",
         "date":"2053-08-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anastasia Badina",
            "first_name":"Anastasia",
            "last_name":"Badina",
            "id":"0ccaaad4-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Sport",
            "id":"b9f924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Business Proposition",
            "id":"9384b82b-3499-e211-a939-e4115bead28a"
         },
@@ -4555,30 +4677,32 @@
         "subject":"rerum|68a20887-8f30-488b-a0ac-e29e0fda151c",
         "notes":"Praesentium odit omnis fuga ut reprehenderit quia sed odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"90eecb26-0c11-4d2c-8efb-97ac51c31770",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Frances Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
            "first_name":"Frances",
            "last_name":"Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
            "job_title":"Senior Accounts Executive",
            "id":"ba66c8bd-5787-4ded-a351-dc5273a0543d"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Frances Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
               "first_name":"Frances",
               "last_name":"Kirlin|9c3badf6-6cd2-4649-ac66-308a4f0287cf",
@@ -4587,7 +4711,7 @@
            }
         ],
         "created_on":"2018-11-22T22:16:54.428620Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4596,7 +4720,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4604,24 +4728,24 @@
         },
         "modified_on":"2018-11-22T22:16:54.428665Z",
         "date":"2053-06-11",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Algar",
            "first_name":"Andrew",
            "last_name":"Algar",
            "id":"bacaaad4-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Sunderland Council",
            "id":"492aca01-8425-e511-b6bc-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Services (Other)",
            "id":"f36eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -4629,30 +4753,32 @@
         "subject":"ut|4463109c-6f92-4563-b60f-e9a806eeb21f",
         "notes":"Dolorum porro at nihil sequi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0f7549c4-1236-48ee-a9a0-019ef8ad9a9b",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "first_name":"Eddie",
            "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "job_title":"Senior Brand Coordinator",
            "id":"afbf7f18-dcb1-41a6-b754-983c752a49d9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
               "first_name":"Eddie",
               "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
@@ -4661,7 +4787,7 @@
            }
         ],
         "created_on":"2018-11-22T18:01:01.202865Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4670,7 +4796,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4678,24 +4804,24 @@
         },
         "modified_on":"2018-11-22T18:01:01.202894Z",
         "date":"2053-05-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Eleanor Butterwick",
            "first_name":"Eleanor",
            "last_name":"Butterwick",
            "id":"b8c204cc-d000-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Food From Britain",
            "id":"8cf924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4703,30 +4829,32 @@
         "subject":"numquam|994e12fa-2f34-4522-b199-c0248265e1a5",
         "notes":"Dolores unde quo pariatur laboriosam voluptates.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"79b956ab-b749-4d7d-890b-52bf89b3cf5c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -4735,7 +4863,7 @@
            }
         ],
         "created_on":"2018-11-22T13:33:53.892415Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4744,7 +4872,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4752,24 +4880,24 @@
         },
         "modified_on":"2018-11-22T13:33:53.892448Z",
         "date":"2053-03-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Antonio Santos",
            "first_name":"Antonio",
            "last_name":"Santos",
            "id":"e740c504-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Glass and Glazing Federation",
            "id":"8ff924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -4777,30 +4905,32 @@
         "subject":"voluptates|28503fe5-e62a-45bc-8816-7e0a82f32fc9",
         "notes":"Eligendi recusandae cum sequi itaque et nam odio.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8072ad3f-dbd6-42d5-917e-7e8c9607c785",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -4809,19 +4939,19 @@
            }
         ],
         "created_on":"2018-04-17T11:12:11.261654Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Hyatt LLC",
            "id":"2213391b-599c-4274-b0d9-72e5f45cafe6"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4829,13 +4959,13 @@
         },
         "modified_on":"2018-04-17T11:12:11.261689Z",
         "date":"2053-02-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Demosthenous",
            "first_name":"Andrew",
            "last_name":"Demosthenous",
            "id":"b5954ce6-a3d1-e511-a5e6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - SR - Director &  PA",
            "id":"1b374ae0-9698-e211-a939-e4115bead28a"
         },
@@ -4843,7 +4973,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -4851,30 +4981,32 @@
         "subject":"aut|5c2726d1-87cb-4e07-8ee7-825e943289c9",
         "notes":"Deserunt amet explicabo assumenda quia aut enim dolor.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6b0b3f86-442b-4a90-a534-ed42d897c00e",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -4883,19 +5015,19 @@
            }
         ],
         "created_on":"2018-12-04T10:54:47.685361Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"My third event",
            "id":"08989891-e768-4f43-b431-dd28d7025768"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4903,13 +5035,13 @@
         },
         "modified_on":"2018-12-04T10:54:47.685409Z",
         "date":"2053-02-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Atma Panray",
            "first_name":"Atma",
            "last_name":"Panray",
            "id":"fff75dc5-bf9d-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - South East Asia",
            "id":"238433c8-9698-e211-a939-e4115bead28a"
         },
@@ -4917,7 +5049,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -4925,30 +5057,32 @@
         "subject":"nihil|6272f9e8-0f1b-47fb-bbf3-cde8023952fc",
         "notes":"Quibusdam cum alias fuga.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"481d8ae5-e7ce-4cef-a984-7a62b035e9b8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -4957,7 +5091,7 @@
            }
         ],
         "created_on":"2018-01-30T16:28:00.502237Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4966,7 +5100,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -4974,24 +5108,24 @@
         },
         "modified_on":"2018-01-30T16:28:00.502286Z",
         "date":"2053-01-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Ana Barragan",
            "first_name":"Ana",
            "last_name":"Barragan",
            "id":"0b3cb3ce-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Riyadh Saudi Arabia",
            "id":"51d616b6-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Webinars",
            "id":"510a4016-4bb9-e211-a646-e4115bead28a"
         },
@@ -4999,30 +5133,32 @@
         "subject":"voluptas",
         "notes":"Consequatur quam quos aut temporibus ad.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"bc4fba97-d45e-443c-8660-0dbf4198b4cb",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -5031,7 +5167,7 @@
            }
         ],
         "created_on":"2018-08-31T14:59:43.118995Z",
-        "created_by":{  
+        "created_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -5040,7 +5176,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Jim Smith",
            "first_name":"Jim",
            "last_name":"Smith",
@@ -5048,24 +5184,24 @@
         },
         "modified_on":"2018-08-31T14:59:43.119025Z",
         "date":"2052-11-05",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alan Roden",
            "first_name":"Alan",
            "last_name":"Roden",
            "id":"f4e8c3b6-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"SG4 - SG 4 International Business Schemes Directorate",
            "id":"73a963f8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -5073,30 +5209,32 @@
         "subject":"magnam|a9a7a91a-f953-4aad-9a2f-9a58ee1fa3f8",
         "notes":"Eveniet est optio ipsum esse officiis eos.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8be1cb46-13ce-4d99-9d0e-5cda88fb0d21",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "first_name":"Anderson",
            "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
            "job_title":"Legacy Assurance Orchestrator",
            "id":"5580e6e4-b484-475b-bf22-fb782f7865f2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Anderson Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
               "first_name":"Anderson",
               "last_name":"Schmeler|53167b22-acf0-48ae-b731-0eb7f62e4160",
@@ -5105,19 +5243,19 @@
            }
         ],
         "created_on":"2018-03-21T13:34:29.490810Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Tillman - Eichmann",
            "id":"6ef89384-1bb2-4dc5-9ebd-cfe5532aac26"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5125,13 +5263,13 @@
         },
         "modified_on":"2018-03-21T13:34:29.490866Z",
         "date":"2052-08-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"David Edmondson",
            "first_name":"David",
            "last_name":"Edmondson",
            "id":"a566eeb2-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - TAP Team",
            "id":"0066239e-9698-e211-a939-e4115bead28a"
         },
@@ -5139,7 +5277,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Win",
            "id":"350bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -5147,30 +5285,32 @@
         "subject":"at|936ef003-6d09-49fa-ab09-0bd30b005f62",
         "notes":"Similique qui libero ipsum possimus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8d30ff46-4304-45f8-ac29-2c38d2ade193",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "first_name":"Eddie",
            "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
            "job_title":"Senior Brand Coordinator",
            "id":"afbf7f18-dcb1-41a6-b754-983c752a49d9"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eddie Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
               "first_name":"Eddie",
               "last_name":"Connelly|31803fc4-a6ef-43a1-8385-676b9769b379",
@@ -5179,7 +5319,7 @@
            }
         ],
         "created_on":"2019-01-07T15:20:11.586885Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5188,7 +5328,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5196,24 +5336,24 @@
         },
         "modified_on":"2019-01-07T15:20:11.586916Z",
         "date":"2052-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Welsh Government (Investment)",
            "id":"bc85aa17-fabd-e511-88b6-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Services",
            "id":"0596b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5221,30 +5361,32 @@
         "subject":"minus|c9088305-1e16-4787-b1a7-7d90c4cc7551",
         "notes":"Quos ea architecto et eaque laudantium quia fugit.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c1a0d89c-a4e7-4923-b2fb-1fea7b5c7586",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -5253,7 +5395,7 @@
            }
         ],
         "created_on":"2019-01-07T16:08:05.517751Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5262,7 +5404,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5270,24 +5412,24 @@
         },
         "modified_on":"2019-01-07T16:08:05.517782Z",
         "date":"2052-07-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"North East LEP.",
            "id":"483a3271-8825-e511-b6bc-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Digital Trade Advisers One-to-One",
            "id":"56c42f6d-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -5295,30 +5437,32 @@
         "subject":"nihil|4eb6dd0d-7398-44ca-80f2-18fac2875474",
         "notes":"Quod hic voluptates placeat sint.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"ef3d9929-b13a-4c3e-a01c-3f599237bccf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Angie Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
            "first_name":"Angie",
            "last_name":"Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
            "job_title":"Direct Branding Coordinator",
            "id":"fb434ee2-e723-468b-a0f2-20ea9a196728"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Angie Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
               "first_name":"Angie",
               "last_name":"Rutherford|a755626a-6d82-4ce8-8c66-2c30d760bfc1",
@@ -5327,19 +5471,19 @@
            }
         ],
         "created_on":"2018-12-07T16:23:41.875215Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Greenfelder and Sons",
            "id":"3c482095-da33-4aff-9a40-02d922ef4025"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5347,13 +5491,13 @@
         },
         "modified_on":"2018-12-07T16:23:41.875246Z",
         "date":"2052-05-01",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Bob Manning",
            "first_name":"Bob",
            "last_name":"Manning",
            "id":"54b8bc28-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Rabat Morocco",
            "id":"2e6e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -5361,7 +5505,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - UK Based",
            "id":"9584b82b-3499-e211-a939-e4115bead28a"
         },
@@ -5369,30 +5513,32 @@
         "subject":"at|095eae01-ce9d-40b5-a69e-f65ccfa00147",
         "notes":"Itaque beatae qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"0df938cf-c94a-4726-b29c-668a02d6f543",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "first_name":"Margaret",
            "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
            "job_title":"Chief Identity Orchestrator",
            "id":"e2b88408-57ef-4bb6-8103-1a2709f59d08"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Margaret Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
               "first_name":"Margaret",
               "last_name":"Ernser|bea123c5-adf8-45a8-842b-497533d53b35",
@@ -5401,7 +5547,7 @@
            }
         ],
         "created_on":"2018-11-22T17:06:38.897456Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5410,7 +5556,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5418,24 +5564,24 @@
         },
         "modified_on":"2018-11-22T17:06:38.897485Z",
         "date":"2052-01-25",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Francesca Varasano-Mitchell",
            "first_name":"Francesca",
            "last_name":"Varasano-Mitchell",
            "id":"579f25c4-ed97-e411-a839-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"TD - Infrastructure & Life Sciences",
            "id":"c8f924aa-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5443,30 +5589,32 @@
         "subject":"asperiores|8e21e6d0-5d11-4841-930c-0bc520708303",
         "notes":"Illo exercitationem accusamus quod et consequatur sunt eligendi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"8347696c-3423-4b36-8ec2-c1f6389268ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Abelardo Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
            "first_name":"Abelardo",
            "last_name":"Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
            "job_title":"Central Accountability Developer",
            "id":"911db4c4-94de-4716-bd1b-6bef5cc81a49"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Abelardo Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
               "first_name":"Abelardo",
               "last_name":"Kutch|e1c9376e-5c7a-4749-862b-961798fa5b67",
@@ -5475,7 +5623,7 @@
            }
         ],
         "created_on":"2018-11-23T08:34:41.925998Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5484,7 +5632,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5492,24 +5640,24 @@
         },
         "modified_on":"2018-11-23T08:34:41.926031Z",
         "date":"2051-11-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Audrianna Sibiski",
            "first_name":"Audrianna",
            "last_name":"Sibiski",
            "id":"6b4b0cae-c6be-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Bandar Seri Begawan Brunei",
            "id":"148433c8-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"A",
            "id":"1783ae93-b78f-e611-8c55-e4115bed50dc"
         },
@@ -5517,30 +5665,32 @@
         "subject":"quo|cc32cc25-95a6-43bd-9b57-31ea3e88ea13",
         "notes":"Nobis autem commodi at sequi.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3fa7e4b0-6ea7-4808-8a34-64c1c952dedf",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Isom Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
            "first_name":"Isom",
            "last_name":"Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
            "job_title":"Regional Optimization Administrator",
            "id":"d0372ad4-aee4-4152-844e-105be0f27beb"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Isom Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
               "first_name":"Isom",
               "last_name":"Effertz|1c66ac47-993a-47c8-9ec8-ca0e4b7d4602",
@@ -5549,7 +5699,7 @@
            }
         ],
         "created_on":"2019-01-07T15:18:05.413548Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5558,7 +5708,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5566,24 +5716,24 @@
         },
         "modified_on":"2019-01-07T15:18:05.413578Z",
         "date":"2051-11-02",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Association of Independent Music Ltd",
            "id":"35f12898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Data Hub placeholder",
            "id":"e7b4bd5a-b78f-e611-8c55-e4115bed50dc"
         },
@@ -5591,30 +5741,32 @@
         "subject":"reprehenderit|8f512bb9-aae9-440b-902d-76734e6c9b30",
         "notes":"Voluptatem reprehenderit facilis voluptatibus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"be6eb6cb-f90d-42d3-b905-5546530ec1c0",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "first_name":"Haskell",
            "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
            "job_title":"District Metrics Executive",
            "id":"e3d18647-7f07-4408-bd51-6e8a047c549f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Haskell Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
               "first_name":"Haskell",
               "last_name":"Zemlak|afb4ced6-b79c-47b7-8e3f-e96915b2e8ac",
@@ -5623,19 +5775,19 @@
            }
         ],
         "created_on":"2019-01-11T16:26:10.542231Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Flatley and Sons",
            "id":"5fbf2978-f8f5-458e-9976-24ba4e20eb28"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5643,13 +5795,13 @@
         },
         "modified_on":"2019-01-11T16:26:10.542260Z",
         "date":"2051-09-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Asmara Eritria",
            "id":"4c841eb0-9698-e211-a939-e4115bead28a"
         },
@@ -5657,7 +5809,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Export Opportunities",
            "id":"d520b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5665,30 +5817,32 @@
         "subject":"aspernatur|fc310eb3-1d03-4458-9a37-49ac76f88f33",
         "notes":"Id quos consequuntur soluta et.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"293cd3d8-8596-413e-ae2e-006ed4e7f03f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -5697,19 +5851,19 @@
            }
         ],
         "created_on":"2018-01-22T16:56:15.228497Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"McKenzie Group",
            "id":"db16b72d-6590-44de-9cd9-61fc6c34b06d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5717,13 +5871,13 @@
         },
         "modified_on":"2018-01-22T16:56:15.228527Z",
         "date":"2051-09-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Babita Shahjahan",
            "first_name":"Babita",
            "last_name":"Shahjahan",
            "id":"b434bf10-9898-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Belgrade Serbia",
            "id":"377c51d4-9698-e211-a939-e4115bead28a"
         },
@@ -5731,7 +5885,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5739,30 +5893,32 @@
         "subject":"atque",
         "notes":"Et veritatis et culpa est sit voluptates nobis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b9a42042-14a7-448d-8462-f62f6fbb44f9",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -5771,19 +5927,19 @@
            }
         ],
         "created_on":"2018-11-22T12:29:59.735863Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Tillman - Kuhic",
            "id":"da32f3c9-580e-4811-a560-a5e5a93e3c3b"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5791,13 +5947,13 @@
         },
         "modified_on":"2018-11-22T12:29:59.735893Z",
         "date":"2051-07-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Antoinette Oliver",
            "first_name":"Antoinette",
            "last_name":"Oliver",
            "id":"3d26bcfe-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Accra Ghana",
            "id":"1c6e1abc-9698-e211-a939-e4115bead28a"
         },
@@ -5805,7 +5961,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Events - Overseas",
            "id":"ccf9b82b-3499-e211-a939-e4115bead28a"
         },
@@ -5813,30 +5969,32 @@
         "subject":"commodi|5ff49bed-71c0-4cd6-a750-3179575afaa8",
         "notes":"Ab iusto adipisci error consequatur non aut earum aut.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"c1b4830f-7ee8-4b9c-9ebf-688b5dc6d948",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -5845,7 +6003,7 @@
            }
         ],
         "created_on":"2019-01-07T15:13:11.126514Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5854,7 +6012,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5862,24 +6020,24 @@
         },
         "modified_on":"2019-01-07T15:13:11.126548Z",
         "date":"2051-06-14",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Rolands Kumpins",
            "first_name":"Rolands",
            "last_name":"Kumpins",
            "id":"6a5e518d-9c98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Safety Industry Federation",
            "id":"d365239e-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Regional Tour",
            "id":"d420b92b-3499-e211-a939-e4115bead28a"
         },
@@ -5887,30 +6045,32 @@
         "subject":"voluptas|03d995ff-79d0-49d3-813e-4b7d5bd07e5f",
         "notes":"Explicabo sequi ullam eos sed neque consequatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4777e0a1-66ad-43ad-8512-c87e9a6e91ee",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Eryn Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
            "first_name":"Eryn",
            "last_name":"Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
            "job_title":"Central Interactions Coordinator",
            "id":"ea85433e-8a1b-4319-bddb-d210596f493e"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Eryn Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
               "first_name":"Eryn",
               "last_name":"Auer|5d434129-2a61-4846-9de1-27b7b3d4e53b",
@@ -5919,7 +6079,7 @@
            }
         ],
         "created_on":"2019-01-07T15:02:28.520574Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5928,7 +6088,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -5936,24 +6096,24 @@
         },
         "modified_on":"2019-01-07T15:02:28.520606Z",
         "date":"2051-06-10",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"DSO Senior Management Team",
            "id":"e9ad674d-16ad-e211-a646-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Enquiry",
            "id":"3a0bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -5961,30 +6121,32 @@
         "subject":"voluptatibus|0532b107-3079-4f8a-a742-c0df07cdfc25",
         "notes":"Reiciendis sint totam odit itaque dolor.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"d240bf42-51d2-40fa-a1cd-32f1839f927c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "first_name":"Lavina",
            "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "job_title":"Regional Usability Liaison",
            "id":"70275f9d-f432-4531-95ed-3b1891759ff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
               "first_name":"Lavina",
               "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
@@ -5993,19 +6155,19 @@
            }
         ],
         "created_on":"2018-12-07T14:02:59.118453Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Altenwerth LLC",
            "id":"7c9bc972-2158-464b-8045-7e99736ded08"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6013,13 +6175,13 @@
         },
         "modified_on":"2018-12-07T14:02:59.118481Z",
         "date":"2051-04-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Fabio Alves",
            "first_name":"Fabio",
            "last_name":"Alves",
            "id":"6f1c4b33-ab5e-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Portsmouth City Council",
            "id":"afabc904-f04d-e611-af02-e4115bead28a"
         },
@@ -6027,7 +6189,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Inbound Referral",
            "id":"9984b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6035,30 +6197,32 @@
         "subject":"natus|c041edcd-c482-4d18-a1be-372b5f1c9e15",
         "notes":"Rerum temporibus repudiandae quis dolore omnis enim.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"6bf50a7f-29b8-4312-be8a-f2aaacefd236",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -6067,19 +6231,19 @@
            }
         ],
         "created_on":"2018-02-02T14:56:40.940368Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Reichel - Lebsack",
            "id":"d25dbfef-544b-4307-8778-b43e7ce6b45e"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6087,13 +6251,13 @@
         },
         "modified_on":"2018-02-02T14:56:40.940413Z",
         "date":"2051-02-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Alastair Roberts",
            "first_name":"Alastair",
            "last_name":"Roberts",
            "id":"48e9c3b6-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"CBBC North EAST",
            "id":"602b971d-5df6-e511-888e-e4115bead28a"
         },
@@ -6101,7 +6265,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Bank Referral",
            "id":"632b8708-28b6-e611-984a-e4115bead28a"
         },
@@ -6109,30 +6273,32 @@
         "subject":"aperiam",
         "notes":"Non mollitia culpa et voluptates maiores numquam ad aut corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2ea59aac-4763-4d1a-84b8-ea0c872a15ba",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Russ Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
            "first_name":"Russ",
            "last_name":"Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
            "job_title":"Senior Operations Manager",
            "id":"3c09ad7f-1ab9-40da-a014-7bc526be3a89"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Russ Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
               "first_name":"Russ",
               "last_name":"Hirthe|6e51b95e-c37e-49cb-a7e7-f8107df68810",
@@ -6141,7 +6307,7 @@
            }
         ],
         "created_on":"2018-12-05T19:28:57.477438Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6150,7 +6316,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6158,24 +6324,24 @@
         },
         "modified_on":"2018-12-05T19:28:57.477471Z",
         "date":"2050-12-04",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"name 27 surname 27",
            "first_name":"name 27",
            "last_name":"surname 27",
            "id":"96488fac-0715-4b00-ae1a-751885abd41b"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Kinshasa Congo",
            "id":"73841eb0-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"TPU - Opportunity",
            "id":"496f0ce8-dcc9-e211-a646-e4115bead28a"
         },
@@ -6183,30 +6349,32 @@
         "subject":"dicta|2875f319-ccf9-48bf-9800-ab54be1e9f5e",
         "notes":"Molestiae nam ut libero consequatur et eaque.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"df351c54-14fb-4edf-93d3-44aa5f0085fe",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "first_name":"Noemie",
            "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
            "job_title":"Central Tactics Coordinator",
            "id":"2156e20e-06c0-4f2d-8661-ef0353f58ea0"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Noemie Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
               "first_name":"Noemie",
               "last_name":"Tremblay|359c3e04-49d4-4392-998d-be1adfa6f3c2",
@@ -6215,19 +6383,19 @@
            }
         ],
         "created_on":"2018-12-07T10:05:16.553507Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Cole LLC",
            "id":"9901b3f0-f48d-4143-a58f-e3fd792d5a38"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6235,13 +6403,13 @@
         },
         "modified_on":"2018-12-07T10:05:16.553536Z",
         "date":"2050-11-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Robert Cashmore",
            "first_name":"Robert",
            "last_name":"Cashmore",
            "id":"2fdae135-1d95-e511-a84e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Oxford City Council",
            "id":"2f958f3c-7f25-e511-b6bc-e4115bead28a"
         },
@@ -6249,7 +6417,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -6257,30 +6425,32 @@
         "subject":"beatae|4c6860f7-a230-4494-a682-fe07a6548358",
         "notes":"Amet in et.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"17eaecd4-ec91-4b05-82c1-9e6abbf8d3c2",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Favian Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
            "first_name":"Favian",
            "last_name":"Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
            "job_title":"Chief Solutions Strategist",
            "id":"8ba2e5a5-8c75-453c-b4b9-e3c0a324aa5f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Favian Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
               "first_name":"Favian",
               "last_name":"Wuckert|d2251743-0902-45c0-823c-ef3fc252e882",
@@ -6289,7 +6459,7 @@
            }
         ],
         "created_on":"2018-11-22T21:39:52.069157Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6298,7 +6468,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6306,24 +6476,24 @@
         },
         "modified_on":"2018-11-22T21:39:52.069199Z",
         "date":"2050-10-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Gary Underhill",
            "first_name":"Gary",
            "last_name":"Underhill",
            "id":"bddbf09e-c4b3-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Prague Czech Republic",
            "id":"467e43ce-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Telephone",
            "id":"72c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Aftercare (IST use only)",
            "id":"bd3d1be3-f9f7-e511-888e-e4115bead28a"
         },
@@ -6331,30 +6501,32 @@
         "subject":"placeat|ddf01d34-5bd7-4f2e-9e01-6bb6b69c8237",
         "notes":"Commodi numquam laborum aliquam aut iusto voluptate excepturi corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3485a6c5-fef4-48f7-9cdf-72aae0d95411",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Sheila Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
            "first_name":"Sheila",
            "last_name":"Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
            "job_title":"District Functionality Liaison",
            "id":"9be76d78-9df0-45b9-a233-f160e8ce5ed8"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Sheila Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
               "first_name":"Sheila",
               "last_name":"Doyle|b55ae4c6-525f-43d9-bd15-26a47dcd2ba3",
@@ -6363,7 +6535,7 @@
            }
         ],
         "created_on":"2019-01-07T16:18:24.147438Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6372,7 +6544,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6380,24 +6552,24 @@
         },
         "modified_on":"2019-01-07T16:18:24.147470Z",
         "date":"2050-08-12",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Events - Planning and Procurement",
            "id":"d0362a92-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Face to Face",
            "id":"a5d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -6405,30 +6577,32 @@
         "subject":"magnam|9677fa73-a2c1-47c4-b429-e708417f0e25",
         "notes":"Corporis vel beatae velit deleniti animi explicabo voluptate.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"b1fab69f-e517-4557-8d72-5ba05d1a6d75",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "first_name":"Lavina",
            "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
            "job_title":"Regional Usability Liaison",
            "id":"70275f9d-f432-4531-95ed-3b1891759ff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Lavina Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
               "first_name":"Lavina",
               "last_name":"Walter|18e9d7fe-a795-4b7d-b516-99b362b45ce5",
@@ -6437,7 +6611,7 @@
            }
         ],
         "created_on":"2019-01-07T13:36:57.355634Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6446,7 +6620,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6454,24 +6628,24 @@
         },
         "modified_on":"2019-01-07T13:36:57.355667Z",
         "date":"2050-07-21",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"City of Lincoln Council",
            "id":"01688297-1353-e611-af02-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -6479,30 +6653,32 @@
         "subject":"qui|629d1aed-6060-4f86-a420-85e471a23723",
         "notes":"Quia sint voluptatibus et laborum qui beatae sint.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"827348a9-d059-4a94-b797-9c7d2025c06f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "first_name":"Carolanne",
            "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
            "job_title":"Investor Interactions Specialist",
            "id":"eb91fb28-8fa4-48af-8d61-24345732a199"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Carolanne Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
               "first_name":"Carolanne",
               "last_name":"Dicki|1e10010d-c19f-4e54-9934-a745f400b521",
@@ -6511,19 +6687,19 @@
            }
         ],
         "created_on":"2019-01-08T20:40:05.793282Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Mante, Quitzon and Rodriguez",
            "id":"0be4a431-5668-438e-92ef-74901fe86d23"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6531,13 +6707,13 @@
         },
         "modified_on":"2019-01-08T20:40:05.793312Z",
         "date":"2050-07-08",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Group Resources - Support Team",
            "id":"18374ae0-9698-e211-a939-e4115bead28a"
         },
@@ -6545,7 +6721,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Bank Referral",
            "id":"632b8708-28b6-e611-984a-e4115bead28a"
         },
@@ -6553,30 +6729,32 @@
         "subject":"architecto|ce89d3df-9034-4672-9e1c-bde051294600",
         "notes":"Optio inventore aspernatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"cb651667-b057-4fdd-8311-72b5bdffbf9a",
-        "company":{  
-           "name":"Krajcik - Johns|6e2bbd0e-b702-4a44-8621-7f30d38b5e14",
-           "id":"c5df0ca8-2471-425c-836e-4a733e74c29a"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Beatrice Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
            "first_name":"Beatrice",
            "last_name":"Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
            "job_title":"Dynamic Optimization Supervisor",
            "id":"91ba22cb-4bb8-4cd1-8316-7df8bf0bc535"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Beatrice Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
               "first_name":"Beatrice",
               "last_name":"Crooks|4e315797-fb0b-4ff3-947f-b8efd94641b8",
@@ -6585,19 +6763,19 @@
            }
         ],
         "created_on":"2017-12-14T16:09:28.280348Z",
-        "created_by":{  
+        "created_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
            "id":"5707c18a-454a-4bd2-b14b-218761a684bc"
         },
-        "event":{  
+        "event":{
            "name":"Rosenbaum - Keeling",
            "id":"a7b4bbfb-5377-453d-8048-6623f2e0042d"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"Venu Reddy",
            "first_name":"Venu",
            "last_name":"Reddy",
@@ -6605,13 +6783,13 @@
         },
         "modified_on":"2017-12-15T17:32:27.953282Z",
         "date":"2050-05-20",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Flavia Silva",
            "first_name":"Flavia",
            "last_name":"Silva",
            "id":"64d5ee24-9998-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Midlands Aerospace Alliance",
            "id":"b779fd34-9798-e211-a939-e4115bead28a"
         },
@@ -6619,7 +6797,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - G3 (07) - Revised Action Plans",
            "id":"1ec5548f-5c9a-e411-a839-e4115bead28a"
         },
@@ -6627,30 +6805,32 @@
         "subject":"et",
         "notes":"Fuga repudiandae similique laborum eos aut illum quis saepe.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"2cdc2340-5818-4f10-a2f5-b7341df1786f",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "first_name":"Darien",
            "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
            "job_title":"Lead Infrastructure Executive",
            "id":"98ca2b3d-09d2-421c-bee5-a54cc67d4205"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Darien Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
               "first_name":"Darien",
               "last_name":"Murphy|0cc380c0-155d-4274-822b-716a1614afa0",
@@ -6659,19 +6839,19 @@
            }
         ],
         "created_on":"2018-01-23T10:30:41.308391Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Goyette - Leuschke",
            "id":"00a5da1a-44ad-4b7a-a9f1-74965f4aa6aa"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6679,13 +6859,13 @@
         },
         "modified_on":"2018-01-23T10:30:41.308421Z",
         "date":"2050-05-03",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anna Faber",
            "first_name":"Anna",
            "last_name":"Faber",
            "id":"298624f8-5619-e311-a78e-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British Embassy Sarajevo Bosnia and Herzegovina",
            "id":"d7db4cda-9698-e211-a939-e4115bead28a"
         },
@@ -6693,7 +6873,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"UK Region Local",
            "id":"9a84b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6701,30 +6881,32 @@
         "subject":"sit",
         "notes":"Esse maiores quis blanditiis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"f6223a6e-16ff-4215-8670-7aecf26dc2db",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "first_name":"Bo",
            "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
            "job_title":"Senior Web Manager",
            "id":"e0149973-7e6e-4388-b548-24a69ae7f844"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Bo Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
               "first_name":"Bo",
               "last_name":"Marks|e29cc5d4-dfb6-493e-bdef-c8ab368d2e0e",
@@ -6733,7 +6915,7 @@
            }
         ],
         "created_on":"2018-12-04T13:02:31.873298Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6742,7 +6924,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6750,24 +6932,24 @@
         },
         "modified_on":"2018-12-04T13:02:31.873327Z",
         "date":"2050-04-29",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"CDMSInstall Last name",
            "first_name":"CDMSInstall",
            "last_name":"Last name",
            "id":"419fe8a8-3e95-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"British High Commission Kingstown St Vincent",
            "id":"017c51d4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - IST Visit (IST use only)",
            "id":"42c71892-f9f7-e511-888e-e4115bead28a"
         },
@@ -6775,30 +6957,32 @@
         "subject":"voluptates|b1dfd2e8-9993-49c9-b9cc-00fc0a504e8d",
         "notes":"Esse animi autem dicta et molestiae.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"fd40eeca-5471-49c1-916e-a7d026695e0c",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "first_name":"Samara",
            "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
            "job_title":"Product Communications Orchestrator",
            "id":"32d40bf8-621f-42b2-988e-b0471fa2fff2"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Samara Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
               "first_name":"Samara",
               "last_name":"Nikolaus|380c13ef-9016-4c25-947d-621e8dc6b4fe",
@@ -6807,7 +6991,7 @@
            }
         ],
         "created_on":"2019-01-10T11:44:14.495015Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6816,7 +7000,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6824,24 +7008,24 @@
         },
         "modified_on":"2019-01-10T11:44:14.495044Z",
         "date":"2050-03-16",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Global Accounts - Adv Man - Aero, Space, Chem",
            "id":"27cab706-fb4d-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"A",
            "id":"1783ae93-b78f-e611-8c55-e4115bed50dc"
         },
@@ -6849,30 +7033,32 @@
         "subject":"aliquid|cb3e45e4-32c8-4aea-8dfd-dc230bdba06d",
         "notes":"At inventore veniam sed adipisci est aut et qui.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"cd6b82bf-99ba-4e41-9650-ec789dccde96",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "first_name":"Unique",
            "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
            "job_title":"Direct Intranet Assistant",
            "id":"f6b8ca61-915c-4df1-8379-d3d9a8b99195"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Unique Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
               "first_name":"Unique",
               "last_name":"Hansen|15932dee-22ef-4931-8dae-bb1a1a5a5ef2",
@@ -6881,7 +7067,7 @@
            }
         ],
         "created_on":"2019-01-07T16:23:04.682375Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6890,7 +7076,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6898,24 +7084,24 @@
         },
         "modified_on":"2019-01-07T16:23:04.682405Z",
         "date":"2050-02-28",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Shipbuilders & Shiprepairer Association",
            "id":"26f12898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Social Media",
            "id":"a8d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Business Proposition",
            "id":"9384b82b-3499-e211-a939-e4115bead28a"
         },
@@ -6923,30 +7109,32 @@
         "subject":"et|e1d8124f-1cbf-4fcb-9ef2-72ac917e4b40",
         "notes":"Sit neque officia cum aliquam illum et optio voluptatibus.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"626663d7-bcaa-4520-9566-ca6932c4665d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "first_name":"Andreane",
            "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
            "job_title":"Investor Mobility Executive",
            "id":"35556a6d-905b-45bd-996d-ad6b2aace586"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Andreane Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
               "first_name":"Andreane",
               "last_name":"Heaney|dd2f91e6-72be-46fe-96c0-effdab13e89e",
@@ -6955,7 +7143,7 @@
            }
         ],
         "created_on":"2018-11-22T20:52:33.863204Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6964,7 +7152,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -6972,24 +7160,24 @@
         },
         "modified_on":"2018-11-22T20:52:33.863233Z",
         "date":"2050-01-09",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Sarah Tyrrell",
            "first_name":"Sarah",
            "last_name":"Tyrrell",
            "id":"fcaf6ecd-9d2e-e411-985c-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IG - Finance & Business Planning",
            "id":"481e03d9-3450-e311-a56a-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -6997,30 +7185,32 @@
         "subject":"rerum|c1181c84-2e26-450b-bc20-e2e74eaf3368",
         "notes":"Sapiente adipisci alias eligendi esse nihil.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"448328c3-5d98-4d71-8d39-1d3f593daab8",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -7029,7 +7219,7 @@
            }
         ],
         "created_on":"2018-03-14T15:46:50.927041Z",
-        "created_by":{  
+        "created_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
@@ -7038,7 +7228,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"Zac Tolley",
            "first_name":"Zac",
            "last_name":"Tolley",
@@ -7046,24 +7236,24 @@
         },
         "modified_on":"2018-03-14T15:46:50.927075Z",
         "date":"2050-01-07",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Amy Fitzgerald",
            "first_name":"Amy",
            "last_name":"Fitzgerald",
            "id":"dc3bb3ce-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"PS8 Ltd",
            "id":"717b1ca4-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Tradeshow Access Programme (TAP) - Solo",
            "id":"fa6eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -7071,30 +7261,32 @@
         "subject":"incidunt|3ecea25c-6e9e-4492-bfc9-8ef5d0713271",
         "notes":"Consequatur enim mollitia rerum dolores et debitis repudiandae molestias consequatur.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"3fb62ec7-17f3-437d-8056-36044accca2e",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "first_name":"Garrick",
            "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
            "job_title":"Dynamic Interactions Designer",
            "id":"684b242a-c9b6-4cc6-98a8-4b6b4dd37e7f"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Garrick Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
               "first_name":"Garrick",
               "last_name":"Ebert|b5be912a-1389-456f-8b5d-a26c1b7f80a8",
@@ -7103,19 +7295,19 @@
            }
         ],
         "created_on":"2018-12-07T13:40:39.932888Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
         },
-        "event":{  
+        "event":{
            "name":"Ians event org",
            "id":"549b6feb-9745-47c8-8736-c5fa0713eb81"
         },
         "is_event":true,
         "kind":"service_delivery",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7123,13 +7315,13 @@
         },
         "modified_on":"2018-12-07T13:40:39.932919Z",
         "date":"2049-12-31",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Ann Morrison",
            "first_name":"Ann",
            "last_name":"Morrison",
            "id":"dff9bdec-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Leicester City Council",
            "id":"88c26d29-4f4e-e611-af02-e4115bead28a"
         },
@@ -7137,7 +7329,7 @@
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Significant Assistance (PIMS)",
            "id":"f56eb92b-3499-e211-a939-e4115bead28a"
         },
@@ -7145,30 +7337,32 @@
         "subject":"animi|3160aac2-2598-47f6-a620-d690aacb7b7d",
         "notes":"Et mollitia illo quo sunt eius quaerat quos officia corporis.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"4cb9cc78-0ec2-4905-9192-a901f3cb049d",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "first_name":"Reuben",
            "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "job_title":"International Directives Supervisor",
            "id":"2356a2a5-9451-49e4-b7eb-d1dcfc4ea40c"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
               "first_name":"Reuben",
               "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
@@ -7177,7 +7371,7 @@
            }
         ],
         "created_on":"2018-11-22T18:14:53.198511Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7186,7 +7380,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7194,24 +7388,24 @@
         },
         "modified_on":"2018-11-22T18:14:53.198561Z",
         "date":"2049-12-24",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Anne Weir",
            "first_name":"Anne",
            "last_name":"Weir",
            "id":"7707bef8-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"Technology, Innovation and Events",
            "id":"b7f02898-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Language and Culture Advisers One-to-One",
            "id":"e96a775a-1ff3-e411-bcbe-e4115bead28a"
         },
@@ -7219,30 +7413,32 @@
         "subject":"harum|71ecdcc0-8ea9-4f64-ac5c-2e9076c10db0",
         "notes":"Architecto et et excepturi facilis aliquid dolores ipsa.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"841ad9f4-6fa8-413f-ace6-30e4ff6ad246",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "first_name":"Mara",
            "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
            "job_title":"Chief Creative Director",
            "id":"adf5ddb4-45ee-47db-9fe0-6f5b0025a134"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Mara Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
               "first_name":"Mara",
               "last_name":"Gorczany|1fb1a5c2-6d9f-465d-a476-e499e75fa65d",
@@ -7251,7 +7447,7 @@
            }
         ],
         "created_on":"2018-11-23T08:09:40.370823Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7260,7 +7456,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7268,24 +7464,24 @@
         },
         "modified_on":"2018-11-23T08:09:40.370854Z",
         "date":"2049-12-22",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Andrew Davis",
            "first_name":"Andrew",
            "last_name":"Davis",
            "id":"d036a9da-9798-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"ST - Central and Latin America",
            "id":"706e1abc-9698-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Email/Website",
            "id":"70c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Company Visit",
            "id":"d320b92b-3499-e211-a939-e4115bead28a"
         },
@@ -7293,30 +7489,32 @@
         "subject":"blanditiis|3756618c-2b3a-4715-9708-6ed68dd54c62",
         "notes":"Deserunt tempore porro.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"7f96cfac-b3e5-4bfa-9ce2-06381b42c814",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "first_name":"Cleve",
            "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
            "job_title":"Senior Marketing Liaison",
            "id":"7701587b-e88f-4f39-874f-0bd06321f7df"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
               "first_name":"Cleve",
               "last_name":"Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
@@ -7325,7 +7523,7 @@
            }
         ],
         "created_on":"2018-11-23T11:22:32.283764Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7334,7 +7532,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7342,24 +7540,24 @@
         },
         "modified_on":"2018-11-23T11:22:32.283793Z",
         "date":"2049-09-23",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Tshegofatso Motaung",
            "first_name":"Tshegofatso",
            "last_name":"Motaung",
            "id":"cccabea2-9d98-e211-a939-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"IST - Shared Services",
            "id":"7bc40cdb-cfe9-e511-8ffa-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Letter/Fax",
            "id":"74c226d7-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Investment - Services",
            "id":"0596b92b-3499-e211-a939-e4115bead28a"
         },
@@ -7367,30 +7565,32 @@
         "subject":"aliquid|c21e49da-a0c0-4c76-ba8d-813134476067",
         "notes":"Suscipit et magni.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false
      },
-     {  
+     {
         "id":"e286e8e4-85b7-4ddc-a270-722002caf5cc",
-        "company":{  
-           "name":"Venus Ltd",
-           "id":"0f5216e0-849f-11e6-ae22-56b6b6499611"
-        },
-        "contact":{  
+        "companies": [
+          {
+            "name": "Venus Ltd",
+            "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+          }
+        ],
+        "contact":{
            "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "first_name":"Reuben",
            "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
            "job_title":"International Directives Supervisor",
            "id":"2356a2a5-9451-49e4-b7eb-d1dcfc4ea40c"
         },
-        "contacts":[  
-           {  
+        "contacts":[
+           {
               "name":"Reuben Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
               "first_name":"Reuben",
               "last_name":"Armstrong|87a00987-27cb-489d-ae67-3e583529535c",
@@ -7399,7 +7599,7 @@
            }
         ],
         "created_on":"2018-11-22T22:06:38.439436Z",
-        "created_by":{  
+        "created_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7408,7 +7608,7 @@
         "event":null,
         "is_event":null,
         "kind":"interaction",
-        "modified_by":{  
+        "modified_by":{
            "name":"DIT Staff",
            "first_name":"DIT",
            "last_name":"Staff",
@@ -7416,24 +7616,24 @@
         },
         "modified_on":"2018-11-22T22:06:38.439465Z",
         "date":"2049-05-18",
-        "dit_adviser":{  
+        "dit_adviser":{
            "name":"Peter Rippingale",
            "first_name":"Peter",
            "last_name":"Rippingale",
            "id":"611bbbcd-ccae-e511-88b6-e4115bead28a"
         },
-        "dit_team":{  
+        "dit_team":{
            "name":"UKTI Team West Midlands - Hereford and Worcester",
            "id":"9610dd28-9798-e211-a939-e4115bead28a"
         },
-        "communication_channel":{  
+        "communication_channel":{
            "name":"Video/Teleconf.",
            "id":"a7d71fdd-5d95-e211-a939-e4115bead28a"
         },
         "grant_amount_offered":null,
         "investment_project":null,
         "net_company_receipt":null,
-        "service":{  
+        "service":{
            "name":"Trade - Enquiry",
            "id":"330bba2b-3499-e211-a939-e4115bead28a"
         },
@@ -7441,11 +7641,11 @@
         "subject":"quis|f2ac81ee-041a-4438-b2da-4f44ee95d956",
         "notes":"Ratione rem consequatur non modi dolorem neque accusamus excepturi voluptatem.",
         "archived_documents_url_path":"",
-        "policy_areas":[  
+        "policy_areas":[
 
         ],
         "policy_feedback_notes":"",
-        "policy_issue_types":[  
+        "policy_issue_types":[
 
         ],
         "was_policy_feedback_provided":false

--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -57,7 +57,7 @@ var getInteractionById = function (req, res) {
 }
 
 var createInteraction = function (req, res) {
-  if (req.body.company === '4e6a4edb-55e3-4461-a88d-84d329ee7eb8') {
+  if (_.isEqual(req.body.companies, ['4e6a4edb-55e3-4461-a88d-84d329ee7eb8'])) {
     return res.json(400, interactionValidationError)
   }
 

--- a/test/sandbox/routes/v4/interaction/interaction.js
+++ b/test/sandbox/routes/v4/interaction/interaction.js
@@ -57,7 +57,7 @@ var getInteractionById = function (req, res) {
 }
 
 var createInteraction = function (req, res) {
-  if (req.body.company === '4e6a4edb-55e3-4461-a88d-84d329ee7eb8') {
+  if (_.isEqual(req.body.companies, ['4e6a4edb-55e3-4461-a88d-84d329ee7eb8'])) {
     return res.json(400, interactionValidationError)
   }
 

--- a/test/unit/data/interactions/draft-future-meeting.json
+++ b/test/unit/data/interactions/draft-future-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "999c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/unit/data/interactions/draft-past-meeting.json
+++ b/test/unit/data/interactions/draft-past-meeting.json
@@ -1,9 +1,11 @@
 {
   "id": "888c12ee-91db-4964-908e-0f18ce823096",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contacts": [
     {
       "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",

--- a/test/unit/data/interactions/interaction-with-feedback.json
+++ b/test/unit/data/interactions/interaction-with-feedback.json
@@ -1,9 +1,11 @@
 {
   "id": "af4aac84-4d6a-47df-a733-5a54e3008c32",
-  "company": {
-    "name": "Venus Ltd",
-    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+  "companies": [
+    {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    }
+  ],
   "contact": {
     "name": "Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
     "id": "7701587b-e88f-4f39-874f-0bd06321f7df"

--- a/test/unit/data/interactions/interaction-with-referral.json
+++ b/test/unit/data/interactions/interaction-with-referral.json
@@ -2,8 +2,8 @@
   "id":"65e984ad-1ad5-4d89-9b12-71cdff5f412d",
   "companies": [
     {
-      "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-      "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+     "name": "Venus Ltd",
+     "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
     }
   ],
   "contact":{
@@ -51,6 +51,44 @@
     "name":"UKTI Team East Midlands - International Trade Team",
     "id":"9010dd28-9798-e211-a939-e4115bead28a"
   },
+  "company_referral": {
+      "id": "cc5b9953-894c-44b4-a4ac-d0f6a6f6128f",
+      "closed_by": null,
+      "closed_on": null,
+      "company": {
+          "name": "Lambda plc",
+          "id": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+      },
+      "completed_by": null,
+      "completed_on": null,
+      "contact": {
+          "name": "Johnny Cakeman",
+          "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef"
+      },
+      "created_by": {
+          "name": "Ian Leggett",
+          "contact_email": "caravans@campervans.com",
+          "dit_team": {
+              "name": "Advanced Manufacturing Sector",
+              "id": "08c14624-2f50-e311-a56a-e4115bead28a"
+          },
+          "id": "0c004222-5626-4ef6-b663-18f99fc67cd6"
+      },
+      "created_on": "2020-02-14T15:07:59.341233Z",
+      "interaction": null,
+      "notes": "Just a note about a referral",
+      "recipient": {
+          "name": "Barry Oling",
+          "contact_email": "barry@barry.com",
+          "dit_team": {
+              "name": "Aberdeen City Council",
+              "id": "cff02898-9698-e211-a939-e4115bead28a"
+          },
+          "id": "a80ff5fd-8904-4940-bf96-fe8047e34be5"
+      },
+      "status": "outstanding",
+      "subject": "I am a subject"
+    },
   "dit_participants": [
     {
       "adviser": {

--- a/test/unit/data/interactions/interaction.json
+++ b/test/unit/data/interactions/interaction.json
@@ -1,9 +1,11 @@
 {
   "id": "af4aac84-4d6a-47df-a733-5a54e3008c32",
-  "company": {
+  "companies": [
+    {
       "name": "Venus Ltd",
       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+    }
+  ],
   "contacts": [{
       "name": "Cleve Wisoky|c95c0a3f-cc44-4419-bd34-648e74d652f5",
       "id": "7701587b-e88f-4f39-874f-0bd06321f7df"

--- a/test/unit/data/interactions/policy-feedback.json
+++ b/test/unit/data/interactions/policy-feedback.json
@@ -1,9 +1,11 @@
 {
   "id": "af4aac84-4d6a-47df-a733-5a54e3008c32",
-  "company": {
+  "companies": [
+    {
       "name": "Venus Ltd",
       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
-  },
+    }
+  ],
   "contact": {
       "name": "Cleve Wisoky",
       "id": "7701587b-e88f-4f39-874f-0bd06321f7df"
@@ -60,5 +62,5 @@
   "policy_areas": [{
     "name": "p a 1",
     "id": "pa1"
-  }],
+  }]
 }

--- a/test/unit/data/interactions/search-interaction-with-feedback.json
+++ b/test/unit/data/interactions/search-interaction-with-feedback.json
@@ -1,10 +1,12 @@
 {
   "was_policy_feedback_provided": true,
   "id": "7265dc3c-e89d-45ee-8106-d1e370c1c73d",
-  "company": {
-    "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
-    "name": "Samsung"
-  },
+  "companies": [
+    {
+      "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
+      "name": "Samsung"
+    }
+  ],
   "contact": {
     "id": "b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306",
     "first_name": "Jackson",

--- a/test/unit/data/interactions/search-interaction.json
+++ b/test/unit/data/interactions/search-interaction.json
@@ -1,10 +1,12 @@
 {
   "was_policy_feedback_provided": false,
   "id": "7265dc3c-e89d-45ee-8106-d1e370c1c73d",
-  "company": {
-    "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
-    "name": "Samsung"
-  },
+  "companies": [
+    {
+      "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
+      "name": "Samsung"
+    }
+  ],
   "contact": {
     "id": "b4919d5d-8cfb-49d1-a3f8-e4eb4b61e306",
     "first_name": "Jackson",

--- a/test/unit/data/interactions/service-delivery.json
+++ b/test/unit/data/interactions/service-delivery.json
@@ -1,10 +1,12 @@
 {
   "kind": "service_delivery",
   "id": "7265dc3c-e89d-45ee-8106-d1e370c1c73d",
-  "company": {
-    "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
-    "name": "Samsung"
-  },
+  "companies": [
+    {
+      "id": "dcdabbc9-1781-e411-8955-e4115bead28a",
+      "name": "Samsung"
+    }
+  ],
   "subject": "Test interactions",
   "notes": "lorem ipsum",
   "date": "2017-05-31T00:00:00",


### PR DESCRIPTION
## Description of change

This PR ensures the Frontend uses the new interaction `companies` field instead of deprecated `company`. 
It does not change the behaviour of the app. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
