### PR TITLE
Remove the left and right padding from the pagination

### DIFF
--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -19,7 +19,7 @@ const StyledNav = styled('nav')`
   line-height: 1;
   display: flex;
   justify-content: space-around;
-  padding: ${SPACING.SCALE_3};
+  padding: ${SPACING.SCALE_3} 0;
 
   ${MEDIA_QUERIES.TABLET} {
     display: block;


### PR DESCRIPTION
## Description of change

We need to reduce the chance of the pagination wrapping when paging through large numbers of results.

## Test instructions
This is hard to replicate locally or even on staging as you need to have thousands of results like production. (See screen shots for the example of what this PR fixes)

## Screenshots
![Screenshot 2021-08-23 at 15 56 33](https://user-images.githubusercontent.com/10154302/130469728-8f471594-fe33-478b-bd10-dfb29435e423.png)

### After
![Screenshot 2021-08-23 at 15 56 59](https://user-images.githubusercontent.com/10154302/130469758-f50795ac-59bf-48bb-9d5d-c11f98157ec9.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
