### PR TITLE
CPS-217 Fix advisers interactions filter for CSV download

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -58,7 +58,7 @@ const InteractionCollection = ({
     id: ID,
     progressMessage: 'Loading advisers',
     startOnRender: {
-      payload: payload.adviser,
+      payload: payload.dit_participants__adviser,
       onSuccessDispatch: INTERACTIONS_SELECTED_ADVISERS,
     },
   }
@@ -115,7 +115,7 @@ const InteractionCollection = ({
           data-test="status-filter"
         />
         <RoutedCheckboxGroupField
-          name="dit_participants__adviser"
+          name="my_interactions"
           qsParam="dit_participants__adviser"
           options={[myInteractionsOption]}
           selectedOptions={myInteractionsSelected ? [myInteractionsOption] : []}
@@ -125,7 +125,7 @@ const InteractionCollection = ({
           taskProps={adviserListTask}
           isMulti={true}
           legend={LABELS.advisers}
-          name="adviser"
+          name="advisers"
           qsParam="dit_participants__adviser"
           placeholder="Search adviser"
           noOptionsMessage={() => <>No advisers found</>}

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -116,7 +116,7 @@ const InteractionCollection = ({
         />
         <RoutedCheckboxGroupField
           name="dit_participants__adviser"
-          qsParam="adviser"
+          qsParam="dit_participants__adviser"
           options={[myInteractionsOption]}
           selectedOptions={myInteractionsSelected ? [myInteractionsOption] : []}
           data-test="my-interactions-filter"
@@ -126,7 +126,7 @@ const InteractionCollection = ({
           isMulti={true}
           legend={LABELS.advisers}
           name="adviser"
-          qsParam="adviser"
+          qsParam="dit_participants__adviser"
           placeholder="Search adviser"
           noOptionsMessage={() => <>No advisers found</>}
           selectedOptions={selectedFilters.advisers.options}

--- a/src/apps/interactions/client/filters.js
+++ b/src/apps/interactions/client/filters.js
@@ -17,7 +17,7 @@ export const buildSelectedFilters = (
     }),
   },
   advisers: {
-    queryParam: 'adviser',
+    queryParam: 'dit_participants__adviser',
     options: selectedAdvisers.map(({ advisers }) => ({
       label: advisers.name,
       value: advisers.id,

--- a/src/apps/interactions/client/tasks.js
+++ b/src/apps/interactions/client/tasks.js
@@ -49,7 +49,7 @@ const getInteractions = ({
   limit = 10,
   page = 1,
   kind,
-  adviser,
+  dit_participants__adviser,
   service,
   date_before,
   date_after,
@@ -65,7 +65,7 @@ const getInteractions = ({
     .post('/api-proxy/v3/search/interaction', {
       limit,
       kind,
-      dit_participants__adviser: adviser,
+      dit_participants__adviser,
       offset: limit * (page - 1),
       sortby,
       date_before,

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -138,7 +138,7 @@ describe('Interactions Collections Filter', () => {
 
     it('should filter from the url', () => {
       const queryParams = buildQueryString({
-        adviser: [adviser.id],
+        dit_participants__adviser: [adviser.id],
       })
 
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
@@ -183,7 +183,7 @@ describe('Interactions Collections Filter', () => {
       cy.wait('@adviserListApiRequest')
       cy.wait('@adviserApiRequest')
       assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('adviser', [adviser.id])
+      assertQueryParams('dit_participants__adviser', [adviser.id])
       assertTypeaheadOptionSelected({
         element: advisersFilter,
         expectedOption: adviser.name,
@@ -216,7 +216,7 @@ describe('Interactions Collections Filter', () => {
     }
     it('should filter from the url', () => {
       const queryString = buildQueryString({
-        adviser: [adviser.id],
+        dit_participants__adviser: [adviser.id],
       })
       cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
       cy.visit(`${interactions.index()}?${queryString}`)


### PR DESCRIPTION
## Description of change

Fixing a live services issue whereby the advisers filter on the interactions page work, however the CSV download contains interactions without the advisers filter applied.

https://uktrade.atlassian.net/browse/CPS-217

## Test instructions

Go to interactions.
Filter by adviser(s).
The interactions should then be filtered by advisers. 
Click the 'Download' button.
The same interactions should be on the CSV, filtered by the selected advisers. 

## Checklist

## Screenshots
Filters to apply:
![image](https://user-images.githubusercontent.com/70902973/128348830-ba539dae-5e46-49d5-a0a2-e34d67ad5c88.png)

Press 'Download' to get the following screenshots.
### Before
![image](https://user-images.githubusercontent.com/70902973/128349106-e755d72d-98bd-4278-8a0b-6cc2cbd257e7.png)

### After
![image](https://user-images.githubusercontent.com/70902973/128348538-beedb987-bf05-4bb9-bcf5-03b5339b55dd.png)


[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
