### PR TITLE
Limit the number of pages on collection lists

### DIFF
--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -26,6 +26,7 @@ const CollectionList = ({
   items,
   activePage = 1,
   onPageClick,
+  maxItemsToPaginate = 10000,
   maxItemsToDownload,
   baseDownloadLink,
   entityName,
@@ -34,6 +35,7 @@ const CollectionList = ({
   metadataRenderer,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
+  const maxPages = Math.ceil(maxItemsToPaginate / itemsPerPage)
   return (
     <GridRow>
       <GridCol setWidth="full">
@@ -86,7 +88,7 @@ const CollectionList = ({
                     ))}
                   </ol>
                   <Pagination
-                    totalPages={totalPages}
+                    totalPages={Math.min(totalPages, maxPages)}
                     onPageClick={onPageClick}
                     activePage={activePage}
                   />
@@ -123,6 +125,7 @@ CollectionList.propTypes = {
       query: PropTypes.object.isRequired,
     }),
   }),
+  maxItemsToPaginate: PropTypes.number,
   maxItemsToDownload: PropTypes.number,
   onPageClick: PropTypes.func.isRequired,
   addItemUrl: PropTypes.string,

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -28,6 +28,7 @@ const FilteredCollectionList = ({
   isComplete,
   children,
   collectionName,
+  maxItemsToPaginate = 10000,
   maxItemsToDownload,
   selectedFilters,
   baseDownloadLink = null,
@@ -38,6 +39,7 @@ const FilteredCollectionList = ({
   titleRenderer = null,
 }) => {
   const totalPages = Math.ceil(count / itemsPerPage)
+  const maxPages = Math.ceil(maxItemsToPaginate / itemsPerPage)
   return (
     <Route>
       {({ history, location }) => {
@@ -94,7 +96,7 @@ const FilteredCollectionList = ({
                         </ol>
                         <RoutedPagination
                           qsParamName="page"
-                          totalPages={totalPages}
+                          totalPages={Math.min(totalPages, maxPages)}
                         />
                       </>
                     )
@@ -132,6 +134,7 @@ FilteredCollectionList.propTypes = {
       query: PropTypes.object.isRequired,
     }),
   }),
+  maxItemsToPaginate: PropTypes.number,
   maxItemsToDownload: PropTypes.number,
   selectedFilters: PropTypes.shape({
     label: PropTypes.string,

--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -78,7 +78,11 @@ function Pagination({ totalPages, activePage, getPageUrl, onPageClick }) {
   }
 
   return (
-    <StyledNav aria-label={`pagination: total ${totalPages} pages`}>
+    <StyledNav
+      data-test="pagination"
+      data-total-pages={totalPages}
+      aria-label={`pagination: total ${totalPages} pages`}
+    >
       <StyledPaginationList>
         {visiblePieces.map(
           ({ type, pageNumber, isActive, isDisabled }, index) => {

--- a/test/functional/cypress/specs/companies/pagination-spec.js
+++ b/test/functional/cypress/specs/companies/pagination-spec.js
@@ -1,0 +1,38 @@
+import urls from '../../../../../src/lib/urls'
+
+import { companyListFaker } from '../../fakers/companies'
+
+describe('Company Collections - Pagination', () => {
+  const companyList = companyListFaker(10)
+
+  it('should show a maximum of 1000 pages', () => {
+    cy.intercept('POST', '/api-proxy/v4/search/company', {
+      body: {
+        count: 20000,
+        results: companyList,
+      },
+    }).as('apiRequest')
+    cy.visit(urls.companies.index())
+    cy.wait('@apiRequest')
+
+    cy.get('[data-test=pagination').should(
+      'have.attr',
+      'data-total-pages',
+      1000
+    )
+  })
+
+  it('should show up to 999 pages', () => {
+    cy.intercept('POST', '/api-proxy/v4/search/company', {
+      body: {
+        // There are 10 items on a page, so 9990 items require 999 pages
+        count: 9990,
+        results: companyList,
+      },
+    }).as('apiRequest')
+    cy.visit(urls.companies.index())
+    cy.wait('@apiRequest')
+
+    cy.get('[data-test=pagination').should('have.attr', 'data-total-pages', 999)
+  })
+})


### PR DESCRIPTION
## Description of change

Limits the maximum number of pages shown on collection list pages to 1000. This is due to a limitation on the backend (specifically with elasticsearch), whereby more than 10,000 items (and therefore 1000 pages) cannot be paginated.

The old nunjucks pages also implemented a limit on the frontend, so this is re-instating that functionality for the react collection lists.

See https://uktrade.atlassian.net/browse/RR-170

## Test instructions

If a collection list has over 10,000 items, the maximum page number in the pagination should be 1000.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
