### PR TITLE
WIP: Add appropriate aria tags to typeahead sub component

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -5,7 +5,7 @@ import AsyncSelect from 'react-select/async'
 import defaultStyles, { errorStyles } from './styles'
 import Highlighter from './Highlighter'
 
-const { Input, Option, NoOptionsMessage, MenuList } = components
+const { Input, Option, NoOptionsMessage, MenuList, Control } = components
 
 export const filterOption = ({ label = '' }, query) =>
   label.toLowerCase().includes(query.toLowerCase())
@@ -28,10 +28,26 @@ const CustomNoOptionsMessage = ({ children, ...props }) => (
     <NoOptionsMessage {...props}>{children}</NoOptionsMessage>
   </li>
 )
+// figure out which aria tag is causing the screen reader to break on option read out
+const CustomControl = ({ children, innerProps, selectProps, ...props }) => {
+  innerProps['aria-owns'] = selectProps['data-aria-id']
+  innerProps['aria-expanded'] = selectProps.menuIsOpen
+  // innerProps.role = 'combobox'
+  // innerProps['aria-haspopup'] = 'listbox'
+  return (
+    <Control {...props} innerProps={innerProps}>
+      {children}
+    </Control>
+  )
+}
 
 const CustomMenuList = ({ children, selectProps, ...props }) => (
   <MenuList {...props}>
-    <ul id={selectProps['data-aria-id']} role="listbox">
+    <ul
+      id={selectProps['data-aria-id']}
+      role="listbox"
+      aria-multiselectable={selectProps.isMulti}
+    >
       {Array.isArray(children)
         ? children.map((child, i) =>
             React.cloneElement(child, {
@@ -52,19 +68,12 @@ const CustomInput = ({ children, selectProps, inputProps, ...props }) => (
   <>
     <Input
       {...props}
-      aria-owns={selectProps['data-aria-id']}
+      aria-activedescendant=""
       aria-autocomplete="list"
-      aria-expanded={selectProps.menuIsOpen}
       aria-describedby={`${selectProps['data-aria-id']}-assistiveHint`}
-      role="combobox"
+      type="text"
+      id="Input"
     />
-    {Boolean(!selectProps.options.length) && (
-      <ul
-        id={selectProps['data-aria-id']}
-        role="listbox"
-        style={{ display: 'none' }}
-      ></ul>
-    )}
   </>
 )
 
@@ -86,6 +95,7 @@ const Typeahead = ({ options, styles, error, name, ...props }) => {
       MenuList: CustomMenuList,
       Input: CustomInput,
       NoOptionsMessage: CustomNoOptionsMessage,
+      Control: CustomControl,
     },
     filterOption,
     'data-aria-id': `autocomplete-${name}`,
@@ -95,6 +105,10 @@ const Typeahead = ({ options, styles, error, name, ...props }) => {
 
   return (
     <>
+      {/* <span id="LaurenId-remove" style={{ display: 'none' }}>
+        remove
+      </span> */}
+
       {options ? (
         <Select {...customisedProps} options={options} />
       ) : (

--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -15,25 +15,27 @@ const CustomOption = ({
   data: { label },
   ariaProps,
   ...props
-}) => (
-  <li {...ariaProps}>
-    <Option {...props}>
-      <Highlighter searchStr={inputValue} optionLabel={label} />
-    </Option>
-  </li>
-)
+}) => {
+  return (
+    <li {...ariaProps}>
+      <Option {...props}>
+        <Highlighter searchStr={inputValue} optionLabel={label} />
+      </Option>
+    </li>
+  )
+}
 
 const CustomNoOptionsMessage = ({ children, ...props }) => (
   <li>
     <NoOptionsMessage {...props}>{children}</NoOptionsMessage>
   </li>
 )
-// figure out which aria tag is causing the screen reader to break on option read out
+
 const CustomControl = ({ children, innerProps, selectProps, ...props }) => {
   innerProps['aria-owns'] = selectProps['data-aria-id']
   innerProps['aria-expanded'] = selectProps.menuIsOpen
-  // innerProps.role = 'combobox'
-  // innerProps['aria-haspopup'] = 'listbox'
+  innerProps.role = 'combobox'
+  innerProps['aria-haspopup'] = 'listbox'
   return (
     <Control {...props} innerProps={innerProps}>
       {children}
@@ -65,14 +67,19 @@ const CustomMenuList = ({ children, selectProps, ...props }) => (
 )
 
 const CustomInput = ({ children, selectProps, inputProps, ...props }) => (
+  // As I pass in the role to inputProps, it gives it to the input too. I override it by
+  // setting the role to textbox
   <>
     <Input
       {...props}
       aria-activedescendant=""
+      // This needs to be what has focus
       aria-autocomplete="list"
       aria-describedby={`${selectProps['data-aria-id']}-assistiveHint`}
       type="text"
+      role="textbox"
       id="Input"
+      //This needs to be something worthy
     />
   </>
 )
@@ -85,6 +92,7 @@ const AssistiveText = ({ name }) => (
 )
 
 const Typeahead = ({ options, styles, error, name, ...props }) => {
+  // Here is where we pass in all our custom options we make above, the select gobbles em up
   const customisedProps = {
     styles: {
       ...(error ? errorStyles : defaultStyles),
@@ -105,10 +113,6 @@ const Typeahead = ({ options, styles, error, name, ...props }) => {
 
   return (
     <>
-      {/* <span id="LaurenId-remove" style={{ display: 'none' }}>
-        remove
-      </span> */}
-
       {options ? (
         <Select {...customisedProps} options={options} />
       ) : (


### PR DESCRIPTION
## Description of change

This PR is a draft.  It focuses around adding the appropriate Aria tags to the Typeahead component in order to make it accessible. It follows along the lines of this [example](https://codepen.io/smhigley/pen/GRgjRVN?editors=1010).  

This work includes adding the matching aria tags from the example, into the most appropriate places in our code. Everything  seems to work, but what is left is to get the `aria-active-descendant` to be the id of whatever option has been focused. The input wants to know the active descendant, but the MenuList is responsible for managing it and they are sister components. 

Potentially we can fiddle with the `onFocus` or `onChange` methods provided in the `selectProps` which are free for everyone to use, but need to figure out where that code should sit and how we pull it out and set it up. 

Here's the [link to the docs](https://react-select.com/props#select-props)

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
