### PR TITLE
Fix display of 'Updated on' value in opportunity collection list

### DIFF
--- a/src/apps/investments/client/opportunities/List/tasks.js
+++ b/src/apps/investments/client/opportunities/List/tasks.js
@@ -14,6 +14,7 @@ export function getOpportunities({ activePage, payload }) {
         id,
         uk_region_locations,
         created_on,
+        modified_on,
       }) {
         const locationNames = getArrayNames(uk_region_locations)
         return {
@@ -28,7 +29,7 @@ export function getOpportunities({ activePage, payload }) {
           metadata: [
             {
               label: 'Updated on',
-              value: formatLongDate(new Date(created_on)),
+              value: formatLongDate(modified_on ? modified_on : created_on),
             },
           ],
         }

--- a/test/functional/cypress/specs/investments/opportunity-list-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-list-spec.js
@@ -1,18 +1,17 @@
 const {
   assertTabbedLocalNav,
-  assertLocalHeader,
   assertBreadcrumbs,
 } = require('../../support/assertions')
 const { investments } = require('../../../../../src/lib/urls')
 
 describe('Investment opportunities', () => {
-  context('When there are 4 profiles and viewing the first page', () => {
+  context('When there are 12 opportunities and viewing the first page', () => {
     before(() => {
       cy.visit(investments.opportunities.index())
     })
 
     it('should render the header', () => {
-      assertLocalHeader('Investments')
+      cy.get('h1').contains('UK opportunities')
     })
 
     it('should render breadcrumbs', () => {
@@ -36,21 +35,35 @@ describe('Investment opportunities', () => {
         .should('have.text', 'Add opportunity')
     })
 
-    it('should display 10 profiles', () => {
+    it('should display 10 opportunities', () => {
       cy.get('h3').should('have.length', 10)
     })
 
-    it('should display download profile text', () => {
+    it('should display download opportunities text', () => {
       cy.get('[data-test="download-data-header"]').should(
         'contain',
         'You can now download these 12 opportunities'
       )
     })
 
-    it('should display download profile button', () => {
+    it('should display download opportunities button', () => {
       cy.get('[data-test="download-data-header"] > div > a')
         .should('be.visible')
         .should('have.attr', 'href', '/investments/opportunities/export')
+    })
+    it('should display opportunity name and created on date where no modified date', () => {
+      cy.get('[data-test="collection-item"]')
+        .eq(0)
+        .should('contain', 'A non-modified opportunity')
+        .should('contain', 'Updated on')
+        .and('contain', '13 May 2019')
+    })
+    it('should display opportunity name and modified date', () => {
+      cy.get('[data-test="collection-item"]')
+        .eq(1)
+        .should('contain', 'A modified opportunity')
+        .should('contain', 'Updated on')
+        .and('contain', '10 April 2021')
     })
   })
 })

--- a/test/sandbox/fixtures/v4/investment/large-capital-opportunity-list.json
+++ b/test/sandbox/fixtures/v4/investment/large-capital-opportunity-list.json
@@ -4,8 +4,8 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
-            "name": "Battersea power station regeneration",
+            "modified_on": null,
+            "name": "A non-modified opportunity",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
             "type": {},
@@ -101,8 +101,8 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
-            "name": "Battersea power station regeneration",
+            "modified_on": "2021-04-10T14:01:11.187885Z",
+            "name": "A modified opportunity",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
             "type": {},
@@ -197,7 +197,7 @@
         },{
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -294,7 +294,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -391,7 +391,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -488,7 +488,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -585,7 +585,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -682,7 +682,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -779,7 +779,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -876,7 +876,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -973,7 +973,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],
@@ -1070,7 +1070,7 @@
         {
             "id": "a84f8405-c419-40a6-84c8-642b7c3209b2",
             "created_on": "2019-05-13T14:01:11.187838Z",
-            "modified_on": "2019-05-13T14:01:11.187885Z",
+            "modified_on": null,
             "name": "Battersea power station regeneration",
             "incomplete_details_fields": [],
             "incomplete_requirements_fields": [],


### PR DESCRIPTION
## Description of change

This PR fixes a bug in the investment oportunities collection list, where no value was showing for `Updated on` in the collection list items.

This PR adds logic to show the `modified_on` date if it exists and the `created_on date` if not - for the `Updated on` value.

I have added a test for this in the opportunity list spec, corrected some errors in the existing tests and also set the modified_on date in the fixtures to be `null` instead of the same as `created_on` to better reflect what would be returned from the API.

## Test instructions

1. Go to `/investments/opportunities`
2. Check that values are showing next to the Updated on label on each opportunity in the list

## Screenshots
### Before

![129219357-cec38269-5796-488f-bc00-07bf306e1b27](https://user-images.githubusercontent.com/22460823/129222545-e55bca63-b025-4853-9410-47e4ff483e84.png)


### After

![Screenshot 2021-08-12 at 15 50 17](https://user-images.githubusercontent.com/22460823/129222565-c258fc01-7d63-450b-8407-a11ef719c546.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
