### PR TITLE
Update README.md to reflect actual development set-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ and be provided with a back end server to provide the API, data storage and sear
 
 ## Getting started
 
-### Running the project within Docker (recommended method)
+### Running the project within Docker 
 
 Please view the dedicated [Docker readme](./docs/Docker.md).
 
-### Running the project natively
+### Running the project natively (recommended method)
 
 **Note for all users** If you wish to run the functional tests against your native frontend, you will need to pass a config flag to point cypress to run against port 3000 - `npm run test:functional:watch --config baseUrl=http://localhost:3000`.
 
@@ -59,7 +59,7 @@ Please view the dedicated [Docker readme](./docs/Docker.md).
     npm install
     ```
 
-4.  Create a copy of the sample `.env` file which points to a mocked API:
+4.  Create a copy of the sample `.env` file which points to a mocked API. (Alternatively, check Vault for environment variables that point to other environments, such as staging and dev):
 
     ```bash
     cp sample.env .env
@@ -124,6 +124,8 @@ These instructions work for both the dockerised environment and the native envir
 ### Environment variables
 
 List of all environment variables can be found in the source code of [envSchema.js](./src/config/envSchema.js).
+
+Check Vault for environment variables that point to other environments, such as staging and dev.
 
 ## Making changes
 


### PR DESCRIPTION
## Description of change

The frontend README.md says that the recommend method of running is via docker, however after a discussion at the dev huddle, it seems that no one (or very few people) actually use this method. Most developers much prefer running the frontend natively as it is a lot faster and much less flaky. 

Until the issues with docker have been fixed, I suggest we specify running the project natively as the recommend method. I have updated the README.md accordingly, but happy for any other thoughts on this!

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
