### PR TITLE
Use correct query param for state / province filters

### DIFF
--- a/src/apps/companies/client/tasks.js
+++ b/src/apps/companies/client/tasks.js
@@ -43,9 +43,7 @@ const getCompanies = ({
       country,
       uk_postcode,
       uk_region,
-      administrative_area: administrativeAreas.length
-        ? administrativeAreas
-        : undefined,
+      area: administrativeAreas.length ? administrativeAreas : undefined,
       archived,
       export_to_countries,
       future_interest_countries,

--- a/test/functional/cypress/specs/companies/filter-react-spec.js
+++ b/test/functional/cypress/specs/companies/filter-react-spec.js
@@ -267,7 +267,7 @@ describe('Companies Collections Filter', () => {
       limit: 10,
       archived: false,
       sortby: 'modified_on:desc',
-      administrative_area: [state.id],
+      area: [state.id],
     }
 
     it('should filter from the url', () => {
@@ -321,7 +321,7 @@ describe('Companies Collections Filter', () => {
       limit: 10,
       archived: false,
       sortby: 'modified_on:desc',
-      administrative_area: [province.id],
+      area: [province.id],
     }
 
     it('should filter from the url', () => {


### PR DESCRIPTION
## Description of change

Uses the correct query param for state / province filtering on the new comapnies collection page.

## Test instructions

Go to /companies

When you filter by state or province, the companies should be correctly filtered.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
