### PR TITLE
Fixed company creation when telephone number is empty

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -4,7 +4,7 @@
 
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { get } from 'lodash'
+import { get, omit } from 'lodash'
 
 import {
   FieldRadios,
@@ -66,6 +66,13 @@ function AddCompanyForm({
     return {}
   }
 
+  function transformPayload(values) {
+    return {
+      ...omit(values, [!values?.telephone_number && 'telephone_number']),
+      csrfToken,
+    }
+  }
+
   return (
     <Form
       id="add-company-form"
@@ -73,7 +80,7 @@ function AddCompanyForm({
       analyticsFormName="addCompanyForm"
       redirectTo={(company) => `/companies/${company.id}`}
       flashMessage={() => 'Company added to Data Hub'}
-      transformPayload={(values) => ({ ...values, csrfToken })}
+      transformPayload={transformPayload}
     >
       {({ values, setFieldValue }) => {
         const country = getCountry(values)


### PR DESCRIPTION
## Description of change

When `telephone_number` field was submitted as empty string, dnb service would return `400 Bad Request` because serializer does not allow blank values. Fix now removes `telephone_number` field from payload when value is empty string.

Jira ticket [CPS-290](https://uktrade.atlassian.net/browse/CPS-290)