### PR TITLE
Convert MatchConfirmation form to use the TaskForm component

### DIFF
--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -6,7 +6,6 @@ import UnorderedList from '@govuk-react/unordered-list'
 import ListItem from '@govuk-react/list-item'
 import InsetText from '@govuk-react/inset-text'
 import { SPACING } from '@govuk-react/constants'
-import ErrorSummary from '@govuk-react/error-summary'
 import Details from '@govuk-react/details'
 
 import { SummaryList } from '../../../../../client/components'
@@ -63,16 +62,8 @@ function MatchConfirmation({
           { href: urls.companies.match.index(company.id), children: 'Back' },
         ]}
       >
-        {({ submissionError }) => (
+        {() => (
           <>
-            {submissionError && (
-              <ErrorSummary
-                heading="There was an error matching this company"
-                description={submissionError.message}
-                errors={[]}
-              />
-            )}
-
             <H4 as="h2">Data Hub business details (un-verified)</H4>
             <InsetText>
               <SummaryList

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -1,22 +1,16 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import axios from 'axios'
 import { H4 } from '@govuk-react/heading'
 import UnorderedList from '@govuk-react/unordered-list'
-import Button from '@govuk-react/button'
-import Link from '@govuk-react/link'
 import ListItem from '@govuk-react/list-item'
 import InsetText from '@govuk-react/inset-text'
 import { SPACING } from '@govuk-react/constants'
 import ErrorSummary from '@govuk-react/error-summary'
 import Details from '@govuk-react/details'
 
-import {
-  SummaryList,
-  FormStateful,
-  FormActions,
-} from '../../../../../client/components'
+import { SummaryList } from '../../../../../client/components'
+import TaskForm from '../../../../../client/components/Task/Form'
 import urls from '../../../../../lib/urls'
 import MatchDuplicate from './MatchDuplicate'
 
@@ -31,16 +25,6 @@ const StyledList = styled(UnorderedList)`
   list-style-type: initial;
   margin-bottom: ${SPACING.SCALE_6};
 `
-
-async function onMatchSubmit({ company, dnbCompany, csrfToken }) {
-  await axios.post(
-    `${urls.companies.match.link(company.id)}?_csrf=${csrfToken}`,
-    {
-      dnbCompany,
-    }
-  )
-  return urls.companies.detail(company.id)
-}
 
 function MatchConfirmation({
   dnbCompanyIsMatched,
@@ -60,8 +44,24 @@ function MatchConfirmation({
 
   return (
     <StyledRoot>
-      <FormStateful
-        onSubmit={() => onMatchSubmit({ company, dnbCompany, csrfToken })}
+      <TaskForm
+        id="match-confirmation-form"
+        submissionTaskName="Match confirmation"
+        analyticsFormName="match-confirmation-form"
+        redirectTo={(company) => urls.companies.detail(company.id)}
+        flashMessage={() => [
+          'Business details verified.',
+          'Thanks for helping to improve the quality of records on Data Hub!',
+        ]}
+        transformPayload={() => ({
+          company,
+          dnbCompany,
+          csrfToken,
+        })}
+        submitButtonLabel="Verify"
+        actionLinks={[
+          { href: urls.companies.match.index(company.id), children: 'Back' },
+        ]}
       >
         {({ submissionError }) => (
           <>
@@ -120,13 +120,9 @@ function MatchConfirmation({
                 future
               </ListItem>
             </StyledList>
-            <FormActions>
-              <Button>Verify</Button>
-              <Link href={urls.companies.match.index(company.id)}>Back</Link>
-            </FormActions>
           </>
         )}
-      </FormStateful>
+      </TaskForm>
     </StyledRoot>
   )
 }

--- a/src/apps/companies/apps/match-company/client/tasks.js
+++ b/src/apps/companies/apps/match-company/client/tasks.js
@@ -1,0 +1,15 @@
+import axios from 'axios'
+import urls from '../../../../../lib/urls'
+
+export const onMatchSubmit = ({ csrfToken, company, dnbCompany }) => {
+  return axios
+    .post(`${urls.companies.match.link(company.id)}?_csrf=${csrfToken}`, {
+      dnbCompany,
+    })
+    .catch((e) => {
+      return Promise.reject(e.message)
+    })
+    .then((response) => {
+      return response.data
+    })
+}

--- a/src/apps/companies/apps/match-company/controllers.js
+++ b/src/apps/companies/apps/match-company/controllers.js
@@ -154,13 +154,6 @@ async function linkCompanies(req, res, next) {
       company.id,
       dnbCompany.duns_number
     )
-
-    req.flashWithBody(
-      'success',
-      'Business details verified.',
-      'Thanks for helping to improve the quality of records on Data Hub!',
-      'message-company-matched'
-    )
     res.json(result)
   } catch (error) {
     next(error)

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -195,6 +195,8 @@ import { ProtectedRoute } from '../client/components'
 
 import routes from './routes'
 
+import { onMatchSubmit } from '../apps/companies/apps/match-company/client/tasks'
+
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
 }
@@ -224,6 +226,7 @@ function App() {
     <Provider
       tasks={{
         'Create company': createCompany,
+        'Match confirmation': onMatchSubmit,
         'Company lists': companyListsTasks.fetchCompanyLists,
         'Company list': companyListsTasks.fetchCompanyList,
         'Exports history': exportsHistoryTasks.fetchExportsHistory,


### PR DESCRIPTION
## Description of change

This PR converts the MatchConfirmation form from `FormStateful` to `TaskForm`. This is part of the Capital Investment team's mission work to improve the forms. 

This PR should only be merged into master once the PR with the `TaskForm` component has been merged.



## Test instructions
 Everything should look and act the same as usual. All tests should still pass, and the form should submit the data as usual. On fail of submission, an error message should be shown, instead of just submitting the form on a false positive. You should also see a loading wheel while the task is in progress! 


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
