### PR TITLE
Data Hub header

### DIFF
--- a/src/client/components/DataHubHeader/LogoBar.jsx
+++ b/src/client/components/DataHubHeader/LogoBar.jsx
@@ -1,0 +1,120 @@
+import { NavLink } from 'react-router-dom'
+import VisuallyHidden from '@govuk-react/visually-hidden'
+import styled from 'styled-components'
+import { BLACK, WHITE, YELLOW } from 'govuk-colours'
+import {
+  SPACING,
+  FONT_SIZE,
+  FONT_WEIGHTS,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
+
+// Colours not defined in 'govuk-colours' which we need for consistency
+// with Find Exporters and Market Access.
+import { DARK_BLUE } from '../../utils/colors'
+
+const StyledLogoContainer = styled.div({
+  maxWidth: 960,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  overflow: 'hidden',
+  fontWeight: FONT_WEIGHTS.bold,
+  boxSizing: 'content-box',
+  padding: `2px ${SPACING.SCALE_3}`,
+  [MEDIA_QUERIES.TABLET]: {
+    padding: `2px ${SPACING.SCALE_5}`,
+  },
+})
+
+const StyledLogo = styled.div({
+  fontSize: 30,
+  fontWeight: FONT_WEIGHTS.bold,
+  display: 'inline-block',
+  paddingRight: '2em',
+})
+
+const StyledLogoNavLink = styled(NavLink)({
+  color: WHITE,
+  textDecoration: 'none',
+  boxShadow: 'none',
+  outline: 'none',
+  '&::after': {
+    content: '" "',
+  },
+})
+
+const StyledTag = styled.strong({
+  display: 'inline-block',
+  position: 'relative',
+  fontSize: FONT_SIZE.SIZE_14,
+  fontWeight: FONT_WEIGHTS.bold,
+  lineHeight: 1.25,
+  padding: '4px 8px 2px 8px',
+  outline: '2px solid transparent',
+  outlineOffset: '-2px',
+  color: WHITE,
+  backgroundColor: DARK_BLUE,
+  letterSpacing: 1,
+  textDecoration: 'none',
+  textTransform: 'uppercase',
+  border: 'none',
+  margin: 0,
+  top: -5,
+})
+
+const NavigationList = styled.ul({
+  display: ({ showVerticalNav }) => (showVerticalNav ? 'block' : 'none'),
+  fontSize: FONT_SIZE.SIZE_16,
+  listStyle: 'none',
+  margin: 0,
+  padding: 0,
+  outline: '3px solid transparent',
+  fontWeight: FONT_WEIGHTS.bold,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'block',
+    float: 'right',
+  },
+})
+
+const NavigationListItem = styled.li({
+  display: 'block',
+  [MEDIA_QUERIES.TABLET]: {
+    padding: `${SPACING.SCALE_1} 0 ${SPACING.SCALE_1} ${SPACING.SCALE_2}`,
+  },
+})
+
+const NavigationLink = styled.a({
+  color: WHITE,
+  textDecoration: 'none',
+  display: 'block',
+  padding: `${SPACING.SCALE_1} 0`,
+  width: '100%',
+  '-webkit-font-smoothing': 'antialiased',
+  ':focus': {
+    color: BLACK,
+    background: YELLOW,
+  },
+})
+
+const LogoBar = ({ showVerticalNav }) => (
+  <StyledLogoContainer>
+    <StyledLogo>
+      <VisuallyHidden>Department for International Trade</VisuallyHidden>
+      <StyledLogoNavLink to="/">Data Hub</StyledLogoNavLink>
+      <StyledTag>beta</StyledTag>
+    </StyledLogo>
+    <NavigationList
+      showVerticalNav={showVerticalNav}
+      id="logo-navigation"
+      aria-label="Header links"
+    >
+      <NavigationListItem>
+        <NavigationLink href="https://data.trade.gov.uk">
+          Switch to Data Workspace
+        </NavigationLink>
+      </NavigationListItem>
+    </NavigationList>
+  </StyledLogoContainer>
+)
+
+export default LogoBar

--- a/src/client/components/DataHubHeader/NavBar.jsx
+++ b/src/client/components/DataHubHeader/NavBar.jsx
@@ -1,0 +1,143 @@
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components'
+import { BLACK } from 'govuk-colours'
+import {
+  FONT_SIZE,
+  FONT_WEIGHTS,
+  BORDER_WIDTH,
+  SPACING,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
+
+// Colours not defined in 'govuk-colours' which we need for consistency
+// with Find Exporters and Market Access.
+import { LIGHT_GREY, DARK_BLUE } from '../../utils/colors'
+
+const StyledNavContainer = styled.div({
+  position: 'relative',
+  backgroundColor: BLACK,
+  lineHeight: 1.5,
+})
+
+const StyledNav = styled.nav({
+  backgroundColor: LIGHT_GREY,
+  fontWeight: FONT_WEIGHTS.bold,
+})
+
+const StyledList = styled.ul({
+  margin: 0,
+  maxWidth: 960,
+  marginLeft: 'auto',
+  marginRight: 'auto',
+  position: 'relative',
+  listStyle: 'none',
+  boxSizing: 'content-box',
+  padding: `0 ${SPACING.SCALE_3}`,
+  display: ({ showVerticalNav }) => (showVerticalNav ? 'block' : 'none'),
+  [MEDIA_QUERIES.TABLET]: {
+    paddingLeft: SPACING.SCALE_5,
+    paddingRight: SPACING.SCALE_5,
+    display: 'block',
+  },
+})
+
+const StyledListItem = styled.li({
+  paddingRight: SPACING.SCALE_4,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'inline-block',
+  },
+})
+
+const styledLinkActive = {
+  content: '""',
+  position: 'absolute',
+  left: 0,
+  right: 0,
+  bottom: 0,
+  borderBottom: `${BORDER_WIDTH} solid`,
+  borderColor: DARK_BLUE,
+}
+
+const styledLink = {
+  position: 'relative',
+  display: 'block',
+  margin: 0,
+  padding: `${SPACING.SCALE_1} 0`,
+  fontSize: FONT_SIZE.SIZE_16,
+  textDecoration: 'none',
+  lineHeight: '23px',
+  color: BLACK,
+  '&.active': {
+    color: DARK_BLUE,
+  },
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'inline-block',
+    padding: '8px 0',
+    ':hover::after': styledLinkActive,
+    '&.active::after': styledLinkActive,
+  },
+}
+
+const StyledNavLink = styled(NavLink)(styledLink)
+const StyledLink = styled.a(styledLink)
+
+const NavBar = ({ onShowVerticalNav, showVerticalNav }) => (
+  <StyledNavContainer>
+    <StyledNav aria-labelledby="navigation">
+      <StyledList
+        showVerticalNav={showVerticalNav}
+        id="navigation"
+        aria-label="Top Level Navigation"
+        onClick={() => onShowVerticalNav(!showVerticalNav)}
+      >
+        <StyledListItem>
+          <StyledNavLink to="/companies" activeClassName="active">
+            Companies
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/contacts" activeClassName="active">
+            Contacts
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/events" activeClassName="active">
+            Events
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/interactions" activeClassName="active">
+            Interactions
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/investments" activeClassName="active">
+            Investments
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/omis" activeClassName="active">
+            Orders
+          </StyledNavLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledLink href="https://find-exporters.datahub.trade.gov.uk/">
+            Find exporters
+          </StyledLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledLink href="https://market-access.trade.gov.uk/">
+            Market Access
+          </StyledLink>
+        </StyledListItem>
+        <StyledListItem>
+          <StyledNavLink to="/support" activeClassName="active">
+            Support
+          </StyledNavLink>
+        </StyledListItem>
+      </StyledList>
+    </StyledNav>
+  </StyledNavContainer>
+)
+
+export default NavBar

--- a/src/client/components/DataHubHeader/NavButton.jsx
+++ b/src/client/components/DataHubHeader/NavButton.jsx
@@ -1,0 +1,59 @@
+import { MEDIA_QUERIES, FONT_SIZE, SPACING } from '@govuk-react/constants'
+import styled from 'styled-components'
+import { BLACK, WHITE, YELLOW } from 'govuk-colours'
+
+const Button = styled.button(({ showVerticalNav }) => ({
+  display: 'block',
+  position: 'absolute',
+  fontWeight: 400,
+  fontSize: FONT_SIZE.SIZE_14,
+  top: SPACING.SCALE_4,
+  right: SPACING.SCALE_5,
+  margin: 0,
+  padding: 0,
+  border: 0,
+  color: WHITE,
+  background: '0 0',
+  outline: 'none',
+  ':focus': {
+    color: BLACK,
+    background: YELLOW,
+  },
+  '&::after': {
+    content: '""',
+    display: 'inline-block',
+    width: 0,
+    height: 0,
+    borderStyle: 'solid',
+    borderColor: 'transparent',
+    borderBottomColor: 'inherit',
+    borderTopColor: 'inherit',
+    marginLeft: SPACING.SCALE_1,
+    ...(showVerticalNav
+      ? {
+          clipPath: 'polygon(50% 0, 0 100%, 100% 100%)',
+          borderWidth: '0 5px 8px 5px',
+        }
+      : {
+          clipPath: 'polygon(0 0, 50% 100%, 100% 0)',
+          borderWidth: '8px 5px 0 5px',
+        }),
+  },
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'none',
+  },
+}))
+
+const NavButton = ({ onShowVerticalNav, showVerticalNav }) => (
+  <Button
+    showVerticalNav={showVerticalNav}
+    onClick={() => onShowVerticalNav(!showVerticalNav)}
+    role="button"
+    aria-label="Show or hide navigation"
+    aria-controls="navigation sub-navigation logo-navigation"
+  >
+    Menu
+  </Button>
+)
+
+export default NavButton

--- a/src/client/components/DataHubHeader/___stories__/DataHubHeader.stories.jsx
+++ b/src/client/components/DataHubHeader/___stories__/DataHubHeader.stories.jsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
+import { storiesOf } from '@storybook/react'
+
+import DataHubHeader from '../index'
+
+const Dashboard = () => <h5>Dashboard</h5>
+const Companies = () => <h5>Companies</h5>
+const Contacts = () => <h5>Contacts</h5>
+const Events = () => <h5>Events</h5>
+const Interactions = () => <h5>Interactions</h5>
+const Investments = () => <h5>Investments</h5>
+const Orders = () => <h5>Orders(OMIS)</h5>
+const Support = () => <h5>Support</h5>
+
+const App = () => {
+  const [showVerticalNav, setShowVerticalNav] = useState(false)
+  return (
+    <Router>
+      <DataHubHeader
+        showVerticalNav={showVerticalNav}
+        onShowVerticalNav={setShowVerticalNav}
+      />
+      <Switch>
+        <Route exact={true} path="/" component={Dashboard} />
+        <Route path="/companies" component={Companies} />
+        <Route path="/contacts" component={Contacts} />
+        <Route path="/events" component={Events} />
+        <Route path="/interactions" component={Interactions} />
+        <Route path="/investments" component={Investments} />
+        <Route path="/omis" component={Orders} />
+        <Route path="/support" component={Support} />
+      </Switch>
+    </Router>
+  )
+}
+
+storiesOf('DataHubHeader', module).add('Data Hub Header', () => <App />)

--- a/src/client/components/DataHubHeader/index.jsx
+++ b/src/client/components/DataHubHeader/index.jsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+import { BLACK } from 'govuk-colours'
+
+import LogoBar from './LogoBar'
+import NavButton from './NavButton'
+import NavBar from './NavBar'
+
+const Header = styled.header({
+  position: 'relative',
+  lineHeight: 1.5,
+  backgroundColor: BLACK,
+})
+
+const DataHubHeader = ({ onShowVerticalNav, showVerticalNav }) => (
+  <Header role="banner">
+    <LogoBar showVerticalNav={showVerticalNav}></LogoBar>
+    <NavButton
+      onShowVerticalNav={onShowVerticalNav}
+      showVerticalNav={showVerticalNav}
+    />
+    <NavBar
+      onShowVerticalNav={onShowVerticalNav}
+      showVerticalNav={showVerticalNav}
+    />
+  </Header>
+)
+
+export default DataHubHeader

--- a/src/client/utils/colors.js
+++ b/src/client/utils/colors.js
@@ -22,8 +22,19 @@ export const rgba = (colorHex, alpha) => `rgba(${hexToRgb(colorHex)},${alpha})`
 // The following colours are not included in either:
 // - https://github.com/penx/govuk-colours or
 // - https://github.com/govuk-react/govuk-react (which references govuk-colours)
-// Instead, the colours have been taken from:
+// Instead, the colours below have been taken from:
 // - https://github.com/alphagov/govuk-frontend (referenced by GOV.UK Design System)
+
+// Taken from the legacy palette, we're unable to choose a colour
+// from the modern palette as it's either too light or too dark
+// for the Data Hub header nav element which sits in between a
+// darker and lighter shade of grey forming a natural gradient.
+export const LIGHT_GREY = '#dee0e2'
+
+// We require this specific blue for the navigation hover/selection.
+// This blue has to match the colour of both 'Find Exporters' and 'Market Access'.
+export const DARK_BLUE = '#005ea5'
+
 export const DARK_GREY = '#505a5f'
 export const MID_GREY = '#b1b4b6'
 export const FOCUS_COLOUR = '#ffdd00'


### PR DESCRIPTION
## Description of change

The Data Hub header rewritten in react.

## Test instructions

For comparisons against the Data Hub header in the _dev_ environment it's beneficial for Storybook to go full screen, this is easily done by adding a Storybook parameter `layout: 'fullscreen` [here](https://github.com/uktrade/data-hub-frontend/blob/master/.storybook/preview.js#L25). For example:
```js
addParameters({
  layout: 'fullscreen',
  options: {
    theme: {},
  },
})
```

**`npm run storybook`** and look for DataHubHeader

<img width="1460" alt="Screenshot 2021-09-02 at 09 00 56" src="https://user-images.githubusercontent.com/964268/131806133-54f92ea4-b3c5-4621-b210-7a9f2848c21a.png">

Now tab between both Storybook and the Data Hub header in the dev environment comparing both implementations - it should be pixel perfect - it works on smaller devices too :-)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
