### PR TITLE
CDS-187 Show State on Contact Address

### DIFF
--- a/src/apps/components/views/keyvaluetables.njk
+++ b/src/apps/components/views/keyvaluetables.njk
@@ -2,8 +2,8 @@
 
 {% block body_main_content %}
   <h2 class="heading-medium">Key value table</h2>
-  {% component 'key-value-table', items=tableData %}
+  {% component 'key-value-table', items=tableData, features=features %}
 
   <h2 class="heading-medium">Key value striped</h2>
-  {% component 'key-value-table', items=tableData, variant='striped' %}
+  {% component 'key-value-table', items=tableData, variant='striped', features=features %}
 {% endblock %}

--- a/src/apps/contacts/__test__/transformers.test.js
+++ b/src/apps/contacts/__test__/transformers.test.js
@@ -301,6 +301,7 @@ describe('Contact transformers', () => {
             address_2: 'Bridge Lane',
             address_town: 'Maidenhead',
             address_county: 'Berkshire',
+            address_area: undefined,
             address_country: {
               id: '80756b9a-5d95-e211-a939-e4115bead28a',
               name: 'United Kingdom',
@@ -321,9 +322,55 @@ describe('Contact transformers', () => {
             town: 'Maidenhead',
             county: 'Berkshire',
             postcode: 'SL1 11LL',
+            area: undefined,
             country: {
               id: '80756b9a-5d95-e211-a939-e4115bead28a',
               name: 'United Kingdom',
+            },
+          },
+        })
+      })
+    })
+
+    context('when the US contact has their own address', () => {
+      beforeEach(() => {
+        this.view = transformContactToView(
+          assign({}, contact, {
+            address_1: 'Bridge House',
+            address_2: 'Bridge Lane',
+            address_town: 'Sunny Town',
+            address_county: undefined,
+            address_area: {
+              id: '80756b9a-5d95-e211-a939-e4115bead28a',
+              name: 'California',
+            },
+            address_country: {
+              id: '80756b9a-5d95-e211-a939-e4115bead28a',
+              name: 'United States',
+            },
+            address_postcode: '90001',
+            address_same_as_company: false,
+          }),
+          company
+        )
+      })
+
+      it('uses the contacts address', () => {
+        expect(this.view.Address).to.deep.equal({
+          type: 'address',
+          address: {
+            line_1: 'Bridge House',
+            line_2: 'Bridge Lane',
+            town: 'Sunny Town',
+            county: undefined,
+            postcode: '90001',
+            area: {
+              id: '80756b9a-5d95-e211-a939-e4115bead28a',
+              name: 'California',
+            },
+            country: {
+              id: '80756b9a-5d95-e211-a939-e4115bead28a',
+              name: 'United States',
             },
           },
         })

--- a/src/apps/contacts/controllers/__test__/details.test.js
+++ b/src/apps/contacts/controllers/__test__/details.test.js
@@ -87,6 +87,7 @@ describe('Contact controller', () => {
     context('when called with a contact', () => {
       beforeEach(() => {
         this.res.locals = assign({}, this.res.locals, { contact })
+        this.res.locals.features = assign({}, this.res.locals.features)
         this.contactController.getDetails(this.req, this.res, this.next)
       })
 

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -43,6 +43,10 @@ function getDetails(req, res, next) {
         res.locals.contact,
         res.locals.company
       ),
+      features: {
+        addressAreaContactRequired:
+          res.locals.features['address-area-contact-required-field'],
+      },
     })
   } catch (error) {
     next(error)

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -45,7 +45,7 @@ function getDetails(req, res, next) {
       ),
       features: {
         addressAreaContactRequired:
-          res.locals.features['address-area-contact-required-field'],
+          res.locals.features['address-area-contact-displayed'],
       },
     })
   } catch (error) {

--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -17,6 +17,7 @@ function getContactAddress(
         town: contactAddressFields.address_town,
         county: contactAddressFields.address_county,
         postcode: contactAddressFields.address_postcode,
+        area: contactAddressFields.address_area,
         country: contactAddressFields.address_country,
       }
 }
@@ -118,6 +119,7 @@ function transformContactToView(
     address_town,
     address_county,
     address_postcode,
+    address_area,
     address_country,
     telephone_alternative,
     email_alternative,
@@ -149,6 +151,7 @@ function transformContactToView(
           address_town,
           address_county,
           address_postcode,
+          address_area,
           address_country,
         },
         company

--- a/src/apps/contacts/views/details.njk
+++ b/src/apps/contacts/views/details.njk
@@ -3,7 +3,7 @@
 {% block main_grid_right_column %}
 
   {% call DetailsContainer({ heading: 'Contact details' }) %}
-    {% component 'key-value-table', variant='striped', items=contactDetails, id='contact-details' %}
+    {% component 'key-value-table', variant='striped', items=contactDetails, id='contact-details', features=features %}
 
     {% if not contact.archived %}
       <p>

--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -218,7 +218,7 @@ const filters = {
     return format(value, dateFormat).replace('AM', 'am').replace('PM', 'pm')
   },
 
-  formatAddress: (address, join = ', ', isAddressAreaEnabled = false) => {
+  formatAddress: (address, join = ', ', featureFlag = false) => {
     if (!address) {
       return
     }
@@ -229,7 +229,7 @@ const filters = {
       address.town,
       address.county,
       address.postcode,
-      address.area && isAddressAreaEnabled ? address.area.name : null,
+      address.area && featureFlag ? address.area.name : null,
       address.country.name,
     ]).join(join)
   },

--- a/src/templates/_components/key-value-table.njk
+++ b/src/templates/_components/key-value-table.njk
@@ -66,7 +66,7 @@
   {% elif data.type === 'details' %}
     {{ details(data) }}
   {% elif data.type === 'address' %}
-    {{ data.address | formatAddress }}
+    {{ data.address | formatAddress(', ', features.addressAreaContactRequired) }}
   {% elif data.type === 'error' %}
     {{ error(data) }}
   {% elif data.type === 'paragraph' %}


### PR DESCRIPTION
## Description of change

The contact details page now shows US State/Province in the address when present.

## Test instructions

Go to a contact with a US/Canadian address that has an address area set. You should see the address area listed as part of the address.

You will need to enable the feature-flag `address-area-contact-required-field` to test this.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/20663545/132336510-5c8efd3e-af30-4634-9934-d993fe6bcc31.png)

### After

![image](https://user-images.githubusercontent.com/20663545/132336660-97b14490-5c7a-4442-9a6d-d11b2017aaea.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
