### PR TITLE
Update collection list markup to use ordered lists

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -9,7 +9,7 @@ import { GREY_2 } from 'govuk-colours'
 import Badge from '../Badge/'
 import Metadata from '../../components/Metadata/'
 
-const ItemWrapper = styled('div')`
+const ItemWrapper = styled('li')`
   border-bottom: 1px solid ${GREY_2};
   padding: ${SPACING.SCALE_3} 0;
 `

--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -58,30 +58,33 @@ const CollectionList = ({
             entityName={entityName}
             entityNamePlural={entityNamePlural}
           />
-          {items.map(
-            (
-              { headingText, headingUrl, subheading, badges, metadata },
-              index
-            ) => (
-              <CollectionItem
-                key={[count, activePage, index].join('-')}
-                headingUrl={headingUrl}
-                headingText={headingText}
-                subheading={subheading}
-                badges={badges}
-                metadata={metadata}
-                metadataRenderer={metadataRenderer}
-              />
-            )
-          )}
-
+          <ol>
+            {items.map(
+              (
+                { headingText, headingUrl, subheading, badges, metadata },
+                index
+              ) => (
+                <CollectionItem
+                  key={[count, activePage, index].join('-')}
+                  headingUrl={headingUrl}
+                  headingText={headingText}
+                  subheading={subheading}
+                  badges={badges}
+                  metadata={metadata}
+                  metadataRenderer={metadataRenderer}
+                />
+              )
+            )}
+          </ol>
           <Task.Status {...taskProps}>
             {() =>
               isComplete && (
                 <>
-                  {results.map((item, i) => (
-                    <CollectionItem {...item} key={i} />
-                  ))}
+                  <ol>
+                    {results.map((item, i) => (
+                      <CollectionItem {...item} key={i} />
+                    ))}
+                  </ol>
                   <Pagination
                     totalPages={totalPages}
                     onPageClick={onPageClick}

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -82,9 +82,11 @@ const FilteredCollectionList = ({
                   {() =>
                     isComplete && (
                       <>
-                        {results.map((item) => (
-                          <CollectionItem {...item} key={item.id} />
-                        ))}
+                        <ol>
+                          {results.map((item) => (
+                            <CollectionItem {...item} key={item.id} />
+                          ))}
+                        </ol>
                         <RoutedPagination
                           qsParamName="page"
                           totalPages={totalPages}


### PR DESCRIPTION
## Description of change

Currently all React collection lists are marked up incorrectly. We need all the list items to be inside an ordered list as this will enhance accessibility. 

## Test instructions
1. Visit any React collection list and visually nothing should change

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
