### PR TITLE
Convert ExportEdits form to use TaskForm component.

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsEdit.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsEdit.jsx
@@ -1,18 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
-import { Button, Link } from 'govuk-react'
-import axios from 'axios'
 import { SPACING_POINTS } from '@govuk-react/constants'
-import {
-  FormActions,
-  FieldSelect,
-  FormStateful,
-} from '../../../../../client/components'
+import { FieldInput, FieldSelect } from '../../../../../client/components'
 
 import GreatProfile from './GreatProfile'
 import urls from '../../../../../lib/urls'
-
-const EXPORT_WIN_FIELD_NAME = 'export_experience_category'
+import TaskForm from '../../../../../client/components/Task/Form'
 
 const StyledDt = styled.dt`
   margin-bottom: ${SPACING_POINTS[1]}px;
@@ -21,15 +14,6 @@ const StyledDd = styled.dd`
   margin-bottom: ${SPACING_POINTS[6]}px;
 `
 
-function saveWinCategory(companyId) {
-  return async (values) => {
-    await axios.patch(`/api-proxy/v4/company/${companyId}`, {
-      [EXPORT_WIN_FIELD_NAME]: values[EXPORT_WIN_FIELD_NAME] || null,
-    })
-
-    return urls.companies.exports.index(companyId)
-  }
-}
 export default ({
   companyId,
   companyNumber,
@@ -38,17 +22,26 @@ export default ({
   exportPotential,
   exportWinCategories,
 }) => (
-  <FormStateful
-    onSubmit={saveWinCategory(companyId)}
-    initialValues={{
-      [EXPORT_WIN_FIELD_NAME]: exportWinCategoryValue?.id,
-    }}
+  <TaskForm
+    id="exports-edit"
+    submissionTaskName="Exports Edit"
+    analyticsFormName="Exports Edit"
+    transformPayload={(values) => ({ ...values, companyId })}
+    redirectTo={() => urls.companies.exports.index(companyId)}
+    submitButtonLabel="Save and return"
+    actionLinks={[
+      {
+        children: 'Return without saving',
+        href: urls.companies.exports.index(companyId),
+      },
+    ]}
   >
     <FieldSelect
       emptyOption="-- Select category --"
       label="Export win category (optional)"
-      name={EXPORT_WIN_FIELD_NAME}
+      name="export_experience_category"
       options={exportWinCategories}
+      initialValue={exportWinCategoryValue?.id}
     />
     <dl>
       <StyledDt>great.gov.uk business profile</StyledDt>
@@ -61,12 +54,6 @@ export default ({
         {exportPotential.value ? exportPotential.value : 'No score given'}
       </StyledDd>
     </dl>
-
-    <FormActions>
-      <Button>Save and return</Button>
-      <Link href={urls.companies.exports.index(companyId)}>
-        Return without saving
-      </Link>
-    </FormActions>
-  </FormStateful>
+    <FieldInput type="hidden" name="companyId" initialValue={companyId} />
+  </TaskForm>
 )

--- a/src/apps/companies/apps/exports/client/tasks.js
+++ b/src/apps/companies/apps/exports/client/tasks.js
@@ -1,0 +1,10 @@
+import { apiProxyAxios } from '../../../../../client/components/Task/utils'
+
+export const saveWinCategory = ({ companyId, export_experience_category }) => {
+  return apiProxyAxios
+    .patch(`/api-proxy/v4/company/${companyId}`, {
+      export_experience_category: export_experience_category || null,
+    })
+    .catch((e) => Promise.reject(e.message))
+    .then((response) => response.data)
+}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -155,6 +155,8 @@ import { TASK_CHECK_FOR_INVESTMENTS } from './components/PersonalisedDashboard/s
 import { fetchOutstandingPropositions } from './components/InvestmentReminders/tasks'
 import { TASK_GET_OUTSTANDING_PROPOSITIONS } from './components/InvestmentReminders/state'
 
+import * as exportsEdit from '../apps/companies/apps/exports/client/tasks'
+
 import {
   getContacts,
   getContactsMetadata,
@@ -301,6 +303,7 @@ function App() {
         [TASK_GET_ORDERS_LIST]: getOrders,
         [TASK_GET_INTERACTIONS_TEAM_NAME]: getTeamNames,
         [TASK_ARCHIVE_COMPANY]: businessDetails.archiveSubmitCallback,
+        'Exports Edit': exportsEdit.saveWinCategory,
         ...resourceTasks,
       }}
     >


### PR DESCRIPTION
## Description of change

This converts ExportEdits form to use TaskForm component.

## Test instructions

Go to company, export tab and then click "Edit" link on the right hand side next to "Exports" header. 
The "Edit exports" form should load. It should function just as the original form.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
