### PR TITLE
Remove these preset plugins as they are part of ES2018 and ES2020

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
   "dependencies": {
     "@babel/core": "^7.15.8",
     "@babel/helper-call-delegate": "^7.12.13",
-    "@babel/plugin-proposal-object-rest-spread": "^7.15.6",
-    "@babel/plugin-proposal-optional-chaining": "^7.14.5",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
     "@govuk-react/constants": "^0.10.0",


### PR DESCRIPTION
## Description of change

These plugins for babel are in @babel/preset-env in ES2018 and ES2020 so shouldn't be needed separately.