### PR TITLE
Dashboard selects to use value from redux

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 import { Select } from '../../components'
 
-const InvestmentListFilter = ({ options, onChange }) => (
+const InvestmentListFilter = ({ initialValue, options, onChange }) => (
   <Select
     label="Stage"
     input={{
       onChange,
+      initialValue,
     }}
   >
     {options.map(({ id, name }, index) => (

--- a/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
@@ -2,11 +2,12 @@ import React from 'react'
 
 import { Select } from '../../components'
 
-const InvestmentListSort = ({ options, onChange }) => (
+const InvestmentListSort = ({ initialValue, options, onChange }) => (
   <Select
     label="Sort by"
     input={{
       onChange,
+      initialValue,
     }}
   >
     {options.map(({ value, name }, index) => (

--- a/src/client/components/MyInvestmentProjects/index.jsx
+++ b/src/client/components/MyInvestmentProjects/index.jsx
@@ -82,10 +82,12 @@ const MyInvestmentProjects = ({
       )}
       <InvestmentListFilter
         options={STAGE_OPTIONS}
+        initialValue={filter}
         onChange={(event) => onFilterChange(event.target.value)}
       />
       <InvestmentListSort
         options={SORT_OPTIONS}
+        initialValue={sort}
         onChange={(event) => onSortChange(event.target.value)}
       />
     </StyledHeader>


### PR DESCRIPTION
## Description of change

Fix for CRMD-39, as described here: https://uktrade.atlassian.net/browse/CRMD-39

Going to the personalised dashboard and switching between the "Investment projects" and "Company lists" tabs should maintain the selected filters and sort by.

## Test instructions

- Go to the personalised dashboard.
- Choose Stage and / or Sort by filters
- Go to the "Company lists" tab
- Go back to the investment projects tab
- The filters you picked should continue to be shown in the select boxes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
