### PR TITLE
Add id's to sort options for tracking in Google analytics...

### DIFF
--- a/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListFilter.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { kebabCase } from 'lodash'
 
 import { Select } from '../../components'
 
@@ -11,7 +12,7 @@ const InvestmentListFilter = ({ initialValue, options, onChange }) => (
     }}
   >
     {options.map(({ id, name }, index) => (
-      <option value={id} aria-label={name} key={index}>
+      <option value={id} aria-label={name} key={index} id={kebabCase(name)}>
         {name}
       </option>
     ))}

--- a/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentListSort.jsx
@@ -11,7 +11,7 @@ const InvestmentListSort = ({ initialValue, options, onChange }) => (
     }}
   >
     {options.map(({ value, name }, index) => (
-      <option value={value} aria-label={name} key={index}>
+      <option value={value} aria-label={name} key={index} id={value}>
         {name}
       </option>
     ))}


### PR DESCRIPTION
## Description of change

We need to know how many people are using the two sort options (Stage and Sort by) available on the new dashboard. In order to track this usage we need id's added to each option inside the two select drop down elements.

## Test instructions

Nothing should change apart from id's should now exist in the markup related to these two select drop downs.

1. Inspect the generated mark up

## Screenshots
![Screenshot 2021-08-10 at 14 52 52](https://user-images.githubusercontent.com/10154302/128881846-c42e16ec-5561-45a2-8915-5c15abeee293.png)
![Screenshot 2021-08-10 at 15 02 16](https://user-images.githubusercontent.com/10154302/128881866-c4a5bc2c-4ef2-4d90-a60a-4b3156420cef.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
