### PR TITLE
Remove deprecated variables from `sample.env`

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -5,9 +5,6 @@
 ACCOUNT_PLAN_URLS={"000000001": "/some-test-account-plan-url","123456789": "/some-other-test-account-plan-urls"}
 API_ROOT=http://api:8000
 ARCHIVED_DOCUMENTS_BASE_URL=https://lookInVault.com/
-# Uncomment these when running locally (required for visual tests)
-# BROWSERSTACK_USERNAME=lookInRattic
-# BROWSERSTACK_ACCESS_KEY=lookInRattic
 DATA_HUB_BACKEND_ACCESS_KEY_ID=frontend-key-id
 DATA_HUB_BACKEND_SECRET_ACCESS_KEY=frontend-key
 DATA_STORE_SERVICE_ACCESS_KEY_ID=data-store-service-id
@@ -24,7 +21,6 @@ HELP_CENTRE_FEED_API_TOKEN=lookInVault
 HELP_CENTRE_URL=https://lookInVault.com/
 NODE_ENV=development
 ONE_LIST_EMAIL=look@in.vault.com
-PERFORMANCE_DASHBOARDS_URL=https://lookInVault.com/
 POSTCODE_KEY=lookInVault
 REDIS_HOST=redis
 REDIS_URL=redis://redis:6379
@@ -62,8 +58,6 @@ DJANGO_SUPERUSER_SSO_EMAIL_USER_ID=change.me@id.trade.local
 ES5_URL=http://es:9200
 ES_APM_ENABLED=False
 ES_INDEX_PREFIX=test_index
-MI_DATABASE_URL=postgresql://user:password@mi-postgres/datahub
-MI_POSTGRES_URL=tcp://mi-postgres:5432
 POSTGRES_URL=tcp://postgres:5432
 REDIS_BASE_URL=redis://redis:6379
 REDIS_CACHE_DB=5

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -129,9 +129,6 @@ const envSchema = Joi.object({
   // Email address to the team responsible for changes to the One List companies
   ONE_LIST_EMAIL: Joi.string().required(),
 
-  // Url to Export Wins performance dashboards, used in the main nav
-  PERFORMANCE_DASHBOARDS_URL: Joi.string().uri().required(),
-
   // Port on which the app runs
   PORT: Joi.number().port().default(3000),
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -87,7 +87,6 @@ const config = {
   currencyFormat: '$0,0.00',
   paginationMaxResults: 10000,
   paginationDefaultSize: 10,
-  performanceDashboardsUrl: envVars.PERFORMANCE_DASHBOARDS_URL,
   archivedDocumentsBaseUrl: envVars.ARCHIVED_DOCUMENTS_BASE_URL,
   oauth: {
     url: envVars.OAUTH2_AUTH_URL,


### PR DESCRIPTION
## Description of change

I've noticed that there are a few deprecated variables in `sample.env`, which I have removed:

- `BROWSERSTACK_USERNAME` and `BROWSERSTACK_ACCESS_KEY` have been removed because we no longer use Browserstack for visual tests.
- `MI_DATABASE_URL` and `MI_POSTGRES_URL` have been removed because the MI database they were referring to has been deleted (see [this PR](https://github.com/uktrade/data-hub-api/pull/3717))
- `PERFORMANCE_DASHBOARDS_URL` has been removed as the performance dashboards sservice has been depracated and is no longer accessible from Data Hub.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
