### PR TITLE
Responsive collection list filters - markup and styling

### DIFF
--- a/src/apps/companies/client/CompaniesCollection.jsx
+++ b/src/apps/companies/client/CompaniesCollection.jsx
@@ -98,7 +98,7 @@ const CompaniesCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.sector}
+          label={LABELS.sector}
           name="sector"
           qsParam="sector_descends"
           placeholder="Search sector"
@@ -108,7 +108,7 @@ const CompaniesCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.country}
+          label={LABELS.country}
           name="country"
           qsParam="country"
           placeholder="Search country"
@@ -119,7 +119,7 @@ const CompaniesCollection = ({
         {features['state-filter'] && (
           <RoutedTypeahead
             isMulti={true}
-            legend={LABELS.usState}
+            label={LABELS.usState}
             name="us_state"
             qsParam="us_state"
             placeholder="Search US state"
@@ -131,7 +131,7 @@ const CompaniesCollection = ({
         {features['province-filter'] && (
           <RoutedTypeahead
             isMulti={true}
-            legend={LABELS.canadianProvince}
+            label={LABELS.canadianProvince}
             name="canadian_province"
             qsParam="canadian_province"
             placeholder="Search Canadian province"
@@ -150,7 +150,7 @@ const CompaniesCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.ukRegion}
+          label={LABELS.ukRegion}
           name="uk_region"
           qsParam="uk_region"
           placeholder="Search UK region"
@@ -169,7 +169,7 @@ const CompaniesCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.currentlyExportingTo}
+          label={LABELS.currentlyExportingTo}
           name="export_to_countries"
           qsParam="export_to_countries"
           placeholder="Search country"
@@ -179,7 +179,7 @@ const CompaniesCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.futureCountriesOfInterest}
+          label={LABELS.futureCountriesOfInterest}
           name="future_interest_countries"
           qsParam="future_interest_countries"
           placeholder="Search country"
@@ -202,7 +202,7 @@ const CompaniesCollection = ({
         <RoutedAdvisersTypeahead
           isMulti={true}
           taskProps={leadItaGlobalAccountManagerTask}
-          legend={LABELS.leadItaOrGlobalAccountManager}
+          label={LABELS.leadItaOrGlobalAccountManager}
           name="one_list_group_global_account_manager"
           qsParam="one_list_group_global_account_manager"
           placeholder="Search adviser"

--- a/src/apps/contacts/client/ContactsCollection.jsx
+++ b/src/apps/contacts/client/ContactsCollection.jsx
@@ -81,7 +81,7 @@ const ContactsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.sector}
+          label={LABELS.sector}
           name="sector"
           qsParam="company_sector_descends"
           placeholder="Search sector"
@@ -91,7 +91,7 @@ const ContactsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.country}
+          label={LABELS.country}
           name="country"
           qsParam="address_country"
           placeholder="Search country"
@@ -101,7 +101,7 @@ const ContactsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.ukRegion}
+          label={LABELS.ukRegion}
           name="uk_region"
           qsParam="company_uk_region"
           placeholder="Search UK region"

--- a/src/apps/events/client/EventsCollection.jsx
+++ b/src/apps/events/client/EventsCollection.jsx
@@ -88,7 +88,7 @@ const EventsCollection = ({
         <RoutedAdvisersTypeahead
           isMulti={true}
           taskProps={organisersTask}
-          legend={LABELS.organiser}
+          label={LABELS.organiser}
           name="organiser"
           qsParam="organiser"
           placeholder="Search organiser"
@@ -110,7 +110,7 @@ const EventsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.country}
+          label={LABELS.country}
           name="address_country"
           qsParam="address_country"
           placeholder="Search country"
@@ -120,7 +120,7 @@ const EventsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.ukRegion}
+          label={LABELS.ukRegion}
           name="uk_region"
           qsParam="uk_region"
           placeholder="Search UK region"

--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -124,7 +124,7 @@ const InteractionCollection = ({
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
           isMulti={true}
-          legend={LABELS.advisers}
+          label={LABELS.advisers}
           name="advisers"
           qsParam="dit_participants__adviser"
           placeholder="Search adviser"
@@ -147,7 +147,7 @@ const InteractionCollection = ({
         <RoutedTeamsTypeahead
           taskProps={teamListTask}
           isMulti={true}
-          legend={LABELS.teams}
+          label={LABELS.teams}
           name="dit_participants__team"
           qsParam="dit_participants__team"
           placeholder="Search teams"
@@ -167,7 +167,7 @@ const InteractionCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.sector}
+          label={LABELS.sector}
           name="sector"
           qsParam="sector_descends"
           placeholder="Search sector"

--- a/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/FilteredLargeCapitalProfileCollection.jsx
@@ -277,7 +277,7 @@ const LargeCapitalProfileCollection = ({
             >
               <RoutedTypeahead
                 isMulti={true}
-                legend="Sector of interest"
+                label="Sector of interest"
                 name="asset-class"
                 qsParam={QS_PARAMS.assetClassesOfInterest}
                 placeholder="Search sector of interest"
@@ -287,7 +287,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Country of origin"
+                label="Country of origin"
                 name="country"
                 qsParam={QS_PARAMS.countryOfOrigin}
                 placeholder="Search country"
@@ -309,7 +309,7 @@ const LargeCapitalProfileCollection = ({
             >
               <RoutedTypeahead
                 isMulti={true}
-                legend="Investor type"
+                label="Investor type"
                 name="investor-type"
                 qsParam={QS_PARAMS.investorTypes}
                 placeholder="Search investor type"
@@ -329,7 +329,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Check clearance"
+                label="Check clearance"
                 name="required-checks-conducted"
                 qsParam={QS_PARAMS.requiredChecksConducted}
                 placeholder="Search clearance"
@@ -344,7 +344,7 @@ const LargeCapitalProfileCollection = ({
             >
               <RoutedTypeahead
                 isMulti={true}
-                legend="Deal ticket size"
+                label="Deal ticket size"
                 name="deal-ticket-size"
                 qsParam={QS_PARAMS.dealTicketSize}
                 placeholder="Search deal ticket size"
@@ -354,7 +354,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Types of investment"
+                label="Types of investment"
                 name="types-of-investment"
                 qsParam={QS_PARAMS.investmentTypes}
                 placeholder="Search types of investment"
@@ -364,7 +364,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Minimum return rate"
+                label="Minimum return rate"
                 name="minimum-return-rate"
                 qsParam={QS_PARAMS.minimumReturnRate}
                 placeholder="Search return rate"
@@ -374,7 +374,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Time horizon"
+                label="Time horizon"
                 name="time-horizon-tenor"
                 qsParam={QS_PARAMS.timeHorizon}
                 placeholder="Search time horizon"
@@ -384,7 +384,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Restrictions and conditions"
+                label="Restrictions and conditions"
                 name="restrictions-conditions"
                 qsParam={QS_PARAMS.restrictions}
                 placeholder="Search restrictions"
@@ -394,7 +394,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Construction risk"
+                label="Construction risk"
                 name="construction-risk"
                 qsParam={QS_PARAMS.constructionRisk}
                 placeholder="Search construction risk"
@@ -404,7 +404,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Minimum equity percentage"
+                label="Minimum equity percentage"
                 name="minimum-equity-percentage"
                 qsParam={QS_PARAMS.minimumEquityPercentage}
                 placeholder="Search equity percentage"
@@ -414,7 +414,7 @@ const LargeCapitalProfileCollection = ({
               />
               <RoutedTypeahead
                 isMulti={true}
-                legend="Desired deal role"
+                label="Desired deal role"
                 name="desired-deal-role"
                 qsParam={QS_PARAMS.desiredDealRole}
                 placeholder="Search desired deal role"
@@ -429,7 +429,7 @@ const LargeCapitalProfileCollection = ({
             >
               <RoutedTypeahead
                 isMulti={true}
-                legend="UK regions of interest"
+                label="UK regions of interest"
                 name="uk-regions-of-interest"
                 qsParam={QS_PARAMS.ukRegionsOfInterest}
                 placeholder="Search UK region"

--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -106,7 +106,7 @@ const ProjectsCollection = ({
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
           isMulti={true}
-          legend="Adviser"
+          label="Adviser"
           name="adviser"
           qsParam="adviser"
           placeholder="Search adviser"
@@ -116,7 +116,7 @@ const ProjectsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend="Sector"
+          label="Sector"
           name="sector"
           qsParam="sector_descends"
           placeholder="Search sector"
@@ -126,7 +126,7 @@ const ProjectsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend="Country of origin"
+          label="Country of origin"
           name="country"
           qsParam="country_investment_originates_from"
           placeholder="Search country"
@@ -136,7 +136,7 @@ const ProjectsCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend="UK region"
+          label="UK region"
           name="uk_region"
           qsParam="uk_region_location"
           placeholder="Search UK region"

--- a/src/apps/omis/client/OrdersCollection.jsx
+++ b/src/apps/omis/client/OrdersCollection.jsx
@@ -153,7 +153,7 @@ const OrdersCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.sector}
+          label={LABELS.sector}
           name="sector_descends"
           qsParam="sector_descends"
           placeholder="Search sector"
@@ -163,7 +163,7 @@ const OrdersCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.primaryMarket}
+          label={LABELS.primaryMarket}
           name="primary_market"
           qsParam="primary_market"
           placeholder="Search country"
@@ -173,7 +173,7 @@ const OrdersCollection = ({
         />
         <RoutedTypeahead
           isMulti={true}
-          legend={LABELS.ukRegion}
+          label={LABELS.ukRegion}
           name="uk_region"
           qsParam="uk_region"
           placeholder="Search UK region"

--- a/src/client/components/CheckboxGroupField/index.jsx
+++ b/src/client/components/CheckboxGroupField/index.jsx
@@ -3,12 +3,24 @@ import MultiChoice from '@govuk-react/multi-choice'
 import PropTypes from 'prop-types'
 import { GREY_2, YELLOW } from 'govuk-colours'
 import styled, { css } from 'styled-components'
-import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+import {
+  FONT_SIZE,
+  SPACING,
+  FONT_WEIGHTS,
+  BREAKPOINTS,
+} from '@govuk-react/constants'
 
 import Checkbox from '../Checkbox'
 import FieldWrapper from '../Form/elements/FieldWrapper'
 
 const checkboxGroupElementStyles = css`
+  legend {
+    font-size: ${FONT_SIZE.SIZE_16};
+    font-weight: ${FONT_WEIGHTS.bold};
+    @media (min-width: ${BREAKPOINTS.TABLET}) {
+      font-size: ${FONT_SIZE.SIZE_19};
+    }
+  }
   label {
     font-weight: normal;
     margin-bottom: 4px;
@@ -54,6 +66,13 @@ const StyledFieldWrapper = styled(FieldWrapper)`
   ${({ maxScrollHeight }) =>
     maxScrollHeight
       ? `
+      fieldset > legend {
+        font-size: ${FONT_SIZE.SIZE_16};
+        font-weight: ${FONT_WEIGHTS.bold};
+        @media (min-width: ${BREAKPOINTS.TABLET}) {
+          font-size: ${FONT_SIZE.SIZE_19};
+        }
+      }
       fieldset > div {
         overflow-y: scroll;
         max-height: ${maxScrollHeight}px;

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -4,7 +4,7 @@ import qs from 'qs'
 import { Route } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { FONT_WEIGHTS } from '@govuk-react/constants'
+import { FONT_WEIGHTS, LINE_HEIGHT } from '@govuk-react/constants'
 
 import FieldWrapper from '../Form/elements/FieldWrapper'
 import Typeahead from '../Typeahead/Typeahead'
@@ -12,6 +12,7 @@ import Typeahead from '../Typeahead/Typeahead'
 const StyledFieldWrapper = styled(FieldWrapper)`
   label {
     font-weight: ${FONT_WEIGHTS.bold};
+    line-height: ${LINE_HEIGHT.SIZE_16};
   }
 `
 

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -11,7 +11,7 @@ import Typeahead from '../Typeahead/Typeahead'
 
 const StyledFieldWrapper = styled(FieldWrapper)`
   label {
-    font-weight: ${FONT_WEIGHTS.regular};
+    font-weight: ${FONT_WEIGHTS.bold};
   }
 `
 

--- a/src/client/components/Typeahead/styles.js
+++ b/src/client/components/Typeahead/styles.js
@@ -15,14 +15,13 @@ import {
   MEDIA_QUERIES,
   FONT_SIZE,
   FONT_WEIGHTS,
-  LINE_HEIGHT,
 } from '@govuk-react/constants'
 
 const defaultStyles = {
   option: (styles, { isFocused }) => ({
     ...styles,
     fontSize: FONT_SIZE.SIZE_16,
-    lineHeight: LINE_HEIGHT.SIZE_16,
+
     fontWeight: FONT_WEIGHTS.regular,
     borderBottom: `1px solid ${BLACK}`,
     borderRadius: 0,
@@ -32,7 +31,6 @@ const defaultStyles = {
     backgroundColor: isFocused ? BLUE : WHITE,
     [MEDIA_QUERIES.TABLET]: {
       fontSize: FONT_SIZE.SIZE_19,
-      lineHeight: LINE_HEIGHT.SIZE_19,
     },
     '&:last-of-type': {
       borderBottom: 0,

--- a/src/client/components/Typeahead/styles.js
+++ b/src/client/components/Typeahead/styles.js
@@ -15,12 +15,14 @@ import {
   MEDIA_QUERIES,
   FONT_SIZE,
   FONT_WEIGHTS,
+  LINE_HEIGHT,
 } from '@govuk-react/constants'
 
 const defaultStyles = {
   option: (styles, { isFocused }) => ({
     ...styles,
     fontSize: FONT_SIZE.SIZE_16,
+    lineHeight: LINE_HEIGHT.SIZE_16,
     fontWeight: FONT_WEIGHTS.regular,
     borderBottom: `1px solid ${BLACK}`,
     borderRadius: 0,
@@ -30,6 +32,7 @@ const defaultStyles = {
     backgroundColor: isFocused ? BLUE : WHITE,
     [MEDIA_QUERIES.TABLET]: {
       fontSize: FONT_SIZE.SIZE_19,
+      lineHeight: LINE_HEIGHT.SIZE_19,
     },
     '&:last-of-type': {
       borderBottom: 0,

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -191,7 +191,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Sector',
+        label: 'Sector',
         placeholder: 'Search sector',
         input: 'aero',
         expectedOption: 'Aerospace',
@@ -239,7 +239,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Country',
+        label: 'Country',
         placeholder: 'Search country',
         input: 'braz',
         expectedOption: 'Brazil',
@@ -293,7 +293,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'US state',
+        label: 'US state',
         placeholder: 'Search US state',
         input: state.name,
         expectedOption: state.name,
@@ -354,7 +354,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Canadian province',
+        label: 'Canadian province',
         placeholder: 'Search Canadian province',
         input: province.name,
         expectedOption: province.name,
@@ -420,7 +420,7 @@ describe('Companies Collections Filter', () => {
       testTypeaheadOptionsLength({ element, length: ukRegions.length })
       testTypeahead({
         element,
-        legend: 'UK region',
+        label: 'UK region',
         placeholder: 'Search UK region',
         input: ukRegion.name,
         expectedOption: ukRegion.name,
@@ -544,7 +544,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Currently exporting to',
+        label: 'Currently exporting to',
         placeholder: 'Search country',
         input: 'braz',
         expectedOption: 'Brazil',
@@ -593,7 +593,7 @@ describe('Companies Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Future countries of interest',
+        label: 'Future countries of interest',
         placeholder: 'Search country',
         input: 'braz',
         expectedOption: 'Brazil',

--- a/test/functional/cypress/specs/contacts/filter-spec.js
+++ b/test/functional/cypress/specs/contacts/filter-spec.js
@@ -196,7 +196,7 @@ describe('Contacts Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Sector',
+        label: 'Sector',
         placeholder: 'Search sector',
         input: 'aero',
         expectedOption: 'Aerospace',
@@ -251,7 +251,7 @@ describe('Contacts Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Country',
+        label: 'Country',
         placeholder: 'Search country',
         input: 'bra',
         expectedOption: 'Brazil',
@@ -306,7 +306,7 @@ describe('Contacts Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'UK region',
+        label: 'UK region',
         placeholder: 'Search UK region',
         input: 'lon',
         expectedOption: 'London',

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -126,7 +126,7 @@ describe('events Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Country',
+        label: 'Country',
         placeholder: 'Search country',
         input: 'braz',
         expectedOption: 'Brazil',
@@ -184,7 +184,7 @@ describe('events Collections Filter', () => {
       testTypeaheadOptionsLength({ element, length: ukRegions.length })
       testTypeahead({
         element,
-        legend: 'UK region',
+        label: 'UK region',
         placeholder: 'Search UK region',
         input: ukRegion.name,
         expectedOption: ukRegion.name,

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -388,7 +388,7 @@ describe('Interactions Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Sector',
+        label: 'Sector',
         placeholder: 'Search sector',
         input: 'aero',
         expectedOption: 'Aerospace',

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -118,7 +118,7 @@ describe('Investments Collections Filter', () => {
     it('should filter by advisers', () => {
       cy.get('@adviserFilter')
         .should('contain', 'Search adviser')
-        .find('legend')
+        .find('label')
         .should('have.text', 'Adviser')
 
       selectFirstAdvisersTypeaheadOption({
@@ -137,7 +137,7 @@ describe('Investments Collections Filter', () => {
     it('should filter by sector', () => {
       testTypeahead({
         element: '@sectorFilter',
-        legend: 'Sector',
+        label: 'Sector',
         placeholder: 'Search sector',
         input: 'adv',
         expectedOption: 'Advanced Engineering',
@@ -152,7 +152,7 @@ describe('Investments Collections Filter', () => {
     it('should filter by country', () => {
       testTypeahead({
         element: '@countryFilter',
-        legend: 'Country of origin',
+        label: 'Country of origin',
         placeholder: 'Search country',
         input: 'sin',
         expectedOption: 'Singapore',
@@ -167,7 +167,7 @@ describe('Investments Collections Filter', () => {
     it('should filter by uk region', () => {
       testTypeahead({
         element: '@ukRegionFilter',
-        legend: 'UK region',
+        label: 'UK region',
         placeholder: 'Search UK region',
         input: 'sou',
         expectedOption: 'South East',

--- a/test/functional/cypress/specs/omis/filter-react-spec.js
+++ b/test/functional/cypress/specs/omis/filter-react-spec.js
@@ -450,7 +450,7 @@ describe('Orders Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Sector',
+        label: 'Sector',
         placeholder: 'Search sector',
         input: 'aero',
         expectedOption: 'Aerospace',
@@ -492,7 +492,7 @@ describe('Orders Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'Market (country)',
+        label: 'Market (country)',
         placeholder: 'Search country',
         input: 'bra',
         expectedOption: 'Brazil',
@@ -535,7 +535,7 @@ describe('Orders Collections Filter', () => {
 
       testTypeahead({
         element,
-        legend: 'UK region',
+        label: 'UK region',
         placeholder: 'Search UK region',
         input: 'lon',
         expectedOption: 'London',

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -462,13 +462,13 @@ const assertCheckboxGroupNoneSelected = (element) => {
 /**
  * Asserts that a typeahead `element` has the given `legend` and `placeholder`
  */
-const assertTypeaheadHints = ({ element, legend, placeholder }) => {
-  cy.get(element)
-    .find('legend')
-    .should('have.text', legend)
+const assertTypeaheadHints = ({ element, legend, label, placeholder }) =>
+  cy
+    .get(element)
+    .find(`${label ? 'label' : 'legend'}`)
+    .should('have.text', label ? label : legend)
     .next()
     .should('contain', placeholder)
-}
 
 /**
  * Asserts that the typeahead `element` has the `expectedOption` selected

--- a/test/functional/cypress/support/tests.js
+++ b/test/functional/cypress/support/tests.js
@@ -19,8 +19,9 @@ export const testTypeahead = ({
   placeholder,
   input,
   expectedOption,
+  label,
 }) => {
-  assertTypeaheadHints({ element, legend, placeholder })
+  assertTypeaheadHints({ element, legend, label, placeholder })
   selectFirstTypeaheadOption({ element, input })
   assertTypeaheadOptionSelected({ element, expectedOption })
 }


### PR DESCRIPTION
## Description of change

A responsive and consistent legend/labels of collection list filters(Companies, Contacts, Events, Interactions, Investments, Orders).

## Test instructions

1. Go to either /companies, /contacts, /events, /interactions, /investments url path.
2. Go to browser developers tools using MAC shortcut keys(`Option+Command`)
3. Next pressing shortcut keys(`Command+Shift+C`) to inspect the elements.
4. Then hover a collection filters label/legend, expect `Font size` equal to `19px`(Desktop/Tablet) and `16px`(Mobile).
5. Expected markups for checkbox group field filters must be `fieldset legend` and Typeahead must be `label`

## Screenshots
### Before

![Screenshot 2021-08-04 at 09 09 49](https://user-images.githubusercontent.com/28296624/128374717-abb2416f-3ec8-4913-a8c0-653e97d0762a.png)


### After
Desktop
![Screenshot 2021-08-05 at 16 07 28](https://user-images.githubusercontent.com/28296624/128374405-76fa6f46-28b1-497e-bdef-d9d34169058d.png)

Mobile
![Screenshot 2021-08-05 at 16 09 20](https://user-images.githubusercontent.com/28296624/128374454-e897d152-6cab-4e96-8471-f6692da604ad.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
