### PR TITLE
Remove dependencies from ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,18 +30,7 @@ updates:
   - dependency-name: "@storybook/react"
     versions:
     - ">= 0"
-  - dependency-name: cypress
-    versions:
-    - 6.1.0
   # ignore all GitHub linguist patch updates
   - dependency-name: "github-linguist"
     update-types: ["version-update:semver-patch"]
-
-  # The latest versions of these dependencies cause issues with IE
-  - dependency-name: core-js
-    versions:
-    - "> 3.9.1"
-  - dependency-name: react-markdown
-    versions:
-    - "> 5.0.3"
   rebase-strategy: disabled


### PR DESCRIPTION
## Description of change

Now that we've removed IE support, we can now upgrade the dependencies that were causing issues with IE. The `cypress` entry has also been removed as we are now past the listed version.

This is being done separately as altering the Dependabot config without any open Dependabot PRs will cause additional PRs to be generated.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
