### PR TITLE
Dependabot weekly updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7738,9 +7738,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.4.1",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -7828,13 +7828,6 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
-          },
-          "dependencies": {
-            "prismjs": {
-              "version": "1.24.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
-            }
           }
         },
         "regenerator-runtime": {
@@ -8079,9 +8072,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.4.1",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -8096,6 +8089,14 @@
             "is-alphanumerical": "^1.0.0",
             "is-decimal": "^1.0.0",
             "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "prismjs": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+          "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+          "requires": {
+            "clipboard": "^2.0.0"
           }
         },
         "react-popper": {
@@ -8169,13 +8170,6 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
-          },
-          "dependencies": {
-            "prismjs": {
-              "version": "1.24.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
-            }
           }
         },
         "regenerator-runtime": {
@@ -8422,9 +8416,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.4.1",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -8439,6 +8433,14 @@
             "is-alphanumerical": "^1.0.0",
             "is-decimal": "^1.0.0",
             "is-hexadecimal": "^1.0.0"
+          }
+        },
+        "prismjs": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+          "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+          "requires": {
+            "clipboard": "^2.0.0"
           }
         },
         "react-popper": {
@@ -8527,13 +8529,6 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
-          },
-          "dependencies": {
-            "prismjs": {
-              "version": "1.24.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
-            }
           }
         },
         "regenerator-runtime": {
@@ -9163,9 +9158,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.4.1",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-              "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -9211,6 +9206,14 @@
                 "ajv-keywords": "^3.1.0"
               }
             }
+          }
+        },
+        "prismjs": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+          "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+          "requires": {
+            "clipboard": "^2.0.0"
           }
         },
         "react-popper": {
@@ -9284,13 +9287,6 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
-          },
-          "dependencies": {
-            "prismjs": {
-              "version": "1.24.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
-            }
           }
         },
         "regenerator-runtime": {
@@ -9713,6 +9709,14 @@
             "is-hexadecimal": "^1.0.0"
           }
         },
+        "prismjs": {
+          "version": "1.23.0",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+          "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
+        },
         "react-popper": {
           "version": "2.2.5",
           "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-2.2.5.tgz",
@@ -9784,13 +9788,6 @@
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
             "prismjs": "~1.23.0"
-          },
-          "dependencies": {
-            "prismjs": {
-              "version": "1.24.0",
-              "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-              "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ=="
-            }
           }
         },
         "regenerator-runtime": {
@@ -9818,6 +9815,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
       "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "dev": true
+    },
+    "@tootallnate/once": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+      "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
       "dev": true
     },
     "@types/aria-query": {
@@ -17334,6 +17337,17 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw=="
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -19853,6 +19867,12 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "optional": true
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -20897,21 +20917,6 @@
         "es6-set": "~0.1.5",
         "es6-symbol": "~3.1.1",
         "event-emitter": "~0.3.5"
-      }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
-    },
-    "es6-promisify": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
-      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
-      "dev": true,
-      "requires": {
-        "es6-promise": "^4.0.3"
       }
     },
     "es6-set": {
@@ -22694,13 +22699,6 @@
       "requires": {
         "html-minifier": "3.5.7",
         "lodash.merge": "4.6.0"
-      },
-      "dependencies": {
-        "lodash.merge": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-        }
       }
     },
     "express-session": {
@@ -24188,6 +24186,15 @@
         }
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -24613,6 +24620,12 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
+    },
+    "highlight.js": {
+      "version": "9.13.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+      "dev": true
     },
     "history": {
       "version": "4.10.1",
@@ -25076,6 +25089,28 @@
         "requires-port": "^1.0.0"
       }
     },
+    "http-proxy-agent": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+      "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+      "dev": true,
+      "requires": {
+        "@tootallnate/once": "1",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        }
+      }
+    },
     "http-proxy-middleware": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.1.tgz",
@@ -25089,9 +25124,9 @@
       },
       "dependencies": {
         "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
         }
       }
     },
@@ -26102,6 +26137,12 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
     },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
+    },
     "is-plain-object": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
@@ -27059,36 +27100,6 @@
             "mime-types": "^2.1.12"
           }
         },
-        "http-proxy-agent": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz",
-          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
-          "dev": true,
-          "requires": {
-            "agent-base": "4",
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "agent-base": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
-              "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
-              "dev": true,
-              "requires": {
-                "es6-promisify": "^5.0.0"
-              }
-            },
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
         "https-proxy-agent": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
@@ -27098,12 +27109,6 @@
             "agent-base": "6",
             "debug": "4"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "source-map": {
           "version": "0.6.1",
@@ -28244,6 +28249,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -28494,9 +28504,9 @@
       },
       "dependencies": {
         "highlight.js": {
-          "version": "10.4.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
+          "version": "9.13.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
           "dev": true
         }
       }
@@ -29036,6 +29046,12 @@
         }
       }
     },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -29341,25 +29357,6 @@
       "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
       "requires": {
         "minipass": "^3.0.0"
-      }
-    },
-    "minizlib": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "requires": {
-        "minipass": "^2.9.0"
-      },
-      "dependencies": {
-        "minipass": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
-          }
-        }
       }
     },
     "mississippi": {
@@ -32690,6 +32687,14 @@
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.23.0.tgz",
+      "integrity": "sha512-c29LVsqOaLbBHuIbsTxaKENh1N2EQBOHaWv7gkHN4dgRbxSREqDnDbtFJYdpPauS4YCplMSNCABQ6Eeor69bAA==",
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -33897,12 +33902,6 @@
         "refractor": "^2.4.1"
       },
       "dependencies": {
-        "highlight.js": {
-          "version": "10.4.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.4.1.tgz",
-          "integrity": "sha512-yR5lWvNz7c85OhVAEAeFhVCc/GV4C30Fjzc/rCP0aCWzc1UUOPUk55dK/qdwTZHBvMZo+eZ2jpk62ndX/xMFlg==",
-          "dev": true
-        },
         "prismjs": {
           "version": "1.24.0",
           "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
@@ -34213,10 +34212,13 @@
       },
       "dependencies": {
         "prismjs": {
-          "version": "1.24.0",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.0.tgz",
-          "integrity": "sha512-SqV5GRsNqnzCL8k5dfAjCNhUrF3pR0A9lTDSCUZeh/LIshheXJEaP0hwLz2t4XHivd2J/v2HR+gRnigzeKe3cQ==",
-          "dev": true
+          "version": "1.17.1",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+          "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+          "dev": true,
+          "requires": {
+            "clipboard": "^2.0.0"
+          }
         }
       }
     },
@@ -35311,12 +35313,6 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "merge": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
-          "dev": true
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -35585,6 +35581,12 @@
           "optional": true
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "optional": true
     },
     "selenium-server": {
       "version": "3.141.59",
@@ -36264,13 +36266,13 @@
       }
     },
     "sinon": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.1.tgz",
-      "integrity": "sha512-ZSSmlkSyhUWbkF01Z9tEbxZLF/5tRC9eojCdFh33gtQaP7ITQVaMWQHGuFM7Cuf/KEfihuh1tTl3/ABju3AQMg==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.8.3",
-        "@sinonjs/fake-timers": "^7.1.0",
+        "@sinonjs/fake-timers": "^7.1.2",
         "@sinonjs/samsam": "^6.0.2",
         "diff": "^5.0.0",
         "nise": "^5.1.0",
@@ -38311,53 +38313,31 @@
           },
           "dependencies": {
             "tar": {
-              "version": "4.4.15",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.15.tgz",
-              "integrity": "sha512-ItbufpujXkry7bHH9NpQyTXPbJ72iTlXgkBAYsAjDXk3Ds8t/3NfO5P4xZGy7u+sYuQUbimgzswX4uQIEeNVOA==",
+              "version": "6.1.6",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.6.tgz",
+              "integrity": "sha512-oaWyu5dQbHaYcyZCTfyPpC+VmI62/OM2RTUYavTk1MDr1cwW5Boi3baeYQKiZbY2uSQJGr+iMOzb/JFxLrft+g==",
               "requires": {
-                "chownr": "^1.1.1",
-                "fs-minipass": "^1.2.5",
-                "minipass": "^2.8.6",
-                "minizlib": "^1.2.1",
-                "mkdirp": "^0.5.0",
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.3"
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
               },
               "dependencies": {
-                "chownr": {
-                  "version": "1.1.4",
-                  "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-                  "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-                },
-                "fs-minipass": {
-                  "version": "1.2.7",
-                  "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                  "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+                "minizlib": {
+                  "version": "2.1.2",
+                  "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+                  "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
                   "requires": {
-                    "minipass": "^2.6.0"
-                  }
-                },
-                "minipass": {
-                  "version": "2.9.0",
-                  "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                  "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-                  "requires": {
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.0"
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.5",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-                  "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-                  "requires": {
-                    "minimist": "^1.2.5"
+                    "minipass": "^3.0.0",
+                    "yallist": "^4.0.0"
                   }
                 },
                 "yallist": {
-                  "version": "3.1.1",
-                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                  "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+                  "version": "4.0.0",
+                  "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+                  "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
                 }
               }
             },
@@ -38550,6 +38530,12 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "optional": true
     },
     "tiny-invariant": {
       "version": "1.1.0",
@@ -39089,9 +39075,9 @@
           "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
         },
         "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
         }
       }
     },
@@ -41136,12 +41122,6 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
           "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,19 +17,19 @@
       "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
     },
     "@babel/core": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
-      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
+      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.14.5",
-        "@babel/helper-compilation-targets": "^7.14.5",
-        "@babel/helper-module-transforms": "^7.14.5",
-        "@babel/helpers": "^7.14.6",
-        "@babel/parser": "^7.14.6",
+        "@babel/generator": "^7.15.0",
+        "@babel/helper-compilation-targets": "^7.15.0",
+        "@babel/helper-module-transforms": "^7.15.0",
+        "@babel/helpers": "^7.14.8",
+        "@babel/parser": "^7.15.0",
         "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.14.5",
-        "@babel/types": "^7.14.5",
+        "@babel/traverse": "^7.15.0",
+        "@babel/types": "^7.15.0",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -47,26 +47,26 @@
           }
         },
         "@babel/compat-data": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-          "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.15.0.tgz",
+          "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
         },
         "@babel/generator": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
-          "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
           "requires": {
-            "@babel/types": "^7.14.5",
+            "@babel/types": "^7.15.0",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-          "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
+          "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
           "requires": {
-            "@babel/compat-data": "^7.14.5",
+            "@babel/compat-data": "^7.15.0",
             "@babel/helper-validator-option": "^7.14.5",
             "browserslist": "^4.16.6",
             "semver": "^6.3.0"
@@ -90,20 +90,12 @@
             "@babel/types": "^7.14.5"
           }
         },
-        "@babel/helper-hoist-variables": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-          "requires": {
-            "@babel/types": "^7.14.5"
-          }
-        },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-          "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.0"
           }
         },
         "@babel/helper-module-imports": {
@@ -115,18 +107,18 @@
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
-          "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
+          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
           "requires": {
             "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.14.5",
-            "@babel/helper-simple-access": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.15.0",
+            "@babel/helper-simple-access": "^7.14.8",
             "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -138,22 +130,14 @@
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-          "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.14.5",
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
             "@babel/helper-optimise-call-expression": "^7.14.5",
-            "@babel/traverse": "^7.14.5",
-            "@babel/types": "^7.14.5"
-          }
-        },
-        "@babel/helper-simple-access": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
-          "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
-          "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
           }
         },
         "@babel/helper-split-export-declaration": {
@@ -165,24 +149,9 @@
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
-          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg=="
-        },
-        "@babel/helper-validator-option": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-          "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
-        },
-        "@babel/helpers": {
-          "version": "7.14.6",
-          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
-          "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
-          "requires": {
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.14.5",
-            "@babel/types": "^7.14.5"
-          }
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
         },
         "@babel/highlight": {
           "version": "7.14.5",
@@ -195,9 +164,9 @@
           }
         },
         "@babel/parser": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
-          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA=="
+          "version": "7.15.2",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
+          "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg=="
         },
         "@babel/template": {
           "version": "7.14.5",
@@ -210,27 +179,27 @@
           }
         },
         "@babel/traverse": {
-          "version": "7.14.7",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
-          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
           "requires": {
             "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.14.5",
+            "@babel/generator": "^7.15.0",
             "@babel/helper-function-name": "^7.14.5",
             "@babel/helper-hoist-variables": "^7.14.5",
             "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.14.7",
-            "@babel/types": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
-          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
           "requires": {
-            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
           }
         },
@@ -801,7 +770,6 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
       "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.5"
       },
@@ -809,14 +777,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-          "dev": true
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
         },
         "@babel/types": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
           "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
@@ -1162,7 +1128,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
       "integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.14.8"
       },
@@ -1170,14 +1135,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-          "dev": true
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
         },
         "@babel/types": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
           "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"
@@ -1351,7 +1314,6 @@
       "version": "7.14.8",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
       "integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
-      "dev": true,
       "requires": {
         "@babel/template": "^7.14.5",
         "@babel/traverse": "^7.14.8",
@@ -1362,7 +1324,6 @@
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
           "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
-          "dev": true,
           "requires": {
             "@babel/highlight": "^7.14.5"
           }
@@ -1371,7 +1332,6 @@
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
           "integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.14.9",
             "jsesc": "^2.5.1",
@@ -1382,7 +1342,6 @@
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
           "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
-          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.14.5",
             "@babel/template": "^7.14.5",
@@ -1393,7 +1352,6 @@
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
           "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.14.5"
           }
@@ -1402,7 +1360,6 @@
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
           "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
-          "dev": true,
           "requires": {
             "@babel/types": "^7.14.5"
           }
@@ -1410,14 +1367,12 @@
         "@babel/helper-validator-identifier": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
-          "dev": true
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
         },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
           "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.5",
             "chalk": "^2.0.0",
@@ -1427,14 +1382,12 @@
         "@babel/parser": {
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-          "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ==",
-          "dev": true
+          "integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ=="
         },
         "@babel/template": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
           "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.14.5",
             "@babel/parser": "^7.14.5",
@@ -1445,7 +1398,6 @@
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
           "integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
-          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.14.5",
             "@babel/generator": "^7.14.9",
@@ -1462,7 +1414,6 @@
           "version": "7.14.9",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
           "integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
-          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37631,9 +37631,9 @@
           }
         },
         "semver": {
-          "version": "7.3.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
-          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "version": "7.3.5",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -37648,9 +37648,9 @@
       }
     },
     "supertest": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.3.tgz",
-      "integrity": "sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.4.tgz",
+      "integrity": "sha512-giC9Zm+Bf1CZP09ciPdUyl+XlMAu6rbch79KYiYKOGcbK2R1wH8h+APul1i/3wN6RF1XfWOIF+8X1ga+7SBrug==",
       "dev": true,
       "requires": {
         "methods": "^1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10357,15 +10357,15 @@
       "dev": true
     },
     "@vue/component-compiler-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.2.0.tgz",
-      "integrity": "sha512-lejBLa7xAMsfiZfNp7Kv51zOzifnb29FwdnMLa96z26kXErPFioSf9BMcePVIQ6/Gc6/mC0UrPpxAWIHyae0vw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@vue/component-compiler-utils/-/component-compiler-utils-3.2.2.tgz",
+      "integrity": "sha512-rAYMLmgMuqJFWAOb3Awjqqv5X3Q3hVr4jH/kgrFJpiU0j3a90tnNBplqbj+snzrgZhC9W128z+dtgMifOiMfJg==",
       "requires": {
         "consolidate": "^0.15.1",
         "hash-sum": "^1.0.2",
         "lru-cache": "^4.1.2",
         "merge-source-map": "^1.1.0",
-        "postcss": "^7.0.14",
+        "postcss": "^7.0.36",
         "postcss-selector-parser": "^6.0.2",
         "prettier": "^1.18.2",
         "source-map": "~0.6.1",
@@ -39553,9 +39553,9 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
     },
     "vue-loader": {
-      "version": "15.9.7",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.7.tgz",
-      "integrity": "sha512-qzlsbLV1HKEMf19IqCJqdNvFJRCI58WNbS6XbPqK13MrLz65es75w392MSQ5TsARAfIjUw+ATm3vlCXUJSOH9Q==",
+      "version": "15.9.8",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.8.tgz",
+      "integrity": "sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==",
       "requires": {
         "@vue/component-compiler-utils": "^3.1.0",
         "hash-sum": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9933,12 +9933,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
       "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
     },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true
-    },
     "@types/keyv": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
@@ -21325,36 +21319,40 @@
       "dev": true
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.5.tgz",
+      "integrity": "sha512-XMoPKjSpXbkeJ7ZZ9icLnJMTY5Mc1kZbCakHquaFsXPpyWOwK0TK6CODO+0ca54UoM9LKOxyUNnoVZRl8TeaAg==",
       "dev": true,
       "requires": {
-        "debug": "^2.6.9",
-        "resolve": "^1.13.1"
+        "debug": "^3.2.7",
+        "resolve": "^1.20.0"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+        "resolve": {
+          "version": "1.20.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+          "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.2.0",
+            "path-parse": "^1.0.6"
+          }
         }
       }
     },
     "eslint-module-utils": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
-      "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
+      "integrity": "sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
@@ -21452,17 +21450,17 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.23.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.4.tgz",
-      "integrity": "sha512-6/wP8zZRsnQFiR3iaPFgh5ImVRM1WN5NUWfTIRqwOdeiGJlBcSk82o1FEVq8yXmy4lkIzTo7YhHCIxlU/2HyEQ==",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.0.tgz",
+      "integrity": "sha512-Kc6xqT9hiYi2cgybOc0I2vC9OgAYga5o/rAFinam/yF/t5uBqxQbauNPMC6fgb640T/89P0gFoO27FOilJ/Cqg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flat": "^1.2.4",
         "debug": "^2.6.9",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.4",
-        "eslint-module-utils": "^2.6.1",
+        "eslint-import-resolver-node": "^0.3.5",
+        "eslint-module-utils": "^2.6.2",
         "find-up": "^2.0.0",
         "has": "^1.0.3",
         "is-core-module": "^2.4.0",
@@ -21485,17 +21483,6 @@
             "es-abstract": "^1.18.0-next.2",
             "get-intrinsic": "^1.1.1",
             "is-string": "^1.0.5"
-          }
-        },
-        "array.prototype.flat": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
-          "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
-          "dev": true,
-          "requires": {
-            "call-bind": "^1.0.0",
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.18.0-next.1"
           }
         },
         "call-bind": {
@@ -21527,9 +21514,9 @@
           }
         },
         "es-abstract": {
-          "version": "1.18.3",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-          "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+          "version": "1.18.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
@@ -21538,11 +21525,12 @@
             "get-intrinsic": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
             "is-callable": "^1.2.3",
             "is-negative-zero": "^2.0.1",
             "is-regex": "^1.1.3",
             "is-string": "^1.0.6",
-            "object-inspect": "^1.10.3",
+            "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
             "string.prototype.trimend": "^1.0.4",
@@ -21557,10 +21545,13 @@
               "dev": true
             },
             "is-string": {
-              "version": "1.0.6",
-              "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-              "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-              "dev": true
+              "version": "1.0.7",
+              "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+              "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+              "dev": true,
+              "requires": {
+                "has-tostringtag": "^1.0.0"
+              }
             }
           }
         },
@@ -21585,27 +21576,19 @@
           }
         },
         "is-callable": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-          "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
           "dev": true
         },
         "is-regex": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-          "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
-            "has-symbols": "^1.0.2"
-          },
-          "dependencies": {
-            "has-symbols": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-              "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
-              "dev": true
-            }
+            "has-tostringtag": "^1.0.0"
           }
         },
         "load-json-file": {
@@ -21637,9 +21620,9 @@
           "dev": true
         },
         "object-inspect": {
-          "version": "1.10.3",
-          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
-          "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
           "dev": true
         },
         "object.assign": {
@@ -24437,6 +24420,23 @@
       "optional": true,
       "requires": {
         "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      },
+      "dependencies": {
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        }
       }
     },
     "has-unicode": {
@@ -38698,24 +38698,23 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw=="
     },
     "tsconfig-paths": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
+      "integrity": "sha512-rETidPDgCpltxF7MjBZlAFPUHv5aHH2MymyPvh+vEyWAED4Eb/WeMbsnD/JDr4OKPOA1TssDHgIcpTN5Kh0p6Q==",
       "dev": true,
       "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.1",
+        "json5": "^2.2.0",
         "minimist": "^1.2.0",
         "strip-bom": "^3.0.0"
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.0"
+            "minimist": "^1.2.5"
           }
         },
         "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": "14.17.0"
   },
   "dependencies": {
-    "@babel/core": "^7.14.6",
+    "@babel/core": "^7.15.0",
     "@babel/helper-call-delegate": "^7.12.13",
     "@babel/plugin-proposal-class-properties": "^7.14.5",
     "@babel/plugin-proposal-object-rest-spread": "^7.14.7",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "cypress-image-diff-js": "1.12.0",
     "eslint": "^7.31.0",
     "eslint-config-prettier": "^8.3.0",
-    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-import": "^2.24.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",
     "eslint-plugin-mocha": "^9.0.0",
     "eslint-plugin-node": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "tar": "^6.1.0",
     "uuid": "^8.3.2",
     "vue": "^2.6.14",
-    "vue-loader": "^15.9.7",
+    "vue-loader": "^15.9.8",
     "vue-multiselect": "^2.1.0",
     "vue-template-compiler": "^2.6.14",
     "wdio-chromedriver-service": "^6.0.4",

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "rewire": "^5.0.0",
     "sass-lint": "^1.12.1",
     "selenium-server": "^3.12.0",
-    "sinon": "^11.1.1",
+    "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "storybook-readme": "^5.0.9",
     "supertest": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -232,7 +232,7 @@
     "sinon": "^11.1.2",
     "sinon-chai": "^3.7.0",
     "storybook-readme": "^5.0.9",
-    "supertest": "^6.1.3"
+    "supertest": "^6.1.4"
   },
   "sasslintConfig": ".sass-lint.yml",
   "resolutions": {


### PR DESCRIPTION
## Description of change

This PR combines this week's dependabot updates. This includes:

- Bump vue-loader from 15.9.7 to 15.9.8
- Bump supertest from 6.1.3 to 6.1.4
- Bump eslint-plugin-import from 2.23.4 to 2.24.0
- Bump @babel/core from 7.14.6 to 7.15.0
- Bump sinon from 11.1.1 to 11.1.2

## Test instructions

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
