### PR TITLE
Add the missing aria-label to the timeline stage

### DIFF
--- a/src/templates/_macros/common/progress.njk
+++ b/src/templates/_macros/common/progress.njk
@@ -11,9 +11,13 @@
     <div class="c-progress">
       <ol class="c-progress-bar">
         {% for stageName in props.stageNames %}
-          <li class="c-progress__stage
-          {{- ' is-active' if props.currentStageName == stageName -}}
-          {{- ' is-complete' if loop.index0 < currentStageIndex -}}"
+          {% set stage =
+            'complete' if loop.index0 < currentStageIndex else
+            ('active' if props.currentStageName == stageName else
+            'incomplete')
+          %}
+          <li class="c-progress__stage is-{{- stage -}}"
+            aria-label="stage {{ stage }}"
           >
             <span class="c-progress__stage-title">{{ stageName }}</span>
           </li>


### PR DESCRIPTION
## Description of change

Add the missing aria-label to the _stage_ of the _timeline_ Nunjuck component.

## Test instructions

1. Go to `/investments/projects/<id>/details`
2. Enable screen reader (command+f5 on Mac)
3. Navigate to the timeline component
4. Jump between the stages of the timeline
5. The screen reader should read out information about the completeness of each particular page

There should be no visual change.
