### PR TITLE
Maintain query params when navigating dashboard tabs

### DIFF
--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -18,6 +18,7 @@ const DashboardTabs = ({ id, adviser, hasInvestmentProjects }) => (
       id={`${id}.TabNav`}
       label="Dashboard"
       routed={true}
+      keepQueryParams={true}
       tabs={{
         [urls.dashboard()]: {
           label: 'Investment projects',

--- a/src/client/components/TabNav/__stories__/usage.md
+++ b/src/client/components/TabNav/__stories__/usage.md
@@ -40,3 +40,4 @@ Accessible, optionally routed tab navigation.
 | `label`| Yes | `undefined`| `String`  | A label required for accessibility |
 | `routed`| No | `false` | `Boolean` | If `true` the component will set the current path of the route to the value of the selected index and vice versa |
 | `tabs`| Yes | `undefined` | An object or array of `{label: string, content: ReactNode}` objects | If `true` the component will set the current path of the route to the value of the selected index |
+| `keepQueryParams` | No | `false` | `Boolean` | If `true`, clicking through the navigation will keep any query params in the url.

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -151,6 +151,7 @@ const TabNav = ({
   onFocusChange,
   id,
   routed,
+  keepQueryParams = false,
 }) => {
   const tabKeys = Object.keys(tabs)
   const tablistRef = useRef()
@@ -161,7 +162,7 @@ const TabNav = ({
 
   return (
     <Route>
-      {({ location: { pathname }, history }) => {
+      {({ location: { pathname, search }, history }) => {
         selectedIndex = routed ? pathname : selectedIndex
         const isSelectedValid = tabKeys.includes(selectedIndex)
 
@@ -222,7 +223,8 @@ const TabNav = ({
                       onClick={() => {
                         onChange(key, index)
                         if (routed && !selected) {
-                          history.push(key)
+                          const url = keepQueryParams ? `${key}${search}` : key
+                          history.push(url)
                         }
                       }}
                     >
@@ -255,6 +257,7 @@ const tabPropType = PropTypes.shape({
 TabNav.propTypes = {
   label: PropTypes.string.isRequired,
   routed: PropTypes.any,
+  keepQueryParams: PropTypes.bool,
   tabs: PropTypes.oneOfType([
     PropTypes.arrayOf(tabPropType),
     PropTypes.objectOf(tabPropType),

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -34,4 +34,25 @@ describe('Dashboard - feature flag', () => {
       )
     })
   })
+
+  context('when a user navigates tabs with the feature flag set', () => {
+    before(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
+      cy.visit('/')
+      cy.get('[data-test="dashboard-tabs"] [data-test="tab-item"]')
+        .eq(1)
+        .click()
+    })
+
+    it('should show an alternative layout', () => {
+      cy.get('[data-test="dashboard"]').should('be.visible')
+    })
+
+    it('should maintain the query param for GA tracking', () => {
+      cy.url('[data-test="dashboard"]').should(
+        'contain',
+        'company-lists?featureTesting=personalised-dashboard'
+      )
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

Makes sure that the `?featureTesting=personalised-dashboard` query param does not disppear when navigating dashboard tabs.

## Test instructions

With the the new personalsed dashboard feature flag enabled, visit the homepage. You should see `?featureTesting=personalised-dashboard` in the url - the query param should stay throughout when clicking on the companies lists tab and back again.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
