### PR TITLE
Rollback ES version to 7.13.4

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -54,7 +54,7 @@ services:
       POSTGRES_PASSWORD: password
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.14.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.4
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: 'false'


### PR DESCRIPTION
## Description of change

We've recently had to rollback the version of `elasticsearch` used in the API (see [this PR](https://github.com/uktrade/data-hub-api/pull/3672) for more context). Due to this change I've rolled back the ES version used for our e2e tests so both versions match.

## Test instructions

The e2e tests should run and pass as normal.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
