### PR TITLE
Add sub-packages with security vulnerabilities to resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7724,9 +7724,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.7.3",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
         },
         "lowlight": {
           "version": "1.20.0",
@@ -7735,6 +7735,13 @@
           "requires": {
             "fault": "^1.0.0",
             "highlight.js": "~10.7.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            }
           }
         },
         "parse-entities": {
@@ -7789,6 +7796,18 @@
             "lowlight": "^1.14.0",
             "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            },
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "react-textarea-autosize": {
@@ -7809,6 +7828,13 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "regenerator-runtime": {
@@ -8039,9 +8065,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.7.3",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
         },
         "lowlight": {
           "version": "1.20.0",
@@ -8050,6 +8076,13 @@
           "requires": {
             "fault": "^1.0.0",
             "highlight.js": "~10.7.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            }
           }
         },
         "parse-entities": {
@@ -8104,6 +8137,18 @@
             "lowlight": "^1.14.0",
             "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            },
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "react-textarea-autosize": {
@@ -8124,6 +8169,13 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "regenerator-runtime": {
@@ -8356,9 +8408,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.7.3",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
         },
         "lowlight": {
           "version": "1.20.0",
@@ -8367,6 +8419,13 @@
           "requires": {
             "fault": "^1.0.0",
             "highlight.js": "~10.7.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            }
           }
         },
         "parse-entities": {
@@ -8436,6 +8495,18 @@
             "lowlight": "^1.14.0",
             "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            },
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "react-textarea-autosize": {
@@ -8456,6 +8527,13 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "regenerator-runtime": {
@@ -9062,9 +9140,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.7.3",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
         },
         "jsonfile": {
           "version": "6.1.0",
@@ -9082,6 +9160,13 @@
           "requires": {
             "fault": "^1.0.0",
             "highlight.js": "~10.7.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            }
           }
         },
         "parse-entities": {
@@ -9167,6 +9252,18 @@
             "lowlight": "^1.14.0",
             "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            },
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "react-textarea-autosize": {
@@ -9187,6 +9284,13 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "regenerator-runtime": {
@@ -9576,9 +9680,9 @@
           }
         },
         "highlight.js": {
-          "version": "10.7.3",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-          "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
         },
         "lowlight": {
           "version": "1.20.0",
@@ -9586,7 +9690,14 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "~10.7.0"
+            "highlight.js": "10.4.1"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            }
           }
         },
         "parse-entities": {
@@ -9637,10 +9748,22 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.1.1",
+            "highlight.js": "10.4.1",
             "lowlight": "^1.14.0",
-            "prismjs": "^1.21.0",
+            "prismjs": "1.24.0",
             "refractor": "^3.1.0"
+          },
+          "dependencies": {
+            "highlight.js": {
+              "version": "10.4.1",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+            },
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "react-textarea-autosize": {
@@ -9661,6 +9784,13 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
+          },
+          "dependencies": {
+            "prismjs": {
+              "version": "1.24.0",
+              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
+            }
           }
         },
         "regenerator-runtime": {
@@ -11793,8 +11923,7 @@
         "lodash.merge": {
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-          "dev": true
+          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "lowercase-keys": {
           "version": "2.0.0",
@@ -11860,6 +11989,14 @@
             "@wdio/utils": "7.0.0",
             "got": "^11.0.2",
             "lodash.merge": "^4.6.1"
+          },
+          "dependencies": {
+            "lodash.merge": {
+              "version": "4.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+              "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+              "dev": true
+            }
           }
         },
         "webdriverio": {
@@ -12714,8 +12851,7 @@
         "lodash.merge": {
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-          "dev": true
+          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
         },
         "lowercase-keys": {
           "version": "2.0.0",
@@ -12898,6 +13034,12 @@
               "version": "15.14.2",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.2.tgz",
               "integrity": "sha512-dvMUE/m2LbXPwlvVuzCyslTEtQ2ZwuuFClDrOQ6mp2CenCg971719PTILZ4I6bTP27xfFFc+o7x2TkLuun/MPw==",
+              "dev": true
+            },
+            "lodash.merge": {
+              "version": "4.6.2",
+              "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+              "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
               "dev": true
             }
           }
@@ -17192,17 +17334,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
-    "clipboard": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
-      "integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -19721,12 +19852,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -22569,6 +22694,13 @@
       "requires": {
         "html-minifier": "3.5.7",
         "lodash.merge": "4.6.0"
+      },
+      "dependencies": {
+        "lodash.merge": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        }
       }
     },
     "express-session": {
@@ -24056,15 +24188,6 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -24490,12 +24613,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
-    },
-    "highlight.js": {
-      "version": "9.13.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-      "dev": true
     },
     "history": {
       "version": "4.10.1",
@@ -28127,11 +28244,6 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -28379,6 +28491,14 @@
       "requires": {
         "fault": "^1.0.2",
         "highlight.js": "~9.13.0"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
+          "dev": true
+        }
       }
     },
     "lpad-align": {
@@ -28915,12 +29035,6 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
-    },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -32576,14 +32690,6 @@
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.23.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
-      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -33789,6 +33895,20 @@
         "lowlight": "~1.11.0",
         "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
+      },
+      "dependencies": {
+        "highlight.js": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
+          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
+          "dev": true
+        },
+        "prismjs": {
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+          "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+          "dev": true
+        }
       }
     },
     "react-textarea-autosize": {
@@ -34093,13 +34213,10 @@
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.17.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-          "dev": true,
-          "requires": {
-            "clipboard": "^2.0.0"
-          }
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+          "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+          "dev": true
         }
       }
     },
@@ -35194,6 +35311,12 @@
             "graceful-fs": "^4.1.6"
           }
         },
+        "merge": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+          "dev": true
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -35462,12 +35585,6 @@
           "optional": true
         }
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "optional": true
     },
     "selenium-server": {
       "version": "3.141.59",
@@ -36907,6 +37024,14 @@
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.24.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
+          "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
+          "dev": true
+        }
       }
     },
     "stream-browserify": {
@@ -38425,12 +38550,6 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
-    },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -236,8 +236,6 @@
   },
   "sasslintConfig": ".sass-lint.yml",
   "resolutions": {
-    "tar": "^4.4.8",
-    "http-proxy-agent": "^2.1.0",
     "is-plain-obj": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -236,6 +236,10 @@
   },
   "sasslintConfig": ".sass-lint.yml",
   "resolutions": {
-    "is-plain-obj": "1.1.0"
+    "is-plain-obj": "1.1.0",
+    "highlight.js": "10.4.1",
+    "prismjs": "1.24.0",
+    "merge": "2.1.1",
+    "lodash.merge": "4.6.2"
   }
 }


### PR DESCRIPTION
## Description of change

This PR addresses the [four dependabot security alerts](https://github.com/uktrade/data-hub-frontend/security/dependabot/package-lock.json/lodash.merge/open) on this repo by adding a secure version of the relevant packages to the `resolutions` object in `package.json`. 

This allows us to use a secure version of a sub-package when the package which it's used by hasn't upgraded to a secure version yet.

I have also removed three package versions from `resolutions` as higher versions of these packages are now being installed as standard through `package-lock.json`.

## Test instructions

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
