### PR TITLE
Add visually hidden text to activity card summary

### DIFF
--- a/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
@@ -58,6 +58,7 @@ export default class CompaniesHouseAccount extends React.PureComponent {
 
         <CardDetails
           summary="View key details for this account"
+          summaryVisuallyHidden={`${company} in Companies House`}
           link={{ taxonomy, text: 'Go to the Companies House accounts page' }}
           showDetails={showDetails}
         >

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
@@ -58,7 +58,7 @@ export default class CompaniesHouseAccount extends React.PureComponent {
 
         <CardDetails
           summary="View key details for this account"
-          summaryVisuallyHidden={`${company} in Companies House`}
+          summaryVisuallyHidden={`${summary} in Companies House`}
           link={{ taxonomy, text: 'Go to the Companies House accounts page' }}
           showDetails={showDetails}
         >

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
@@ -78,7 +78,7 @@ export default class CompaniesHouseCompany extends React.PureComponent {
 
         <CardDetails
           summary="View key details for this company"
-          summaryVisuallyHidden={`${company} from Companies House`}
+          summaryVisuallyHidden={`${summary} from Companies House`}
           showDetails={showDetails}
         >
           <CardTable

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
@@ -78,6 +78,7 @@ export default class CompaniesHouseCompany extends React.PureComponent {
 
         <CardDetails
           summary="View key details for this company"
+          summaryVisuallyHidden={`${company} from Companies House`}
           showDetails={showDetails}
         >
           <CardTable

--- a/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
+++ b/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
@@ -5,6 +5,7 @@ import { get } from 'lodash'
 import { Card, CardDetails, CardHeader, CardTable } from './card'
 import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
 import CardUtils from './card/CardUtils'
+import { format } from '../../../utils/date'
 
 const FORM_URL_TO_NAME_MAP = {
   '/contact/export-advice/comment/': 'Export enquiry',
@@ -39,6 +40,9 @@ export default class DirectoryFormsApi extends React.PureComponent {
         />
         <CardDetails
           summary="View key details for this enquiry"
+          summaryVisuallyHidden={` on great.gov.uk, sent on ${format(
+            sentDate
+          )}`}
           showDetails={showDetails}
         >
           <CardTable

--- a/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
+++ b/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
@@ -54,6 +54,7 @@ export default class HmrcExporter extends React.PureComponent {
 
         <CardDetails
           summary="View key export details"
+          summaryVisuallyHidden={` for ${reference}`}
           showDetails={showDetails}
         >
           <CardTable

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -49,6 +49,7 @@ export default class Interaction extends React.PureComponent {
 
         <CardDetails
           summary={`View ${transformed.typeText} details`}
+          summaryVisuallyHidden={` for ${transformed.subject}`}
           link={{
             url: transformed.url,
             text: `You can view more on the ${transformed.typeText} detail page`,

--- a/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
+++ b/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
@@ -74,6 +74,7 @@ export default class InvestmentProject extends React.PureComponent {
 
         <CardDetails
           summary="Key details and people for this project"
+          summaryVisuallyHidden={` ${name}`}
           link={{ url, text: 'Go to the investment project detail page' }}
           showDetails={showDetails}
         >

--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -46,6 +46,7 @@ export default class MaxemailCampaign extends React.PureComponent {
 
         <CardDetails
           summary="View details of this campaign"
+          summaryVisuallyHidden={` ${emailSubject}`}
           showDetails={showDetails}
         >
           <CardTable

--- a/src/client/components/ActivityFeed/activities/Omis.jsx
+++ b/src/client/components/ActivityFeed/activities/Omis.jsx
@@ -50,6 +50,7 @@ export default class Omis extends React.PureComponent {
 
         <CardDetails
           summary="View key details and people for this order"
+          summaryVisuallyHidden={` reference ${reference}`}
           link={{ url, text: 'Go to the order detail page' }}
           showDetails={showDetails}
         >

--- a/src/client/components/ActivityFeed/activities/card/CardDetails.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardDetails.jsx
@@ -3,6 +3,7 @@ import Details from '@govuk-react/details'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
 import { SPACING, MEDIA_QUERIES, FONT_SIZE } from '@govuk-react/constants'
+import { VisuallyHidden } from 'govuk-react'
 import PropTypes from 'prop-types'
 
 const GovUkDetails = styled(Details)`
@@ -27,6 +28,7 @@ const GovUkDetails = styled(Details)`
 export default class CardDetails extends React.PureComponent {
   static propTypes = {
     summary: PropTypes.string.isRequired,
+    summaryVisuallyHidden: PropTypes.string,
     showDetails: PropTypes.bool.isRequired,
     link: PropTypes.shape({
       url: PropTypes.string,
@@ -48,10 +50,21 @@ export default class CardDetails extends React.PureComponent {
   }
 
   render() {
-    const { summary, showDetails, link, children } = this.props
+    const { summary, showDetails, link, children, summaryVisuallyHidden } =
+      this.props
+
+    const SummaryWithHiddenContent = (
+      <>
+        {summary}
+        <VisuallyHidden>{summaryVisuallyHidden}</VisuallyHidden>
+      </>
+    )
 
     return (
-      <GovUkDetails summary={summary} open={showDetails}>
+      <GovUkDetails
+        summary={summaryVisuallyHidden ? SummaryWithHiddenContent : summary}
+        open={showDetails}
+      >
         {children}
         {this.renderLink(link)}
       </GovUkDetails>

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -213,7 +213,10 @@ describe('Company activity feed', () => {
         .should('have.text', '10 Nov 2020GREAT.GOV.UK')
       cy.get('@exportEnquiry')
         .find('details summary')
-        .should('have.text', 'View key details for this enquiry')
+        .should(
+          'have.text',
+          'View key details for this enquiry on great.gov.uk, sent on 10 Nov 2020'
+        )
         .click()
       assertTable(selectors.companyActivity.activityFeed.item(1), exportEnquiry)
     })
@@ -267,7 +270,10 @@ describe('Company activity feed', () => {
 
       cy.get('@maxemailCampaign')
         .find('details summary')
-        .should('have.text', 'View details of this campaign')
+        .should(
+          'have.text',
+          'View details of this campaign British Business Network Update - December 2020'
+        )
         .click()
 
       assertTable(selectors.companyActivity.activityFeed.item(2), [


### PR DESCRIPTION
## Description of change

This PR introduces visually hidden text to the end of the card details text on the Activity Feed. This is because, when tabbing through the page with a screen reader, that details text gets read aloud first alongside the links, so the text of the details should be unique to avoid confusion on which button or link is for what. Visually, it makes sense as each card has its own details, but to a screen reader, it doesn't. After doing some research, the `<VisuallyHidden>` component from GovUk is the most accessible option for this, to add hidden text to the end of the text which a screen reader reads, but visually, doesn't show. 

Grammatically it doesn't quite join up fluently, but after discussion, it feels like the meaning is conveyed enough. 

For ease, this is what's been added for each card ( **visible text** / _hidden text_): 
| Card type | Visible text | Hidden add on |
|-----------|------------|----------------|
| Interaction / Service Delivery | **View interaction/service delivery details** | _for (interaction subject)_ |
| Investment project | **Key details and people for this project**| _(name)_ |
| OMIS order | **View key details and people for this order**| _reference (reference number)_|
| Company's accounts | **View key details for this account**| _(summary) in companies house_|
| Company's record |  **View key details for this company**| _(summary) from companies house_|
| HMRC export |  **View key export details**| _for (reference number)_|
| GREAT enquiry | **View key details for this enquiry**| _on great.gov.uk, sent on (date)_|
| Marketing email | **View details of this campaign**| _(email subject)_ |

## Test instructions

Visually, you shouldn't see anything. On dev, not every type of card is available, but head over to Companies, pick a company then look at their activity feed. For a mac, press cmd + f5 to start up VoiceOver. Click use VoiceOver, then tab your way down through the buttons and links till you get to the first card. Tab onto the detail component, and visually you should see only the visible text... but you should hear the hidden add on immediately after as if it was one sentence. 

This can also be tested on Storybook to see a wider variety of cards, however be warned, VoiceOver doesn't seem to like Storybook 😭 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
