### PR TITLE
Refactor the Add company form with TaskForm

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -4,13 +4,11 @@
 
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import axios from 'axios'
 import { get } from 'lodash'
 
 import {
   FieldRadios,
   FieldSelect,
-  FormStateful,
   Step,
 } from '../../../../../client/components'
 
@@ -20,6 +18,8 @@ import CompanySearchStep from './CompanySearchStep'
 import CompanyRegionAndSector from './CompanyRegionAndSector'
 import InformationList from './InformationList'
 import { ISO_CODE } from './constants'
+
+import TaskForm from '../../../../../client/components/Task/Form'
 
 function AddCompanyForm({
   csrfToken,
@@ -66,17 +66,14 @@ function AddCompanyForm({
     return {}
   }
 
-  async function onSubmit(values) {
-    const path = values.cannotFind ? 'company-investigation' : 'company-create'
-    const postUrl = `/companies/create/dnb/${path}?_csrf=${csrfToken}`
-    const { data } = await axios.post(postUrl, values)
-    return `/companies/${data.id}`
-  }
-
   return (
-    <FormStateful
-      onSubmit={onSubmit}
-      onExit={() => 'Changes that you made will not be saved.'}
+    <TaskForm
+      id="add-company-form"
+      submissionTaskName="Create company"
+      analyticsFormName="add-company-form"
+      redirectTo={(company) => `/companies/${company.id}`}
+      flashMessage={() => 'Company added to Data Hub'}
+      transformPayload={(values) => ({ ...values, csrfToken })}
     >
       {({ values, setFieldValue }) => {
         const country = getCountry(values)
@@ -159,7 +156,7 @@ function AddCompanyForm({
           </>
         )
       }}
-    </FormStateful>
+    </TaskForm>
   )
 }
 

--- a/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyRegionAndSector.jsx
@@ -21,20 +21,20 @@ function CompanyRegionAndSector({ regions, region, sectors, isUK, postcode }) {
             onSuccessDispatch: ADD_COMPANY__REGION_LOADED,
           }}
         >
-          {() => (
-            <FieldSelect
-              key={region?.value}
-              name="uk_region"
-              label="DIT region"
-              initialValue={region?.value}
-              emptyOption="-- Select DIT region --"
-              options={regions}
-              required="Select DIT region"
-            />
-          )}
+          {() =>
+            region && (
+              <FieldSelect
+                name="uk_region"
+                label="DIT region"
+                initialValue={region.value}
+                emptyOption="-- Select DIT region --"
+                options={regions}
+                required="Select DIT region"
+              />
+            )
+          }
         </Task.Status>
       )}
-
       <FieldSelect
         name="sector"
         label="DIT sector"

--- a/src/apps/companies/apps/add-company/client/tasks.js
+++ b/src/apps/companies/apps/add-company/client/tasks.js
@@ -6,3 +6,12 @@ export default (postcode) =>
     .get(`/api/postcode-to-region-lookup/${postcode}`)
     .catch(catchApiError)
     .then(({ data }) => data)
+
+export const createCompany = ({ csrfToken, ...values }) => {
+  const path = values.cannotFind ? 'company-investigation' : 'company-create'
+  const postUrl = `/companies/create/dnb/${path}?_csrf=${csrfToken}`
+  return axios
+    .post(postUrl, values)
+    .catch((e) => Promise.reject(e.message))
+    .then((response) => response.data)
+}

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -75,7 +75,6 @@ async function postAddDnbCompany(req, res, next) {
       sector,
     })
 
-    req.flash('success', 'Company added to Data Hub')
     res.json(result)
   } catch (error) {
     next(error)
@@ -100,7 +99,6 @@ async function postAddDnbCompanyInvestigation(req, res, next) {
     )
     await createDnbCompanyInvestigation(req, create)
 
-    req.flash('success', 'Company added to Data Hub')
     res.json(company)
   } catch (error) {
     next(error)

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -63,7 +63,9 @@ import * as referralsSendTasks from '../apps/companies/apps/referrals/send-refer
 import * as exportWinsTasks from '../apps/companies/apps/exports/client/ExportWins/tasks'
 import { TASK_NAME as EXPORT_COUNTRIES_EDIT_NAME } from '../apps/companies/apps/exports/client/ExportCountriesEdit/state'
 import * as exportCountriesEditTasks from '../apps/companies/apps/exports/client/ExportCountriesEdit/tasks'
-import addCompanyPostcodeToRegionTask from '../apps/companies/apps/add-company/client/tasks'
+import addCompanyPostcodeToRegionTask, {
+  createCompany,
+} from '../apps/companies/apps/add-company/client/tasks'
 import { TASK_SAVE_ONE_LIST_DETAILS } from '../apps/companies/apps/edit-one-list/client/state'
 import * as editOneListTasks from '../apps/companies/apps/edit-one-list/client/tasks'
 import {
@@ -220,6 +222,7 @@ function App() {
   return (
     <Provider
       tasks={{
+        'Create company': createCompany,
         'Company lists': companyListsTasks.fetchCompanyLists,
         'Company list': companyListsTasks.fetchCompanyList,
         'Exports history': exportsHistoryTasks.fetchExportsHistory,


### PR DESCRIPTION
## Description of change

Refactors the _add company form_ with the `TaskForm` component.

## Test instructions

1. Go to `/companies/create`
2. Tweak the [`postAddDnbCompany `](https://github.com/uktrade/data-hub-frontend/blob/master/src/apps/companies/apps/add-company/controllers.js#L68-L83) request handler of the form's 
2. Try out all the possible user journeys of the form
3. They should all work as before
4. When you submit the form, the POST request should fail
5. You should see an error message overlaid on top of the form

## Screenshots
### Before

No error handling of rejected requests
<img width="700" alt="Screen Shot 2021-11-02 at 1 36 47 PM" src="https://user-images.githubusercontent.com/2333157/139857516-49fddbe5-4539-431b-ab2b-69a52156c47c.png">

### After

<img width="699" alt="Screen Shot 2021-11-02 at 1 31 58 PM" src="https://user-images.githubusercontent.com/2333157/139856753-cd4e74cf-6dfc-4b59-b3a8-35e9163ae1d8.png">

