### PR TITLE
Remove duplicate button from `SectionArchive`

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -70,7 +70,7 @@ function AddCompanyForm({
     <TaskForm
       id="add-company-form"
       submissionTaskName="Create company"
-      analyticsFormName="add-company-form"
+      analyticsFormName="addCompanyForm"
       redirectTo={(company) => `/companies/${company.id}`}
       flashMessage={() => 'Company added to Data Hub'}
       transformPayload={(values) => ({ ...values, csrfToken })}

--- a/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
+++ b/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
@@ -72,7 +72,7 @@ const Add = ({ cancelUrl, currentLeadITA, companyName, companyId }) => (
       <TaskForm
         id="manage-adviser"
         submissionTaskName="Update Lead ITA"
-        analyticsFormName="Update Lead ITA"
+        analyticsFormName="updateLeadITA"
         transformPayload={(values) => ({ ...values, companyId })}
         redirectTo={() => urls.companies.advisers.index(companyId)}
         flashMessage={({ name, email }) => [

--- a/src/apps/companies/apps/business-details/client/SectionArchive.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionArchive.jsx
@@ -3,15 +3,10 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { BLACK, GREY_3 } from 'govuk-colours'
 import Button from '@govuk-react/button'
-import { ButtonLink } from '../../../../../client/components/'
 import { typography } from '@govuk-react/lib'
 import { SPACING } from '@govuk-react/constants'
 
-import {
-  FormActions,
-  FieldRadios,
-  FieldInput,
-} from '../../../../../client/components'
+import { FieldRadios, FieldInput } from '../../../../../client/components'
 
 import TaskForm from '../../../../../client/components/Task/Form'
 
@@ -43,8 +38,15 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
             values,
             urls,
           })}
+          submitButtonLabel="Archive"
           redirectTo={() => urls.companyBusinessDetails}
           analyticsFormName="archive-company"
+          actionLinks={[
+            {
+              href: urls.companyBusinessDetails,
+              children: 'Cancel',
+            },
+          ]}
         >
           <FieldRadios
             label="Archive reason"
@@ -65,11 +67,6 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
               },
             ]}
           />
-
-          <FormActions>
-            <Button>Archive</Button>
-            <ButtonLink onClick={() => setFormIsOpen(false)}>Cancel</ButtonLink>
-          </FormActions>
         </TaskForm>
       )}
 

--- a/src/apps/companies/apps/business-details/client/SectionArchive.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionArchive.jsx
@@ -40,7 +40,7 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
           })}
           submitButtonLabel="Archive"
           redirectTo={() => urls.companyBusinessDetails}
-          analyticsFormName="archive-company"
+          analyticsFormName="archiveCompany"
           actionLinks={[
             {
               href: urls.companyBusinessDetails,

--- a/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
@@ -61,7 +61,7 @@ export default ({ companyId, countryOptions, fields }) => {
           transformPayload={(values) => ({ values, companyId })}
           redirectTo={() => urls.companies.exports.index(companyId)}
           submissionTaskName={TASK_NAME}
-          analyticsFormName={TASK_NAME}
+          analyticsFormName="exportCountriesEdit"
           actionLinks={[
             {
               children: 'Return without saving',

--- a/src/apps/companies/apps/exports/client/ExportsEdit.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsEdit.jsx
@@ -25,7 +25,7 @@ export default ({
   <TaskForm
     id="exports-edit"
     submissionTaskName="Exports Edit"
-    analyticsFormName="Exports Edit"
+    analyticsFormName="exportsEdit"
     transformPayload={(values) => ({ ...values, companyId })}
     redirectTo={() => urls.companies.exports.index(companyId)}
     submitButtonLabel="Save and return"

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -46,7 +46,7 @@ function MatchConfirmation({
       <TaskForm
         id="match-confirmation-form"
         submissionTaskName="Match confirmation"
-        analyticsFormName="match-confirmation-form"
+        analyticsFormName="matchConfirmationForm"
         redirectTo={(company) => urls.companies.detail(company.id)}
         flashMessage={() => [
           'Business details verified.',

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -83,7 +83,7 @@ const InteractionDetailsForm = ({
                   id={STATE_ID}
                   submissionTaskName={TASK_SAVE_INTERACTION}
                   analyticsFormName={
-                    interactionId ? 'edit_interaction' : 'create_interaction'
+                    interactionId ? 'editInteraction' : 'createInteraction'
                   }
                   analyticsData={(values) =>
                     _.pick(

--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -55,7 +55,7 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
       <TaskForm
         id="opportunity-details"
         submissionTaskName={TASK_SAVE_OPPORTUNITY_DETAILS}
-        analyticsFormName="Opportunity details"
+        analyticsFormName="opportunityDetailsForm"
         transformPayload={(values) => ({ opportunityId, values })}
         onSuccess={(opportunity) =>
           dispatch({

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -74,7 +74,7 @@ const OpportunityRequirementsForm = (state) => {
               <TaskForm
                 id="opportunity-requirements"
                 submissionTaskName={TASK_SAVE_OPPORTUNITY_REQUIREMENTS}
-                analyticsFormName="Opportunity requirements"
+                analyticsFormName="opportunityRequirementsForm"
                 transformPayload={(values) => ({ opportunityId, values })}
                 onSuccess={(opportunity) =>
                   dispatch({

--- a/src/client/components/Task/Form/__stories__/TaskForm.stories.jsx
+++ b/src/client/components/Task/Form/__stories__/TaskForm.stories.jsx
@@ -27,7 +27,7 @@ storiesOf('Task/Form', module)
     <TaskForm
       id="lazy-field-example"
       submissionTaskName="Submit TaskForm example"
-      analyticsFormName="task-form-example"
+      analyticsFormName="taskFormExample"
       initialValues={{
         select: 'b',
         // radios: 'b',
@@ -117,7 +117,7 @@ storiesOf('Task/Form', module)
           ...initialValues,
           reject: 'yes',
         })}
-        analyticsFormName="task-form-example"
+        analyticsFormName="taskFormExample"
         redirectTo={(submissionTaskResult, formValues) =>
           '#' + JSON.stringify({ submissionTaskResult, formValues })
         }
@@ -182,7 +182,7 @@ storiesOf('Task/Form', module)
         submissionTaskName="Submit TaskForm example"
         initialValuesTaskName="Load initial values"
         initialValuesPayload="reject"
-        analyticsFormName="task-form-example"
+        analyticsFormName="taskFormExample"
         redirectTo={(submissionTaskResult, formValues) =>
           '#' + JSON.stringify({ submissionTaskResult, formValues })
         }
@@ -215,7 +215,7 @@ storiesOf('Task/Form', module)
       <TaskForm
         id="task-form-example-initialValues-prop"
         submissionTaskName="Submit TaskForm example"
-        analyticsFormName="task-form-example"
+        analyticsFormName="taskFormExample"
         initialValues={{ foo: 'Foo', bar: 'b' }}
         redirectTo={(submissionTaskResult, formValues) =>
           '#' + JSON.stringify({ submissionTaskResult, formValues })
@@ -269,7 +269,7 @@ storiesOf('Task/Form', module)
           ...initialValues,
           reject: 'yes',
         })}
-        analyticsFormName="Example"
+        analyticsFormName="taskFormExample"
         redirectTo={(submissionTaskResult, formValues) =>
           '#' + JSON.stringify({ submissionTaskResult, formValues })
         }
@@ -337,7 +337,7 @@ storiesOf('Task/Form', module)
               ...initialValues,
               reject: 'yes',
             })}
-            analyticsFormName="task-form-example"
+            analyticsFormName="taskFormExample"
             // eslint-disable-next-line no-unused-vars
             redirectTo={(submissionTaskResult, formValues) => '/success'}
             // eslint-disable-next-line no-unused-vars

--- a/src/client/components/Task/Form/__stories__/basic-example.md
+++ b/src/client/components/Task/Form/__stories__/basic-example.md
@@ -36,7 +36,7 @@ This is a basic example of all the capabilities of `TaskForm`. It:
     initialValuesTaskName="Load initial values"
     initialValuesPayload="resolve"
     transformInitialValues={initialValues => ({...initialValues, reject: 'yes'})}
-    analyticsFormName="task-form-example"
+    analyticsFormName="taskFormExample"
     redirectTo={(submissionTaskResult, formValues) => '#' + JSON.stringify({submissionTaskResult, formValues})}
     flashMessage={(submissionTaskResult, formValues) => 'Form was submitted successfully'}
   >

--- a/src/client/components/Task/Form/__stories__/initial-values-as-prop.md
+++ b/src/client/components/Task/Form/__stories__/initial-values-as-prop.md
@@ -17,7 +17,7 @@ The initial values of `TaskForm` can also be set with the `initialValues` prop.
     id="task-form-example-reject-initial-values"
     initialValues={{ foo: 'Foo', bar: 'b' }}
     submissionTaskName="Submit TaskForm example"
-    analyticsFormName="task-form-example"
+    analyticsFormName="taskFormExample"
     redirectTo={(submissionTaskResult, formValues) => '#'}
     flashMessage={(submissionTaskResult, formValues) =>
       'Form was submitted successfully'

--- a/src/client/components/Task/Form/__stories__/multi-step.md
+++ b/src/client/components/Task/Form/__stories__/multi-step.md
@@ -29,7 +29,7 @@
       ...initialValues,
       reject: 'yes',
     })}
-    analyticsFormName="Example"
+    analyticsFormName="multiStepExample"
     flashMessage={(submissionTaskResult, formValues) =>
       'Form was submitted successfully'
     }

--- a/src/client/components/Task/Form/__stories__/reject-initial-values.md
+++ b/src/client/components/Task/Form/__stories__/reject-initial-values.md
@@ -27,7 +27,7 @@ This example demonstrates the rejection of the initial values task.
     id="task-form-example-reject-initial-values"
     initialValuesTaskName="Load initial values"
     submissionTaskName="Submit TaskForm example"
-    analyticsFormName="task-form-example"
+    analyticsFormName="taskFormExample"
     redirectTo={(submissionTaskResult, formValues) => '#'}
     flashMessage={(submissionTaskResult, formValues) => 'Form was submitted successfully'}
   >

--- a/src/client/components/Task/Form/__stories__/soft-redirect.md
+++ b/src/client/components/Task/Form/__stories__/soft-redirect.md
@@ -41,7 +41,7 @@ import { Switch, Route, Link } from 'react-router-dom'
           ...initialValues,
           reject: 'yes',
         })}
-        analyticsFormName="task-form-example"
+        analyticsFormName="taskFormExample"
         redirectTo={(submissionTaskResult, formValues) => '/success'}
         // eslint-disable-next-line no-unused-vars
         flashMessage={(submissionTaskResult, formValues) =>


### PR DESCRIPTION
## Description of change

This PR fixes two minor issues that have been identified during the forms refactoring work:

- The `SectionArchive` form contains a duplicate submit button (which I've removed)
- The `analyticsFormName` prop needs to be in snake case at the request of the analysts. All occurences that weren't in snake case have been changed to meet this requirement.

## Test instructions

_What should I see?_

## Screenshots
### Before

<img width="299" alt="Screenshot 2021-12-07 at 14 54 31" src="https://user-images.githubusercontent.com/36161814/145054799-4e823f04-7f42-458d-8534-67ff3c9efe49.png">


### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
