### PR TITLE
Refactor OpportunityChangeStatusForm to use TaskForm

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
@@ -1,20 +1,17 @@
-import axios from 'axios'
 import React from 'react'
 import PropTypes from 'prop-types'
 
 import urls from '../../../../../lib/urls'
 import LocalHeader from '../../../../../client/components/LocalHeader/LocalHeader'
-import Button from '@govuk-react/button'
-import Link from '@govuk-react/link'
 
-import {
-  Main,
-  FormActions,
-  FormStateful,
-} from '../../../../../client/components'
+import { Main } from '../../../../../client/components'
 
 import OpportunityResource from '../../../../../client/components/Resource/Opportunity'
 import FieldOpportunityStatuses from '../../../../../client/components/Form/elements/FieldOpportunityStatuses'
+
+import TaskForm from '../../../../../client/components/Task/Form'
+
+import { TASK_SAVE_OPPORTUNITY_STATUS } from './state'
 
 const OpportunityChangeStatusForm = ({ opportunityId }) => {
   const opportunityUrl = urls.investments.opportunities.details(opportunityId)
@@ -40,27 +37,27 @@ const OpportunityChangeStatusForm = ({ opportunityId }) => {
             heading="Change opportunity status"
           />
           <Main>
-            <FormStateful
-              showErrorSummary={true}
-              onSubmit={async (values) => {
-                await axios.patch(
-                  `/api-proxy/v4/large-capital-opportunity/${opportunityId}`,
-                  {
-                    status: values.status,
-                  }
-                )
-                return opportunityUrl
-              }}
+            <TaskForm
+              id="opportunity-change-status"
+              analyticsFormName="opportunityChangeStatus"
+              submissionTaskName={TASK_SAVE_OPPORTUNITY_STATUS}
+              transformPayload={(values) => ({
+                values,
+                opportunityId,
+              })}
+              redirectTo={() => opportunityUrl}
+              actionLinks={[
+                {
+                  href: opportunityUrl,
+                  children: 'Cancel',
+                },
+              ]}
             >
               <FieldOpportunityStatuses
                 name="status"
                 initialValue={status.id}
               />
-              <FormActions>
-                <Button data-test="edit-button">Save</Button>
-                <Link href={opportunityUrl}>Cancel</Link>
-              </FormActions>
-            </FormStateful>
+            </TaskForm>
           </Main>
         </>
       )}

--- a/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
@@ -2,15 +2,19 @@ import axios from 'axios'
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import urls from '../../lib/urls'
-import LocalHeader from './LocalHeader/LocalHeader'
+import urls from '../../../../../lib/urls'
+import LocalHeader from '../../../../../client/components/LocalHeader/LocalHeader'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 
-import { Main, FormActions, FormStateful } from '.'
+import {
+  Main,
+  FormActions,
+  FormStateful,
+} from '../../../../../client/components'
 
-import OpportunityResource from './Resource/Opportunity'
-import FieldOpportunityStatuses from './Form/elements/FieldOpportunityStatuses'
+import OpportunityResource from '../../../../../client/components/Resource/Opportunity'
+import FieldOpportunityStatuses from '../../../../../client/components/Form/elements/FieldOpportunityStatuses'
 
 const OpportunityChangeStatusForm = ({ opportunityId }) => {
   const opportunityUrl = urls.investments.opportunities.details(opportunityId)

--- a/src/apps/investments/client/opportunities/Details/state.js
+++ b/src/apps/investments/client/opportunities/Details/state.js
@@ -8,6 +8,8 @@ export const TASK_SAVE_OPPORTUNITY_DETAILS = 'TASK_SAVE_OPPORTUNITY_DETAILS'
 export const TASK_SAVE_OPPORTUNITY_REQUIREMENTS =
   'TASK_SAVE_OPPORTUNITY_REQUIREMENTS'
 
+export const TASK_SAVE_OPPORTUNITY_STATUS = 'TASK_SAVE_OPPORTUNITY_STATUS'
+
 export const ID = 'opportunityDetails'
 
 export const state2props = (state) => state[ID]

--- a/src/apps/investments/client/opportunities/Details/tasks.js
+++ b/src/apps/investments/client/opportunities/Details/tasks.js
@@ -78,3 +78,9 @@ export function saveOpportunityRequirements({ values, opportunityId }) {
     })
     .then(({ data }) => transformInvestmentOpportunityDetails(data))
 }
+
+export function saveOpportunityStatus({ opportunityId, values }) {
+  return apiProxyAxios.patch(`v4/large-capital-opportunity/${opportunityId}`, {
+    status: values.status,
+  })
+}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -139,6 +139,7 @@ import * as investmentOpportunitiesListTasks from '../apps/investments/client/op
 import {
   TASK_SAVE_OPPORTUNITY_DETAILS,
   TASK_SAVE_OPPORTUNITY_REQUIREMENTS,
+  TASK_SAVE_OPPORTUNITY_STATUS,
   TASK_GET_OPPORTUNITY_DETAILS,
   TASK_GET_OPPORTUNITY_REQUIREMENTS_METADATA,
 } from '../apps/investments/client/opportunities/Details/state'
@@ -277,6 +278,8 @@ function App() {
         [TASK_UPDATE_STAGE]: investmentAdminTasks.updateProjectStage,
         [TASK_SAVE_OPPORTUNITY_DETAILS]:
           investmentOpportunitiesDetailsTasks.saveOpportunityDetails,
+        [TASK_SAVE_OPPORTUNITY_STATUS]:
+          investmentOpportunitiesDetailsTasks.saveOpportunityStatus,
         [TASK_SAVE_OPPORTUNITY_REQUIREMENTS]:
           investmentOpportunitiesDetailsTasks.saveOpportunityRequirements,
         [TASK_GET_OPPORTUNITY_DETAILS]:

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -46,7 +46,7 @@ import InvestmentProjectsCollection from '../apps/investments/client/projects/Pr
 import CompanyProjectsCollection from '../apps/investments/client/projects/CompanyProjectsCollection.jsx'
 import Opportunity from '../apps/investments/client/opportunities/Details/Opportunity'
 import CompaniesContactsCollection from '../client/modules/Contacts/CollectionList/CompanyContactsCollection.jsx'
-import OpportunityChangeStatusForm from './components/OpportunityChangeStatusForm'
+import OpportunityChangeStatusForm from '../apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx'
 import CreateUKInvestmentOpportunity from './components/CreateUKInvestmentOpportunity'
 import createUKInvestmentOpportunityTask from './components/CreateUKInvestmentOpportunity/tasks'
 


### PR DESCRIPTION
## Description of change

This PR refactors the `OpportunityChangeStatusForm` to use the `TaskForm` component.

## Test instructions

Changing the status of an investment opportunity should work as normal.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
