### PR TITLE
Remove Stage option from investment filtering

### DIFF
--- a/src/apps/investments/client/projects/constants.js
+++ b/src/apps/investments/client/projects/constants.js
@@ -32,10 +32,6 @@ export const SORT_OPTIONS = [
     name: 'Project name A-Z',
     value: 'name:asc',
   },
-  {
-    name: 'Stage',
-    value: 'stage.name',
-  },
 ]
 
 export const INVOLVEMENT_LEVEL_OPTIONS = [

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -152,7 +152,6 @@ describe('Company Investments Collection Page', () => {
           { value: 'estimated_land_date:asc', label: 'Earliest land date' },
           { value: 'estimated_land_date:desc', label: 'Latest land date' },
           { value: 'name:asc', label: 'Project name A-Z' },
-          { value: 'stage.name', label: 'Stage' },
         ])
       })
     })


### PR DESCRIPTION
## Description of change

As we have a checkbox field to sort by each of the individual project stages, having a 'Sort by' option for stage is no longer required.

## Test instructions

Go to the investments collection list. The option to sort by stage shouldn't be there.

## Screenshots
### Before
<img width="524" alt="Screenshot 2021-12-23 at 10 43 17" src="https://user-images.githubusercontent.com/36161814/147229186-67f928bb-a918-46b9-9894-f5a6e37dcf50.png">



### After

<img width="536" alt="Screenshot 2021-12-23 at 10 40 19" src="https://user-images.githubusercontent.com/36161814/147229178-d983441f-bccb-4b0d-90ab-49fd1a059d1f.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
