### PR TITLE
Fix flaky details form functional tests

### DIFF
--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -306,7 +306,8 @@ function submitForm(kind, theme, values) {
       cy.get('#event')
         .parent()
         .selectTypeaheadOption('Sort event')
-        .should('contain', 'Sort event')
+        .parent()
+        .should('contain', 'Sort Event')
     }
 
     if (theme == THEMES.INVESTMENT) {

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -210,17 +210,20 @@ function fillCommonFields({
     .parent()
     .find("[data-test='trade-agreement-field-0']")
     .selectTypeaheadOption('UK-Australia Mutual Recognition Agreement')
+    .should('contain', 'UK-Australia Mutual Recognition Agreement')
 
   cy.contains(ELEMENT_TRADE_AGREEMENTS.legend)
     .parent()
     .find("[data-test='trade-agreement-field-1']")
     .selectTypeaheadOption('UK-Mexico Trade Continuity Agreement')
+    .should('contain', 'UK-Mexico Trade Continuity Agreement')
 
   if (contact) {
     cy.contains(ELEMENT_CONTACT.label)
       .next()
       .next()
       .selectTypeaheadOption(contact)
+      .should('contain', contact)
   }
 
   cy.contains(ELEMENT_SUBJECT.label).next().find('input').type('Some subject')
@@ -241,6 +244,7 @@ function fillCommonFields({
   cy.contains(ELEMENT_POLICY_AREAS.label)
     .next()
     .selectTypeaheadOption('State Aid')
+    .should('contain', 'State Aid')
 
   cy.contains(ELEMENT_POLICY_FEEDBACK_NOTES.label)
     .next()
@@ -255,14 +259,17 @@ function fillExportCountriesFields() {
   cy.contains(ELEMENT_COUNTRIES_CURRENTLY_EXPORTING.label)
     .parent()
     .selectTypeaheadOption('Iceland')
+    .should('contain', 'Iceland')
 
   cy.contains(ELEMENT_COUNTRIES_FUTURE_INTEREST.label)
     .parent()
     .selectTypeaheadOption('Austria')
+    .should('contain', 'Austria')
 
   cy.contains(ELEMENT_COUNTRIES_NOT_INTERESTED.label)
     .parent()
     .selectTypeaheadOption('Germany')
+    .should('contain', 'Germany')
 }
 
 function submitForm(kind, theme, values) {
@@ -277,6 +284,7 @@ function submitForm(kind, theme, values) {
       cy.contains(ELEMENT_COMMUNICATION_CHANNEL.label)
         .next()
         .selectTypeaheadOption('Telephone')
+        .should('contain', 'Telephone')
     } else if (kind === KINDS.SERVICE_DELIVERY) {
       cy.contains(ELEMENT_SERVICE_STATUS.label)
         .next()
@@ -295,7 +303,10 @@ function submitForm(kind, theme, values) {
 
       cy.contains(ELEMENT_IS_EVENT.legend).next().find('input').check('yes')
 
-      cy.get('#event').parent().selectTypeaheadOption('Sort event')
+      cy.get('#event')
+        .parent()
+        .selectTypeaheadOption('Sort event')
+        .should('contain', 'Sort event')
     }
 
     if (theme == THEMES.INVESTMENT) {
@@ -306,6 +317,7 @@ function submitForm(kind, theme, values) {
       cy.contains(ELEMENT_OPPORTUNITY.legend)
         .next()
         .selectTypeaheadOption('A modified opportunity')
+        .should('contain', 'A modified opportunity')
     }
 
     clickAddInteraction()

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -359,14 +359,12 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
 }
 
 const assertFieldDate = ({ element, label, value = {} }) => {
-  const labels = element.find('label')
   const inputs = element.find('input')
 
-  label && expect(labels[0]).to.have.text(label)
-
-  expect(labels[1]).to.have.text('Day')
-  expect(labels[2]).to.have.text('Month')
-  expect(labels[3]).to.have.text('Year')
+  expect(element).to.contain.text(label)
+  expect(element).to.contain.text('Day')
+  expect(element).to.contain.text('Month')
+  expect(element).to.contain.text('Year')
 
   value.day && expect(inputs[0]).to.have.value(value.day)
   value.month && expect(inputs[1]).to.have.value(value.month)


### PR DESCRIPTION
This MR intent is to sort out the top flaky tests in the cypress functional test suite:

- should render all form fields specs/interaction/details-form-spec.js (trade agreement)
- should render all form fields specs/interaction/details-form-spec.js (service delivery)
- should render all form fields specs/interaction/details-form-spec.js (investment)
- should render all form fields specs/interaction/details-form-spec.js (interaction)
- should give an error if a status is not selected specs/investments/opportunity-status-form-spec.js
- should be able to create an interaction from referral test/functional/cypress/specs/interaction/details-form-spec.js

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
