### PR TITLE
Refactor Datahub dashboard - reminders features toggle menu

### DIFF
--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -93,7 +93,7 @@ const PersonalisedDashboard = ({
                       )
                     }
                     major={true}
-                    isOpen={true}
+                    isOpen={false}
                     data-test="investment-reminders-section"
                   >
                     <InvestmentReminders adviser={adviser} />

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -154,11 +154,10 @@ describe('Dashboard reminders', () => {
     })
 
     it('should be in a togglable section that starts opened', () => {
+      cy.get('@investmentRemindersToggleButton').click()
       cy.get('@investmentReminders').should('be.visible')
       cy.get('@investmentRemindersToggleButton').click()
       cy.get('@investmentReminders').should('not.be.visible')
-      cy.get('@investmentRemindersToggleButton').click()
-      cy.get('@investmentReminders').should('be.visible')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Refactor Datahub Dashboard - reminders features in order to maximised the space of the page.

## Test instructions
1. Click Data Hub Beta link on the page header, which it will display Datahub dashboard(if permission features allows).
2. From top-most filter at the sidebar, it shown a default minimised Reminders toggle.

## Screenshots
### Before
![Screenshot 2021-08-11 at 15 04 47](https://user-images.githubusercontent.com/28296624/129044412-0cb7ee1b-8e5c-45f9-a49f-ab09490d93ba.png)

### After

![Screenshot 2021-08-11 at 15 05 03](https://user-images.githubusercontent.com/28296624/129044591-2a8a2416-e5d1-4dd9-91dc-7fa2a5378328.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
