### PR TITLE
Fix duplicate API call by transforming data from opportunity patch

### DIFF
--- a/src/apps/investments/client/opportunities/Details/Opportunities.jsx
+++ b/src/apps/investments/client/opportunities/Details/Opportunities.jsx
@@ -93,7 +93,6 @@ const Opportunities = ({
     incompleteRequirementsFields,
     isEditingDetails,
     isEditingRequirements,
-    formSaved,
   } = details
   return (
     <Task.Status
@@ -103,7 +102,6 @@ const Opportunities = ({
       startOnRender={{
         payload: {
           opportunityId,
-          formSaved,
         },
         onSuccessDispatch: INVESTMENT_OPPORTUNITY_DETAILS__LOADED,
       }}

--- a/src/apps/investments/client/opportunities/Details/reducer.js
+++ b/src/apps/investments/client/opportunities/Details/reducer.js
@@ -15,7 +15,6 @@ const initialState = {
   details: {
     isEditingDetails: false,
     isEditingRequirements: false,
-    formSaved: false,
     detailsFields: {
       name: '',
       description: '',
@@ -107,12 +106,22 @@ export default (state = initialState, { type, result }) => {
     case INVESTMENT_OPPORTUNITY__DETAILS_CHANGE:
       return {
         ...state,
-        details: { ...state.details, ...result, formSaved: true },
+        details: {
+          ...state.details,
+          ...result,
+          isEditingDetails: false,
+          isEditingRequirements: false,
+        },
       }
     case INVESTMENT_OPPORTUNITY__REQUIREMENTS_CHANGE:
       return {
         ...state,
-        details: { ...state.details, ...result, formSaved: true },
+        details: {
+          ...state.details,
+          ...result,
+          isEditingDetails: false,
+          isEditingRequirements: false,
+        },
       }
     default:
       return state

--- a/src/apps/investments/client/opportunities/Details/tasks.js
+++ b/src/apps/investments/client/opportunities/Details/tasks.js
@@ -57,9 +57,7 @@ export function saveOpportunityDetails({ values, opportunityId }) {
       description: values.description,
       opportunity_value: values.opportunityValue,
     })
-    .then(({ data }) => {
-      return data
-    })
+    .then(({ data }) => transformInvestmentOpportunityDetails(data))
 }
 
 export function saveOpportunityRequirements({ values, opportunityId }) {
@@ -72,7 +70,5 @@ export function saveOpportunityRequirements({ values, opportunityId }) {
       // TODO: Remove array bracket after refactoring endpoint.
       time_horizons: values.time_horizons ? [values.time_horizons] : [],
     })
-    .then(({ data }) => {
-      return data
-    })
+    .then(({ data }) => transformInvestmentOpportunityDetails(data))
 }


### PR DESCRIPTION
## Description of change

This PR fixes an issue where the `TASK_GET_OPPORTUNITY_DETAILS` task was being called twice every time an investment opportunity details page loads.

This error was caused by the `formSaved` prop being passed to the payload of the task, which had originally been introduced to force the task to run after a user had edited one of the forms on the page, as the new values they'd entered in the form weren't displaying in the summary table.

This issue was being caused by the results of the `patch` task which saves the updates to an opportunity not being transformed into the expected shape. Meaning the updated data the user has just entered in the form was not in the section of the store expected by the summary table component, therefore the old values were never overwritten.

This PR:

- Passes the result of the patch request to the existing `transformInvestmentOpportunityDetails` function in the task, which means the updated values now overwrite the previous ones in the store
- Removes the `formSaved` prop, which is no longer necessary
- Sets the two `isEditing` props to false when either form is saved to ensure the summary table is displayed

## Test instructions

1. Go to `/investments/opportunities` and choose any opportunity
2. Open the redux dev tools
3. In the list of actions, the `TASK_GET_OPPORTUNITY_DETAILS` should only have been dispatched once
4. Edit some values in the requirements form
5. Check those values are updated in the table
6. Try the same in the details form (all fields are mandatory)

_What should I see?_

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
