### PR TITLE
Change FindCompany form to use TaskForm component

### DIFF
--- a/src/apps/companies/apps/match-company/client/FindCompany.jsx
+++ b/src/apps/companies/apps/match-company/client/FindCompany.jsx
@@ -4,16 +4,14 @@ import { H4 } from '@govuk-react/heading'
 import InsetText from '@govuk-react/inset-text'
 
 import urls from '../../../../../lib/urls'
-import {
-  SummaryList,
-  FieldDnbCompany,
-  FormStateful,
-} from '../../../../../client/components'
+import { SummaryList, FieldDnbCompany } from '../../../../../client/components'
 import EntityListItem from '../../../../../client/components/EntityList/EntityListItem'
+import TaskForm from '../../../../../client/components/Task/Form'
 
 function FindCompany({ company, csrfToken }) {
   return (
-    <FormStateful
+    <TaskForm
+      id="find-company"
       initialValues={{
         dnbCompanyName: company.name,
         dnbPostalCode: company.postcode,
@@ -56,7 +54,7 @@ function FindCompany({ company, csrfToken }) {
          company. You'll be given a chance to review the new business details
           before you verify."
       />
-    </FormStateful>
+    </TaskForm>
   )
 }
 

--- a/test/sandbox/fixtures/dnb/companies-search.json
+++ b/test/sandbox/fixtures/dnb/companies-search.json
@@ -1,0 +1,15 @@
+{
+  "results": [
+    {
+      "duns_number": "123456999",
+      "primary_name": "Lambda PLC",
+      "address_line_1": "12 St George's Road",
+      "address_line_2": "",
+      "address_town": "Paris",
+      "address_county": "",
+      "address_area_name": "",
+      "address_postcode": "75001",
+      "address_country": "FR"
+    }
+  ]
+}

--- a/test/sandbox/routes/api/dnbService.js
+++ b/test/sandbox/routes/api/dnbService.js
@@ -1,0 +1,5 @@
+var companiesSearch = require('../../fixtures/dnb/companies-search.json')
+
+exports.companiesSearch = function (req, res) {
+  res.json(companiesSearch)
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -62,6 +62,8 @@ var v4Proposition = require('./routes/v4/proposition/proposition.js')
 // Datahub API 3rd party dependencies
 var consentService = require('./routes/api/consentService.js')
 
+var dnbService = require('./routes/api/dnbService.js')
+
 // Data store service (github.com/uktrade/data-store-service)
 app.get('/api/v1/get-postcode-data/', postcode.toRegion)
 app.get('/api/v1/get-postcode-data/:postCode', postcode.toRegion)
@@ -547,6 +549,8 @@ app.delete(
 
 app.post('/api/v1/person', consentService.person)
 app.get('/api/v1/person/bulk_lookup', consentService.bulkPerson)
+
+app.post('/companies/search', dnbService.companiesSearch)
 
 app.post('/v4/large-capital-opportunity', (req, res) =>
   res.json({ id: 'new-large-capital-uk-opportunity-id' })


### PR DESCRIPTION
## Description of change

This changes FindCompany form to use TaskForm. To test you can go to any unverified company, click "Verify business details" and on the following page click "Find company" button. It should display a list of candidates if there are any matches. Clicking any should get you to a confirmation page where you can compare the details and approve if they look correct.

I have added a little endpoint to sandbox that mimics response of DnB service just enough so that the form does not show an error when running e2e stack.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
