### PR TITLE
Refactor match duplicate form to use TaskForm

### DIFF
--- a/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
@@ -1,14 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import axios from 'axios'
-import Link from '@govuk-react/link'
 import ListItem from '@govuk-react/list-item'
 import { H4 } from '@govuk-react/heading'
 import styled from 'styled-components'
-import Button from '@govuk-react/button'
-import { ErrorSummary, UnorderedList } from 'govuk-react'
+import { UnorderedList } from 'govuk-react'
 import { SPACING } from '@govuk-react/constants'
-import { FormStateful, FormActions } from '../../../../../client/components'
+import TaskForm from '../../../../../client/components/Task/Form/index.jsx'
 
 import urls from '../../../../../lib/urls'
 
@@ -18,61 +15,49 @@ const StyledList = styled(UnorderedList)`
   margin-bottom: ${SPACING.SCALE_6};
 `
 
-async function onFormSubmit({ company, dnbCompany, csrfToken }) {
-  await axios.post(
-    `${urls.companies.match.merge(company.id)}?_csrf=${csrfToken}`,
-    {
+const MatchDuplicate = ({ company, dnbCompany, csrfToken }) => (
+  <TaskForm
+    id="match-duplicate-form"
+    analyticsFormName="matchDuplicate"
+    submissionTaskName="Submit merge request"
+    transformPayload={() => ({
+      company,
       dnbCompany,
+      csrfToken,
+    })}
+    submitButtonLabel="Request merge"
+    actionLinks={[
+      { href: urls.companies.match.index(company.id), children: 'Back' },
+    ]}
+    flashMessage={() =>
+      'Company merge requested. Thanks for keeping Data Hub running smoothly.'
     }
-  )
-  return urls.companies.detail(company.id)
-}
+    redirectTo={(company) => urls.companies.detail(company.id)}
+  >
+    <>
+      <p>
+        This can happen when there are duplicate company records in Data Hub. To
+        resolve this, you can ask the Support Team to merge these duplicates
+        into one record.
+      </p>
 
-function MatchDuplicate({ company, dnbCompany, csrfToken }) {
-  return (
-    <FormStateful
-      onSubmit={() => onFormSubmit({ company, dnbCompany, csrfToken })}
-    >
-      {({ submissionError }) => (
-        <>
-          {submissionError && (
-            <ErrorSummary
-              heading="There was an error merging this company"
-              description={submissionError.message}
-              errors={[]}
-            />
-          )}
-
-          <p>
-            This can happen when there are duplicate company records in Data
-            Hub. To resolve this, you can ask the Support Team to merge these
-            duplicates into one record.
-          </p>
-
-          <H4 as="h2">Requesting records merge will:</H4>
-          <StyledList>
-            <ListItem>
-              send a request to the Support Team to merge these records
-            </ListItem>
-            <ListItem>
-              preserve all recorded activity (interactions, OMIS Orders and
-              Investment Projects) and contacts from BOTH records and link them
-              to the merged record
-            </ListItem>
-            <ListItem>
-              ensure the business details are automatically updated in the
-              future
-            </ListItem>
-          </StyledList>
-          <FormActions>
-            <Button>Request merge</Button>
-            <Link href={urls.companies.match.index(company.id)}>Back</Link>
-          </FormActions>
-        </>
-      )}
-    </FormStateful>
-  )
-}
+      <H4 as="h2">Requesting records merge will:</H4>
+      <StyledList>
+        <ListItem>
+          send a request to the Support Team to merge these records
+        </ListItem>
+        <ListItem>
+          preserve all recorded activity (interactions, OMIS Orders and
+          Investment Projects) and contacts from BOTH records and link them to
+          the merged record
+        </ListItem>
+        <ListItem>
+          ensure the business details are automatically updated in the future
+        </ListItem>
+      </StyledList>
+    </>
+  </TaskForm>
+)
 
 MatchDuplicate.props = {
   company: PropTypes.shape({

--- a/src/apps/companies/apps/match-company/client/tasks.js
+++ b/src/apps/companies/apps/match-company/client/tasks.js
@@ -26,3 +26,13 @@ export const cannotFindMatchSubmit = ({ csrfToken, values, company }) =>
     .then((response) => {
       return response.data
     })
+
+export async function submitMergeRequest({ company, dnbCompany, csrfToken }) {
+  await axios.post(
+    `${urls.companies.match.merge(company.id)}?_csrf=${csrfToken}`,
+    {
+      dnbCompany,
+    }
+  )
+  return company
+}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -243,6 +243,7 @@ function App() {
         'Create company': createCompany,
         'Match confirmation': matchCompanyTasks.onMatchSubmit,
         'Cannot find match': matchCompanyTasks.cannotFindMatchSubmit,
+        'Submit merge request': matchCompanyTasks.submitMergeRequest,
         'Company lists': companyListsTasks.fetchCompanyLists,
         'Company list': companyListsTasks.fetchCompanyList,
         'Exports history': exportsHistoryTasks.fetchExportsHistory,


### PR DESCRIPTION
## Description of change

This PR refactors the MatchDuplicate form to use the `TaskForm` component. In order to do this, the submission function for the form has been extracted into a task.

## Test instructions

- In the deployment to Heroku go to this url: `/companies/0a2e06f8-cc03-45c6-b5ee-8bbf3b2d478d/match/217237085`
- You should be able submit the form and see a flash message on the next page

_What should I see?_

There should be no changes in functionality.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
