### PR TITLE
Add the financial year filter to the allowed list of query params

### DIFF
--- a/src/apps/investments/constants.js
+++ b/src/apps/investments/constants.js
@@ -168,6 +168,7 @@ const QUERY_FIELDS = [
   'likelihood_to_land',
   'level_of_involvement_simplified',
   'country_investment_originates_from',
+  'financial_year_start',
 ]
 
 const QUERY_DATE_FIELDS = [


### PR DESCRIPTION
## Description of change
Add the `financial_year_start` filter to the allowed list of query params. This fixes a bug where users are downloading Investments where the financial year filter has been applied but the results are ignoring the filter.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
