### PR TITLE
Allow filtering of inactive advisors

### DIFF
--- a/src/apps/interactions/client/InteractionsCollection.jsx
+++ b/src/apps/interactions/client/InteractionsCollection.jsx
@@ -124,6 +124,7 @@ const InteractionCollection = ({
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
           isMulti={true}
+          onlyShowActiveAdvisers={false}
           label={LABELS.advisers}
           name="advisers"
           qsParam="dit_participants__adviser"

--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -106,6 +106,7 @@ const ProjectsCollection = ({
         <RoutedAdvisersTypeahead
           taskProps={adviserListTask}
           isMulti={true}
+          onlyShowActiveAdvisers={false}
           label="Adviser"
           name="adviser"
           qsParam="adviser"

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -10,14 +10,13 @@ import Task from '../Task'
 import { parseAdviserData } from '../../../common/formatAdviser'
 
 const fetchAdvisers = (onlyShowActiveAdvisers) => {
-  const isActiveParameter = onlyShowActiveAdvisers ? true : null
   return throttle(
     (searchString) =>
       axios
         .get('/api-proxy/adviser/', {
           params: {
             autocomplete: searchString,
-            is_active: isActiveParameter,
+            is_active: onlyShowActiveAdvisers ? true : null,
           },
         })
         .then(({ data: { results } }) => parseAdviserData(results)),

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -9,13 +9,15 @@ import Task from '../Task'
 
 import { parseAdviserData } from '../../../common/formatAdviser'
 
-const fetchAdvisers = () => {
+const fetchAdvisers = (onlyShowActiveAdvisers) => {
+  const isActiveParameter = onlyShowActiveAdvisers ? true : null
   return throttle(
     (searchString) =>
       axios
         .get('/api-proxy/adviser/', {
           params: {
             autocomplete: searchString,
+            is_active: isActiveParameter,
           },
         })
         .then(({ data: { results } }) => parseAdviserData(results)),
@@ -25,7 +27,8 @@ const fetchAdvisers = () => {
 
 const RoutedAdvisersTypeahead = ({
   taskProps,
-  loadOptions = fetchAdvisers(),
+  onlyShowActiveAdvisers = true,
+  loadOptions = fetchAdvisers(onlyShowActiveAdvisers),
   ...props
 }) => (
   <Task.Status {...taskProps}>

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -9,14 +9,13 @@ import Task from '../Task'
 
 import { parseAdviserData } from '../../../common/formatAdviser'
 
-const fetchAdvisers = (onlyShowActiveAdvisers) => {
+const fetchAdvisers = () => {
   return throttle(
     (searchString) =>
       axios
         .get('/api-proxy/adviser/', {
           params: {
             autocomplete: searchString,
-            is_active: onlyShowActiveAdvisers,
           },
         })
         .then(({ data: { results } }) => parseAdviserData(results)),
@@ -26,8 +25,7 @@ const fetchAdvisers = (onlyShowActiveAdvisers) => {
 
 const RoutedAdvisersTypeahead = ({
   taskProps,
-  onlyShowActiveAdvisers = true,
-  loadOptions = fetchAdvisers(onlyShowActiveAdvisers),
+  loadOptions = fetchAdvisers(),
   ...props
 }) => (
   <Task.Status {...taskProps}>


### PR DESCRIPTION
## Description of change
This is a fix for the live services issue found [here](https://uktrade.atlassian.net/browse/CPS-220), whereby a user cannot see an inactive advisor in the advisors filter dropdown.

## Test instructions
Navigate to /interactions or /investments/projects.
Search for an inactive advisor on the Advisors filter (on the local development environment, search for Ava Walsh).
You should be able to see the inactive advisor in the dropdown list in addition to active advisors.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/70902973/128735074-20200298-c448-4e00-bc05-fbd281cbcfbb.png)

### After

![image](https://user-images.githubusercontent.com/70902973/128734926-23a96874-eb79-4475-86c8-5ef306cbbd4e.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
