### PR TITLE
Fix referrals interaction returnLink

### DIFF
--- a/src/apps/companies/apps/referrals/middleware/interactions.js
+++ b/src/apps/companies/apps/referrals/middleware/interactions.js
@@ -14,7 +14,10 @@ function setInteractionsDetails(req, res, next) {
   const { referralId } = req.params
   const { company } = res.locals
   res.locals.interactions = {
-    returnLink: urls.companies.referrals.details(company.id, referralId),
+    returnLink: urls.companies.referrals.interactions.index(
+      company.id,
+      referralId
+    ),
     referralId: referralId,
     canAdd: true,
     showCompany: true,

--- a/test/end-to-end/cypress/specs/DIT/referrals-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/referrals-spec.js
@@ -90,6 +90,11 @@ describe('Referrals', () => {
         .parents()
         .find(selectors.interaction.details.interaction.referralDetails)
         .should('contain', 'Example subject')
+      cy.location().then(({ pathname }) =>
+        cy
+          .contains('a', 'Edit interaction')
+          .should('have.attr', 'href', `${pathname}/edit`)
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change

This PR fixes a bug where the 'Edit interaction' button link on an interaction created from accepting a referral had an incorrect address - giving the user a 404. (E.g. [here on dev](https://www.datahub.dev.uktrade.io/companies/c05f9136-a848-4d76-9d00-859069ad9da6/referrals/43b878d9-0c53-460f-99f3-c185130d34bd/interactions/30b4f276-971c-40e1-adad-31a670c2987a)).

I have updated the e2e referral spec to check that the button has the correct link.

## Test instructions

- Go to a company, click refer this company
- Find your referral on the homepage, selecting 'sent referrals' on the filter
- Complete the referral with an interaction
- Once complete, check the 'Edit interaction' button takes you to the correct link 

## Screenshots
### Before

![Screenshot 2021-12-21 at 09 23 28](https://user-images.githubusercontent.com/22460823/146904986-02949739-caa7-47c5-95de-2904a9d9c10b.png)

### After



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
