### PR TITLE
US ZIP Code Validation

### DIFF
--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -174,23 +174,31 @@ const FieldAddress = ({
 
   const usZipCodeRegex = /^\d{5}(-\d{4})?$/i
 
-  const canadianPostalCodeRegex =
+  const canadaPostalCodeRegex =
     /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i
+
+  const usZipCodeValidator = (value) => {
+    if (!value) {
+      return 'Enter a ZIP Code'
+    } else if (value && !usZipCodeRegex.test(value)) {
+      return 'Enter a valid ZIP Code'
+    }
+  }
+
+  const canadaPostalCodeValidator = (value) => {
+    if (!value) {
+      return 'Enter a Postal Code'
+    } else if (value && !canadaPostalCodeRegex.test(value)) {
+      return 'Enter a valid Postal Code'
+    }
+  }
 
   const postcodeValidator = (value) => {
     if (isUS) {
-      if (!value) {
-        return 'Enter a ZIP Code'
-      } else if (value && !usZipCodeRegex.test(value)) {
-        return 'Enter a valid ZIP Code'
-      }
+      return usZipCodeValidator(value)
     }
     if (isCanada) {
-      if (!value) {
-        return 'Enter a Postal Code'
-      } else if (value && !canadianPostalCodeRegex.test(value)) {
-        return 'Enter a valid Postal Code'
-      }
+      return canadaPostalCodeValidator(value)
     }
     return null
   }

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -172,25 +172,25 @@ const FieldAddress = ({
     return 'Postcode (optional)'
   }
 
+  const usZipCodeRegex = /^\d{5}(-\d{4})?$/i
+
   const canadianPostalCodeRegex =
     /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i
 
-  const usZipCodeRegex = /^\d{5}(-\d{4})?$/i
-
-  const zipCodeValidator = (value) => {
-    if (!value && isUS) {
-      return 'Enter a ZIP Code'
-    } else if (value && isUS && !usZipCodeRegex.test(value)) {
-      return 'Enter a valid ZIP Code'
+  const postcodeValidator = (value) => {
+    if (isUS) {
+      if (!value) {
+        return 'Enter a ZIP Code'
+      } else if (value && !usZipCodeRegex.test(value)) {
+        return 'Enter a valid ZIP Code'
+      }
     }
-    return null
-  }
-
-  const postalCodeValidator = (value) => {
-    if (!value && isCanada) {
-      return 'Enter a Postal Code'
-    } else if (value && isCanada && !canadianPostalCodeRegex.test(value)) {
-      return 'Enter a valid Postal Code'
+    if (isCanada) {
+      if (!value) {
+        return 'Enter a Postal Code'
+      } else if (value && !canadianPostalCodeRegex.test(value)) {
+        return 'Enter a valid Postal Code'
+      }
     }
     return null
   }
@@ -209,7 +209,7 @@ const FieldAddress = ({
           postcodeValidationEnabled ? postcodeLabel() : 'Postcode (optional)'
         }
         required={postcodeValidationEnabled ? postcodeErrorMessage() : null}
-        validate={isUS ? zipCodeValidator : postalCodeValidator}
+        validate={postcodeValidator}
       />
     )
   }

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -175,6 +175,17 @@ const FieldAddress = ({
   const canadianPostalCodeRegex =
     /^[ABCEGHJ-NPRSTVXY]\d[ABCEGHJ-NPRSTV-Z][ -]?\d[ABCEGHJ-NPRSTV-Z]\d$/i
 
+  const usZipCodeRegex = /^\d{5}(-\d{4})?$/i
+
+  const zipCodeValidator = (value) => {
+    if (!value && isUS) {
+      return 'Enter a ZIP Code'
+    } else if (value && isUS && !usZipCodeRegex.test(value)) {
+      return 'Enter a valid ZIP Code'
+    }
+    return null
+  }
+
   const postalCodeValidator = (value) => {
     if (!value && isCanada) {
       return 'Enter a Postal Code'
@@ -198,7 +209,7 @@ const FieldAddress = ({
           postcodeValidationEnabled ? postcodeLabel() : 'Postcode (optional)'
         }
         required={postcodeValidationEnabled ? postcodeErrorMessage() : null}
-        validate={postalCodeValidator}
+        validate={isUS ? zipCodeValidator : postalCodeValidator}
       />
     )
   }

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -651,7 +651,10 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.continueButton).click()
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid Postal Code',
+        'Enter a valid Postal Code'
+      )
+      cy.get(selectors.companyAdd.form).should(
+        'not.contain',
         'Enter a valid ZIP Code'
       )
     })

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -643,7 +643,7 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.form).contains('Poland')
     })
 
-    it('should not show an invalid postal code error', () => {
+    it('should not show an invalid postal or ZIP code error', () => {
       cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).clear()
       cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).type(
         'ABC 123'
@@ -651,7 +651,8 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.continueButton).click()
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid Postal Code'
+        'Enter a valid Postal Code',
+        'Enter a valid ZIP Code'
       )
     })
 
@@ -767,6 +768,26 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.form).contains('Enter a town or city')
       cy.get(selectors.companyAdd.form).contains('Select a state')
       cy.get(selectors.companyAdd.form).contains('Enter a ZIP code')
+    })
+
+    it('should show an invalid ZIP code error', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).type(
+        'A1A 1A1'
+      )
+      cy.get(selectors.companyAdd.continueButton).click()
+      cy.get(selectors.companyAdd.form).contains('Enter a valid ZIP Code')
+    })
+
+    it('should not show an invalid ZIP code error when completed correctly', () => {
+      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).clear()
+      cy.get(selectors.companyAdd.newCompanyRecordForm.address.postcode).type(
+        '48222'
+      )
+      cy.get(selectors.companyAdd.continueButton).click()
+      cy.get(selectors.companyAdd.form).should(
+        'not.contain',
+        'Enter a valid ZIP Code'
+      )
     })
   })
 

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -251,10 +251,27 @@ describe('Company edit', () => {
       ],
     })
 
-    it('renders errors correctly', () => {
+    it('renders state selection errors correctly', () => {
       cy.get(selectors.companyEdit.address.areaUS).select('-- Select state --')
       cy.contains('Submit').click()
       cy.get(selectors.companyEdit.form).contains('Select a state')
+    })
+
+    it('renders ZIP code errors if ZIP code is not valid', () => {
+      cy.get(selectors.companyEdit.address.postcode).clear()
+      cy.get(selectors.companyEdit.address.postcode).type('ABC 123')
+      cy.contains('Submit').click()
+      cy.get(selectors.companyEdit.form).contains('Enter a valid ZIP Code')
+    })
+
+    it('does not render ZIP code errors if ZIP code is valid', () => {
+      cy.get(selectors.companyEdit.address.postcode).clear()
+      cy.get(selectors.companyEdit.address.postcode).type('12345')
+      cy.contains('Submit').click()
+      cy.get(selectors.companyEdit.form).should(
+        'not.contain',
+        'Enter a valid ZIP Code'
+      )
     })
   })
 

--- a/test/sandbox/fixtures/v4/company/company-mars-exports-ltd.json
+++ b/test/sandbox/fixtures/v4/company/company-mars-exports-ltd.json
@@ -145,7 +145,7 @@
     "line_2": "",
     "town": "New York",
     "county": "",
-    "postcode": "765413",
+    "postcode": "12345",
     "area": {
       "name": "New York",
       "id": "aa65b701-244a-41fc-bd31-0a546303106a"
@@ -160,7 +160,7 @@
     "line_2": "",
     "town": "New York",
     "county": "",
-    "postcode": "765413",
+    "postcode": "12345",
     "country": {
       "name": "United States",
       "id": "81756b9a-5d95-e211-a939-e4115bead28a"


### PR DESCRIPTION
## Description of change

This PR adds ZIP Code validation for US companies on the Add Company form and the Edit Business Details form. 

US ZIP Codes now have to match the standard 5 digit US ZIP Codes, or US ZIP + 4 standard e.g. 48222 or 48222-1746

## Test instructions
Navigate to the Add Company form for a US company.
Type an invalid ZIP code (e.g. 123456789 ) into the ZIP Code box. There should be the error 'Enter a valid ZIP Code'.
Type a valid ZIP code (e.g. 12345 or 12345-1234) into the ZIP Code box. The error should no longer be present.

The same can be repeated for the Edit Business Details form for a US company. 

## Screenshots
### Before
No validation present.
![image](https://user-images.githubusercontent.com/70902973/142198633-51c6bcb7-fa15-4289-8ea5-01a856e3ef56.png)

### After
With validation.
![image](https://user-images.githubusercontent.com/70902973/142198304-769fef78-f07f-4b36-a086-804400200988.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
