### PR TITLE
Add trim to npm resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5984,6 +5984,13 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "trim": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
+            }
           }
         }
       }
@@ -6875,6 +6882,11 @@
             "space-separated-tokens": "^1.0.0"
           }
         },
+        "highlight.js": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+        },
         "lowlight": {
           "version": "1.20.0",
           "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.20.0.tgz",
@@ -7662,6 +7674,11 @@
             "property-information": "^5.0.0",
             "space-separated-tokens": "^1.0.0"
           }
+        },
+        "highlight.js": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
         },
         "jsonfile": {
           "version": "6.1.0",
@@ -9654,6 +9671,11 @@
             "property-information": "^5.0.0",
             "space-separated-tokens": "^1.0.0"
           }
+        },
+        "highlight.js": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
         },
         "lowlight": {
           "version": "1.20.0",
@@ -34459,6 +34481,13 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "trim": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
+            }
           }
         }
       }
@@ -38785,11 +38814,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -239,6 +239,7 @@
     "highlight.js": "11.2.0",
     "prismjs": "1.24.1",
     "merge": "2.1.1",
-    "lodash.merge": "4.6.2"
+    "lodash.merge": "4.6.2",
+    "trim": "0.0.3"
   }
 }


### PR DESCRIPTION
## Description of change

This PR fixes the [security vulnerability](https://github.com/uktrade/data-hub-frontend/security/dependabot/package-lock.json/trim/open) brought in by upgrading storybook. `trim` is a sup-dependency of `storybook/react`, however the package which requires it uses version 0.0.1, whereas the secure version is 0.0.3.

In order to address this, I have added the trim package and its secure version to resolutions in package.json to force the use of this version.

Due to us removing support for IE, this PR also includes removing testing IE in the visual tests as this test has been extremely flaky and is no longer needed.

## Test instructions

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
