### PR TITLE
Replace IE11 with Edge in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,4 +22,4 @@ https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20gu
 
 - [ ] Has the branch been rebased to master?
 - [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
-- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
+- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)


### PR DESCRIPTION
## Description of change

We aren't supporting IE anymore so we don't need it in the PR template.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, IE11, Safari)
