### PR TITLE
Removed currency converter

### DIFF
--- a/src/apps/companies/apps/business-details/__test__/transformers.test.js
+++ b/src/apps/companies/apps/business-details/__test__/transformers.test.js
@@ -51,6 +51,7 @@ describe('Company business details transformers', () => {
           },
           business_type: 'Private limited company',
           turnover_range: '£33.5M+',
+          turnover: 987,
           employee_range: '500+',
           sector: 'Retail',
           uk_region: 'North West',

--- a/src/apps/companies/apps/business-details/transformers.js
+++ b/src/apps/companies/apps/business-details/transformers.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 const { get, pick, compact, omitBy } = require('lodash')
 const { hqLabels } = require('../../labels')
-const { convertUsdToGbp } = require('../../../../common/currency')
 
 const transformGlobalAccountManager = (globalAccountManager) => {
   if (!globalAccountManager) {
@@ -45,7 +44,7 @@ const transformCompanyToBusinessDetails = (company) => {
         'export_segment',
         'export_sub_segment',
       ]),
-      turnover: convertUsdToGbp(company.turnover),
+      turnover: company.turnover_gbp,
       business_type: get(company.business_type, 'name'),
       turnover_range: get(company.turnover_range, 'name'),
       employee_range: get(company.employee_range, 'name'),

--- a/src/apps/companies/apps/edit-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/edit-company/__test__/transformers.test.js
@@ -1,4 +1,7 @@
-const { transformFormToDnbChangeRequest } = require('../transformers')
+const {
+  transformFormToDnbChangeRequest,
+  transformCompanyToForm,
+} = require('../transformers')
 
 describe('#transformFormToDnbChangeRequest', () => {
   context('when all fields are populated', () => {
@@ -58,4 +61,77 @@ describe('#transformFormToDnbChangeRequest', () => {
       })
     })
   })
+})
+
+describe('#transformCompanyToForm', () => {
+  context(
+    'when all fields except whitelisted fields populated with duns_number is null',
+    () => {
+      const company = {
+        trading_names: [''],
+        duns_number: null,
+        employee_range: {
+          name: '500+',
+          id: '41afd8d0-5d95-e211-a939-e4115bead28a',
+        },
+        sector: {
+          name: 'Retail',
+          id: '355f977b-8ac3-e211-a646-e4115bead28a',
+        },
+        turnover_range: {
+          name: '£33.5M+',
+          id: '7a4cd12a-6095-e211-a939-e4115bead28a',
+        },
+        turnover: 123,
+        turnover_gbp: 987,
+        uk_region: {
+          name: 'North West',
+          id: '824cd12a-6095-e211-a939-e4115bead28a',
+        },
+        address: {
+          line_1: '82 Ramsgate Rd',
+          line_2: '',
+          town: 'Willington',
+          county: '',
+          postcode: 'NE28 5JB',
+          country: {
+            name: 'United Kingdom',
+            id: '80756b9a-5d95-e211-a939-e4115bead28a',
+          },
+        },
+      }
+
+      const actual = transformCompanyToForm(company)
+
+      const expected = {
+        address: {
+          line_1: '82 Ramsgate Rd',
+          line_2: '',
+          town: 'Willington',
+          county: '',
+          postcode: 'NE28 5JB',
+          country: {
+            name: 'United Kingdom',
+            id: '80756b9a-5d95-e211-a939-e4115bead28a',
+          },
+        },
+        address1: '82 Ramsgate Rd',
+        address2: '',
+        city: 'Willington',
+        county: '',
+        postcode: 'NE28 5JB',
+        headquarter_type: '',
+        uk_region: '824cd12a-6095-e211-a939-e4115bead28a',
+        sector: '355f977b-8ac3-e211-a646-e4115bead28a',
+        employee_range: '41afd8d0-5d95-e211-a939-e4115bead28a',
+        turnover_range: '7a4cd12a-6095-e211-a939-e4115bead28a',
+        trading_names: '',
+        turnover: 990,
+      }
+
+      it('should transform the request body', () => {
+        expect(actual).to.deep.equal(expected)
+      })
+    }
+  )
 })

--- a/src/apps/companies/apps/edit-company/__test__/transformers.test.js
+++ b/src/apps/companies/apps/edit-company/__test__/transformers.test.js
@@ -134,4 +134,168 @@ describe('#transformCompanyToForm', () => {
       })
     }
   )
+
+  context('when all fields populated with duns_number is null', () => {
+    const company = {
+      business_type: {
+        name: 'Private limited company',
+        id: '6f75408b-03e7-e611-bca1-e4115bead28a',
+      },
+      vat_number: '',
+      website: null,
+      description: 'This is a dummy company for testing',
+      headquarter_type: null,
+      export_segment: 'hep',
+      export_sub_segment: 'sustain_nurture_and_grow',
+      trading_names: [''],
+      duns_number: null,
+      employee_range: {
+        name: '500+',
+        id: '41afd8d0-5d95-e211-a939-e4115bead28a',
+      },
+      sector: {
+        name: 'Retail',
+        id: '355f977b-8ac3-e211-a646-e4115bead28a',
+      },
+      turnover_range: {
+        name: '£33.5M+',
+        id: '7a4cd12a-6095-e211-a939-e4115bead28a',
+      },
+      turnover: 123,
+      turnover_gbp: 987,
+      uk_region: {
+        name: 'North West',
+        id: '824cd12a-6095-e211-a939-e4115bead28a',
+      },
+      address: {
+        line_1: '82 Ramsgate Rd',
+        line_2: '',
+        town: 'Willington',
+        county: '',
+        postcode: 'NE28 5JB',
+        country: {
+          name: 'United Kingdom',
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+      },
+    }
+
+    const actual = transformCompanyToForm(company)
+
+    const expected = {
+      address: {
+        line_1: '82 Ramsgate Rd',
+        line_2: '',
+        town: 'Willington',
+        county: '',
+        postcode: 'NE28 5JB',
+        country: {
+          name: 'United Kingdom',
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+      },
+      vat_number: '',
+      export_segment: 'hep',
+      export_sub_segment: 'sustain_nurture_and_grow',
+      description: 'This is a dummy company for testing',
+      website: null,
+      business_type: {
+        name: 'Private limited company',
+        id: '6f75408b-03e7-e611-bca1-e4115bead28a',
+      },
+      address1: '82 Ramsgate Rd',
+      address2: '',
+      city: 'Willington',
+      county: '',
+      postcode: 'NE28 5JB',
+      headquarter_type: '',
+      uk_region: '824cd12a-6095-e211-a939-e4115bead28a',
+      sector: '355f977b-8ac3-e211-a646-e4115bead28a',
+      employee_range: '41afd8d0-5d95-e211-a939-e4115bead28a',
+      turnover_range: '7a4cd12a-6095-e211-a939-e4115bead28a',
+      trading_names: '',
+      turnover: 990,
+    }
+
+    it('should transform the request body', () => {
+      expect(actual).to.deep.equal(expected)
+    })
+  })
+
+  context('when all fields populated with duns_number has a value', () => {
+    const company = {
+      name: 'sample-company',
+      number_of_employees: 321,
+      vat_number: 54321,
+      website: null,
+      description: 'This is a dummy company for testing',
+      headquarter_type: null,
+      export_segment: 'hep',
+      export_sub_segment: 'sustain_nurture_and_grow',
+      trading_names: [''],
+      duns_number: 123,
+      employee_range: {
+        name: '500+',
+        id: '41afd8d0-5d95-e211-a939-e4115bead28a',
+      },
+      sector: {
+        name: 'Retail',
+        id: '355f977b-8ac3-e211-a646-e4115bead28a',
+      },
+      turnover_range: {
+        name: '£33.5M+',
+        id: '7a4cd12a-6095-e211-a939-e4115bead28a',
+      },
+      turnover: 123,
+      turnover_gbp: 987,
+      uk_region: {
+        name: 'North West',
+        id: '824cd12a-6095-e211-a939-e4115bead28a',
+      },
+      address: {
+        line_1: '82 Ramsgate Rd',
+        line_2: '',
+        town: 'Willington',
+        county: '',
+        postcode: 'NE28 5JB',
+        country: {
+          name: 'United Kingdom',
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+        },
+        area: {
+          id: '80756b9a-5d95-e211-a939-e4115bead28a',
+          name: 'California',
+        },
+      },
+    }
+
+    const actual = transformCompanyToForm(company)
+
+    const expected = {
+      vat_number: 54321,
+      export_segment: 'hep',
+      export_sub_segment: 'sustain_nurture_and_grow',
+      description: 'This is a dummy company for testing',
+      website: null,
+      address1: '82 Ramsgate Rd',
+      address2: '',
+      area: '80756b9a-5d95-e211-a939-e4115bead28a',
+      city: 'Willington',
+      county: '',
+      postcode: 'NE28 5JB',
+      headquarter_type: '',
+      name: 'sample-company',
+      number_of_employees: 321,
+      uk_region: '824cd12a-6095-e211-a939-e4115bead28a',
+      sector: '355f977b-8ac3-e211-a646-e4115bead28a',
+      employee_range: '41afd8d0-5d95-e211-a939-e4115bead28a',
+      turnover_range: '7a4cd12a-6095-e211-a939-e4115bead28a',
+      trading_names: '',
+      turnover: 990,
+    }
+
+    it('should transform the request body', () => {
+      expect(actual).to.deep.equal(expected)
+    })
+  })
 })

--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -1,10 +1,7 @@
 /* eslint-disable camelcase */
 const { castArray, get, isEmpty, omitBy, pick, isUndefined } = require('lodash')
 const { roundToSignificantDigits } = require('../../../../common/number')
-const {
-  convertUsdToGbp,
-  convertGbpToUsd,
-} = require('../../../../common/currency')
+const { convertGbpToUsd } = require('../../../../common/currency')
 
 const UNMATCHED_COMPANY_EDITABLE_FIELDS = [
   'business_type',
@@ -65,7 +62,7 @@ const transformCompanyToForm = (company) => {
       employee_range: get(company.employee_range, 'id'),
       turnover_range: get(company.turnover_range, 'id'),
       trading_names: get(company.trading_names, '0'),
-      turnover: roundToSignificantDigits(convertUsdToGbp(company.turnover), 2),
+      turnover: roundToSignificantDigits(company.turnover_gbp, 2),
     },
     isUndefined
   )

--- a/src/apps/companies/apps/edit-company/transformers.js
+++ b/src/apps/companies/apps/edit-company/transformers.js
@@ -1,7 +1,6 @@
 /* eslint-disable camelcase */
 const { castArray, get, isEmpty, omitBy, pick, isUndefined } = require('lodash')
 const { roundToSignificantDigits } = require('../../../../common/number')
-const { convertGbpToUsd } = require('../../../../common/currency')
 
 const UNMATCHED_COMPANY_EDITABLE_FIELDS = [
   'business_type',
@@ -153,9 +152,8 @@ const transformFormToDnbChangeRequest = (company, formValues, res) => {
   delete obj.trading_names
 
   if (obj.turnover) {
-    obj.turnover = Math.round(
-      convertGbpToUsd(parseInt(formValues.turnover, 10))
-    ).toString()
+    obj.turnover_gbp = Math.round(parseInt(formValues.turnover, 10)).toString()
+    delete obj.turnover
   }
 
   const dnbChangeRequest = {

--- a/src/apps/companies/apps/edit-history/client/CompanyEditHistory.jsx
+++ b/src/apps/companies/apps/edit-history/client/CompanyEditHistory.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { isBoolean, isNumber } from 'lodash'
-import { convertUsdToGbp } from '../../../../../common/currency'
 
 import EditHistory from '../../../../../client/components/EditHistory/EditHistory'
 import { currencyGBP } from '../../../../../client/utils/number-utils'
@@ -43,7 +42,7 @@ function getValue(value, field) {
 
   if (isNumber(value)) {
     return CURRENCY_FIELDS.includes(field)
-      ? currencyGBP(convertUsdToGbp(value), {
+      ? currencyGBP(value, {
           maximumSignificantDigits: 2,
         })
       : value.toString()

--- a/test/functional/cypress/specs/companies/edit-history-spec.js
+++ b/test/functional/cypress/specs/companies/edit-history-spec.js
@@ -155,8 +155,8 @@ describe('Edit History', () => {
       assertChanges(
         editHistory.change(5).table(2),
         'Turnover',
-        '£1,700,000',
-        '£1,300,000'
+        '£2,400,000',
+        '£1,800,000'
       )
     })
 

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -1,4 +1,3 @@
-const { convertUsdToGbp } = require('../../../../../src/common/currency')
 const { roundToSignificantDigits } = require('../../../../../src/common/number')
 const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
@@ -436,7 +435,7 @@ describe('Company edit', () => {
         {
           label: 'Annual turnover (optional)',
           hint: 'Amount in GBP',
-          value: roundToSignificantDigits(convertUsdToGbp(company.turnover), 2),
+          value: roundToSignificantDigits(company.turnover_gbp, 2),
           assert: assertFieldInput,
         },
         {

--- a/test/sandbox/fixtures/v4/company/company-dnb-corp.json
+++ b/test/sandbox/fixtures/v4/company/company-dnb-corp.json
@@ -48,6 +48,7 @@
     "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
   },
   "turnover": 1000000,
+  "turnover_gbp": 720000,
   "is_turnover_estimated": true,
   "uk_region": null,
   "export_experience_category": null,

--- a/test/sandbox/fixtures/v4/company/company-dnb-ltd.json
+++ b/test/sandbox/fixtures/v4/company/company-dnb-ltd.json
@@ -77,6 +77,7 @@
     "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
   },
   "turnover": 1000000,
+  "turnover_gbp": 720000,
   "is_turnover_estimated": true,
   "uk_region": null,
   "export_experience_category": {

--- a/test/unit/data/companies/company-v4.json
+++ b/test/unit/data/companies/company-v4.json
@@ -59,7 +59,8 @@
     "name": "£33.5M+",
     "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
   },
-  "turnover": null,
+  "turnover": 123,
+  "turnover_gbp": 987,
   "is_turnover_estimated": null,
   "uk_region": {
     "name": "North West",


### PR DESCRIPTION
## Description of change

Removing GBP-USD conversion constant and ingest converted `turnover_gbp` field from the backend.

## Test instructions
`Companies > Business Details`
- From `Companies` collection list, select company from the list. At `Company activity` page navigate `View full business details` link. 
- Figure out the `Annual turnover` value which taken from converted `turnover_gbp` field backend response.

`Companies > Edit Company`
- From `Companies` collection list, select company from the list. At `Company activity` page navigate `View full business details > Edit` link. 
- Figure out the `Annual turnover (optional)`,  modify value then save. It converts the value from GBP to USB then save at DnB `company-change-request`.

`Companies > Edit history`
- From `Companies` collection list, select company from the list. At `Company activity` page navigate `View full business details > Edit history page` link. Figure out the `Annual turnover (optional)` value which taken from `turnover_gbp` field.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
