### PR TITLE
Refactor no options label at typeahead

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -43,7 +43,7 @@ const CustomMenuList = ({ children, selectProps, ...props }) => (
               },
             })
           )
-        : children}
+        : Boolean(!!selectProps.inputValue.length) && children}
     </ul>
   </MenuList>
 )


### PR DESCRIPTION
## Description of change
Refactor no option label upon clicking of React Events(Organiser), Interactions(Adviser and Teams) and Investment(Adviser) filters.

## Test instructions
1. Go to events/react then click Organiser filter.
2. Go to interactions/react then click Adviser or Teams filter.
3. Got to investment/react then click Adviser filter.

## Screenshots
### Before

![Screenshot 2021-07-26 at 16 14 26](https://user-images.githubusercontent.com/28296624/127024461-582497f8-0e3c-49d5-b282-9105cd96bbae.png)
![Screenshot 2021-07-26 at 16 15 06](https://user-images.githubusercontent.com/28296624/127024529-1bf1539b-d385-4b06-88a4-f104c0d56133.png)


### After

![Screenshot 2021-07-26 at 16 01 40](https://user-images.githubusercontent.com/28296624/127024576-fbcab44e-1260-43a7-8f19-ceb1c74f78b7.png)
![Screenshot 2021-07-26 at 15 59 51](https://user-images.githubusercontent.com/28296624/127024588-a5af4583-7199-49dd-89c4-855c8226259f.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
