### PR TITLE
Make checkbox filter legends read by screen reader

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -165,6 +165,7 @@ const CompaniesCollection = ({
           options={optionMetadata.companyStatusOptions}
           selectedOptions={selectedFilters.companyStatuses.options}
           data-test="company-status-filter"
+          groupId="company-status-filter"
         />
         <RoutedTypeahead
           isMulti={true}

--- a/src/apps/contacts/client/ContactsCollection.jsx
+++ b/src/apps/contacts/client/ContactsCollection.jsx
@@ -116,6 +116,7 @@ const ContactsCollection = ({
           options={optionMetadata.statusOptions}
           selectedOptions={selectedFilters.statuses.options}
           data-test="status-filter"
+          groupId="status-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/events/client/EventsCollection.jsx
+++ b/src/apps/events/client/EventsCollection.jsx
@@ -136,6 +136,7 @@ const EventsCollection = ({
           options={optionMetadata.eventTypeOptions}
           selectedOptions={selectedFilters.eventTypes.options}
           data-test="event-type-filter"
+          groupId="event-type-filter"
         />
       </CollectionFilters>
     </FilteredCollectionList>

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -163,6 +163,7 @@ const InteractionCollection = ({
           options={optionMetadata.serviceOptions}
           selectedOptions={selectedFilters.service.options}
           data-test="service-filter"
+          groupId="service-filter"
         />
         <RoutedTypeahead
           isMulti={true}
@@ -190,6 +191,7 @@ const InteractionCollection = ({
           options={optionMetadata.policyAreaOptions}
           selectedOptions={selectedFilters.policyArea.options}
           data-test="policy-area-filter"
+          groupId="policy-area-filter"
         />
         <RoutedCheckboxGroupField
           legend={LABELS.policyIssueType}
@@ -198,6 +200,7 @@ const InteractionCollection = ({
           options={optionMetadata.policyIssueTypeOptions}
           selectedOptions={selectedFilters.policyIssueType.options}
           data-test="policy-issue-type-filter"
+          groupId="policy-issue-type-filter"
         />
         <RoutedCheckboxGroupField
           maxScrollHeight={370}

--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -101,6 +101,7 @@ const OrdersCollection = ({
           options={optionMetadata.statusOptions}
           selectedOptions={selectedFilters.statuses.options}
           data-test="status-filter"
+          groupId="status-filter"
         />
         <RoutedInputField
           id="OrdersCollection.reference"


### PR DESCRIPTION
This PR makes the checkbox filters on collection pages screen reader-friendly by making sure that the legend of the checkbox group is read out after each individual checkbox label.

This is done by giving the legend of the group an id via the prop `groupId`, which is then passed to the `aria-labelledby` attribute of the checkbox input after the checkbox's label.

I haven't applied this to the following filters as I didn't feel reading the group legend out after each label would add value:
- `Type` on companies
- `Kind` on interactions
- `My interactions` on interactions
- `Company One List Group Tier` on interactions
- `My projects` on investment projects

This PR is a continuation of #3841  which applied this change to investment project filters, following feedback in the accessibility audit, and it was agreed it was a change that could be applied to all checkbox filters.

## Test instructions

1. Go to the collection list pages
2. With voiceover or another screenreader activated, tab through the checkbox fields on the page.
3. For each one (minus the list above), the legend of the checkbox group should be read out after the checkbox's label


## Screenshots
No visual changes. Aria-labelledby attribute should show the checkbox label id and the legend id: 

![Screenshot 2021-08-05 at 11 12 56](https://user-images.githubusercontent.com/22460823/128333410-3dac5aea-d289-4175-8e98-d8e1b630c8b6.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
