### PR TITLE
Add content to title to assist with accessibility

### DIFF
--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -1,5 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import styled from 'styled-components'
+import Link from '@govuk-react/link'
+import { H3 } from '@govuk-react/heading'
+import { HEADING_SIZES } from '@govuk-react/constants'
+import VisuallyHidden from '@govuk-react/visually-hidden'
+
 import { LABELS } from './constants'
 
 import {
@@ -22,6 +28,19 @@ import {
   TASK_GET_ORDERS_LIST,
   TASK_GET_ORDERS_METADATA,
 } from './state'
+
+const StyledHeader = styled(H3)`
+  font-size: ${HEADING_SIZES.SMALL}px;
+`
+
+const StyledLinkHeader = styled(StyledHeader)`
+  & > a:link,
+  a:visited,
+  a:hover,
+  a:active {
+    text-decoration: none;
+  }
+`
 
 const OrdersCollection = ({
   payload,
@@ -49,6 +68,14 @@ const OrdersCollection = ({
     },
   }
 
+  const TitleRenderer = (title, url) => (
+    <StyledLinkHeader>
+      <Link href={url}>
+        {title} <VisuallyHidden>(Order reference)</VisuallyHidden>
+      </Link>
+    </StyledLinkHeader>
+  )
+
   return (
     <FilteredCollectionList
       {...props}
@@ -60,6 +87,7 @@ const OrdersCollection = ({
       entityName="order"
       entityNamePlural="orders"
       baseDownloadLink="/omis/export"
+      titleRenderer={TitleRenderer}
       defaultQueryParams={{
         page: 1,
         sortby: 'created_on:desc',

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -70,16 +70,15 @@ const CollectionItem = ({
       </StyledBadgesWrapper>
     )}
 
-    {titleRenderer
-      ? titleRenderer(headingText, headingUrl)
-      : (headingText, headingUrl) =>
-          headingUrl ? (
-            <StyledLinkHeader>
-              <Link href={headingUrl}>{headingText}</Link>
-            </StyledLinkHeader>
-          ) : (
-            <StyledHeader>{headingText}</StyledHeader>
-          )}
+    {titleRenderer ? (
+      titleRenderer(headingText, headingUrl)
+    ) : headingUrl ? (
+      <StyledLinkHeader>
+        <Link href={headingUrl}>{headingText}</Link>
+      </StyledLinkHeader>
+    ) : (
+      <StyledHeader>{headingText}</StyledHeader>
+    )}
 
     {subheading && <StyledSubheading>{subheading}</StyledSubheading>}
 

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -57,6 +57,7 @@ const CollectionItem = ({
   badges,
   metadata,
   metadataRenderer,
+  titleRenderer = null,
 }) => (
   <ItemWrapper data-test="collection-item">
     {badges && (
@@ -69,13 +70,16 @@ const CollectionItem = ({
       </StyledBadgesWrapper>
     )}
 
-    {headingUrl ? (
-      <StyledLinkHeader>
-        <Link href={headingUrl}>{headingText}</Link>
-      </StyledLinkHeader>
-    ) : (
-      <StyledHeader>{headingText}</StyledHeader>
-    )}
+    {titleRenderer
+      ? titleRenderer(headingText, headingUrl)
+      : (headingText, headingUrl) =>
+          headingUrl ? (
+            <StyledLinkHeader>
+              <Link href={headingUrl}>{headingText}</Link>
+            </StyledLinkHeader>
+          ) : (
+            <StyledHeader>{headingText}</StyledHeader>
+          )}
 
     {subheading && <StyledSubheading>{subheading}</StyledSubheading>}
 
@@ -86,7 +90,6 @@ const CollectionItem = ({
     )}
   </ItemWrapper>
 )
-
 CollectionItem.propTypes = {
   headingUrl: PropTypes.string,
   headingText: PropTypes.string.isRequired,
@@ -105,6 +108,7 @@ CollectionItem.propTypes = {
   ),
   type: PropTypes.string,
   metadataRenderer: PropTypes.func,
+  titleRenderer: PropTypes.func,
 }
 
 export default CollectionItem

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -35,6 +35,7 @@ const FilteredCollectionList = ({
   entityNamePlural,
   addItemUrl,
   defaultQueryParams,
+  titleRenderer = null,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
   return (
@@ -84,7 +85,11 @@ const FilteredCollectionList = ({
                       <>
                         <ol>
                           {results.map((item) => (
-                            <CollectionItem {...item} key={item.id} />
+                            <CollectionItem
+                              {...item}
+                              key={item.id}
+                              titleRenderer={titleRenderer}
+                            />
                           ))}
                         </ol>
                         <RoutedPagination
@@ -134,6 +139,7 @@ FilteredCollectionList.propTypes = {
   }),
   summary: PropTypes.object,
   defaultQueryParams: PropTypes.object,
+  titleRenderer: PropTypes.func,
 }
 
 export default FilteredCollectionList

--- a/test/functional/cypress/specs/omis/collection-react-spec.js
+++ b/test/functional/cypress/specs/omis/collection-react-spec.js
@@ -88,7 +88,7 @@ describe('Orders (OMIS) Collection List Page - React', () => {
       cy.get('@firstListItem')
         .find('h3')
         .children()
-        .should('have.text', 'TMY947/21')
+        .should('have.text', 'TMY947/21 (Order reference)')
         .should('have.attr', 'href', '/omis/111/work-order')
     })
 


### PR DESCRIPTION
## Description of change

This solves one of the issues that was raised in the accessibility audit created by the DAC (Digital accessibility centre) (page 53). This was all around adding a little more content to the describe the titles in the Orders collection list as they are currently just order references. By adding the right content users using screen readers would be able to understand what this order reference number is, without it it just sounds like a random string of characters and numbers. This additional text is hidden from sighted users however you will see it in the DOM.

Note: I have updated a functional test to capture the content change, however the test to wether its visibly shown on the screen will be captured via the VRT so no visual test should fail.

## Test instructions

1. Go to `/orders/react`
2. Inspect the html around the header on each collection list item
3. You should see a hidden `<span>(Order reference)</span>` in the DOM

## Screenshots
![Screenshot 2021-07-29 at 15 36 53](https://user-images.githubusercontent.com/10154302/127515997-37c10480-a822-42d9-94cf-4204278ed796.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
