### PR TITLE
Remove uses of deprecated actionLinks

### DIFF
--- a/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
+++ b/src/apps/companies/apps/advisers/client/ManageAdviser.jsx
@@ -82,7 +82,7 @@ const Add = ({ cancelUrl, currentLeadITA, companyName, companyId }) => (
               email ? `: <a href="mailto:${email}">${email}</a>` : '.'
             }`,
         ]}
-        actionLinks={[{ children: 'Cancel', href: cancelUrl }]}
+        cancelRedirectTo={() => cancelUrl}
         submitButtonLabel="Add Lead ITA"
       >
         <FieldActiveITA

--- a/src/apps/companies/apps/business-details/client/SectionArchive.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionArchive.jsx
@@ -41,12 +41,7 @@ const SectionArchive = ({ isArchived, isDnbCompany, urls }) => {
           submitButtonLabel="Archive"
           redirectTo={() => urls.companyBusinessDetails}
           analyticsFormName="archiveCompany"
-          actionLinks={[
-            {
-              href: urls.companyBusinessDetails,
-              children: 'Cancel',
-            },
-          ]}
+          cancelRedirectTo={() => urls.companyBusinessDetails}
         >
           <FieldRadios
             label="Archive reason"

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -54,12 +54,8 @@ function EditCompanyForm({
         }
       }}
       submitButtonLabel="Submit"
-      actionLinks={[
-        {
-          href: urls.companies.businessDetails(company.id),
-          children: 'Return without saving',
-        },
-      ]}
+      cancelButtonLabel="Return without saving"
+      cancelRedirectTo={() => urls.companies.businessDetails(company.id)}
       transformPayload={(values) => ({
         company,
         csrfToken,

--- a/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
@@ -62,12 +62,8 @@ export default ({ companyId, countryOptions, fields }) => {
           redirectTo={() => urls.companies.exports.index(companyId)}
           submissionTaskName={TASK_NAME}
           analyticsFormName="exportCountriesEdit"
-          actionLinks={[
-            {
-              children: 'Return without saving',
-              href: urls.companies.exports.index(companyId),
-            },
-          ]}
+          cancelRedirectTo={() => urls.companies.exports.index(companyId)}
+          cancelButtonLabel="Return without saving"
           initialValues={fields
             .filter(({ values }) => !!values?.length)
             .reduce((acc, { name, values }) => {

--- a/src/apps/companies/apps/exports/client/ExportsEdit.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsEdit.jsx
@@ -29,12 +29,8 @@ export default ({
     transformPayload={(values) => ({ ...values, companyId })}
     redirectTo={() => urls.companies.exports.index(companyId)}
     submitButtonLabel="Save and return"
-    actionLinks={[
-      {
-        children: 'Return without saving',
-        href: urls.companies.exports.index(companyId),
-      },
-    ]}
+    cancelRedirectTo={() => urls.companies.exports.index(companyId)}
+    cancelButtonLabel="Return without saving"
   >
     <FieldSelect
       emptyOption="-- Select category --"

--- a/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
+++ b/src/apps/companies/apps/match-company/client/CannotFindMatch.jsx
@@ -54,12 +54,8 @@ function CannotFindMatch({ company, csrfToken }) {
             'Verification request sent for third party review'
           }
           submitButtonLabel="Send"
-          actionLinks={[
-            {
-              children: 'Back',
-              href: urls.companies.match.index(company.id),
-            },
-          ]}
+          cancelRedirectTo={() => urls.companies.match.index(company.id)}
+          cancelButtonLabel="Back"
         >
           {() => (
             <>

--- a/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchConfirmation.jsx
@@ -58,9 +58,8 @@ function MatchConfirmation({
           csrfToken,
         })}
         submitButtonLabel="Verify"
-        actionLinks={[
-          { href: urls.companies.match.index(company.id), children: 'Back' },
-        ]}
+        cancelRedirectTo={() => urls.companies.match.index(company.id)}
+        cancelButtonLabel="Back"
       >
         {() => (
           <>

--- a/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
+++ b/src/apps/companies/apps/match-company/client/MatchDuplicate.jsx
@@ -26,9 +26,8 @@ const MatchDuplicate = ({ company, dnbCompany, csrfToken }) => (
       csrfToken,
     })}
     submitButtonLabel="Request merge"
-    actionLinks={[
-      { href: urls.companies.match.index(company.id), children: 'Back' },
-    ]}
+    cancelRedirectTo={() => urls.companies.match.index(company.id)}
+    cancelButtonLabel="Back"
     flashMessage={() =>
       'Company merge requested. Thanks for keeping Data Hub running smoothly.'
     }

--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -19,12 +19,7 @@ const CreateListForm = ({
     redirectTo={() => cancelUrl}
     flashMessage={() => 'Company list created'}
     submitButtonLabel="Create list"
-    actionLinks={[
-      {
-        href: cancelUrl,
-        children: 'Cancel',
-      },
-    ]}
+    cancelRedirectTo={() => cancelUrl}
     transformPayload={(values) => ({
       id,
       values,

--- a/src/apps/company-lists/client/EditCompanyList.jsx
+++ b/src/apps/company-lists/client/EditCompanyList.jsx
@@ -11,7 +11,7 @@ const EditCompanyList = ({ cancelUrl, listName, csrfToken, id, returnUrl }) => (
     analyticsFormName="editCompanyList"
     submissionTaskName="Edit company list"
     initialValues={{ listName }}
-    actionLinks={[{ children: 'Cancel', href: cancelUrl }]}
+    cancelRedirectTo={() => cancelUrl}
     transformPayload={(values) => ({ ...values, id, csrfToken })}
     redirectTo={() => returnUrl}
   >

--- a/src/apps/investments/client/opportunities/Details/CreateUKInvestmentOpportunity.jsx
+++ b/src/apps/investments/client/opportunities/Details/CreateUKInvestmentOpportunity.jsx
@@ -15,12 +15,7 @@ const CreateUKInvestmentOpportunity = () => (
       redirectTo={(newOpportunityId) =>
         urls.investments.opportunities.details(newOpportunityId)
       }
-      actionLinks={[
-        {
-          href: urls.investments.opportunities.index(),
-          children: 'Cancel',
-        },
-      ]}
+      cancelRedirectTo={() => urls.investments.opportunities.index()}
     >
       <FieldInput
         name="name"

--- a/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityChangeStatusForm.jsx
@@ -46,12 +46,7 @@ const OpportunityChangeStatusForm = ({ opportunityId }) => {
                 opportunityId,
               })}
               redirectTo={() => opportunityUrl}
-              actionLinks={[
-                {
-                  href: opportunityUrl,
-                  children: 'Cancel',
-                },
-              ]}
+              cancelRedirectTo={() => opportunityUrl}
             >
               <FieldOpportunityStatuses
                 name="status"

--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -63,12 +63,9 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
             opportunity,
           })
         }
-        actionLinks={[
-          {
-            children: 'Cancel',
-            href: urls.investments.opportunities.details(opportunityId),
-          },
-        ]}
+        cancelRedirectTo={() =>
+          urls.investments.opportunities.details(opportunityId)
+        }
       >
         {(values) => (
           <>

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -82,12 +82,9 @@ const OpportunityRequirementsForm = (state) => {
                     opportunity,
                   })
                 }
-                actionLinks={[
-                  {
-                    children: 'Cancel',
-                    href: urls.investments.opportunities.details(opportunityId),
-                  },
-                ]}
+                cancelRedirectTo={() =>
+                  urls.investments.opportunities.details(opportunityId)
+                }
               >
                 <FieldInput
                   label="Total investment sought"

--- a/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
+++ b/src/apps/investments/views/admin/client/InvestmentProjectAdmin.jsx
@@ -45,12 +45,7 @@ const InvestmentProjectAdmin = ({
           <StyledP>Current stage: {projectStage.name}</StyledP>
         </InsetText>
         <TaskForm
-          actionLinks={[
-            {
-              children: 'Cancel',
-              href: urls.investments.projects.project(projectId),
-            },
-          ]}
+          cancelRedirectTo={() => urls.investments.projects.project(projectId)}
           analyticsFormName="investmentProjectAdmin"
           flashMessage={() => 'Project stage saved'}
           id="investmentProjectAdmin"

--- a/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/AddPipelineItemForm.jsx
@@ -129,12 +129,7 @@ function AddPipelineItemForm({
                       `You added ${result.name} to your pipeline`
                     }
                     submitButtonLabel="Create project"
-                    actionLinks={[
-                      {
-                        href: urls.companies.detail(companyId),
-                        children: 'Cancel',
-                      },
-                    ]}
+                    cancelRedirectTo={() => urls.companies.detail(companyId)}
                   />
                 </PipelineCheck>
               </>

--- a/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/ArchivePipelineItemForm.jsx
@@ -48,12 +48,7 @@ const ArchivePipelineItemForm = ({ pipelineItemId }) => (
             })}
             redirectTo={(result) => getPipelineUrl(result.status)}
             submitButtonLabel={'Archive project'}
-            actionLinks={[
-              {
-                href: getPipelineUrl(pipelineItem.status),
-                children: 'Cancel',
-              },
-            ]}
+            cancelRedirectTo={() => getPipelineUrl(pipelineItem.status)}
             flashMessage={() => `You archived ${pipelineItem.name}`}
           >
             <br />

--- a/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/DeletePipelineItemForm.jsx
@@ -48,12 +48,7 @@ const DeletePipelineItemForm = ({ pipelineItemId }) => (
             })}
             redirectTo={() => getPipelineUrl(pipelineItem.status)}
             submitButtonLabel={'Delete project'}
-            actionLinks={[
-              {
-                href: getPipelineUrl(pipelineItem.status),
-                children: 'Cancel',
-              },
-            ]}
+            cancelRedirectTo={() => getPipelineUrl(pipelineItem.status)}
             flashMessage={() =>
               `You deleted ${pipelineItem.name} from your pipeline`
             }

--- a/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/EditPipelineItemForm.jsx
@@ -65,12 +65,7 @@ function EditPipelineItemForm({ pipelineItemId, contacts, sectors }) {
               initialValues={formatInitialValues(pipelineItem)}
               sectors={sectors}
               contacts={contacts}
-              actionLinks={[
-                {
-                  href: getPipelineUrl(pipelineItem.status),
-                  children: 'Cancel',
-                },
-              ]}
+              cancelRedirectTo={() => getPipelineUrl(pipelineItem.status)}
               flashMessage={(result) => `You saved changes to ${result.name}`}
               redirectTo={(result) => getPipelineUrl(result.status)}
             />

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -31,7 +31,8 @@ function PipelineForm({
   flashMessage,
   submitButtonLabel,
   companyId,
-  actionLinks,
+  cancelRedirectTo,
+  cancelButtonLabel,
   initialValues,
 }) {
   return (
@@ -43,8 +44,9 @@ function PipelineForm({
       redirectTo={redirectTo}
       flashMessage={flashMessage}
       submitButtonLabel={submitButtonLabel}
-      actionLinks={actionLinks}
       initialValues={initialValues}
+      cancelRedirectTo={cancelRedirectTo}
+      cancelButtonLabel={cancelButtonLabel}
     >
       {({ values }) => (
         <>
@@ -77,8 +79,8 @@ function PipelineForm({
             isClearable={true}
             className="govuk-!-width-two-thirds"
           />
-          {/* 
-            This template form needs to cater for both the Add and Edit use cases. 
+          {/*
+            This template form needs to cater for both the Add and Edit use cases.
             As both use cases have different params we need to check where to get
             the company information from before firing the resource.
           */}

--- a/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
+++ b/src/apps/my-pipeline/client/UnarchivePipelineItemForm.jsx
@@ -46,12 +46,7 @@ const UnarchivePipelineItemForm = ({ pipelineItemId }) => (
             })}
             redirectTo={(result) => getPipelineUrl(result.status)}
             submitButtonLabel={'Unarchive project'}
-            actionLinks={[
-              {
-                href: getPipelineUrl(pipelineItem.status),
-                children: 'Cancel',
-              },
-            ]}
+            cancelRedirectTo={() => getPipelineUrl(pipelineItem.status)}
             flashMessage={() => `You unarchived ${pipelineItem.name}`}
           />
         </Main>

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -218,12 +218,12 @@ const _ContactForm = ({
                     submitButtonLabel={
                       update ? 'Save and return' : 'Add contact'
                     }
-                    actionLinks={[
-                      {
-                        href: referrerUrl ? stripHost(referrerUrl) : '/',
-                        children: update ? 'Return without saving' : 'Cancel',
-                      },
-                    ]}
+                    cancelRedirectTo={() =>
+                      referrerUrl ? stripHost(referrerUrl) : '/'
+                    }
+                    cancelButtonLabel={
+                      update ? 'Return without saving' : 'Cancel'
+                    }
                     initialValues={{
                       ...props,
                       postcode,

--- a/src/client/modules/Events/EventForm/index.jsx
+++ b/src/client/modules/Events/EventForm/index.jsx
@@ -34,13 +34,6 @@ const EventForm = () => {
     },
   ]
 
-  const cancelLink = [
-    {
-      children: DISPLAY_CANCEL,
-      to: id ? urls.events.details(id) : urls.events.index(),
-    },
-  ]
-
   const flashMessage = (submissionTaskResult) => {
     const { name } = submissionTaskResult?.data
     return `'${name}' event has been ${id ? 'updated' : 'created'}`
@@ -65,8 +58,11 @@ const EventForm = () => {
         redirectMode="soft"
         flashMessage={flashMessage}
         submitButtonLabel={id ? DISPLAY_SAVE : DISPLAY_ADD_EVENT}
-        actionLinks={cancelLink}
         transformPayload={transformEventFormForAPIRequest}
+        cancelButtonLabel={DISPLAY_CANCEL}
+        cancelRedirectTo={() =>
+          id ? urls.events.details(id) : urls.events.index()
+        } //this originally used the react to: instead of a hard redirect, so it might break after being switched, watch out
       >
         {({ values }) => <EventFormFields values={values} />}
       </TaskForm>


### PR DESCRIPTION
## Description of change
https://github.com/uktrade/data-hub-frontend/pull/4222 adds the cancelRedirectTo and cancelLabel props that fulfil the usecase of actionLinks and simplify things. This PR goes through and removes the uses of actionLinks.

## Test instructions

The entire application should continue to function normally and workflows should be unchanged.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
