### PR TITLE
Conditionally pluralise 'fields' in opportunity incomplete badge

### DIFF
--- a/src/apps/investments/client/opportunities/Details/Opportunities.jsx
+++ b/src/apps/investments/client/opportunities/Details/Opportunities.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
+import pluralize from 'pluralize'
 
 import { TASK_GET_OPPORTUNITY_DETAILS, ID, state2props } from '../Details/state'
 import {
@@ -35,7 +36,7 @@ const StyledLabel = styled('label')`
   border: none;
   font-size: 19px;
   margin: 10px 5px 5px;
-  color: ${(props) => props.color};
+  color: ${RED};
 `
 
 const StyledDetails = styled(Details)`
@@ -44,11 +45,13 @@ const StyledDetails = styled(Details)`
   }
 `
 
-const RequiredFields = (fieldCount) => {
-  if (fieldCount == 0) {
-    return <StyledLabel color={RED}>Complete</StyledLabel>
-  }
-  return <StyledLabel color={RED}>{fieldCount} fields incomplete</StyledLabel>
+const IncompleteFieldsBadge = (incompleteFieldCount) => {
+  const badgeText =
+    incompleteFieldCount == 0
+      ? 'Complete'
+      : `${pluralize('field', incompleteFieldCount, true)} incomplete`
+
+  return <StyledLabel>{badgeText}</StyledLabel>
 }
 
 const OpportunitySection = ({
@@ -65,7 +68,7 @@ const OpportunitySection = ({
     <ToggleSection
       label={toggleName}
       id={`${id}_toggle`}
-      badge={RequiredFields(incompleteFields)}
+      badge={IncompleteFieldsBadge(incompleteFields)}
       justifyHeaderContent={true}
     >
       {isEditing ? (


### PR DESCRIPTION
## Description of change

This PR fixes a bug where when there is only 1 field incomplete on either the opportunity details or requirements form, the badge currently shows `1 fields incomplete` instead of `1 field incomplete`.

I have used the [pluralize package](https://www.npmjs.com/package/pluralize) to conditionally pluralise the word 'fields' depending on how many incomplete fields there are. 

I have also tidied up the logic and naming of the incomplete fields badge to make it clearer/more DRY.

## Test instructions

Go to this investment opportunity (on Heroku deployed instance)
Check that the red badges displays `1 field incomplete` and `2 fields incomplete`

## Screenshots

### Before

![Screenshot 2021-08-10 at 16 09 48](https://user-images.githubusercontent.com/22460823/128892211-90d08101-0779-47c9-99b8-157ee886fd32.png)

### After

![Screenshot 2021-08-10 at 16 01 49](https://user-images.githubusercontent.com/22460823/128892119-f9cf11e6-7adf-4935-afb2-997c5d4eb3da.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
