### PR TITLE
Fix filename property causing uploads to fail

### DIFF
--- a/src/apps/documents/repos.js
+++ b/src/apps/documents/repos.js
@@ -24,7 +24,7 @@ function createRequest(req, urls, file) {
   request({
     url: urls.s3Url,
     method: 'PUT',
-    data: fs.readFileSync(file.path),
+    data: fs.readFileSync(file.filepath),
     headers: {
       'Content-Type': 'application/octet-stream',
     },

--- a/src/apps/documents/repos.js
+++ b/src/apps/documents/repos.js
@@ -24,7 +24,7 @@ function createRequest(req, urls, file) {
   request({
     url: urls.s3Url,
     method: 'PUT',
-    data: fs.readFileSync(file.filepath),
+    data: fs.readFileSync(file.filepath || file.path),
     headers: {
       'Content-Type': 'application/octet-stream',
     },
@@ -39,7 +39,7 @@ function createRequest(req, urls, file) {
 function getDocumentUploadS3Url(req, { file, url, fields, textFields = {} }) {
   const body = {
     ...textFields,
-    original_filename: file.originalFilename,
+    original_filename: file.originalFilename || file.name,
   }
 
   const options = {

--- a/src/apps/documents/repos.js
+++ b/src/apps/documents/repos.js
@@ -39,7 +39,7 @@ function createRequest(req, urls, file) {
 function getDocumentUploadS3Url(req, { file, url, fields, textFields = {} }) {
   const body = {
     ...textFields,
-    original_filename: file.name,
+    original_filename: file.originalFilename,
   }
 
   const options = {


### PR DESCRIPTION
## Description of change

Due to file property change, uploads started failing as we were failing to send the original_filename to the backend. This PR handles remapping the file name property.
