### PR TITLE
Proof of concept mocha based unit tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,8 @@
     "test:visual:update": "cypress-image-diff -u",
     "test:component": "CYPRESS_coverage=false CYPRESS_integrationFolder=test/component/cypress/specs cypress run-ct",
     "test:component:watch": "CYPRESS_coverage=false CYPRESS_integrationFolder=test/component/cypress/specs cypress open-ct",
+    "test:component:mocha": "NODE_ENV=test WEBPACK_ENV=develop MOCHA_FILE=junit/test-results.xml npx mochapack --webpack-config webpack.config.js --opts ./test/component/mocha/mocha.opts ./test/component/mocha/**/*.test.{js,jsx}",
+    "test:component:mocha:watch": "NODE_ENV=test WEBPACK_ENV=develop MOCHA_FILE=junit/test-results.xml npx mochapack --watch --webpack-config webpack.config.js --opts ./test/component/mocha/mocha.opts ./test/component/mocha/**/*.test.{js,jsx}",
     "coverage": "npx nyc --reporter=html --reporter=json --reporter=text --reporter=lcov --report-dir=coverage npm run test:unit",
     "circle:unit": "npx nyc --reporter=lcov --reporter=json --report-dir=coverage npm run test:unit -- --reporter mocha-circleci-reporter",
     "circle:unit-client": "npm run test:unit-client --reporter mocha-circleci-reporter",

--- a/test/component/mocha/Badge.test.js
+++ b/test/component/mocha/Badge.test.js
@@ -1,0 +1,43 @@
+import React from 'react'
+import Badge from 'client/components/Badge'
+import { act } from 'react-dom/test-utils'
+import { expect } from 'chai'
+import ReactDOM from 'react-dom'
+import './bootstrap'
+
+const mount = (component) => {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    ReactDOM.render(component, container)
+  })
+  return container
+}
+
+describe('Badge', () => {
+  const badgeText = 'example'
+
+  context('When no props are passed', () => {
+    let container
+    beforeEach(() => {
+      container = mount(<Badge>{badgeText}</Badge>)
+    })
+
+    it('should set the content with children', () => {
+      const badge = container.querySelector('[data-test="badge"]')
+      expect(badge.textContent).to.equal('example')
+    })
+  })
+
+  context('When a "label" prop is passed passed', () => {
+    let container
+    beforeEach(() => {
+      container = mount(<Badge label="testLabel">{badgeText}</Badge>)
+    })
+
+    it('should set the content with children', () => {
+      const badge = container.querySelector('[data-test="badge"]')
+      expect(badge.textContent).to.equal('testLabelexample')
+    })
+  })
+})

--- a/test/component/mocha/Badge.test.js
+++ b/test/component/mocha/Badge.test.js
@@ -27,17 +27,33 @@ describe('Badge', () => {
       const badge = container.querySelector('[data-test="badge"]')
       expect(badge.textContent).to.equal('example')
     })
+
+    it('should render with a default border', () => {
+      const badge = container.querySelector('[data-test="badge"]')
+      const styles = window.getComputedStyle(badge)
+      expect(styles.border).to.equal('2px solid #bfc1c3')
+    })
   })
 
   context('When a "label" prop is passed passed', () => {
     let container
     beforeEach(() => {
-      container = mount(<Badge label="testLabel">{badgeText}</Badge>)
+      container = mount(
+        <Badge borderColour="red" label="testLabel">
+          {badgeText}
+        </Badge>
+      )
     })
 
     it('should set the content with children', () => {
       const badge = container.querySelector('[data-test="badge"]')
       expect(badge.textContent).to.equal('testLabelexample')
+    })
+
+    it('should render with a red border', () => {
+      const badge = container.querySelector('[data-test="badge"]')
+      const styles = window.getComputedStyle(badge)
+      expect(styles.border).to.equal('2px solid red')
     })
   })
 })

--- a/test/component/mocha/bootstrap.js
+++ b/test/component/mocha/bootstrap.js
@@ -1,0 +1,4 @@
+before((done) => {
+  document.body.innerHTML = ''
+  done()
+})

--- a/test/component/mocha/dom.js
+++ b/test/component/mocha/dom.js
@@ -1,0 +1,21 @@
+const { JSDOM } = require('jsdom')
+
+var { document } = new JSDOM('<!doctype html><html><body></body></html>', {
+  url: 'http://localhost/',
+}).window
+
+var win = document.defaultView
+
+global.document = document
+global.window = document.defaultView
+
+propagateToGlobal(win)
+
+function propagateToGlobal(window) {
+  for (let key in window) {
+    if (!window.hasOwnProperty(key)) continue
+    if (key in global) continue
+
+    global[key] = window[key]
+  }
+}

--- a/test/component/mocha/mocha.opts
+++ b/test/component/mocha/mocha.opts
@@ -1,3 +1,2 @@
 --require test/component/mocha/dom.js
---file test/component/mocha/bootstrap.js
 --recursive

--- a/test/component/mocha/mocha.opts
+++ b/test/component/mocha/mocha.opts
@@ -1,0 +1,3 @@
+--require test/component/mocha/dom.js
+--file test/component/mocha/bootstrap.js
+--recursive

--- a/test/component/mocha/test.test.js
+++ b/test/component/mocha/test.test.js
@@ -1,0 +1,29 @@
+var React = require('react')
+var { Simulate, act } = require('react-dom/test-utils')
+var ReactDOM = require('react-dom')
+const { expect } = require('chai')
+
+require('./bootstrap.js')
+
+const SomeJSX = (props) => <button onClick={props.onClick}></button>
+
+describe('SomeJSX', () => {
+  it('should be clickable', (done) => {
+    var a = 0
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    act(() => {
+      ReactDOM.render(<SomeJSX onClick={() => (a = a + 1)} />, container)
+      expect(a).to.equal(0)
+    })
+
+    var button = container.querySelector('button')
+
+    act(() => {
+      Simulate.click(button)
+      expect(a).to.equal(1)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds mocha-based unit tests that can render react components against jsdom.

For this level of testing I would expect us to be testing behaviours i.e. "when this button was clicked, this text is now visible", and not visual aspects e.g. "this button is red".

*Update:* I noticed we're using styled-components in conjunction with variables and if statements - which means that often the styling applied is "behaviour". In 84b7c19 I added a PoC of how to assert computed styles

[ ] Add to circle ci jobs