### PR TITLE
Fix disabled region options

### DIFF
--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -73,7 +73,7 @@ const getCompaniesMetadata = () =>
       },
     }),
     getHeadquarterTypeOptions(urls.metadata.headquarterType()),
-    getMetadataOptions(urls.metadata.ukRegion()),
+    getMetadataOptions(urls.metadata.ukRegion(), { filterDisabled: false }),
     getMetadataOptions(urls.metadata.administrativeArea(), {
       params: { country: usa },
     }),

--- a/src/apps/events/client/tasks.js
+++ b/src/apps/events/client/tasks.js
@@ -38,7 +38,7 @@ const getEvents = ({
 const getEventsMetadata = () =>
   Promise.all([
     getMetadataOptions(urls.metadata.country()),
-    getMetadataOptions(urls.metadata.ukRegion()),
+    getMetadataOptions(urls.metadata.ukRegion(), { filterDisabled: false }),
     getMetadataOptions(urls.metadata.eventType(), { filterDisabled: false }),
   ])
     .then(([countryOptions, ukRegionOptions, eventTypeOptions]) => ({

--- a/test/functional/cypress/fakers/regions.js
+++ b/test/functional/cypress/fakers/regions.js
@@ -1,23 +1,15 @@
 import faker from 'faker'
 
-const ukRegions = [
-  'All',
-  'East Midlands',
-  'East of England',
-  'London',
-  'North East',
-  'North West',
-  'Northern Ireland',
-  'Scotland',
-  'South East',
-  'South West',
-  'UKTI Dubai Hub',
-  'Wales',
-  'West Midlands',
-  'Yorkshire and the Humber',
-]
+import { listFaker } from './utils'
 
-export const ukRegionFaker = () => ({
+export const ukRegionFaker = (overrides = {}) => ({
   id: faker.datatype.uuid(),
-  name: faker.random.arrayElement(ukRegions),
+  name: faker.lorem.words(),
+  disabled_on: null,
+  ...overrides,
 })
+
+export const ukRegionListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: ukRegionFaker, length, overrides })
+
+export default ukRegionListFaker


### PR DESCRIPTION
## Description of change

Disabled regions should appear in the companies collection list region filter

## Test instructions

Go to /companies/react and /events/react and check that the uk regions filter includes disabled regions

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
