### PR TITLE
Dependabot - 20/09/2021

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6566,7 +6566,7 @@
             "parse-entities": "^2.0.0",
             "repeat-string": "^1.5.4",
             "state-toggle": "^1.0.0",
-            "trim": "0.0.3",
+            "trim": "0.0.1",
             "trim-trailing-lines": "^1.0.0",
             "unherit": "^1.0.4",
             "unist-util-remove-position": "^2.0.0",
@@ -6806,52 +6806,6 @@
             "glob": "^7.1.3"
           }
         }
-      }
-    },
-    "@pmmmwh/react-refresh-webpack-plugin": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0.tgz",
-      "integrity": "sha512-VRmiCnVHudkmzGh4gD1eW42matvNL8Y0OZ8FCEWs79iPTldihsuEi5GTMFjU+UfKRQxinN2e0/MDhJzExuiIyA==",
-      "dependencies": {
-        "ajv": {
-          "version": "6.12.6",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-keywords": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
-        },
-        "schema-utils": {
-          "version": "2.7.1",
-          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
-          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
-          "requires": {
-            "@types/json-schema": "^7.0.5",
-            "ajv": "^6.12.4",
-            "ajv-keywords": "^3.5.2"
-          }
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
-        }
-      },
-      "requires": {
-        "ansi-html": "^0.0.7",
-        "error-stack-parser": "^2.0.6",
-        "html-entities": "^1.2.1",
-        "native-url": "^0.2.6",
-        "schema-utils": "^2.6.5",
-        "source-map": "^0.7.3"
       }
     },
     "@popperjs/core": {
@@ -7221,7 +7175,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "11.2.0"
+            "highlight.js": "~10.7.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -7302,9 +7256,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "11.2.0",
+            "highlight.js": "^10.1.1",
             "lowlight": "^1.14.0",
-            "prismjs": "1.24.1",
+            "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -7337,7 +7291,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "1.24.1"
+            "prismjs": "~1.24.0"
           },
           "dependencies": {
             "prismjs": {
@@ -7507,7 +7461,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "11.2.0"
+            "highlight.js": "~10.7.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -7588,9 +7542,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "11.2.0",
+            "highlight.js": "^10.1.1",
             "lowlight": "^1.14.0",
-            "prismjs": "1.24.1",
+            "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -7623,7 +7577,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "1.24.1"
+            "prismjs": "~1.24.0"
           },
           "dependencies": {
             "prismjs": {
@@ -8349,7 +8303,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "11.2.0"
+            "highlight.js": "~10.7.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -8506,9 +8460,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "11.2.0",
+            "highlight.js": "^10.1.1",
             "lowlight": "^1.14.0",
-            "prismjs": "1.24.1",
+            "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -8541,7 +8495,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "1.24.1"
+            "prismjs": "~1.24.0"
           },
           "dependencies": {
             "prismjs": {
@@ -9869,7 +9823,7 @@
       "requires": {
         "@babel/preset-flow": "^7.12.1",
         "@babel/preset-react": "^7.12.10",
-        "@pmmmwh/react-refresh-webpack-plugin": "0.5.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
         "@storybook/addons": "6.3.8",
         "@storybook/core": "6.3.8",
         "@storybook/core-common": "6.3.8",
@@ -9897,15 +9851,15 @@
           "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0.tgz",
           "integrity": "sha512-VRmiCnVHudkmzGh4gD1eW42matvNL8Y0OZ8FCEWs79iPTldihsuEi5GTMFjU+UfKRQxinN2e0/MDhJzExuiIyA==",
           "requires": {
-            "loader-utils": "^2.0.0",
-            "error-stack-parser": "^2.0.6",
+            "ansi-html-community": "^0.0.8",
             "common-path-prefix": "^3.0.0",
             "core-js-pure": "^3.8.1",
-            "html-entities": "^2.1.0",
-            "source-map": "^0.7.3",
-            "ansi-html-community": "^0.0.8",
+            "error-stack-parser": "^2.0.6",
             "find-up": "^5.0.0",
-            "schema-utils": "^3.0.0"
+            "html-entities": "^2.1.0",
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0",
+            "source-map": "^0.7.3"
           }
         },
         "@types/json-schema": {
@@ -10264,7 +10218,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "11.2.0"
+            "highlight.js": "~10.7.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -10362,9 +10316,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "11.2.0",
+            "highlight.js": "^10.1.1",
             "lowlight": "^1.14.0",
-            "prismjs": "1.24.1",
+            "prismjs": "^1.21.0",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -10397,7 +10351,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "1.24.1"
+            "prismjs": "~1.24.0"
           },
           "dependencies": {
             "prismjs": {
@@ -13869,12 +13823,20 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": "4.0.1",
+        "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       },
       "dependencies": {
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -13883,7 +13845,10 @@
         "set-value": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
-          "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ=="
+          "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
         }
       }
     },
@@ -13937,7 +13902,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "optional": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           },
           "dependencies": {
             "is-plain-obj": {
@@ -14504,18 +14469,6 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
-    },
-    "clipboard": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
-      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "good-listener": "^1.2.2",
-        "select": "^1.1.2",
-        "tiny-emitter": "^2.0.0"
-      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -16900,13 +16853,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
-    "delegate": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-      "dev": true,
-      "optional": true
-    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -18053,7 +17999,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash.merge": "4.6.2",
+        "lodash.merge": "^4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -19594,7 +19540,7 @@
       "integrity": "sha512-T31JAiPYPCosfiBeKX5CTkIUhbs78NHAn8dfvX4T5wz1PRLkgGJmLqEzDk1BgIzzzXcmbsof9YtNF6cJQEsPrw==",
       "requires": {
         "html-minifier": "3.5.7",
-        "lodash.merge": "4.6.2"
+        "lodash.merge": "4.6.0"
       },
       "dependencies": {
         "lodash.merge": {
@@ -20237,7 +20183,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "optional": true,
       "requires": {
-        "semver-regex": "3.1.3"
+        "semver-regex": "^2.0.0"
       },
       "dependencies": {
         "semver-regex": {
@@ -21166,16 +21112,6 @@
         }
       }
     },
-    "good-listener": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
-      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "delegate": "^3.1.2"
-      }
-    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -21185,7 +21121,7 @@
         "decompress-response": "^3.2.0",
         "duplexer3": "^0.1.4",
         "get-stream": "^3.0.0",
-        "is-plain-obj": "1.1.0",
+        "is-plain-obj": "^1.1.0",
         "is-retry-allowed": "^1.0.0",
         "is-stream": "^1.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -21687,11 +21623,6 @@
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
-    "highlight.js": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
-      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
-    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -22189,7 +22120,7 @@
         "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
-        "is-plain-obj": "1.1.0",
+        "is-plain-obj": "^3.0.0",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -22601,11 +22532,6 @@
         "exec-buffer": "^3.0.0",
         "is-cwebp-readable": "^3.0.0"
       }
-    },
-    "immer": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
-      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
     },
     "immutable": {
       "version": "3.8.2",
@@ -23293,11 +23219,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "3.0.1",
@@ -24962,11 +24883,6 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -25188,7 +25104,7 @@
       "dev": true,
       "requires": {
         "fault": "^1.0.2",
-        "highlight.js": "11.2.0"
+        "highlight.js": "~9.13.0"
       },
       "dependencies": {
         "highlight.js": {
@@ -25761,12 +25677,6 @@
         }
       }
     },
-    "merge": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
-      "dev": true
-    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -26029,7 +25939,7 @@
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "1.1.0",
+        "is-plain-obj": "^1.1.0",
         "kind-of": "^6.0.3"
       },
       "dependencies": {
@@ -26962,14 +26872,6 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
-      }
-    },
-    "native-url": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
-      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
-      "requires": {
-        "querystring": "^0.2.0"
       }
     },
     "natural-compare": {
@@ -29461,15 +29363,6 @@
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
     },
-    "prismjs": {
-      "version": "1.24.1",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-      "dev": true,
-      "requires": {
-        "clipboard": "^2.0.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -30085,7 +29978,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "9.0.6",
+        "immer": "8.0.1",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -30586,9 +30479,9 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "11.2.0",
+        "highlight.js": "~9.13.0",
         "lowlight": "~1.11.0",
-        "prismjs": "1.24.1",
+        "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -30877,13 +30770,14 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "1.24.1"
+        "prismjs": "~1.17.0"
       },
       "dependencies": {
         "prismjs": {
           "version": "1.24.1",
           "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
+          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+          "dev": true
         }
       }
     },
@@ -31221,7 +31115,7 @@
             "parse-entities": "^2.0.0",
             "repeat-string": "^1.5.4",
             "state-toggle": "^1.0.0",
-            "trim": "0.0.3",
+            "trim": "0.0.1",
             "trim-trailing-lines": "^1.0.0",
             "unherit": "^1.0.4",
             "unist-util-remove-position": "^2.0.0",
@@ -31931,7 +31825,7 @@
         "known-css-properties": "^0.3.0",
         "lodash.capitalize": "^4.1.0",
         "lodash.kebabcase": "^4.0.0",
-        "merge": "2.1.1",
+        "merge": "^1.2.0",
         "path-is-absolute": "^1.0.0",
         "util": "^0.10.3"
       },
@@ -32188,7 +32082,8 @@
         "merge": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w=="
+          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -32459,13 +32354,6 @@
         }
       }
     },
-    "select": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-      "dev": true,
-      "optional": true
-    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -32664,40 +32552,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
       "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
-    },
-    "set-value": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
-      "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
-      "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
-        }
-      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -33245,7 +33099,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "optional": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       },
       "dependencies": {
         "is-plain-obj": {
@@ -33592,7 +33446,7 @@
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "1.24.1",
+        "prismjs": "^1.16.0",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"
@@ -34959,13 +34813,6 @@
         "setimmediate": "^1.0.4"
       }
     },
-    "tiny-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "dev": true,
-      "optional": true
-    },
     "tiny-invariant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -35125,11 +34972,6 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
-    },
-    "trim": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
-      "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -35504,7 +35346,7 @@
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
       },
@@ -35529,7 +35371,7 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "4.0.1"
+        "set-value": "^2.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -35558,10 +35400,7 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
           "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "is-plain-object": "^2.0.4"
           }
         }
       }
@@ -37329,7 +37168,7 @@
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18725,20 +18725,20 @@
       "dev": true
     },
     "eslint-plugin-react": {
-      "version": "7.25.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.1.tgz",
-      "integrity": "sha512-P4j9K1dHoFXxDNP05AtixcJEvIT6ht8FhYKsrkY0MPCPaUMYijhpWwNiRDZVtA8KFuZOkGSeft6QwH8KuVpJug==",
+      "version": "7.25.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.25.3.tgz",
+      "integrity": "sha512-ZMbFvZ1WAYSZKY662MBVEWR45VaBT6KSJCiupjrNlcdakB90juaZeDCbJq19e73JZQubqFtgETohwgAt8u5P6w==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.3",
         "array.prototype.flatmap": "^1.2.4",
         "doctrine": "^2.1.0",
         "estraverse": "^5.2.0",
-        "has": "^1.0.3",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.0.4",
         "object.entries": "^1.1.4",
         "object.fromentries": "^2.0.4",
+        "object.hasown": "^1.0.0",
         "object.values": "^1.1.4",
         "prop-types": "^15.7.2",
         "resolve": "^2.0.0-next.3",
@@ -23783,12 +23783,12 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
-      "integrity": "sha512-EIsmt3O3ljsU6sot/J4E1zDRxfBNrhjyf/OKjlydwgEimQuznlM4Wv7U+ueONJMyEn1WRE0K8dhi3dVAXYT24Q==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.1.tgz",
+      "integrity": "sha512-uP5vu8xfy2F9A6LGC22KO7e2/vGTS1MhP+18f++ZNlf0Ohaxbc9nIEwHAsejlJKyzfZzU5UIhe5ItYkitcZnZA==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.2",
+        "array-includes": "^3.1.3",
         "object.assign": "^4.1.2"
       },
       "dependencies": {
@@ -23816,22 +23816,23 @@
           }
         },
         "es-abstract": {
-          "version": "1.18.5",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
-          "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
           "dev": true,
           "requires": {
             "call-bind": "^1.0.2",
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
             "has": "^1.0.3",
             "has-symbols": "^1.0.2",
             "internal-slot": "^1.0.3",
-            "is-callable": "^1.2.3",
+            "is-callable": "^1.2.4",
             "is-negative-zero": "^2.0.1",
-            "is-regex": "^1.1.3",
-            "is-string": "^1.0.6",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
             "object-inspect": "^1.11.0",
             "object-keys": "^1.1.1",
             "object.assign": "^4.1.2",
@@ -27489,6 +27490,134 @@
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.0-next.1"
+      }
+    },
+    "object.hasown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.0.0.tgz",
+      "integrity": "sha512-qYMF2CLIjxxLGleeM0jrcB4kiv3loGVAjKQKvH8pSU/i2VcRRvUNmxbD+nEMmrXRfORhuVJuH8OtSYCZoue3zA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.1"
+      },
+      "dependencies": {
+        "call-bind": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+          "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.0.2"
+          }
+        },
+        "es-abstract": {
+          "version": "1.18.6",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+          "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "get-intrinsic": "^1.1.1",
+            "get-symbol-description": "^1.0.0",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.2",
+            "internal-slot": "^1.0.3",
+            "is-callable": "^1.2.4",
+            "is-negative-zero": "^2.0.1",
+            "is-regex": "^1.1.4",
+            "is-string": "^1.0.7",
+            "object-inspect": "^1.11.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.2",
+            "string.prototype.trimend": "^1.0.4",
+            "string.prototype.trimstart": "^1.0.4",
+            "unbox-primitive": "^1.0.1"
+          }
+        },
+        "get-intrinsic": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+          "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+          "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.4",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+          "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+          "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "is-string": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+          "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+          "dev": true,
+          "requires": {
+            "has-tostringtag": "^1.0.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.11.0",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+          "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        },
+        "string.prototype.trimend": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+          "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        },
+        "string.prototype.trimstart": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+          "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.2",
+            "define-properties": "^1.1.3"
+          }
+        }
       }
     },
     "object.pick": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4797,9 +4797,9 @@
       }
     },
     "@cypress/request": {
-      "version": "2.88.5",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.5.tgz",
-      "integrity": "sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==",
+      "version": "2.88.6",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
+      "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
       "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
@@ -4815,25 +4815,18 @@
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "qs": {
           "version": "6.5.2",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-          "dev": true
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
           "dev": true
         }
       }
@@ -10669,9 +10662,9 @@
       }
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
+      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g==",
       "dev": true
     },
     "@types/sizzle": {
@@ -10753,9 +10746,9 @@
       }
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -15781,12 +15774,12 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "cypress": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.3.0.tgz",
-      "integrity": "sha512-zA5Rcq8AZIfRfPXU0CCcauofF+YpaU9HYbfqkunFTmFV0Kdlo14tNjH2E3++MkjXKFnv3/pXq+HgxWtw8CSe8Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.4.1.tgz",
+      "integrity": "sha512-itJXq0Vx3sXCUrDyBi2IUrkxVu/gTTp1VhjB5tzGgkeCR8Ae+/T8WV63rsZ7fS8Tpq7LPPXiyoM/sEdOX7cR6A==",
       "dev": true,
       "requires": {
-        "@cypress/request": "^2.88.5",
+        "@cypress/request": "^2.88.6",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "^6.0.2",
@@ -15830,9 +15823,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.17.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
-          "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==",
+          "version": "14.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
+          "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
           "dev": true
         },
         "ansi-styles": {
@@ -19505,9 +19498,9 @@
       },
       "dependencies": {
         "get-stream": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
             "pump": "^3.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4883,9 +4883,9 @@
       }
     },
     "@elastic/ecs-pino-format": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@elastic/ecs-pino-format/-/ecs-pino-format-1.2.0.tgz",
-      "integrity": "sha512-7TGPoxPMHkhqdp98u9F1+4aNwktgh8tlG/PX2c/d/RcAqHziaRCc72tuwGLMu9K/w/M5bWz0eKbcFXr4fSZGwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@elastic/ecs-pino-format/-/ecs-pino-format-1.3.0.tgz",
+      "integrity": "sha512-U8D57gPECYoRCcwREsrXKBtqeyFFF/KAwHi4rG1u/oQhAg91Kzw8ZtUQJXD/DMDieLOqtbItFr2FRBWI3t3wog==",
       "requires": {
         "@elastic/ecs-helpers": "^1.1.0"
       }
@@ -6569,7 +6569,7 @@
             "parse-entities": "^2.0.0",
             "repeat-string": "^1.5.4",
             "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
+            "trim": "0.0.3",
             "trim-trailing-lines": "^1.0.0",
             "unherit": "^1.0.4",
             "unist-util-remove-position": "^2.0.0",
@@ -6809,6 +6809,52 @@
             "glob": "^7.1.3"
           }
         }
+      }
+    },
+    "@pmmmwh/react-refresh-webpack-plugin": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0.tgz",
+      "integrity": "sha512-VRmiCnVHudkmzGh4gD1eW42matvNL8Y0OZ8FCEWs79iPTldihsuEi5GTMFjU+UfKRQxinN2e0/MDhJzExuiIyA==",
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+        },
+        "schema-utils": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
+          "integrity": "sha512-SHiNtMOUGWBQJwzISiVYKu82GiV4QYGePp3odlY1tuKO7gPtphAT5R/py0fA6xtbgLL/RvtJZnU9b8s0F1q0Xg==",
+          "requires": {
+            "@types/json-schema": "^7.0.5",
+            "ajv": "^6.12.4",
+            "ajv-keywords": "^3.5.2"
+          }
+        },
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+        }
+      },
+      "requires": {
+        "ansi-html": "^0.0.7",
+        "error-stack-parser": "^2.0.6",
+        "html-entities": "^1.2.1",
+        "native-url": "^0.2.6",
+        "schema-utils": "^2.6.5",
+        "source-map": "^0.7.3"
       }
     },
     "@popperjs/core": {
@@ -7178,7 +7224,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "~10.7.0"
+            "highlight.js": "11.2.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -7259,9 +7305,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.1.1",
+            "highlight.js": "11.2.0",
             "lowlight": "^1.14.0",
-            "prismjs": "^1.21.0",
+            "prismjs": "1.24.1",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -7294,7 +7340,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "~1.24.0"
+            "prismjs": "1.24.1"
           },
           "dependencies": {
             "prismjs": {
@@ -7464,7 +7510,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "~10.7.0"
+            "highlight.js": "11.2.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -7545,9 +7591,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.1.1",
+            "highlight.js": "11.2.0",
             "lowlight": "^1.14.0",
-            "prismjs": "^1.21.0",
+            "prismjs": "1.24.1",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -7580,7 +7626,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "~1.24.0"
+            "prismjs": "1.24.1"
           },
           "dependencies": {
             "prismjs": {
@@ -8306,7 +8352,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "~10.7.0"
+            "highlight.js": "11.2.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -8463,9 +8509,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.1.1",
+            "highlight.js": "11.2.0",
             "lowlight": "^1.14.0",
-            "prismjs": "^1.21.0",
+            "prismjs": "1.24.1",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -8498,7 +8544,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "~1.24.0"
+            "prismjs": "1.24.1"
           },
           "dependencies": {
             "prismjs": {
@@ -9826,7 +9872,7 @@
       "requires": {
         "@babel/preset-flow": "^7.12.1",
         "@babel/preset-react": "^7.12.10",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.4.3",
+        "@pmmmwh/react-refresh-webpack-plugin": "0.5.0",
         "@storybook/addons": "6.3.8",
         "@storybook/core": "6.3.8",
         "@storybook/core-common": "6.3.8",
@@ -9854,15 +9900,15 @@
           "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.0.tgz",
           "integrity": "sha512-VRmiCnVHudkmzGh4gD1eW42matvNL8Y0OZ8FCEWs79iPTldihsuEi5GTMFjU+UfKRQxinN2e0/MDhJzExuiIyA==",
           "requires": {
-            "ansi-html-community": "^0.0.8",
+            "loader-utils": "^2.0.0",
+            "error-stack-parser": "^2.0.6",
             "common-path-prefix": "^3.0.0",
             "core-js-pure": "^3.8.1",
-            "error-stack-parser": "^2.0.6",
-            "find-up": "^5.0.0",
             "html-entities": "^2.1.0",
-            "loader-utils": "^2.0.0",
-            "schema-utils": "^3.0.0",
-            "source-map": "^0.7.3"
+            "source-map": "^0.7.3",
+            "ansi-html-community": "^0.0.8",
+            "find-up": "^5.0.0",
+            "schema-utils": "^3.0.0"
           }
         },
         "@types/json-schema": {
@@ -10221,7 +10267,7 @@
           "integrity": "sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==",
           "requires": {
             "fault": "^1.0.0",
-            "highlight.js": "~10.7.0"
+            "highlight.js": "11.2.0"
           },
           "dependencies": {
             "highlight.js": {
@@ -10319,9 +10365,9 @@
           "integrity": "sha512-crPaF+QGPeHNIblxxCdf2Lg936NAHKhNhuMzRL3F9ct6aYXL3NcZtCL0Rms9+qVo6Y1EQLdXGypBNSbPL/r+qg==",
           "requires": {
             "@babel/runtime": "^7.3.1",
-            "highlight.js": "^10.1.1",
+            "highlight.js": "11.2.0",
             "lowlight": "^1.14.0",
-            "prismjs": "^1.21.0",
+            "prismjs": "1.24.1",
             "refractor": "^3.1.0"
           },
           "dependencies": {
@@ -10354,7 +10400,7 @@
           "requires": {
             "hastscript": "^6.0.0",
             "parse-entities": "^2.0.0",
-            "prismjs": "~1.24.0"
+            "prismjs": "1.24.1"
           },
           "dependencies": {
             "prismjs": {
@@ -13826,20 +13872,12 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
+        "set-value": "4.0.1",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
       },
       "dependencies": {
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "requires": {
-            "isobject": "^3.0.1"
-          }
-        },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
@@ -13848,10 +13886,7 @@
         "set-value": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
-          "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
-          "requires": {
-            "is-plain-object": "^2.0.4"
-          }
+          "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ=="
         }
       }
     },
@@ -13905,7 +13940,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "optional": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           },
           "dependencies": {
             "is-plain-obj": {
@@ -14472,6 +14507,18 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "dev": true
+    },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -16543,6 +16590,13 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
+      "dev": true,
+      "optional": true
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -17055,9 +17109,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elastic-apm-http-client": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-9.9.0.tgz",
-      "integrity": "sha512-6AXlZtGoo1B9qZMNw51vU9CmJa0G37fUZV5HXPF58kfhztWiYW2RwZCn8Kjx+EUk9eV6wAGms4rqw9DLROZxzw==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-10.0.0.tgz",
+      "integrity": "sha512-D0Frzaqo2h6RxrbxkwfTZSu7tKkmmP3UGYLCp2Fq25cGT/3px4hBWvTc+nV7iDwj2rwdQl7CNkcathYNkyHRWQ==",
       "requires": {
         "breadth-filter": "^2.0.0",
         "container-info": "^1.0.1",
@@ -17066,8 +17120,7 @@
         "fast-stream-to-buffer": "^1.0.0",
         "object-filter-sequence": "^1.0.0",
         "readable-stream": "^3.4.0",
-        "stream-chopper": "^3.0.1",
-        "unicode-byte-truncate": "^1.0.0"
+        "stream-chopper": "^3.0.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -17083,9 +17136,9 @@
       }
     },
     "elastic-apm-node": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.20.0.tgz",
-      "integrity": "sha512-oaUrj3IrtCUg3kzQnoFClw210OpXaCFzIdMO3EnY7z7+zHcjd5fLEMDHQ64qFzKeMt3aPrLBu6ou0HwuUe48Eg==",
+      "version": "3.21.1",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.21.1.tgz",
+      "integrity": "sha512-qnYWvWXQx00pS98IFYxkRQ9+T+R8oh0KdsbCU8t1ouSozZI6l5frlwC9CVpsqakPnAuvWP/qIYJEKF3CkYPv0w==",
       "requires": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",
@@ -17094,7 +17147,7 @@
         "basic-auth": "^2.0.1",
         "cookie": "^0.4.0",
         "core-util-is": "^1.0.2",
-        "elastic-apm-http-client": "^9.8.1",
+        "elastic-apm-http-client": "^10.0.0",
         "end-of-stream": "^1.4.4",
         "error-callsites": "^2.0.4",
         "error-stack-parser": "^2.0.6",
@@ -17690,7 +17743,7 @@
         "js-yaml": "^3.13.1",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
+        "lodash.merge": "4.6.2",
         "minimatch": "^3.0.4",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.1",
@@ -19231,7 +19284,7 @@
       "integrity": "sha512-T31JAiPYPCosfiBeKX5CTkIUhbs78NHAn8dfvX4T5wz1PRLkgGJmLqEzDk1BgIzzzXcmbsof9YtNF6cJQEsPrw==",
       "requires": {
         "html-minifier": "3.5.7",
-        "lodash.merge": "4.6.0"
+        "lodash.merge": "4.6.2"
       },
       "dependencies": {
         "lodash.merge": {
@@ -19508,9 +19561,9 @@
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
     "fast-json-stringify": {
-      "version": "2.7.8",
-      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.8.tgz",
-      "integrity": "sha512-HRSGwEWe0/5EH7GEaWg1by4dInnBb1WFf4umMPr+lL5xb0VP0VbpNGklp4L0/BseD+BmtIZpjqJjnLFwaQ21dg==",
+      "version": "2.7.10",
+      "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-2.7.10.tgz",
+      "integrity": "sha512-MPuVXMMueV8e3TRVLOpxxicJnSdu5mwbHrsO9IZU15zqfay6k19OqIv7N2DCeNPDOCNOmZwjvMUTwvblZsUmFw==",
       "requires": {
         "ajv": "^6.11.0",
         "deepmerge": "^4.2.2",
@@ -19525,9 +19578,9 @@
       "dev": true
     },
     "fast-redact": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.1.tgz",
-      "integrity": "sha512-kYpn4Y/valC9MdrISg47tZOpYBNoTXKgT9GYXFpHN/jYFs+lFkPoisY+LcBODdKVMY96ATzvzsWv+ES/4Kmufw=="
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.0.2.tgz",
+      "integrity": "sha512-YN+CYfCVRVMUZOUPeinHNKgytM1wPI/C/UCLEi56EsY2dwwvI00kIJHJoI7pMVqGoMew8SMZ2SSfHKHULHXDsg=="
     },
     "fast-safe-stringify": {
       "version": "2.0.7",
@@ -19874,7 +19927,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "optional": true,
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "3.1.3"
       },
       "dependencies": {
         "semver-regex": {
@@ -20803,6 +20856,16 @@
         }
       }
     },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "delegate": "^3.1.2"
+      }
+    },
     "got": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/got/-/got-7.1.0.tgz",
@@ -20812,7 +20875,7 @@
         "decompress-response": "^3.2.0",
         "duplexer3": "^0.1.4",
         "get-stream": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "1.1.0",
         "is-retry-allowed": "^1.0.0",
         "is-stream": "^1.0.0",
         "isurl": "^1.0.0-alpha5",
@@ -21314,6 +21377,11 @@
       "resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.1.0.tgz",
       "integrity": "sha512-n7xsIfyBkFChITGPh6FLtxNzAt2HxZLcQIY9hYH4gm2gmMQJHMguMH3E+jnmvUbSTF5QrmFnGab5Ippi+D7e/g=="
     },
+    "highlight.js": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.2.0.tgz",
+      "integrity": "sha512-JOySjtOEcyG8s4MLR2MNbLUyaXqUunmSnL2kdV/KuGJOmHZuAR5xC54Ko7goAXBWNhf09Vy3B+U7vR62UZ/0iw=="
+    },
     "history": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
@@ -21811,7 +21879,7 @@
         "@types/http-proxy": "^1.17.5",
         "http-proxy": "^1.18.1",
         "is-glob": "^4.0.1",
-        "is-plain-obj": "^3.0.0",
+        "is-plain-obj": "1.1.0",
         "micromatch": "^4.0.2"
       },
       "dependencies": {
@@ -22223,6 +22291,11 @@
         "exec-buffer": "^3.0.0",
         "is-cwebp-readable": "^3.0.0"
       }
+    },
+    "immer": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.6.tgz",
+      "integrity": "sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ=="
     },
     "immutable": {
       "version": "3.8.2",
@@ -22910,6 +22983,11 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
     },
     "is-plain-object": {
       "version": "3.0.1",
@@ -24573,6 +24651,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -24794,7 +24877,7 @@
       "dev": true,
       "requires": {
         "fault": "^1.0.2",
-        "highlight.js": "~9.13.0"
+        "highlight.js": "11.2.0"
       },
       "dependencies": {
         "highlight.js": {
@@ -25367,6 +25450,12 @@
         }
       }
     },
+    "merge": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
+      "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
+      "dev": true
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -25629,7 +25718,7 @@
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
       "requires": {
         "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "1.1.0",
         "kind-of": "^6.0.3"
       },
       "dependencies": {
@@ -26562,6 +26651,14 @@
         "regex-not": "^1.0.0",
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
+      }
+    },
+    "native-url": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/native-url/-/native-url-0.2.6.tgz",
+      "integrity": "sha512-k4bDC87WtgrdD362gZz6zoiXQrl40kYlBmpfmSjwRO1VU0V5ccwJTlxuE72F6m3V0vc1xOf6n3UCP9QyerRqmA==",
+      "requires": {
+        "querystring": "^0.2.0"
       }
     },
     "natural-compare": {
@@ -28114,9 +28211,9 @@
       }
     },
     "pino": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.1.tgz",
-      "integrity": "sha512-QQf67BU+cANnc/2U+wzUV20UjO5oBryWpnNyKshdLfT9BdeiXlh9wxLGmOjAuBWMYITdMs+BtJSQQNlGRNbWpA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.2.tgz",
+      "integrity": "sha512-vmD/cabJ4xKqo9GVuAoAEeQhra8XJ7YydPV/JyIP+0zDtFTu5JSKdtt8eksGVWKtTSrNGcRrzJ4/IzvUWep3FA==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.8",
@@ -28128,9 +28225,9 @@
       },
       "dependencies": {
         "fast-safe-stringify": {
-          "version": "2.0.8",
-          "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz",
-          "integrity": "sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag=="
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+          "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
         }
       }
     },
@@ -28925,6 +29022,15 @@
       "integrity": "sha512-aqKD610WNYO90MVXm0xM8P1pX5jPHyTjbAefV0TtWFLZk7eNWnGqLGx+HH6Xxlf9hiC66VjBeCP7m3P72FS+ZQ==",
       "dev": true
     },
+    "prismjs": {
+      "version": "1.24.1",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
+      "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
+      "dev": true,
+      "requires": {
+        "clipboard": "^2.0.0"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -29540,7 +29646,7 @@
         "global-modules": "2.0.0",
         "globby": "11.0.1",
         "gzip-size": "5.1.1",
-        "immer": "8.0.1",
+        "immer": "9.0.6",
         "is-root": "2.1.0",
         "loader-utils": "2.0.0",
         "open": "^7.0.2",
@@ -30041,9 +30147,9 @@
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "highlight.js": "~9.13.0",
+        "highlight.js": "11.2.0",
         "lowlight": "~1.11.0",
-        "prismjs": "^1.8.4",
+        "prismjs": "1.24.1",
         "refractor": "^2.4.1"
       },
       "dependencies": {
@@ -30332,14 +30438,13 @@
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
-        "prismjs": "~1.17.0"
+        "prismjs": "1.24.1"
       },
       "dependencies": {
         "prismjs": {
           "version": "1.24.1",
           "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.24.1.tgz",
-          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow==",
-          "dev": true
+          "integrity": "sha512-mNPsedLuk90RVJioIky8ANZEwYm5w9LcvCXrxHlwf4fNVSn8jEipMybMkWUyyF0JhnC+C4VcOVSBuHRKs1L5Ow=="
         }
       }
     },
@@ -30677,7 +30782,7 @@
             "parse-entities": "^2.0.0",
             "repeat-string": "^1.5.4",
             "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
+            "trim": "0.0.3",
             "trim-trailing-lines": "^1.0.0",
             "unherit": "^1.0.4",
             "unist-util-remove-position": "^2.0.0",
@@ -31387,7 +31492,7 @@
         "known-css-properties": "^0.3.0",
         "lodash.capitalize": "^4.1.0",
         "lodash.kebabcase": "^4.0.0",
-        "merge": "^1.2.0",
+        "merge": "2.1.1",
         "path-is-absolute": "^1.0.0",
         "util": "^0.10.3"
       },
@@ -31644,8 +31749,7 @@
         "merge": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/merge/-/merge-2.1.1.tgz",
-          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==",
-          "dev": true
+          "integrity": "sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w=="
         },
         "ms": {
           "version": "2.0.0",
@@ -31916,6 +32020,13 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
+      "dev": true,
+      "optional": true
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -32114,6 +32225,40 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
       "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
+    },
+    "set-value": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
+      "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
+      "requires": {
+        "extend-shallow": "^2.0.1",
+        "is-extendable": "^0.1.1",
+        "is-plain-object": "^2.0.3",
+        "split-string": "^3.0.1"
+      },
+      "dependencies": {
+        "extend-shallow": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+          "requires": {
+            "is-extendable": "^0.1.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+          "requires": {
+            "isobject": "^3.0.1"
+          }
+        },
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        }
+      }
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -32661,7 +32806,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "optional": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       },
       "dependencies": {
         "is-plain-obj": {
@@ -33008,7 +33153,7 @@
         "marked": "^0.7.0",
         "node-emoji": "1.10.0",
         "prism-themes": "^1.1.0",
-        "prismjs": "^1.16.0",
+        "prismjs": "1.24.1",
         "react-element-to-jsx-string": "^14.0.2",
         "string-raw": "^1.0.1",
         "vuex": "^3.1.0"
@@ -34375,6 +34520,13 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "dev": true,
+      "optional": true
+    },
     "tiny-invariant": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
@@ -34534,6 +34686,11 @@
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
+    "trim": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+      "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg=="
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -34908,7 +35065,7 @@
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
+        "is-plain-obj": "1.1.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
       },
@@ -34933,7 +35090,7 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "set-value": "4.0.1"
       },
       "dependencies": {
         "extend-shallow": {
@@ -34962,7 +35119,10 @@
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
           "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           }
         }
       }
@@ -36730,7 +36890,7 @@
         "camelcase": "^6.0.0",
         "decamelize": "^4.0.0",
         "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
+        "is-plain-obj": "1.1.0"
       },
       "dependencies": {
         "camelcase": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16065,15 +16065,15 @@
       "integrity": "sha512-fCIy7RiDCm7t30U3C99gGwQrUO307EYE1QqXNaf9ToK4DVqW8y5on+0a/kUHMrHdlls2rENF6TN9ZPpPpwLrnw=="
     },
     "cypress-image-diff-js": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.14.2.tgz",
-      "integrity": "sha512-xvqEqXmlTzsi/PErmRC5JeWOiqAK3B8f04IVf1p5qh+1gk1rJaNxS9cJVGpI3NkTjXveQlTWswgch5eHTGHrlA==",
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.14.4.tgz",
+      "integrity": "sha512-MP/7jDCcICRCPANoCl1dLGypmU0YWVlEau5+jJ6FFwWt93lqVUygBPBbL2DE1HNwuo39oJVTcWv1Nu2dIxqn+w==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "arg": "^4.1.1",
         "colors": "^1.4.0",
-        "cypress": "^8.2.0",
+        "cypress": "^8.4.0",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.7",
         "pixelmatch": "^5.1.0",
@@ -16087,6 +16087,319 @@
           "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "@cypress/request": {
+          "version": "2.88.6",
+          "resolved": "https://registry.npmjs.org/@cypress/request/-/request-2.88.6.tgz",
+          "integrity": "sha512-z0UxBE/+qaESAHY9p9sM2h8Y4XqtsbDCt0/DPOrqA/RZgKi4PkxdpXyK4wCCnSk1xHqWHZZAE+gV6aDAR6+caQ==",
+          "dev": true,
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@types/node": {
+          "version": "14.17.17",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.17.tgz",
+          "integrity": "sha512-niAjcewgEYvSPCZm3OaM9y6YQrL2SEPH9PymtE6fuZAvFiP6ereCcvApGl2jKTq7copTIguX3PBvfP08LN4LvQ==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "arch": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+          "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ci-info": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
+          "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+          "dev": true
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "cypress": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/cypress/-/cypress-8.4.1.tgz",
+          "integrity": "sha512-itJXq0Vx3sXCUrDyBi2IUrkxVu/gTTp1VhjB5tzGgkeCR8Ae+/T8WV63rsZ7fS8Tpq7LPPXiyoM/sEdOX7cR6A==",
+          "dev": true,
+          "requires": {
+            "@cypress/request": "^2.88.6",
+            "@cypress/xvfb": "^1.2.4",
+            "@types/node": "^14.14.31",
+            "@types/sinonjs__fake-timers": "^6.0.2",
+            "@types/sizzle": "^2.3.2",
+            "arch": "^2.2.0",
+            "blob-util": "^2.0.2",
+            "bluebird": "^3.7.2",
+            "cachedir": "^2.3.0",
+            "chalk": "^4.1.0",
+            "check-more-types": "^2.24.0",
+            "cli-cursor": "^3.1.0",
+            "cli-table3": "~0.6.0",
+            "commander": "^5.1.0",
+            "common-tags": "^1.8.0",
+            "dayjs": "^1.10.4",
+            "debug": "^4.3.2",
+            "enquirer": "^2.3.6",
+            "eventemitter2": "^6.4.3",
+            "execa": "4.1.0",
+            "executable": "^4.1.1",
+            "extract-zip": "2.0.1",
+            "figures": "^3.2.0",
+            "fs-extra": "^9.1.0",
+            "getos": "^3.2.1",
+            "is-ci": "^3.0.0",
+            "is-installed-globally": "~0.4.0",
+            "lazy-ass": "^1.6.0",
+            "listr2": "^3.8.3",
+            "lodash": "^4.17.21",
+            "log-symbols": "^4.0.0",
+            "minimist": "^1.2.5",
+            "ospath": "^1.2.2",
+            "pretty-bytes": "^5.6.0",
+            "ramda": "~0.27.1",
+            "request-progress": "^3.0.0",
+            "supports-color": "^8.1.1",
+            "tmp": "~0.2.1",
+            "untildify": "^4.0.0",
+            "url": "^0.11.0",
+            "yauzl": "^2.10.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "global-dirs": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-3.0.0.tgz",
+          "integrity": "sha512-v8ho2DS5RiCjftj1nD9NmnfaOzTdud7RRnVd9kFNOjqZbISlx5DQ+OrTkywgd0dIt7oFCvKetZSHoHcP3sDdiA==",
+          "dev": true,
+          "requires": {
+            "ini": "2.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-ci": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.0.tgz",
+          "integrity": "sha512-kDXyttuLeslKAHYL/K28F2YkM3x5jvFPEw3yXbRptXydjD9rpLEz+C5K5iutY9ZiUu6AP41JdvRQwF4Iqs4ZCQ==",
+          "dev": true,
+          "requires": {
+            "ci-info": "^3.1.1"
+          }
+        },
+        "is-installed-globally": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.4.0.tgz",
+          "integrity": "sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^3.0.0",
+            "is-path-inside": "^3.0.2"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+          "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          }
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
+        },
+        "ramda": {
+          "version": "0.27.1",
+          "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+          "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "tmp": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+          "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
+          "dev": true,
+          "requires": {
+            "rimraf": "^3.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,19 +17,19 @@
       "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
     },
     "@babel/core": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.0.tgz",
-      "integrity": "sha512-tXtmTminrze5HEUPn/a0JtOzzfp0nk+UEXQ/tqIJo3WDGypl/2OFQEMll/zSFU8f/lfmfLXvTaORHF3cfXIQMw==",
+      "version": "7.15.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.15.5.tgz",
+      "integrity": "sha512-pYgXxiwAgQpgM1bNkZsDEq85f0ggXMA5L7c+o3tskGMh2BunCI9QUwB9Z4jpvXUOuMdyGKiGKQiRe11VS6Jzvg==",
       "requires": {
         "@babel/code-frame": "^7.14.5",
-        "@babel/generator": "^7.15.0",
-        "@babel/helper-compilation-targets": "^7.15.0",
-        "@babel/helper-module-transforms": "^7.15.0",
-        "@babel/helpers": "^7.14.8",
-        "@babel/parser": "^7.15.0",
-        "@babel/template": "^7.14.5",
-        "@babel/traverse": "^7.15.0",
-        "@babel/types": "^7.15.0",
+        "@babel/generator": "^7.15.4",
+        "@babel/helper-compilation-targets": "^7.15.4",
+        "@babel/helper-module-transforms": "^7.15.4",
+        "@babel/helpers": "^7.15.4",
+        "@babel/parser": "^7.15.5",
+        "@babel/template": "^7.15.4",
+        "@babel/traverse": "^7.15.4",
+        "@babel/types": "^7.15.4",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -52,19 +52,19 @@
           "integrity": "sha512-0NqAC1IJE0S0+lL1SWFMxMkz1pKCNCjI4tr2Zx4LJSXxCLAdr6KyArnY+sno5m3yH9g737ygOyPABDsnXkpxiA=="
         },
         "@babel/generator": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
-          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.4.tgz",
+          "integrity": "sha512-d3itta0tu+UayjEORPNz6e1T3FtvWlP5N4V5M+lhp/CxT4oAA7/NcScnpRyspUMLK6tu9MNHmQHxRykuN2R7hw==",
           "requires": {
-            "@babel/types": "^7.15.0",
+            "@babel/types": "^7.15.4",
             "jsesc": "^2.5.1",
             "source-map": "^0.5.0"
           }
         },
         "@babel/helper-compilation-targets": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.0.tgz",
-          "integrity": "sha512-h+/9t0ncd4jfZ8wsdAsoIxSa61qhBYlycXiHWqJaQBCXAhDCMbPRSMTGnZIkkmt1u4ag+UQmuqcILwqKzZ4N2A==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
+          "integrity": "sha512-rMWPCirulnPSe4d+gwdWXLfAXTTBj8M3guAf5xFQJ0nvFY7tfNAFnWdqaHegHlgDZOCT4qvhF3BYlSJag8yhqQ==",
           "requires": {
             "@babel/compat-data": "^7.15.0",
             "@babel/helper-validator-option": "^7.14.5",
@@ -73,13 +73,13 @@
           }
         },
         "@babel/helper-function-name": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.15.4.tgz",
+          "integrity": "sha512-Z91cOMM4DseLIGOnog+Z8OI6YseR9bua+HpvLAQ2XayUGU+neTtX+97caALaLdyu53I/fjhbeCnWnRH1O3jFOw==",
           "requires": {
-            "@babel/helper-get-function-arity": "^7.14.5",
-            "@babel/template": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "@babel/helper-get-function-arity": "^7.15.4",
+            "@babel/template": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-get-function-arity": {
@@ -88,48 +88,45 @@
           "integrity": "sha512-1/AlxSF92CmGZzHnC515hm4SirTxtpDnLEJ0UyEMgTMZN+6bxXKg04dKhiRx5Enel+SUA1G1t5Ed/yQia0efrA==",
           "requires": {
             "@babel/types": "^7.15.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.15.6",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-              "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.14.9",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.15.4.tgz",
+          "integrity": "sha512-VTy085egb3jUGVK9ycIxQiPbquesq0HUQ+tPO0uv5mPEBZipk+5FkRKiWq5apuyTE9FUrjENB0rCf8y+n+UuhA==",
+          "requires": {
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-member-expression-to-functions": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
-          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
+          "integrity": "sha512-cokOMkxC/BTyNP1AlY25HuBWM32iCEsLPI4BHDpJCHHm1FU2E7dKWWIXJgQgSFiu4lp8q3bL1BIKwqkSUviqtA==",
           "requires": {
-            "@babel/types": "^7.15.0"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-module-imports": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
+          "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-module-transforms": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.0.tgz",
-          "integrity": "sha512-RkGiW5Rer7fpXv9m1B3iHIFDZdItnO2/BLfWVW/9q7+KqQSDY5kUfQEbzdXM1MVhJGcugKV7kRrNVzNxmk7NBg==",
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.15.7.tgz",
+          "integrity": "sha512-ZNqjjQG/AuFfekFTY+7nY4RgBSklgTu970c7Rj3m/JOhIu5KPBUuTA9AY6zaKcUvk4g6EbDXdBnhi35FAssdSw==",
           "requires": {
-            "@babel/helper-module-imports": "^7.14.5",
-            "@babel/helper-replace-supers": "^7.15.0",
-            "@babel/helper-simple-access": "^7.14.8",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "@babel/template": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
+            "@babel/helper-module-imports": "^7.15.4",
+            "@babel/helper-replace-supers": "^7.15.4",
+            "@babel/helper-simple-access": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/helper-validator-identifier": "^7.15.7",
+            "@babel/template": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.6"
           }
         },
         "@babel/helper-optimise-call-expression": {
@@ -138,42 +135,49 @@
           "integrity": "sha512-E/z9rfbAOt1vDW1DR7k4SzhzotVV5+qMciWV6LaG1g4jeFrkDlJedjtV4h0i4Q/ITnUu+Pk08M7fczsB9GXBDw==",
           "requires": {
             "@babel/types": "^7.15.4"
-          },
-          "dependencies": {
-            "@babel/types": {
-              "version": "7.15.6",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-              "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.14.9",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
           }
         },
         "@babel/helper-replace-supers": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
-          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.4.tgz",
+          "integrity": "sha512-/ztT6khaXF37MS47fufrKvIsiQkx1LBRvSJNzRqmbyeZnTwU9qBxXYLaaT/6KaxfKhjs2Wy8kG8ZdsFUuWBjzw==",
           "requires": {
-            "@babel/helper-member-expression-to-functions": "^7.15.0",
-            "@babel/helper-optimise-call-expression": "^7.14.5",
-            "@babel/traverse": "^7.15.0",
-            "@babel/types": "^7.15.0"
+            "@babel/helper-member-expression-to-functions": "^7.15.4",
+            "@babel/helper-optimise-call-expression": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.15.4.tgz",
+          "integrity": "sha512-UzazrDoIVOZZcTeHHEPYrr1MvTR/K+wgLg6MY6e1CJyaRhbibftF6fR2KU2sFRtI/nERUZR9fBd6aKgBlIBaPg==",
+          "requires": {
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-split-export-declaration": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.15.4.tgz",
+          "integrity": "sha512-HsFqhLDZ08DxCpBdEVtKmywj6PQbwnF6HHybur0MAnkAKnlS6uHkwnmRIkElB2Owpfb4xL4NwDmDLFubueDXsw==",
           "requires": {
-            "@babel/types": "^7.14.5"
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/helper-validator-identifier": {
-          "version": "7.14.9",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+        },
+        "@babel/helpers": {
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.15.4.tgz",
+          "integrity": "sha512-V45u6dqEJ3w2rlryYYXf6i9rQ5YMNu4FLS6ngs8ikblhu2VdR1AqAd6aJjBzmf2Qzh6KOLqKHxEN9+TFbAkAVQ==",
+          "requires": {
+            "@babel/template": "^7.15.4",
+            "@babel/traverse": "^7.15.4",
+            "@babel/types": "^7.15.4"
+          }
         },
         "@babel/highlight": {
           "version": "7.14.5",
@@ -186,40 +190,40 @@
           }
         },
         "@babel/parser": {
-          "version": "7.15.2",
-          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.2.tgz",
-          "integrity": "sha512-bMJXql1Ss8lFnvr11TZDH4ArtwlAS5NG9qBmdiFW2UHHm6MVoR+GDc5XE2b9K938cyjc9O6/+vjjcffLDtfuDg=="
+          "version": "7.15.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.7.tgz",
+          "integrity": "sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g=="
         },
         "@babel/template": {
-          "version": "7.14.5",
-          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.15.4.tgz",
+          "integrity": "sha512-UgBAfEa1oGuYgDIPM2G+aHa4Nlo9Lh6mGD2bDBGMTbYnc38vulXPuC1MGjYILIEmlwl6Rd+BPR9ee3gm20CBtg==",
           "requires": {
             "@babel/code-frame": "^7.14.5",
-            "@babel/parser": "^7.14.5",
-            "@babel/types": "^7.14.5"
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4"
           }
         },
         "@babel/traverse": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
-          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "version": "7.15.4",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.4.tgz",
+          "integrity": "sha512-W6lQD8l4rUbQR/vYgSuCAE75ADyyQvOpFVsvPPdkhf6lATXAsQIG9YdtOcu8BB1dZ0LKu+Zo3c1wEcbKeuhdlA==",
           "requires": {
             "@babel/code-frame": "^7.14.5",
-            "@babel/generator": "^7.15.0",
-            "@babel/helper-function-name": "^7.14.5",
-            "@babel/helper-hoist-variables": "^7.14.5",
-            "@babel/helper-split-export-declaration": "^7.14.5",
-            "@babel/parser": "^7.15.0",
-            "@babel/types": "^7.15.0",
+            "@babel/generator": "^7.15.4",
+            "@babel/helper-function-name": "^7.15.4",
+            "@babel/helper-hoist-variables": "^7.15.4",
+            "@babel/helper-split-export-declaration": "^7.15.4",
+            "@babel/parser": "^7.15.4",
+            "@babel/types": "^7.15.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
           }
         },
         "@babel/types": {
-          "version": "7.15.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
-          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "version": "7.15.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
+          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
           "requires": {
             "@babel/helper-validator-identifier": "^7.14.9",
             "to-fast-properties": "^2.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16210,9 +16210,9 @@
       }
     },
     "date-fns": {
-      "version": "2.23.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.23.0.tgz",
-      "integrity": "sha512-5ycpauovVyAk0kXNZz6ZoB9AYMZB4DObse7P3BPWmyEjXNORTI8EJ6X0uaSAq4sCHzM1uajzrkr6HnsLQpxGXA=="
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.24.0.tgz",
+      "integrity": "sha512-6ujwvwgPID6zbI0o7UbURi2vlLDR9uP26+tW6Lg+Ji3w7dd0i3DOcjcClLjLPranT60SSEFBwdSyYwn/ZkPIuw=="
     },
     "dayjs": {
       "version": "1.10.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15110,9 +15110,9 @@
       }
     },
     "core-js": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-      "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+      "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w=="
     },
     "core-js-compat": {
       "version": "3.16.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31461,9 +31461,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.39.2",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.39.2.tgz",
-      "integrity": "sha512-4/6Vn2RPc+qNwSclUSKvssh7dqK1Ih3FfHBW16I/GfH47b3scbYeOw65UIrYG7PkweFiKbpJjgkf5CV8EMmvzw==",
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.41.1.tgz",
+      "integrity": "sha512-vIjX7izRxw3Wsiez7SX7D+j76v7tenfO18P59nonjr/nzCkZuoHuF7I/Fo0ZRZPKr88v29ivIdE9BqGDgQD/Nw==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "node": "14.17.0"
   },
   "dependencies": {
-    "@babel/core": "^7.15.0",
+    "@babel/core": "^7.15.5",
     "@babel/helper-call-delegate": "^7.12.13",
     "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
     "@babel/plugin-proposal-optional-chaining": "^7.14.5",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "css-loader": "^5.2.7",
     "csurf": "^1.9.0",
     "cypress-axe": "^0.13.0",
-    "date-fns": "^2.23.0",
+    "date-fns": "^2.24.0",
     "del-cli": "^4.0.1",
     "details-element-polyfill": "^2.4.0",
     "dotenv": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
     "request": "^2.87.0",
     "request-promise": "^4.2.6",
     "resolve-url-loader": "^4.0.0",
-    "sass": "^1.39.2",
+    "sass": "^1.41.1",
     "sass-loader": "^10.0.4",
     "serve-favicon": "^2.5.0",
     "sniffr": "^1.1.4",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
     "cypress": "^8.4.1",
-    "cypress-image-diff-js": "1.14.2",
+    "cypress-image-diff-js": "1.14.4",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.24.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "del-cli": "^4.0.1",
     "details-element-polyfill": "^2.4.0",
     "dotenv": "^10.0.0",
-    "elastic-apm-node": "^3.20.0",
+    "elastic-apm-node": "^3.21.1",
     "element-closest": "^3.0.2",
     "express": "^4.16.2",
     "express-minify-html": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-promise": "^5.1.0",
-    "eslint-plugin-react": "^7.25.1",
+    "eslint-plugin-react": "^7.25.3",
     "eslint-plugin-react-hooks": "^4.2.0",
     "faker": "^5.5.3",
     "git-directory-deploy": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "connected-react-router": "^6.9.1",
     "constate": "^3.3.0",
     "cookie-parser": "^1.4.5",
-    "core-js": "^3.17.3",
+    "core-js": "^3.18.0",
     "css-loader": "^5.2.7",
     "csurf": "^1.9.0",
     "cypress-axe": "^0.13.0",

--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
-    "cypress": "^8.3.0",
+    "cypress": "^8.4.1",
     "cypress-image-diff-js": "1.14.2",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
## Description of change

Automated dependabot updates for this week including:

- Bump elastic-apm-node from 3.20.0 to 3.21.1
- Bump cypress from 8.3.0 to 8.4.1
- Bump sass from 1.39.2 to 1.41.1
- Bump core-js from 3.17.3 to 3.18.0
- Bump eslint-plugin-react from 7.25.1 to 7.25.3
- Bump date-fns from 2.23.0 to 2.24.0

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
