### PR TITLE
Change MA, FEx, and DW links to use Staging sites on Data Hub staging

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -18,7 +18,6 @@ ELASTIC_APM_SERVICE_NAME='some-service'
 ELASTIC_APM_SERVER_URL=https://some-service.com
 ELASTIC_APM_SECRET_TOKEN=12345
 ELASTIC_APM_SERVER_TIMEOUT=1
-FIND_EXPORTERS_URL=https://lookInVault.com/
 HELP_CENTRE_ANNOUNCMENTS_URL=https://lookInVault.com/
 HELP_CENTRE_API_FEED=http://api:8000/help-centre/announcement
 HELP_CENTRE_FEED_API_TOKEN=lookInVault
@@ -36,6 +35,12 @@ SESSION_SECRET=lookInVault
 ZEN_EMAIL=look@in.vault.com
 ZEN_TICKETS_URL=https://lookInVault.com/
 ZEN_TOKEN=lookInVault
+
+# See Vault for the correct URLs to use. 
+# These URLs will default to production sites (as per the current behaviour) if left commented out. 
+# MARKET_ACCESS_URL=
+# FIND_EXPORTERS_URL=
+# DATA_WORKSPACE_URL=
 
 # API vars
 ACTIVITY_STREAM_ACCESS_KEY_ID=some-id

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -61,8 +61,11 @@ const envSchema = Joi.object({
   // Data store service API endpoint
   DATA_STORE_SERVICE_POSTCODE_TO_REGION_URL: Joi.string().required(),
 
+  // Url to Data Workspace app
+  DATA_WORKSPACE_URL: Joi.string().uri(),
+  
   // Url to Find Exporters app
-  FIND_EXPORTERS_URL: Joi.string().uri().required(),
+  FIND_EXPORTERS_URL: Joi.string().uri(),
 
   // Force using an HTTPS connection
   FORCE_HTTPS: Joi.when('NODE_ENV', {
@@ -91,6 +94,9 @@ const envSchema = Joi.object({
   LOG_LEVEL: Joi.string()
     .valid('error', 'warn', 'info', 'http', 'verbose', 'debug', 'silly')
     .default('error'),
+
+  // Url to Market Access app
+  MARKET_ACCESS_URL: Joi.string().uri(),
 
   // How long to store dropdown data etc for, in seconds. Defaults to 15 minutes
   METADATA_TTL: Joi.number().integer().default(15 * 60),

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -48,6 +48,9 @@ const config = {
   isDev,
   isProd,
   isTest,
+  marketAccessUrl: envVars.MARKET_ACCESS_URL,
+  findExportersUrl: envVars.FIND_EXPORTERS_URL,
+  dataWorkspaceUrl: envVars.DATA_WORKSPACE_URL,
   version: envVars.GIT_BRANCH,
   noCache: envVars.CACHE_ASSETS ? false : isDev,
   port: envVars.PORT,
@@ -85,7 +88,6 @@ const config = {
   paginationMaxResults: 10000,
   paginationDefaultSize: 10,
   performanceDashboardsUrl: envVars.PERFORMANCE_DASHBOARDS_URL,
-  findExportersUrl: envVars.FIND_EXPORTERS_URL,
   archivedDocumentsBaseUrl: envVars.ARCHIVED_DOCUMENTS_BASE_URL,
   oauth: {
     url: envVars.OAUTH2_AUTH_URL,

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -26,6 +26,9 @@ module.exports = function locals(req, res, next) {
     GOOGLE_TAG_MANAGER_KEY: config.googleTagManagerKey,
     IS_XHR: req.xhr,
     QUERY: req.query,
+    MARKET_ACCESS_URL: config.marketAccessUrl,
+    FIND_EXPORTERS_URL: config.findExportersUrl,
+    DATA_WORKSPACE_URL: config.dataWorkspaceUrl,
 
     getPageTitle() {
       const items = res.breadcrumb().map((item) => item.text)

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -120,7 +120,10 @@
       fluid: false,
       user: user,
       domains: {
-        datahub: '/'
+        datahub: '/',
+        findExporters: FIND_EXPORTERS_URL,
+        marketAccess: MARKET_ACCESS_URL,
+        dataWorkspaceDomain: DATA_WORKSPACE_URL
       }
     })
   }}


### PR DESCRIPTION
## Description of change

On Staging, if you click on the Market Access / Find Exporters tabs, or the 'Switch to Data Workspace' button, you will end up on their respective Production sites, instead of the Staging sites. This leads to the risk of changes being made on Production by users thinking that they are still on Staging. 

This PR changes the links depending on which Data Hub environment they are on via environment variables. For the local dev environment, MA, FEx and Data Workspace will still default to production unless you uncomment the environment variables and paste in the Staging environment URLs from Vault/Playbook. 

## Test instructions
**Local Dev**
Will default to Production sites unless you uncomment the environment variables `MARKET_ACCESS_URL`, `FIND_EXPORTERS_URL`, and `DATA_WORKSPACE_URL` and paste in their respective staging links from Vault/Playbook. 

**Staging**
Should send you to Find Exporters and Data Workspace Staging sites, and Market Access UAT site.

**Production**
Should send you to the respective Production site.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
