### PR TITLE
Fix for flaky interaction teams filter test

### DIFF
--- a/test/functional/cypress/specs/interaction/filter-react-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-react-spec.js
@@ -6,7 +6,7 @@ import {
   clickCheckboxGroupOption,
   removeChip,
   selectFirstAdvisersTypeaheadOption,
-  selectFirstTeamsTypeaheadOption,
+  selectFirstTypeaheadOption,
   inputDateValue,
 } from '../../support/actions'
 
@@ -325,9 +325,7 @@ describe('Interactions Collections Filter', () => {
 
   context('Teams', () => {
     const teams = teamListFaker(10)
-
     const team = teams[0]
-
     const expectedPayload = {
       ...minimumPayload,
       dit_participants__team: [team.id],
@@ -360,7 +358,7 @@ describe('Interactions Collections Filter', () => {
 
       cy.visit(`${interactions.react()}?${queryString}`)
       cy.wait('@apiRequest')
-      selectFirstTeamsTypeaheadOption({
+      selectFirstTypeaheadOption({
         element: teamsFilter,
         input: team.name,
       })

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -14,20 +14,6 @@ export const selectFirstAdvisersTypeaheadOption = ({ element, input }) =>
   })
 
 /**
- * Enter `input` into an teams typeahead `element` and select the first result
- *
- * This waits for the team api request to complete before selecting the
- * first option.
- */
-export const selectFirstTeamsTypeaheadOption = ({ element, input }) =>
-  cy.get(element).within(() => {
-    cy.intercept('/api-proxy/v4/metadata/team?*').as('teamResults')
-    cy.get('div').eq(0).type(input)
-    cy.wait('@teamResults')
-    cy.get('[class*="menu"] > div').click()
-  })
-
-/**
  * Clicks the checkbox option with the given value
  */
 export const clickCheckboxGroupOption = ({ element, value }) => {


### PR DESCRIPTION
## Description of change

Fixes a flaky interaction team filter test - the old test was intercepting the request to the team autocomplete endpoint twice, so would often not resolve the second call - in addition, the returned results could not be predicted.

## Test instructions

The test should pass without flaking

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
