### PR TITLE
Fix/investment summary chart

### DIFF
--- a/src/client/components/DataSummaryPicker/DataSummary.jsx
+++ b/src/client/components/DataSummaryPicker/DataSummary.jsx
@@ -66,7 +66,7 @@ const DataSummary = ({
   const total = data.reduce((prev, curr) => prev + curr.value, 0)
   const chartData = data.map(({ label, value }) => ({
     id: label,
-    label,
+    label: `${label} (${value})`,
     value,
   }))
 

--- a/src/client/components/DataSummaryPicker/___stories__/DataSummaryPicker.stories.jsx
+++ b/src/client/components/DataSummaryPicker/___stories__/DataSummaryPicker.stories.jsx
@@ -11,19 +11,19 @@ const dataRanges = [
       {
         label: 'Prospect',
         id: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
-        value: 10,
+        value: 101,
         link: '#',
       },
       {
         label: 'Assigned',
         id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
-        value: 3,
+        value: 381,
         link: '#',
       },
       {
         label: 'Active',
         id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
-        value: 5,
+        value: 201,
         link: '#',
       },
       {
@@ -35,7 +35,7 @@ const dataRanges = [
       {
         label: 'Won',
         id: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
-        value: 3,
+        value: 31,
         link: '#',
       },
     ],

--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -100,7 +100,7 @@ const PersonalisedDashboard = ({
                   </DashboardToggleSection>
 
                   <DashboardToggleSection
-                    label="Investment project summary"
+                    label="Investment projects summary"
                     id="investment-project-summary-section"
                     isOpen={true}
                     data-test="investment-project-summary-section"

--- a/src/client/components/PieChart/_stories_/pieChart.stories.jsx
+++ b/src/client/components/PieChart/_stories_/pieChart.stories.jsx
@@ -8,17 +8,17 @@ const stageData = [
   {
     id: 'Prospect',
     label: 'Prospect',
-    value: 7,
+    value: 318,
   },
   {
     id: 'Assign PM',
     label: 'Assign PM',
-    value: 2,
+    value: 201,
   },
   {
     id: 'Active',
     label: 'Active',
-    value: 5,
+    value: 57,
   },
   {
     id: 'Verify win',
@@ -28,7 +28,7 @@ const stageData = [
   {
     id: 'Won',
     label: 'Won',
-    value: 2,
+    value: 21,
   },
 ]
 

--- a/src/client/components/PieChart/index.jsx
+++ b/src/client/components/PieChart/index.jsx
@@ -1,13 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import {
-  BLUE,
-  YELLOW,
-  GREEN,
-  TURQUOISE,
-  GRASS_GREEN,
-  GREY_2,
-} from 'govuk-colours'
+import { BLUE, YELLOW, GREEN, TURQUOISE, GRASS_GREEN } from 'govuk-colours'
 import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import { ResponsivePie } from '@nivo/pie'
 import styled from 'styled-components'
@@ -56,27 +49,17 @@ const PieChart = ({ data, height }) => (
       }}
       data={data}
       colors={segmentColours}
-      margin={{ top: 20, bottom: 150, left: 50, right: 50 }}
+      margin={{ top: 20, bottom: 150 }}
       startAngle={-90}
       innerRadius={0.75}
       padAngle={0}
       enableArcLabels={false}
-      arcLinkLabel="value"
-      arcLinkLabelsSkipAngle={10}
-      arcLinkLabelsOffset={3}
-      arcLinkLabelsColor={GREY_2}
-      arcLinkLabelsTextColor={GREY_2}
-      arcLinkLabelsThickness={3}
-      arcLinkLabelsDiagonalLength={9}
-      arcLinkLabelsStraightLength={12}
-      arcLinkLabelsTextOffset={2}
       isInteractive={false}
-      layers={['arcs', 'arcLinkLabels', 'legends', CentredProjectTotal]}
+      layers={['arcs', 'legends', CentredProjectTotal]}
       legends={[
         {
           anchor: 'bottom-left',
           direction: 'column',
-          translateX: -50,
           translateY: 150,
           itemWidth: 100,
           itemHeight: 18,

--- a/src/client/components/PieChart/index.jsx
+++ b/src/client/components/PieChart/index.jsx
@@ -42,7 +42,7 @@ const CentredProjectTotal = ({ dataWithArc, centerX, centerY }) => {
 
   return (
     <>
-      {centredText(total, 80, centerX, centerY - 20)}
+      {centredText(total, 60, centerX, centerY - 20)}
       {centredText('Projects', 20, centerX, centerY + 30)}
     </>
   )
@@ -56,7 +56,7 @@ const PieChart = ({ data, height }) => (
       }}
       data={data}
       colors={segmentColours}
-      margin={{ top: 20, bottom: 150 }}
+      margin={{ top: 20, bottom: 150, left: 50, right: 50 }}
       startAngle={-90}
       innerRadius={0.75}
       padAngle={0}
@@ -76,6 +76,7 @@ const PieChart = ({ data, height }) => (
         {
           anchor: 'bottom-left',
           direction: 'column',
+          translateX: -50,
           translateY: 150,
           itemWidth: 100,
           itemHeight: 18,

--- a/test/functional/cypress/specs/dashboard-new/investment-project-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/investment-project-summary-spec.js
@@ -40,10 +40,10 @@ describe('Investment projects summary', () => {
   })
 
   context('Common elements to both Chart and Table views', () => {
-    it('should display an "Investment project summary" toggle', () => {
+    it('should display an "Investment projects summary" toggle', () => {
       cy.get('[data-test=toggle-section-button-content]').should(
         'contain',
-        'Investment project summary'
+        'Investment projects summary'
       )
     })
 

--- a/test/sandbox/fixtures/v4/adviser/investment-summary.json
+++ b/test/sandbox/fixtures/v4/adviser/investment-summary.json
@@ -10,17 +10,17 @@
         "prospect": {
           "label": "Prospect",
           "id": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
-          "value": 3
+          "value": 301
         },
         "assign_pm": {
           "label": "Assign PM",
           "id": "c9864359-fb1a-4646-a4c1-97d10189fc03",
-          "value": 1
+          "value": 18
         },
         "active": {
           "label": "Active",
           "id": "7606cc19-20da-4b74-aba1-2cec0d753ad8",
-          "value": 5
+          "value": 14
         },
         "verify_win": {
           "label": "Verify Win",
@@ -30,7 +30,7 @@
         "won": {
           "label": "Won",
           "id": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6",
-          "value": 0
+          "value": 125
         }
       }
     },


### PR DESCRIPTION
## Description of change

Stops the investment project summary from cropping

## Test instructions

Go to the personliased dashboard page at / (you may need to enable the `personalised-dashboard` feature flag). Check that all of the chart labels are not cropped even when you have hundreds of projects. You can also check out storybook.

## Screenshots

### Before

![investment projects summary old](https://user-images.githubusercontent.com/1234577/128008079-985f85bf-7003-468d-9fc0-ab15790c00b8.png)

### After

![chart- no labels](https://user-images.githubusercontent.com/1234577/128149153-7317ea37-8bb1-4d60-a3fa-026e9ededd90.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
