### PR TITLE
Use correct query param for event country filter

### DIFF
--- a/src/apps/events/client/EventsCollection.jsx
+++ b/src/apps/events/client/EventsCollection.jsx
@@ -111,8 +111,8 @@ const EventsCollection = ({
         <RoutedTypeahead
           isMulti={true}
           legend={LABELS.country}
-          name="country"
-          qsParam="country"
+          name="address_country"
+          qsParam="address_country"
           placeholder="Search country"
           options={optionMetadata.countryOptions}
           selectedOptions={selectedFilters.countries.options}

--- a/src/apps/events/client/filters.js
+++ b/src/apps/events/client/filters.js
@@ -40,10 +40,10 @@ export const buildSelectedFilters = (
     }),
   },
   countries: {
-    queryParam: 'country',
+    queryParam: 'address_country',
     options: buildOptionsFilter({
       options: metadata.countryOptions,
-      value: queryParams.country,
+      value: queryParams.address_country,
       categoryLabel: LABELS.country,
     }),
   },

--- a/src/apps/events/client/tasks.js
+++ b/src/apps/events/client/tasks.js
@@ -15,7 +15,7 @@ const getEvents = ({
   organiser,
   start_date_before,
   start_date_after,
-  country,
+  address_country,
   uk_region,
   event_type,
 }) =>
@@ -28,7 +28,7 @@ const getEvents = ({
       organiser,
       start_date_before,
       start_date_after,
-      country,
+      address_country,
       uk_region,
       event_type,
     })

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -104,12 +104,12 @@ describe('events Collections Filter', () => {
       offset: 0,
       limit: 10,
       sortby: 'modified_on:desc',
-      country: [brazilCountryId],
+      address_country: [brazilCountryId],
     }
 
     it('should filter from the url', () => {
       const queryString = buildQueryString({
-        country: [brazilCountryId],
+        address_country: [brazilCountryId],
       })
       cy.intercept('POST', searchEndpoint).as('apiRequest')
       cy.visit(`${urls.events.index()}?${queryString}`)
@@ -132,7 +132,7 @@ describe('events Collections Filter', () => {
         expectedOption: 'Brazil',
       })
       assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('country', [brazilCountryId])
+      assertQueryParams('address_country', [brazilCountryId])
       assertChipExists({ label: 'Brazil', position: 1 })
       removeChip(brazilCountryId)
       assertPayload('@apiRequest', minimumPayload)
@@ -387,7 +387,7 @@ describe('events Collections Filter', () => {
       const queryString = qs.stringify({
         page: 1,
         name: 'Big Event',
-        country: [ukCountryId],
+        address_country: [ukCountryId],
         uk_region: [ukRegions[0].id],
         organiser: [adviserId],
         event_type: [eventType.id],


### PR DESCRIPTION
## Description of change

Fixes events collection list page country filter. The previous filter used the wrong query param, so the results were not properly filtered.

## Test instructions

Go to events collection list page and filter by country - results should be filtered appropriately. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
