### PR TITLE
Fix clearing address fields in contact form

### DIFF
--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -148,7 +148,7 @@ const _ContactForm = ({
                 return (
                   <TaskForm
                     id="add-contact-form"
-                    analyticsFormName={update ? 'edit_contact' : 'add_contact'}
+                    analyticsFormName={update ? 'editContact' : 'addContact'}
                     submissionTaskName="Save contact"
                     transformPayload={({
                       address1,

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -175,7 +175,7 @@ const _ContactForm = ({
                           addressSameAsCompany.includes(YES),
                         // The API is complaining if we send the address fields when address_same_as_company is true
                         // If answer changes from yes to no, need to clear address fields on object
-                        ...(values.addressSameAsCompany == YES
+                        ...(addressSameAsCompany == YES
                           ? {
                               address_1: null,
                               address_2: null,


### PR DESCRIPTION
## Description of change

This PR fixes an issue brought in in my last PR #4204 .

I had introduced logic to fix an issue where if address same as company is changed from true to false, the API gave an error as you can't have address fields and addressSameAsCompany both truthy.

However I referred to `values.addressSameAsCompany` instead of `addressSameAsCompany`, which has now been corrected in this PR.

I also realised i had the wrong casing for the analytics form name, so have fixed this too.

## Test instructions

- Go to a contact
- If not already selected, select no for the 'Address the same as company address' field
- Save contact
- Edit contact again and select yes instead
- The form should submit without problems

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
