### PR TITLE
Lep e2e dynamic data

### DIFF
--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -24,15 +24,16 @@ describe('Collection', () => {
     })
   })
 
-  /* describe('contact', () => {
+  describe('contact', () => {
     before(() => {
       cy.visit(contacts.index())
     })
 
     it('should return the results summary for a contact collection', () => {
-      cy.get('[data-test="collectionCount"]').should('have.text', '7')
+      // result could be 7 or more given we add contacts on permission spec
+      cy.get('[data-test="collectionCount"]').should('be.gte', '7')
     })
-  }) */
+  })
 
   context('investment', () => {
     describe('projects', () => {

--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -3,7 +3,7 @@ const selectors = require('../../../../selectors')
 
 const {
   companies,
-  // contacts,
+  contacts,
   investments,
 } = require('../../../../../src/lib/urls')
 
@@ -31,7 +31,11 @@ describe('Collection', () => {
 
     it('should return the results summary for a contact collection', () => {
       // result could be 7 or more given we add contacts on permission spec
-      cy.get('[data-test="collectionCount"]').should('be.gte', '7')
+      cy.get('[data-test="collectionCount"]')
+        .invoke('text')
+        .then((count) => {
+          expect(parseInt(count)).to.be.gte(7)
+        })
     })
   })
 

--- a/test/end-to-end/cypress/specs/LEP/collection-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/collection-spec.js
@@ -30,7 +30,8 @@ describe('Collection', () => {
     })
 
     it('should return the results summary for a contact collection', () => {
-      cy.get('[data-test="collectionCount"]').should('have.text', '7')
+      // result could be 7 or more given we add contacts on permission spec
+      cy.get('[data-test="collectionCount"]').should('be.gte', '7')
     })
   })
 

--- a/test/end-to-end/cypress/specs/LEP/collection-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/collection-spec.js
@@ -31,7 +31,11 @@ describe('Collection', () => {
 
     it('should return the results summary for a contact collection', () => {
       // result could be 7 or more given we add contacts on permission spec
-      cy.get('[data-test="collectionCount"]').should('be.gte', '7')
+      cy.get('[data-test="collectionCount"]')
+        .invoke('text')
+        .then((count) => {
+          expect(parseInt(count)).to.be.gte(7)
+        })
     })
   })
 

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -12,8 +12,11 @@ const { assertLocalNav } = require('../../support/assertions')
 
 describe('LEP Permission', () => {
   describe('activity', () => {
+    const company = fixtures.company.create.corp()
+
     before(() => {
-      cy.visit(companies.detail(fixtures.company.oneListCorp.id))
+      cy.loadFixture([company])
+      cy.visit(companies.detail(company.pk))
     })
 
     it('should display LEP only tabs', () => {
@@ -41,8 +44,13 @@ describe('LEP Permission', () => {
   })
 
   describe('contact details', () => {
+    const company = fixtures.company.create.defaultCompany('local nav lep')
+    const contact = fixtures.contact.create(company.pk)
+
     before(() => {
-      cy.visit(contacts.details(fixtures.contact.johnnyCakeman.id))
+      cy.loadFixture([company])
+      cy.loadFixture([contact])
+      cy.visit(contacts.details(contact.pk))
     })
 
     it('should display LEP only tabs', () => {

--- a/test/end-to-end/cypress/specs/LEP/permission-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/permission-spec.js
@@ -110,7 +110,7 @@ describe('LEP Permission', () => {
 
   context('investment', () => {
     describe('investment document', () => {
-      investmentProjectNewZoo = fixtures.investmentProject.create.newZoo()
+      investmentProjectNewZoo = fixtures.investmentProject.create.newZooLEP()
 
       before(() => {
         cy.loadFixture([investmentProjectNewGolf])
@@ -127,7 +127,7 @@ describe('LEP Permission', () => {
 
     describe('interaction', () => {
       investmentProjectNewGolf =
-        fixtures.investmentProject.create.newGolfCourse()
+        fixtures.investmentProject.create.newGolfCourseDA()
 
       before(() => {
         cy.loadFixture([investmentProjectNewZoo])

--- a/test/end-to-end/cypress/specs/LEP/permission-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/permission-spec.js
@@ -110,13 +110,13 @@ describe('LEP Permission', () => {
 
   context('investment', () => {
     describe('investment document', () => {
+      investmentProjectNewZoo = fixtures.investmentProject.create.newZoo()
+
       before(() => {
-        cy.visit(
-          investments.projects.documents(fixtures.investmentProject.newZoo.id),
-          {
-            failOnStatusCode: false,
-          }
-        )
+        cy.loadFixture([investmentProjectNewGolf])
+        cy.visit(investments.projects.documents(investmentProjectNewZoo.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -126,14 +126,14 @@ describe('LEP Permission', () => {
     })
 
     describe('interaction', () => {
+      investmentProjectNewGolf =
+        fixtures.investmentProject.create.newGolfCourse()
+
       before(() => {
+        cy.loadFixture([investmentProjectNewZoo])
         cy.visit(
-          investments.projects.interactions.index(
-            fixtures.investmentProject.newGolfCourse.id
-          ),
-          {
-            failOnStatusCode: false,
-          }
+          investments.projects.interactions.index(investmentProjectNewGolf.pk),
+          { failOnStatusCode: false }
         )
       })
 
@@ -144,15 +144,14 @@ describe('LEP Permission', () => {
     })
 
     describe('team', () => {
+      investmentProjectFancyDress =
+        fixtures.investmentProject.create.fancyDressManufacturing()
+
       before(() => {
-        cy.visit(
-          investments.projects.team(
-            fixtures.investmentProject.fancyDressManufacturing.id
-          ),
-          {
-            failOnStatusCode: false,
-          }
-        )
+        cy.loadFixture([investmentProjectFancyDress])
+        cy.visit(investments.projects.team(investmentProjectFancyDress.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it("should prevent LEP users from accessing a team they don't have access to", () => {
@@ -164,10 +163,13 @@ describe('LEP Permission', () => {
 
   context('contacts', () => {
     describe('documents', () => {
+      const company = fixtures.company.create.defaultCompany('contact lep')
+      const contact = fixtures.contact.create(company.pk)
+
       before(() => {
-        cy.visit(contacts.documents(fixtures.contact.johnnyCakeman.id), {
-          failOnStatusCode: false,
-        })
+        cy.loadFixture([company])
+        cy.loadFixture([contact])
+        cy.visit(contacts.documents(contact.pk), { failOnStatusCode: false })
       })
 
       it('should prevent LEP users from accessing the page', () => {
@@ -177,11 +179,15 @@ describe('LEP Permission', () => {
     })
 
     describe('interactions', () => {
+      const company = fixtures.company.create.defaultCompany('contact lep')
+      const contact = fixtures.contact.create(company.pk)
+
       before(() => {
-        cy.visit(
-          contacts.contactInteractions(fixtures.contact.johnnyCakeman.id),
-          { failOnStatusCode: false }
-        )
+        cy.loadFixture([company])
+        cy.loadFixture([contact])
+        cy.visit(contacts.contactInteractions(contact.pk), {
+          failOnStatusCode: false,
+        })
       })
 
       it('should prevent LEP users from accessing the page', () => {


### PR DESCRIPTION
## Description of change

The intent of this PR is to ensure LEP e2e tests create their own data so they are more repeatable and maintainable. 

## Test instructions

make start-e2e-lep

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
