### PR TITLE
Update e2e tests to use Postgres 12

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -20,12 +20,11 @@ services:
       - 8000:8000
     depends_on:
       - postgres
-      - mi-postgres
       - es
       - redis
       - celery
       - mock-sso
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
     command: /app/setup-uat.sh || echo "all good"
 
   celery:
@@ -33,21 +32,13 @@ services:
     env_file: .env
     depends_on:
       - postgres
-      - mi-postgres
       - es
       - redis
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
     command: celery worker -A config -l info -Q celery -B
 
   postgres:
-    image: postgres:10
-    environment:
-      POSTGRES_DB: datahub
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-
-  mi-postgres:
-    image: postgres:9.6
+    image: postgres:12
     environment:
       POSTGRES_DB: datahub
       POSTGRES_USER: user


### PR DESCRIPTION
## Description of change

The API database has now been upgraded to Postgres 12, and the e2e tests need to be updated to match. I also removed a couple of references to the (now deleted) MI database.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
