### PR TITLE
Improve experience for screen reader users on investment form elements

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -93,6 +93,7 @@ const ProjectsCollection = ({
           options={optionMetadata.projectStageOptions}
           selectedOptions={selectedFilters.stages.options}
           data-test="stage-filter"
+          groupId="stage-filter"
         />
         <RoutedCheckboxGroupField
           legend="My projects"
@@ -150,6 +151,7 @@ const ProjectsCollection = ({
           options={optionMetadata.projectStatusOptions}
           selectedOptions={selectedFilters.statuses.options}
           data-test="project-status-filter"
+          groupId="status-filter"
         />
         <RoutedCheckboxGroupField
           legend="Type of investment"
@@ -158,6 +160,7 @@ const ProjectsCollection = ({
           options={optionMetadata.investmentTypeOptions}
           selectedOptions={selectedFilters.investmentTypes.options}
           data-test="investment-type-filter"
+          groupId="investment-type-filter"
         />
         <RoutedCheckboxGroupField
           legend="Likelihood to land"
@@ -166,6 +169,7 @@ const ProjectsCollection = ({
           options={optionMetadata.likelihoodToLandOptions}
           selectedOptions={selectedFilters.likelihoodToLand.options}
           data-test="likelihood-to-land-filter"
+          groupId="likelihood-to-land-filter"
         />
         <RoutedDateField
           label="Estimated land date before"
@@ -198,6 +202,7 @@ const ProjectsCollection = ({
           options={optionMetadata.involvementLevelOptions}
           selectedOptions={selectedFilters.involvementLevels.options}
           data-test="involvement-level-filter"
+          groupId="involvement-level-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -108,6 +108,7 @@ const CheckboxGroupField = ({
   selectedOptions = [],
   onChange = () => null,
   id,
+  groupId = '',
   maxScrollHeight = 0,
   ...props
 }) => {
@@ -130,6 +131,7 @@ const CheckboxGroupField = ({
       name={name}
       hint={hint}
       data-test={`checkbox-group-field-${name}`}
+      groupId={groupId}
       {...props}
     >
       {loading ? (
@@ -163,16 +165,18 @@ const CheckboxGroupField = ({
                     onChange(otherOptions)
                   }
                 }
+                const getCheckboxId = (name) => `field-${name}-${i + 1}`
                 return (
                   <li>
                     <Checkbox
-                      id={`field-${name}-${i + 1}`}
+                      id={getCheckboxId(name)}
                       key={optionValue}
                       name={name}
                       initialChecked={checked}
                       value={optionValue}
                       onChange={handleChange}
                       aria-label={optionLabel}
+                      aria-labelledby={`${getCheckboxId(name)} ${groupId}`}
                       {...optionProps}
                     >
                       {optionLabel}
@@ -208,6 +212,7 @@ CheckboxGroupField.propTypes = {
   onChange: PropTypes.func,
   id: PropTypes.string,
   maxScrollHeight: PropTypes.number,
+  groupId: PropTypes.string,
 }
 
 export default CheckboxGroupField

--- a/src/client/components/CheckboxGroupField/usage.md
+++ b/src/client/components/CheckboxGroupField/usage.md
@@ -8,6 +8,8 @@ If you have a lot of options to display consider using the `visibleHeight`
 property to create a scrollable area. Selected option count will only show
 when you use the `visibleHeight` property.
 
+If when a screenreader reads the label of the checkboxes in isolation it is not clear what they refer to, use the `groupId` prop to ensure the legend of the checkbox group is read after each checkbox label.
+
 ### Usage
 
 ```jsx
@@ -15,6 +17,7 @@ when you use the `visibleHeight` property.
   visibleHeight={215}
   name="countries"
   legend="What are your favourite countries?"
+  groupId="countries-filters"
   options={moreThanFiveOptions}
   selectedOptions={[
     {

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -111,7 +111,14 @@ const StyledHint = styled(HintText)`
   `}
 `
 
-const FieldInner = ({ legend, error, showBorder, children, bigLegend }) =>
+const FieldInner = ({
+  legend,
+  error,
+  showBorder,
+  children,
+  bigLegend,
+  groupId,
+}) =>
   legend ? (
     <StyledFieldset showBorder={showBorder}>
       <StyledLegend
@@ -119,6 +126,7 @@ const FieldInner = ({ legend, error, showBorder, children, bigLegend }) =>
         error={error}
         showBorder={showBorder}
         bigLegend={bigLegend}
+        id={groupId}
       >
         {legend}
       </StyledLegend>
@@ -140,6 +148,7 @@ const FieldWrapper = ({
   reduced,
   reducedPadding,
   isIE,
+  groupId,
   ...rest
 }) => (
   <StyledFormGroup
@@ -155,6 +164,7 @@ const FieldWrapper = ({
       error={error}
       showBorder={showBorder}
       bigLegend={bigLegend}
+      groupId={groupId}
     >
       {label && (
         <StyledLabel error={error} htmlFor={name}>

--- a/src/templates/_macros/form/multiple-choice-field.njk
+++ b/src/templates/_macros/form/multiple-choice-field.njk
@@ -64,6 +64,7 @@
           type="{{ props.type }}"
           name="{{ props.name }}"
           id="{{ props.fieldId }}-0"
+          aria-label="{{ option.label }}"
           value=""
           {% if not props.value %}checked{% endif %}
           {% if props.inputData.test %}
@@ -93,6 +94,7 @@
           type="{{ props.type }}"
           name="{{ props.name }}"
           value="{{ option.value }}"
+          aria-label="{{ option.label }}"
           id="{{ props.fieldId }}-{{ loop.index }}"
           {% if isSelected %}checked="checked"{% endif %}
           {% if props.hint %}aria-describedby="hint-{{ props.fieldId }}"{% endif %}


### PR DESCRIPTION
## Description of change

This PR addresses two issues in investment form elements raised by the accessibility report last year.

1. It adds an `aria-label` attributes to the nunjucks multiple-choice-field macro to ensure that the label of these fields are read out by screenreaders. This particularly addresses this issue when changing the status of an investment project.

2. It adds an `aria-labelledby` attribute to the `GroupCheckBoxField` component, which when the group is given an id via the `groupId` prop, will ensure a screen reader reads out the legend of the checkbox group after each option. This was particularly to address the checkbox filters on the investment projects collection.

## Test instructions

**For the nunjucks aria-label change**

1. Go to an investment project
2. Click the link to change the status of the project in the left of the header.
3. With voiceover or another screenreader activated, tab through the radio options.
4. The label for each radio option should be read out.

**For the checkbox aria-labelledby change**

1. Go to the investment projects collection list `/investments`
2. With voiceover or another screenreader activated, tab through the checkbox fields on the page.
3. For each one, the legend of the checkbox group should be read out after the checkbox's label

## Screenshots
No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
