### PR TITLE
Add prop to conditionally move badge to far end of container

### DIFF
--- a/src/apps/investments/client/opportunities/Details/Opportunities.jsx
+++ b/src/apps/investments/client/opportunities/Details/Opportunities.jsx
@@ -34,12 +34,8 @@ const StyledLabel = styled('label')`
   background: transparent;
   border: none;
   font-size: 19px;
-  float: right;
-  margin: 5px;
+  margin: 10px 5px 5px;
   color: ${(props) => props.color};
-  @media screen and (max-width: 600px) {
-    float: None;
-  }
 `
 
 const StyledDetails = styled(Details)`
@@ -70,6 +66,7 @@ const OpportunitySection = ({
       label={toggleName}
       id={`${id}_toggle`}
       badge={RequiredFields(incompleteFields)}
+      justifyHeaderContent={true}
     >
       {isEditing ? (
         <>{form}</>

--- a/src/client/components/ToggleSection/BaseToggleSection.jsx
+++ b/src/client/components/ToggleSection/BaseToggleSection.jsx
@@ -13,7 +13,10 @@ const ToggleContainer = styled('div')``
 
 export const ToggleHeader = styled('div')`
   display: flex;
-  align-items: center;
+  ${({ justifyHeaderContent }) =>
+    justifyHeaderContent
+      ? `justify-content: space-between;`
+      : `align-items: center;`}
 `
 
 export const ToggleButton = styled('button')`
@@ -62,10 +65,11 @@ const BaseToggleSection = ({
   open,
   isOpen = false,
   children,
+  justifyHeaderContent = false,
   ...props
 }) => (
   <ToggleContainer {...props}>
-    <ToggleHeader>
+    <ToggleHeader justifyHeaderContent={justifyHeaderContent}>
       <ToggleButton
         data-test="toggle-section-button"
         onClick={() => open(!isOpen)}
@@ -95,6 +99,7 @@ BaseToggleSection.propTypes = {
   isOpen: PropTypes.bool,
   children: PropTypes.node,
   major: PropTypes.bool,
+  justifyHeaderContent: PropTypes.bool,
 }
 
 export const MultiInstanceToggleSection = multiInstance({


### PR DESCRIPTION
## Description of change

This PR moves the 'Completed' and 'X fields incomplete' badges to the right side of the Opportunity toggles, as in line with designs.

## Test instructions

Go to Investments > UK opportunities > click an opportunity. The badges should sit on the far right side of the toggles, rather than right next to the toggle label. 

## Screenshots
### Before

<img width="1125" alt="Screenshot 2021-08-06 at 14 50 08" src="https://user-images.githubusercontent.com/46787754/128520432-cfa02f47-e28b-45b5-ac62-6a359217d34f.png">

### After

<img width="1070" alt="Screenshot 2021-08-06 at 15 04 00" src="https://user-images.githubusercontent.com/46787754/128522306-032ae562-8296-451e-9ae2-632f1f091d85.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
