### PR TITLE
Update the `/api-proxy/v3/event` endpoint to `v4`

### DIFF
--- a/src/client/modules/Events/EventDetails/tasks.js
+++ b/src/client/modules/Events/EventDetails/tasks.js
@@ -3,5 +3,5 @@ import { transformResponseToEventDetails } from '../transformers'
 
 export const getEventDetails = (eventId) =>
   apiProxyAxios
-    .get(`/api-proxy/v3/event/${eventId}`)
+    .get(`/api-proxy/v4/event/${eventId}`)
     .then(({ data }) => transformResponseToEventDetails(data))


### PR DESCRIPTION
## Description of change

Update the `/api-proxy/v3/event` endpoint to `v4` so it matches a corresponding entry within the allowed  [list](https://github.com/uktrade/data-hub-frontend/blob/master/src/middleware/api-proxy.js#L47) of proxied endpoints.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
