### PR TITLE
Use data infrastructure shared network

### DIFF
--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -17,3 +17,7 @@ services:
       MOCK_SSO_USERNAME: test@gov.uk
       MOCK_SSO_VALIDATE_TOKEN: "true"
 
+networks:
+  default:
+    external:
+      name: data-infrastructure-shared-network


### PR DESCRIPTION
## Description of change
* Utilize data-infrastructure-shared-network for data-flow compatibility
    * data-flow has an existing shared network, we should switch to using this network for our ecosystem to enable compatibility with running data-flow in development against data-hub-api in development
    * This change is reflected across data-hub-frontend and dnb-service so there should be no compatibility issues

## Linked PRs
* https://github.com/uktrade/dnb-service/pull/111
* https://github.com/uktrade/data-hub-api/pull/3805

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
