### PR TITLE
Events: fixes a `TypeError` when referencing `organiser.name` when `organiser` is `null`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38698,6 +38698,12 @@
             "source-map": "^0.7.3"
           },
           "dependencies": {
+            "@types/json-schema": {
+              "version": "7.0.9",
+              "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
+              "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
+              "dev": true
+            },
             "find-up": {
               "version": "5.0.0",
               "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -38707,6 +38713,12 @@
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
               }
+            },
+            "html-entities": {
+              "version": "2.3.2",
+              "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
+              "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
+              "dev": true
             },
             "loader-utils": {
               "version": "2.0.2",
@@ -38726,6 +38738,17 @@
               "dev": true,
               "requires": {
                 "p-locate": "^5.0.0"
+              }
+            },
+            "schema-utils": {
+              "version": "3.1.1",
+              "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
+              "integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+              "dev": true,
+              "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
               }
             },
             "source-map": {

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { isEmpty } from 'lodash'
 
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
@@ -108,58 +109,50 @@ const EventDetails = ({
                       }
                       children={startDate}
                     />
-
                     {eventDays > 1 ? (
                       <SummaryTable.Row
                         heading="Event end date"
                         children={endDate}
                       />
                     ) : null}
-
-                    <SummaryTable.Row
-                      heading="Event location type"
-                      children={locationType}
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.Row
-                      heading="Address"
-                      children={fullAddress}
-                    />
-                    <SummaryTable.Row
-                      heading="Region"
-                      children={ukRegion}
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.Row
-                      heading="Notes"
-                      children={notes}
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.Row heading="Lead team" children={leadTeam} />
-                    <SummaryTable.Row
-                      heading="Organiser"
-                      children={organiser}
-                    />
+                    <SummaryTable.Row heading="Event location type">
+                      {isEmpty(locationType) ? 'Not set' : locationType}
+                    </SummaryTable.Row>
+                    <SummaryTable.Row heading="Address">
+                      {fullAddress}
+                    </SummaryTable.Row>
+                    <SummaryTable.Row heading="Region" hideWhenEmpty={false}>
+                      {isEmpty(ukRegion) ? 'Not set' : ukRegion}
+                    </SummaryTable.Row>
+                    <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
+                      {isEmpty(notes) ? 'Not set' : notes}
+                    </SummaryTable.Row>
+                    <SummaryTable.Row heading="Lead team">
+                      {isEmpty(leadTeam) ? 'Not set' : leadTeam}
+                    </SummaryTable.Row>
+                    <SummaryTable.Row heading="Organiser">
+                      {isEmpty(organiser) ? 'Not set' : organiser}
+                    </SummaryTable.Row>
                     <SummaryTable.ListRow
                       heading="Other teams"
                       value={otherTeams}
-                      emptyValue=""
+                      emptyValue="Not set"
                       hideWhenEmpty={false}
                     />
                     <SummaryTable.ListRow
                       heading="Related programmes"
                       value={relatedProgrammes}
-                      emptyValue=""
+                      emptyValue="Not set"
                       hideWhenEmpty={false}
                     />
                     <SummaryTable.ListRow
                       heading="Related Trade Agreements"
                       value={relatedTradeAgreements}
-                      emptyValue=""
+                      emptyValue="Not set"
                       hideWhenEmpty={false}
                     />
                     <SummaryTable.Row heading="Service" children={service} />
-                    {archivedDocumentsUrlPath && (
+                    {!!archivedDocumentsUrlPath && (
                       <SummaryTable.Row heading="Documents">
                         <NewWindowLink href={archivedDocumentsUrlPath}>
                           View files and documents

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash'
+import { get, compact } from 'lodash'
 
 import urls from '../../../lib/urls'
 
@@ -110,17 +110,18 @@ const transformResponseToEventDetails = ({
   eventDays:
     getDifferenceInDays(end_date) - getDifferenceInDays(start_date) + 1,
   locationType: location_type?.name,
-  fullAddress:
-    `${address_1 ? `${address_1}, ` : ''}` +
-    `${address_2 ? `${address_2}, ` : ''}` +
-    `${address_town ? `${address_town}, ` : ''}` +
-    `${address_county ? `${address_county}, ` : ''}` +
-    `${address_postcode ? `${address_postcode}, ` : ''}` +
-    `${address_country.name ? address_country.name : ''}`,
+  fullAddress: compact([
+    address_1,
+    address_2,
+    address_town,
+    address_county,
+    address_postcode,
+    address_country?.name,
+  ]).join(', '),
   ukRegion: uk_region?.name,
   notes: notes,
-  leadTeam: lead_team.name,
-  organiser: organiser.name,
+  leadTeam: lead_team?.name,
+  organiser: organiser?.name,
   otherTeams: teams?.map(transformIdNameToValueLabel),
   relatedProgrammes: related_programmes?.map(transformIdNameToValueLabel),
   relatedTradeAgreements: related_trade_agreements?.map(

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -26,7 +26,7 @@ describe('Event Details', () => {
       'Event location type': 'HQ',
       Address:
         'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
-      Region: '',
+      Region: 'Not set',
       Notes: 'This is a dummy event for testing.',
       'Lead team': 'CBBC Hangzhou',
       Organiser: 'John Rogers',
@@ -61,19 +61,77 @@ describe('Event Details', () => {
         'Event location type': 'HQ',
         Address:
           'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
-        Region: '',
+        Region: 'Not set',
         Notes: 'This is a dummy event for testing.',
         'Lead team': 'CBBC Hangzhou',
         Organiser: 'John Rogers',
         'Other teams': 'CBBC HangzhouCBBC North West',
         'Related programmes': 'Grown in Britain',
-        'Related Trade Agreements': '',
+        'Related Trade Agreements': 'Not set',
         Service: 'Events : UK Based',
       })
     })
 
     it('should hide edit event button for disabled events', () => {
       cy.get(selectors.entityCollection.editEvent).should('not.exist')
+    })
+  })
+
+  describe('Certain fields that are null', () => {
+    before(() => {
+      cy.intercept(
+        'GET',
+        `/api-proxy/v4/event/${fixtures.event.teddyBearExpo.id}`,
+        {
+          address_1: '16 Grande Parade',
+          address_2: '',
+          address_country: {
+            name: 'China',
+            id: '63af72a6-5d95-e211-a939-e4115bead28a',
+          },
+          address_county: '',
+          address_postcode: '',
+          address_town: 'Shanghai',
+          end_date: '2016-03-16',
+          event_type: {
+            name: 'Exhibition',
+            id: '2fade471-e868-4ea9-b125-945eb90ae5d4',
+          },
+          lead_team: {
+            name: 'UK Fashion and Textile Association Ltd (UKFT)',
+            id: '23f12898-9698-e211-a939-e4115bead28a',
+          },
+          name: 'Shanghai Fashion Week including The Hub, Chic-Pure-Intertextile March 2016',
+          notes: null,
+          organiser: null,
+          start_date: '2016-03-16',
+          service: {
+            name: 'A Specific DIT Export Service or Funding : Tradeshow Access Programme (TAP)',
+            id: '380bba2b-3499-e211-a939-e4115bead28a',
+          },
+          uk_region: null,
+        }
+      ).as('apiRequest')
+      cy.visit(urls.events.details(fixtures.event.teddyBearExpo.id))
+      cy.wait('@apiRequest')
+    })
+
+    it('should set fields that are null to "Not set"', () => {
+      assertKeyValueTable('eventDetails', {
+        'Type of event': 'Exhibition',
+        'Event date': '16 March 2016',
+        'Event location type': 'Not set',
+        Address: '16 Grande Parade, Shanghai, China',
+        Region: 'Not set',
+        Notes: 'Not set',
+        'Lead team': 'UK Fashion and Textile Association Ltd (UKFT)',
+        Organiser: 'Not set',
+        'Other teams': 'Not set',
+        'Related programmes': 'Not set',
+        'Related Trade Agreements': 'Not set',
+        Service:
+          'A Specific DIT Export Service or Funding : Tradeshow Access Programme (TAP)',
+      })
     })
   })
 })


### PR DESCRIPTION
## Description of change
Fixes a production issue: `/events/9fb43fc5-b8be-e511-88b6-e4115bead28a/details`

When an event organiser has been removed from an event in Django (it's a mandatory field when creating an event on DH) the UI was throwing a `TypeError`. This fix simply puts several safeguards in place to ensure it doesn't happen again.

## Test instructions

1. Create an event: `/events/create`
2. Remove the event organiser within Django and save
3. Refresh the UI: `/events/<event-id>/details`

Here the organiser should be set to `Not set`

## Screenshots

<img width="1895" alt="before" src="https://user-images.githubusercontent.com/964268/144865443-59d2f5a1-958d-4b88-ab7d-6dcc4e746863.png">

_Add a screenshot_

### After
<img width="1006" alt="after" src="https://user-images.githubusercontent.com/964268/144868713-31e7a868-80a9-4b77-91ca-50aa1afb77b1.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
