### PR TITLE
Refactor send referral form to use TaskForm

### DIFF
--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -15,7 +15,7 @@ services:
       MOCK_SSO_TOKEN: 123
       MOCK_SSO_EMAIL_USER_ID: test@gov.uk
       MOCK_SSO_USERNAME: test@gov.uk
-#      MOCK_SSO_VALIDATE_TOKEN: "true"
+      MOCK_SSO_VALIDATE_TOKEN: "true"
 
 networks:
   default:

--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -15,7 +15,7 @@ services:
       MOCK_SSO_TOKEN: 123
       MOCK_SSO_EMAIL_USER_ID: test@gov.uk
       MOCK_SSO_USERNAME: test@gov.uk
-      MOCK_SSO_VALIDATE_TOKEN: "true"
+#      MOCK_SSO_VALIDATE_TOKEN: "true"
 
 networks:
   default:

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -48,7 +48,7 @@ const SendReferralForm = ({
           companyId,
         })}
         submissionTaskName={TASK_SAVE_REFERRAL}
-        analyticsFormName="send-referral-form"
+        analyticsFormName="sendReferralForm"
         analyticsData={({ adviser, subject }) => ({
           event: 'send_referral',
           sendingAdviserTeam: sendingAdviserTeamName,

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
-//import { SEND_REFERRAL_FORM__SUBMIT } from '../../../../../../client/actions' //not sure if this is still useful for anything
 import StepReferralDetails from './StepReferralDetails'
 import StepReferralConfirmation from './StepReferralConfirmation'
 import Step from '../../../../../../client/components/Form/elements/Step.jsx'
@@ -18,16 +17,11 @@ import {
   TASK_SAVE_REFERRAL,
 } from './state'
 
-//this is apparently not restoring values when returning from the contact form loop, we'll need to fix that
 const SendReferralForm = ({
   cancelUrl,
   companyContacts,
   companyName,
   companyId,
-  subject,
-  notes,
-  contact,
-  adviser,
   sendingAdviserTeamName,
   flashMessages,
 }) => (
@@ -61,10 +55,7 @@ const SendReferralForm = ({
           receivingAdviserTeam: adviser.label?.split(', ')[1],
           referralSubject: subject,
         })}
-        //we need to make it redirect back from the contact form
-        initialValuesPayload={{ adviser, subject, notes, contact }}
         initialValuesTaskName="Get send referral initial values"
-        
         redirectTo={() => companies.detail(companyId)}
         flashMessage={() => [
           'Referral sent',

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -62,8 +62,9 @@ const SendReferralForm = ({
           referralSubject: subject,
         })}
         //we need to make it redirect back from the contact form
-        //initialValuesPayload={{ adviser, subject, notes, contact }}
-        //initialValuesTaskName="Get send referral initial values"
+        initialValuesPayload={{ adviser, subject, notes, contact }}
+        initialValuesTaskName="Get send referral initial values"
+        
         redirectTo={() => companies.detail(companyId)}
         flashMessage={() => [
           'Referral sent',

--- a/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/SendReferralForm.jsx
@@ -18,6 +18,7 @@ import {
   TASK_SAVE_REFERRAL,
 } from './state'
 
+//this is apparently not restoring values when returning from the contact form loop, we'll need to fix that
 const SendReferralForm = ({
   cancelUrl,
   companyContacts,
@@ -60,7 +61,9 @@ const SendReferralForm = ({
           receivingAdviserTeam: adviser.label?.split(', ')[1],
           referralSubject: subject,
         })}
-        initialValues={{ adviser, subject, notes, contact }}
+        //we need to make it redirect back from the contact form
+        //initialValuesPayload={{ adviser, subject, notes, contact }}
+        //initialValuesTaskName="Get send referral initial values"
         redirectTo={() => companies.detail(companyId)}
         flashMessage={() => [
           'Referral sent',

--- a/src/apps/companies/apps/referrals/send-referral/client/tasks.js
+++ b/src/apps/companies/apps/referrals/send-referral/client/tasks.js
@@ -6,8 +6,16 @@ export async function getInitialFormValues({ adviser, subject, notes, contact })
   const valuesFromStorage = JSON.parse(
     window.sessionStorage.getItem(STORE_ID)
   )
-  console.log("VALUES FROM STORAGE")
-  console.log(valuesFromStorage)
+
+  const queryContact = getContactFromQuery()
+
+  if (queryContact.label && queryContact.value) {
+    valuesFromStorage.contact = {
+      label: queryContact.label,
+      value: queryContact.value,
+    }
+  }
+
   return valuesFromStorage
 }
 
@@ -15,30 +23,10 @@ export function openContactForm({ values, url }) {
   window.sessionStorage.setItem(
     STORE_ID,
     JSON.stringify({
-      values,
+      ...values,
     })
   )
   window.location.href = url
-}
-
-export function restoreState() {
-  const stateFromStorage = window.sessionStorage.getItem(STORE_ID)
-
-  if (!stateFromStorage) {
-    return {}
-  }
-
-  const queryContact = getContactFromQuery()
-  if (queryContact.label && queryContact.value) {
-    const updatedState = JSON.parse(stateFromStorage)
-    updatedState.values.contact = {
-      label: queryContact.label,
-      value: queryContact.value,
-    }
-    return updatedState
-  }
-
-  return JSON.parse(stateFromStorage)
 }
 
 export async function saveReferral({ values, companyId }) {

--- a/src/apps/companies/apps/referrals/send-referral/client/tasks.js
+++ b/src/apps/companies/apps/referrals/send-referral/client/tasks.js
@@ -2,10 +2,8 @@ import { ID as STORE_ID } from './state'
 import getContactFromQuery from '../../../../../../client/utils/getContactFromQuery'
 import { apiProxyAxios } from '../../../../../../client/components/Task/utils'
 
-export async function getInitialFormValues({ adviser, subject, notes, contact }) {
-  const valuesFromStorage = JSON.parse(
-    window.sessionStorage.getItem(STORE_ID)
-  )
+export async function getInitialFormValues() {
+  const valuesFromStorage = JSON.parse(window.sessionStorage.getItem(STORE_ID))
 
   const queryContact = getContactFromQuery()
 

--- a/src/apps/companies/apps/referrals/send-referral/client/tasks.js
+++ b/src/apps/companies/apps/referrals/send-referral/client/tasks.js
@@ -2,6 +2,15 @@ import { ID as STORE_ID } from './state'
 import getContactFromQuery from '../../../../../../client/utils/getContactFromQuery'
 import { apiProxyAxios } from '../../../../../../client/components/Task/utils'
 
+export async function getInitialFormValues({ adviser, subject, notes, contact }) {
+  const valuesFromStorage = JSON.parse(
+    window.sessionStorage.getItem(STORE_ID)
+  )
+  console.log("VALUES FROM STORAGE")
+  console.log(valuesFromStorage)
+  return valuesFromStorage
+}
+
 export function openContactForm({ values, url }) {
   window.sessionStorage.setItem(
     STORE_ID,

--- a/src/client/components/Analytics/saga.js
+++ b/src/client/components/Analytics/saga.js
@@ -8,6 +8,7 @@ data layer. */
 export default function* () {
   while (true) {
     const { category, action, label, extra } = yield take(ANALYTICS__PUSH)
+
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
       ...extra,

--- a/src/client/components/Resource/index.jsx
+++ b/src/client/components/Resource/index.jsx
@@ -21,7 +21,7 @@ const deepKeysToCamelCase = (x) =>
 /**
  * @function Resource
  * This component abstracts away the loading of a resource which has an ID.
- * It's basically a {Task} whith the result persisted in the state without the
+ * It's basically a {Task} with the result persisted in the state without the
  * need to deal with the {onSuccessDispatch} mechanism and to add any reducers.
  * @param {Object} props
  * @param {string} props.name - The name of the task which loads the resource

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -233,6 +233,7 @@ Task.Status = ({
         onSuccessDispatch,
         dismissError,
       } = getTask(name, id)
+
       return (
         <>
           {!!startOnRender && (

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -236,7 +236,8 @@ function App() {
         'Referral details': referralTasks.fetchReferralDetails,
         Referrals: referralListTask,
         'Export wins': exportWinsTasks.fetchExportWins,
-        'Get send referral initial values': referralsSendTasks.getInitialFormValues,
+        'Get send referral initial values':
+          referralsSendTasks.getInitialFormValues,
         [TASK_OPEN_REFERRALS_CONTACT_FORM]: referralsSendTasks.openContactForm,
         [TASK_SAVE_REFERRAL]: referralsSendTasks.saveReferral,
         [TASK_SAVE_ONE_LIST_DETAILS]: editOneListTasks.saveOneListDetails,

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -236,6 +236,7 @@ function App() {
         'Referral details': referralTasks.fetchReferralDetails,
         Referrals: referralListTask,
         'Export wins': exportWinsTasks.fetchExportWins,
+        'Get send referral initial values': referralsSendTasks.getInitialFormValues,
         [TASK_OPEN_REFERRALS_CONTACT_FORM]: referralsSendTasks.openContactForm,
         [TASK_SAVE_REFERRAL]: referralsSendTasks.saveReferral,
         [TASK_SAVE_ONE_LIST_DETAILS]: editOneListTasks.saveOneListDetails,

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -195,17 +195,6 @@ const store = createStore(
   }),
   {
     referrerUrl: window.document.referrer,
-    Form: {
-      [REFERRALS_SEND_ID]: {
-        values: {},
-        touched: {},
-        errors: {},
-        fields: {},
-        steps: [],
-        currentStep: 0,
-        ...referralsSendTasks.restoreState(),
-      },
-    },
   },
   composeWithDevTools(
     applyMiddleware(sagaMiddleware, routerMiddleware(history))

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -25,7 +25,6 @@ import referralsReducer from '../apps/companies/apps/referrals/details/client/re
 
 import { ID as REFERRALS_SEND_ID } from '../apps/companies/apps/referrals/send-referral/client/state'
 import referralsSendReducer from '../apps/companies/apps/referrals/send-referral/client/reducer'
-import * as referralsSendTasks from '../apps/companies/apps/referrals/send-referral/client/tasks'
 
 import { ID as EXPORTS_HISTORY_ID } from '../apps/companies/apps/exports/client/ExportsHistory/state'
 import exportsHistoryReducer from '../apps/companies/apps/exports/client/ExportsHistory/reducer'

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -348,7 +348,7 @@ describe('Contact loop', () => {
       window.sessionStorage.clear()
     })
 
-    it('should redirect the user back to the interaction form after the contact is added', () => {
+    it('should redirect the user back to the interaction form and add the contact after the contact is added', () => {
       cy.get(selectors.sendReferral.subjectField)
         .click()
         .type('Test if values are restored')
@@ -387,6 +387,11 @@ describe('Contact loop', () => {
         'have.attr',
         'value',
         'Test if values are restored'
+      )
+
+      cy.get(selectors.sendReferral.contactField).should(
+        'contain',
+        'Json Russel'
       )
     })
   })


### PR DESCRIPTION
## Description of change

As part of the work to move towards a unified form system, this migrates the previous `<MultiInstanceForm/>` based referral form to `<TaskForm/>`

## Test instructions

The send referral form should continue to function as expected.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari): 
  - Some TaskForms including this and the Interaction Form seem to have various issues for which the solution is not immediately obvious in Firefox including the form unmounting itself and the contact loop refusing to redirect back to the form, I believe this issue is out of scope for this PR and requires further investigation