### PR TITLE
Dependency updates 12/08/21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6341,59 +6341,59 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@sentry/browser": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.10.0.tgz",
-      "integrity": "sha512-H0Blgp8f8bomebkkGWIgxHVjabtQAlsKJDiFXBg7gIc75YcarRxwH0R3hMog1/h8mmv4CGGUsy5ljYW6jsNnvA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.11.0.tgz",
+      "integrity": "sha512-Qr2QRA0t5/S9QQqxzYKvM9W8prvmiWuldfwRX4hubovXzcXLgUi4WK0/H612wSbYZ4dNAEcQbtlxFWJNN4wxdg==",
       "requires": {
-        "@sentry/core": "6.10.0",
-        "@sentry/types": "6.10.0",
-        "@sentry/utils": "6.10.0",
+        "@sentry/core": "6.11.0",
+        "@sentry/types": "6.11.0",
+        "@sentry/utils": "6.11.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.10.0.tgz",
-      "integrity": "sha512-5KlxHJlbD7AMo+b9pMGkjxUOfMILtsqCtGgI7DMvZNfEkdohO8QgUY+hPqr540kmwArFS91ipQYWhqzGaOhM3Q==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.11.0.tgz",
+      "integrity": "sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==",
       "requires": {
-        "@sentry/hub": "6.10.0",
-        "@sentry/minimal": "6.10.0",
-        "@sentry/types": "6.10.0",
-        "@sentry/utils": "6.10.0",
+        "@sentry/hub": "6.11.0",
+        "@sentry/minimal": "6.11.0",
+        "@sentry/types": "6.11.0",
+        "@sentry/utils": "6.11.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.10.0.tgz",
-      "integrity": "sha512-MV8wjhWiFAXZAhmj7Ef5QdBr2IF93u8xXiIo2J+dRZ7eVa4/ZszoUiDbhUcl/TPxczaw4oW2a6tINBNFLzXiig==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.11.0.tgz",
+      "integrity": "sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==",
       "requires": {
-        "@sentry/types": "6.10.0",
-        "@sentry/utils": "6.10.0",
+        "@sentry/types": "6.11.0",
+        "@sentry/utils": "6.11.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.10.0.tgz",
-      "integrity": "sha512-yarm046UgUFIBoxqnBan2+BEgaO9KZCrLzsIsmALiQvpfW92K1lHurSawl5W6SR7wCYBnNn7CPvPE/BHFdy4YA==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.11.0.tgz",
+      "integrity": "sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==",
       "requires": {
-        "@sentry/hub": "6.10.0",
-        "@sentry/types": "6.10.0",
+        "@sentry/hub": "6.11.0",
+        "@sentry/types": "6.11.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.10.0.tgz",
-      "integrity": "sha512-M7s0JFgG7/6/yNVYoPUbxzaXDhnzyIQYRRJJKRaTD77YO4MHvi4Ke8alBWqD5fer0cPIfcSkBqa9BLdqRqcMWw=="
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.11.0.tgz",
+      "integrity": "sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg=="
     },
     "@sentry/utils": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.10.0.tgz",
-      "integrity": "sha512-F9OczOcZMFtazYVZ6LfRIe65/eOfQbiAedIKS0li4npuMz0jKYRbxrjd/U7oLiNQkPAp4/BujU4m1ZIwq6a+tg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.11.0.tgz",
+      "integrity": "sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==",
       "requires": {
-        "@sentry/types": "6.10.0",
+        "@sentry/types": "6.11.0",
         "tslib": "^1.9.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19364,9 +19364,9 @@
       }
     },
     "decimal.js": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
-      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
+      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
       "dev": true
     },
     "decode-uri-component": {
@@ -26994,9 +26994,9 @@
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
     "jsdom": {
-      "version": "16.6.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
-      "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.7.0.tgz",
+      "integrity": "sha512-u9Smc2G1USStM+s/x1ru5Sxrl6mPYCbByG1U/hUmqaVsm4tbNyS7CicOSRyuGQYZhTu0h84qkZZQ/I+dzizSVw==",
       "dev": true,
       "requires": {
         "abab": "^2.0.5",
@@ -27024,14 +27024,14 @@
         "whatwg-encoding": "^1.0.5",
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.5.0",
-        "ws": "^7.4.5",
+        "ws": "^7.4.6",
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
         "acorn": {
-          "version": "8.2.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
-          "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+          "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA==",
           "dev": true
         },
         "agent-base": {
@@ -27100,12 +27100,6 @@
             "punycode": "^2.1.1",
             "universalify": "^0.1.2"
           }
-        },
-        "ws": {
-          "version": "7.5.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
-          "integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-          "dev": true
         }
       }
     },
@@ -40893,13 +40887,13 @@
       "dev": true
     },
     "whatwg-url": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.5.0.tgz",
-      "integrity": "sha512-fy+R77xWv0AiqfLl4nuGUlQ3/6b5uNfQ4WAbGQVMYshCTCCPK9psC1nWh3XHuxGVCtlcDDQPQW1csmmIQo+fwg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
       "dev": true,
       "requires": {
         "lodash": "^4.7.0",
-        "tr46": "^2.0.2",
+        "tr46": "^2.1.0",
         "webidl-conversions": "^6.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -17168,6 +17168,91 @@
         }
       }
     },
+    "cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "astral-regex": "^2.0.0",
+            "is-fullwidth-code-point": "^3.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
+      }
+    },
     "cli-width": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
@@ -27555,9 +27640,9 @@
       }
     },
     "lint-staged": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.0.0.tgz",
-      "integrity": "sha512-3rsRIoyaE8IphSUtO1RVTFl1e0SLBtxxUOPBtHxQgBHS5/i6nqvjcUfNioMa4BU9yGnPzbO+xkfLtXtxBpCzjw==",
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-11.1.2.tgz",
+      "integrity": "sha512-6lYpNoA9wGqkL6Hew/4n1H6lRqF3qCsujVT0Oq5Z4hiSAM7S6NksPJ3gnr7A7R52xCtiZMcEUNNQ6d6X5Bvh9w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.1",
@@ -27565,7 +27650,6 @@
         "commander": "^7.2.0",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.3.1",
-        "dedent": "^0.7.0",
         "enquirer": "^2.3.6",
         "execa": "^5.0.0",
         "listr2": "^3.8.2",
@@ -27577,12 +27661,6 @@
         "stringify-object": "^3.3.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -27602,23 +27680,13 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
-          }
-        },
-        "cli-truncate": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-          "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-          "dev": true,
-          "requires": {
-            "slice-ansi": "^3.0.0",
-            "string-width": "^4.2.0"
           }
         },
         "color-convert": {
@@ -27667,19 +27735,13 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
           }
-        },
-        "emoji-regex": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-          "dev": true
         },
         "execa": {
           "version": "5.1.1",
@@ -27725,12 +27787,6 @@
           "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
           "dev": true
         },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-          "dev": true
-        },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -27738,9 +27794,9 @@
           "dev": true
         },
         "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
           "dev": true
         },
         "log-symbols": {
@@ -27807,37 +27863,6 @@
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
           "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
-        },
-        "slice-ansi": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-          "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "astral-regex": "^2.0.0",
-            "is-fullwidth-code-point": "^3.0.0"
-          }
-        },
-        "string-width": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         },
         "supports-color": {
           "version": "7.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20337,9 +20337,9 @@
       }
     },
     "elastic-apm-node": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.18.0.tgz",
-      "integrity": "sha512-IrOvLwccu6nP+FP+ytarB1kQE9VCxqrBxFX4rMx1HZrmikQ49GIFwvrddiElFZepAk7WeE6JX9f42pVr+PMFMw==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.19.0.tgz",
+      "integrity": "sha512-Drj8J8qZu/GKg0Mhplyt4mmOt1QB9Vi0889QHUWX2f24fvf72DFp5nowcabdKMLpGVKnpiBA1U4VE7FugnwEow==",
       "requires": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5984,14 +5984,12 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
-          },
-          "dependencies": {
-            "trim": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
-              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
-            }
           }
+        },
+        "trim": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
         }
       }
     },
@@ -6606,9 +6604,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -6689,11 +6687,6 @@
             "refractor": "^3.1.0"
           },
           "dependencies": {
-            "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
-            },
             "prismjs": {
               "version": "1.24.1",
               "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
@@ -6897,9 +6890,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -6981,9 +6974,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -7707,9 +7700,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -7867,9 +7860,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -9687,9 +9680,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             }
           }
         },
@@ -9788,9 +9781,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "11.2.0",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+              "version": "10.7.3",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -17181,6 +17174,18 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -19703,6 +19708,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -22535,13 +22547,6 @@
       "requires": {
         "html-minifier": "3.5.7",
         "lodash.merge": "4.6.0"
-      },
-      "dependencies": {
-        "lodash.merge": {
-          "version": "4.6.2",
-          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-        }
       }
     },
     "express-session": {
@@ -24031,6 +24036,16 @@
         }
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -24542,6 +24557,11 @@
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
+    "highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -25044,9 +25064,9 @@
       },
       "dependencies": {
         "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
         }
       }
     },
@@ -26073,6 +26093,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "3.0.1",
@@ -28192,6 +28217,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -28447,9 +28477,9 @@
       },
       "dependencies": {
         "highlight.js": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
+          "version": "9.13.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
           "dev": true
         }
       }
@@ -29027,6 +29057,12 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
+    },
+    "merge": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -31791,9 +31827,9 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-platform": {
       "version": "0.11.15",
@@ -32664,6 +32700,15 @@
       "resolved": "https://registry.npmjs.org/prism-themes/-/prism-themes-1.5.0.tgz",
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
+    },
+    "prismjs": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
+      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
     },
     "private": {
       "version": "0.1.8",
@@ -33843,9 +33888,9 @@
       },
       "dependencies": {
         "highlight.js": {
-          "version": "11.2.0",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
+          "version": "9.13.1",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
+          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
           "dev": true
         },
         "prismjs": {
@@ -34139,14 +34184,6 @@
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
         "prismjs": "~1.17.0"
-      },
-      "dependencies": {
-        "prismjs": {
-          "version": "1.24.1",
-          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-          "dev": true
-        }
       }
     },
     "regenerate": {
@@ -34481,13 +34518,6 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
-          },
-          "dependencies": {
-            "trim": {
-              "version": "0.0.3",
-              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
-              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
-            }
           }
         }
       }
@@ -35468,12 +35498,6 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "merge": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
-          "dev": true
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -35742,6 +35766,13 @@
           "optional": true
         }
       }
+    },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
     },
     "selenium-server": {
       "version": "3.141.59",
@@ -38655,6 +38686,13 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
+    },
     "tiny-invariant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -38814,6 +38852,11 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "trim": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -39200,11 +39243,6 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
           "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
-        },
-        "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         }
       }
     },
@@ -41298,9 +41336,9 @@
           "dev": true
         },
         "is-plain-obj": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20911,9 +20911,9 @@
       }
     },
     "eslint": {
-      "version": "7.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.31.0.tgz",
-      "integrity": "sha512-vafgJpSh2ia8tnTkNUkwxGmnumgckLh5aAbLa1xRmIn9+owi8qBNGKL+B881kNKNTy7FFqTEkpNkUvmw0n6PkA==",
+      "version": "7.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+      "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.12.11",
@@ -20983,9 +20983,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5984,12 +5984,19 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "trim": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
+            }
           }
         },
         "trim": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-          "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+          "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
         }
       }
     },
@@ -6604,9 +6611,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             }
           }
         },
@@ -6687,6 +6694,11 @@
             "refractor": "^3.1.0"
           },
           "dependencies": {
+            "highlight.js": {
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+            },
             "prismjs": {
               "version": "1.24.1",
               "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
@@ -6890,9 +6902,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             }
           }
         },
@@ -6974,9 +6986,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -7700,9 +7712,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             }
           }
         },
@@ -7860,9 +7872,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -9680,9 +9692,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             }
           }
         },
@@ -9781,9 +9793,9 @@
           },
           "dependencies": {
             "highlight.js": {
-              "version": "10.7.3",
-              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-              "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
+              "version": "11.2.0",
+              "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+              "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
             },
             "prismjs": {
               "version": "1.24.1",
@@ -10407,9 +10419,9 @@
       }
     },
     "@uktrade/datahub-header": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.4.2.tgz",
-      "integrity": "sha512-p0wvu5PJHHpra7TbxH4nUH092vXbdABglpZlR9k8IYeRY1eGfVWPz/OpQ7knqt/Aawc+1hNduyb4fACJ/Qmp3A=="
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.4.3.tgz",
+      "integrity": "sha512-c6JzPx3VNSEamWe9LE6ZgnKGD02xj8f7pWAEuXKT3qsVMt0Lqmz6jDps+cEWFR7N764FxZONVuDgzGsfPifBeg=="
     },
     "@uktrade/wdio-image-diff-js": {
       "version": "1.9.2",
@@ -17259,18 +17271,6 @@
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
     },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
-    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -19793,13 +19793,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -22632,6 +22625,13 @@
       "requires": {
         "html-minifier": "3.5.7",
         "lodash.merge": "4.6.0"
+      },
+      "dependencies": {
+        "lodash.merge": {
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+          "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+        }
       }
     },
     "express-session": {
@@ -24121,16 +24121,6 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -24642,11 +24632,6 @@
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
-    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -25149,9 +25134,9 @@
       },
       "dependencies": {
         "is-plain-obj": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-          "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA=="
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         }
       }
     },
@@ -26178,11 +26163,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
-    },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
     },
     "is-plain-object": {
       "version": "3.0.1",
@@ -28236,11 +28216,6 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
-      "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -28496,9 +28471,9 @@
       },
       "dependencies": {
         "highlight.js": {
-          "version": "9.13.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
           "dev": true
         }
       }
@@ -29076,12 +29051,6 @@
           "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
-    },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -32720,15 +32689,6 @@
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.17.1.tgz",
-      "integrity": "sha512-PrEDJAFdUGbOP6xK/UsfkC5ghJsPJviKgnQOoxaDbBjwc8op68Quupwt1DeAFoG8GImPhiKXAvvsH7wDSLsu1Q==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -33907,9 +33867,9 @@
       },
       "dependencies": {
         "highlight.js": {
-          "version": "9.13.1",
-          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-          "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+          "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw==",
           "dev": true
         },
         "prismjs": {
@@ -34203,6 +34163,14 @@
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
         "prismjs": "~1.17.0"
+      },
+      "dependencies": {
+        "prismjs": {
+          "version": "1.24.1",
+          "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
+          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+          "dev": true
+        }
       }
     },
     "regenerate": {
@@ -34537,6 +34505,13 @@
             "unist-util-remove-position": "^2.0.0",
             "vfile-location": "^3.0.0",
             "xtend": "^4.0.1"
+          },
+          "dependencies": {
+            "trim": {
+              "version": "0.0.3",
+              "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+              "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
+            }
           }
         }
       }
@@ -35517,6 +35492,12 @@
             "graceful-fs": "^4.1.6"
           }
         },
+        "merge": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+          "dev": true
+        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -35785,13 +35766,6 @@
           "optional": true
         }
       }
-    },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
     },
     "selenium-server": {
       "version": "3.141.59",
@@ -38705,13 +38679,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
-    },
     "tiny-invariant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -38871,11 +38838,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -39262,6 +39224,11 @@
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
           "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
         }
       }
     },
@@ -41355,9 +41322,9 @@
           "dev": true
         },
         "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "chromedriver": "^92.0.0",
     "cypress": "^7.6.0",
     "cypress-image-diff-js": "1.12.0",
-    "eslint": "^7.31.0",
+    "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.0",
     "eslint-plugin-jsx-a11y": "^6.4.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "del-cli": "^4.0.1",
     "details-element-polyfill": "^2.4.0",
     "dotenv": "^10.0.0",
-    "elastic-apm-node": "^3.18.0",
+    "elastic-apm-node": "^3.19.0",
     "element-closest": "^3.0.2",
     "express": "^4.16.2",
     "express-minify-html": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "istanbul": "^0.4.5",
     "istanbul-lib-coverage": "^3.0.0",
     "js-beautify": "^1.14.0",
-    "jsdom": "^16.6.0",
+    "jsdom": "^16.7.0",
     "jsdom-global": "^3.0.2",
     "json-schema-faker": "^0.5.0-rcv.38",
     "lint-staged": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "jsdom": "^16.7.0",
     "jsdom-global": "^3.0.2",
     "json-schema-faker": "^0.5.0-rcv.38",
-    "lint-staged": "^11.0.0",
+    "lint-staged": "^11.1.2",
     "mocha": "^8.4.0",
     "mocha-circleci-reporter": "0.0.3",
     "mocha-multi": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@hapi/joi": "^17.1.1",
     "@nivo/core": "^0.69.0",
     "@nivo/pie": "^0.69.0",
-    "@sentry/browser": "^6.10.0",
+    "@sentry/browser": "^6.11.0",
     "@storybook/addon-a11y": "^6.3.7",
     "@storybook/addon-actions": "^6.3.7",
     "@storybook/addon-knobs": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@storybook/addon-knobs": "^6.3.0",
     "@storybook/addons": "^6.3.7",
     "@storybook/react": "^6.3.7",
-    "@uktrade/datahub-header": "^1.4.2",
+    "@uktrade/datahub-header": "^1.4.3",
     "autoprefixer": "^9.8.6",
     "axios": "^0.21.1",
     "babel-loader": "^8.2.2",


### PR DESCRIPTION
## Description of change

This PR updates the following packages:

- Update datahub-header to version 1.4.3
- Bump path-parse from 1.0.6 to 1.0.7
- Bump elastic-apm-node from 3.18.0 to 3.19.0
- Bump jsdom from 16.6.0 to 16.7.0
- Bump eslint from 7.31.0 to 7.32.0
- Bump @sentry/browser from 6.10.0 to 6.11.0
- Bump lint-staged from 11.0.0 to 11.1.2

## Test instructions

No visual changes

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
