### PR TITLE
Removing additional ellipsis from pagination collection list

### DIFF
--- a/src/client/components/Pagination/computeVisiblePieces.js
+++ b/src/client/components/Pagination/computeVisiblePieces.js
@@ -39,7 +39,7 @@ function computeVisiblePieces(
       pageNumber: 1,
       isActive: activePage === 1,
     })
-    visiblePieces.push({ type: PAGINATION_PIECE_ELLIPSIS })
+    if (activePage > 4) visiblePieces.push({ type: PAGINATION_PIECE_ELLIPSIS })
   }
 
   for (let i = lowerLimit; i <= upperLimit; i += 1) {


### PR DESCRIPTION
## Description of change

Removing additional ellipsis from pagination collection list, that causes unexpected to show-up when clicking three times a`Next` button at pagination from initial state.

## Test instructions

1. Go to /investments/projects
2. Click three times `Next` button at pagination
3. Ellipsis `...` was taken-out in between page 1 and 2 button

## Screenshots
### Before
![Screenshot 2021-08-18 at 15 34 50](https://user-images.githubusercontent.com/28296624/129922044-0d5d32f8-0bd3-4f7a-991b-453cd4ea96a7.png)

### After

![Screenshot 2021-08-18 at 15 22 22](https://user-images.githubusercontent.com/28296624/129922518-0c063f19-32b2-47af-8fed-d13b733f6d7c.png)




## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
