### PR TITLE
Add user id to the datalayer for Google anayltics

### DIFF
--- a/src/templates/_includes/google-tag-manager-snippet.njk
+++ b/src/templates/_includes/google-tag-manager-snippet.njk
@@ -1,5 +1,8 @@
 {% if GOOGLE_TAG_MANAGER_KEY %}
 <script>
+ dataLayer = [{
+    'userId': '{{user.id}}',
+  }];
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
     var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),


### PR DESCRIPTION
## Description of change

This just adds the user id to the data layer for Google analytics  to track user behaviour.

## Test instructions

Nothing should change. Easiest was to check if this is inserted properly is to 

1. Manually check the source code and look for the Google tag manager snippet. 
2. Add a Chrome extension such as datalayer checker - https://chrome.google.com/webstore/detail/datalayer-checker/ffljdddodmkedhkcjhpmdajhjdbkogke?hl=en

You should see 

```
 dataLayer = [{
    'userId': '[user id goes in here...]',
  }];
```

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
