### PR TITLE
Align service timeouts within development environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 docker-base = docker-compose -p dh -f docker-compose.base.yml
 docker-mock = docker-compose -p dh -f docker-compose.base.yml -f docker-compose.mock.yml
 docker-e2e = docker-compose -p dh -f docker-compose.base.yml -f docker-compose.e2e.frontend.yml -f docker-compose.e2e.backend.yml -f docker-compose.services.yml
-docker-dev = docker-compose -p dh -f docker-compose.base.yml -f docker-compose.frontend.dev.yml
+docker-dev = COMPOSE_HTTP_TIMEOUT=300 docker-compose -p dh -f docker-compose.base.yml -f docker-compose.frontend.dev.yml
 docker-storybook = docker-compose -p dh -f docker-compose.storybook.yml
 
 wait-for-frontend = dockerize -wait tcp://localhost:3000/healthcheck -timeout 5m -wait-retry-interval 5s

--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -3,7 +3,7 @@ services:
   frontend:
     depends_on:
       - mock-sso
-    entrypoint: dockerize -wait tcp://api:8000 -timeout 3m -wait-retry-interval 5s
+    entrypoint: dockerize -wait tcp://api:8000 -timeout 5m -wait-retry-interval 5s
     env_file: .env
 
   mock-sso:
@@ -15,9 +15,9 @@ services:
       MOCK_SSO_TOKEN: 123
       MOCK_SSO_EMAIL_USER_ID: test@gov.uk
       MOCK_SSO_USERNAME: test@gov.uk
-      MOCK_SSO_VALIDATE_TOKEN: "true"
 
 networks:
   default:
     external:
       name: data-infrastructure-shared-network
+


### PR DESCRIPTION

## Description of change
* Align service timeouts within development environment such that they are all 5 minutes
* Fallback to less-strict token checking in `mock-sso` for development environment

_Document what the PR does and why the change is needed_

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
