### PR TITLE
Add service_answers field to interaction creation

### DIFF
--- a/src/apps/events/attendees/controllers/create.js
+++ b/src/apps/events/attendees/controllers/create.js
@@ -44,6 +44,7 @@ async function createAttendee(req, res, next) {
       kind: 'service_delivery',
       theme: 'other',
       service: get(event, 'service.id'),
+      service_answers: {},
       subject: `Attended ${event.name}`,
       was_policy_feedback_provided: false,
       were_countries_discussed: false,


### PR DESCRIPTION
## Description of change

The intent of this MR is to fix a production issue where the user is unable to add attendees to an event. The reason  why this is occurring is because the backend complains service_answers should be present.

I am unsure why this is required now as no code has been changed for a long time around this but sending an empty field should do the trick.
