### PR TITLE
Add aria-live attribute to StatusMessage component

### DIFF
--- a/src/client/components/StatusMessage/index.jsx
+++ b/src/client/components/StatusMessage/index.jsx
@@ -22,6 +22,7 @@ StatusMessage.propTypes = {
 StatusMessage.defaultProps = {
   colour: BLUE,
   'data-test': 'status-message',
+  'aria-live': 'polite',
 }
 
 export default StatusMessage

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -291,6 +291,7 @@ describe('Add company form', () => {
       cy.get('[data-test="status-message"]')
         .should('exist')
         .should('contain.text', 'Error occurred while searching for company.')
+        .should('have.attr', 'aria-live', 'polite')
     })
   })
 


### PR DESCRIPTION
## Description of change

This PR addresses one of the accessibility issues raised in the audit. In particular, the lack of accessible signposting when a status message appears. Previously, when a status message appeared, a screen reader would not read out the message, which is problematic to users who need this info. I've added an `aria-live='polite'` attribute to the status message, to ensure that screen readers read out the text. I chose this attribute, as the WCAG guidelines suggested that aria-role is too aggressive for this type of notification. If I were to choose aria-role, it would stop what it was currently reading, to read the status message, however polite will read it out after it's done doing what it's doing

## Test instructions

 Go to the add a company form and get to the find a company section. use cmd +f5 to bring up VoiceOver (on a mac, sorry don't know windows 😭 ) and use the tab key to enter a company name and then click find company. On dev, the status message will come up but the screen reader won't say anything. On this branch, the screen reader will finish what they have to say (politely) then read out the status message text. 


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
