### PR TITLE
Make event's related programmes field optional.

### DIFF
--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -145,7 +145,7 @@ export const EventFormFields = ({ values }) => (
       options={values?.metadata?.teams}
       required="Select at least one team hosting the event"
       placeholder="Select team"
-      aria-label="Select an team"
+      aria-label="Select a team"
       noOptionsMessage={() => <span>No hosting team found</span>}
     />
     <FieldTypeahead
@@ -188,14 +188,13 @@ export const EventFormFields = ({ values }) => (
       inline={true}
     />
     <FieldTypeahead
-      label="Related programmes"
+      label="Related programmes (optional)"
       isMulti={true}
       closeMenuOnSelect={true}
       name="related_programmes"
       options={values?.metadata?.programmes}
       placeholder="Select programme"
-      required="Select at least one related programme"
-      aria-label="Select at least one related programme"
+      aria-label="Select programme"
       noOptionsMessage={() => <span>No programmes found</span>}
     />
   </>

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -164,7 +164,6 @@ describe('Event create', () => {
         'Select at least one team hosting the event',
         'Select at least one service',
         'Enter at least one organiser',
-        'Select at least one related programme',
       ])
     })
 
@@ -187,7 +186,6 @@ describe('Event create', () => {
         'Select at least one team hosting the event',
         'Select at least one service',
         'Enter at least one organiser',
-        'Select at least one related programme',
         'Select at least one trade agreement',
         'Select at least one team',
         'Select a UK region',
@@ -197,6 +195,7 @@ describe('Event create', () => {
 
   context('when filling in a valid event form', () => {
     it('should save with expected values and endpoint', () => {
+      // it automatically submits the form
       fillEventForm({
         address1: 'Bussiness 1',
         address2: 'Street 2',
@@ -221,7 +220,7 @@ describe('Event create', () => {
           'Comprehensive and Progressive Agreement for Trans-Pacific Partnership',
           'UK-Australia Mutual Recognition Agreement',
         ],
-        relatedProgrammes: ['Aid Funded Business Service (AFBS)', 'CEN Energy'],
+        relatedProgrammes: ['CEN Energy', 'CEN Services'],
         startDate: {
           year: '2021',
           month: '12',
@@ -231,8 +230,6 @@ describe('Event create', () => {
         teams: ['BPI', 'BN America', 'BPI'],
         service: 'Making Other Introductions : UK Export Finance (UKEF)',
       })
-
-      clickAddEventButton()
 
       const expectedBody = {
         has_related_trade_agreements: true,
@@ -253,8 +250,8 @@ describe('Event create', () => {
         organiser: '3442c516-9898-e211-a939-e4115bead28a',
         event_shared: true,
         related_programmes: [
-          'e2a8be20-7a54-e311-a33a-e4115bead28a',
           '058dde7c-19d5-e311-8a2b-e4115bead28a',
+          'cad5df2e-1ad5-e311-8a2b-e4115bead28a',
         ],
         related_trade_agreements: [
           'af704a93-5404-4bc6-adda-381756993902',

--- a/test/functional/cypress/support/eventform-fillers.js
+++ b/test/functional/cypress/support/eventform-fillers.js
@@ -37,6 +37,10 @@ export const fillEventForm = ({
   teams,
   service,
 } = {}) => {
+  // fill optional field first, as form gets submitted once
+  // all required fields are filled in
+  fillProgrammes(relatedProgrammes)
+
   fillHasRelatedTradeAgreementsRadio(hasRelatedTradeAgreements)
   if (hasRelatedTradeAgreements && relatedTradeAgreements) {
     fillRelatedTradeAgreements(relatedTradeAgreements)
@@ -63,7 +67,6 @@ export const fillEventForm = ({
   if (eventShared && teams) {
     fillTeams(teams)
   }
-  fillProgrammes(relatedProgrammes)
 }
 
 export const fillEventNotes = (notes) => {
@@ -119,7 +122,7 @@ export const fillAndAssertProgrammes = (programmes = []) => {
 
   assertMultiOptionTypeaheadValues(
     selectors.relatedProgrammesFieldId,
-    'Related programmes',
+    'Related programmes (optional)',
     programmes
   )
 }


### PR DESCRIPTION
## Description of change

The Event's related programmes field is optional in the API, but the form required it to be completed. 
This PR makes the field optional. 

## Test instructions

Go to `Events` section and then click `Add event`. Fill in the form as required, leaving out the related programmes. It should get submitted and a new event added.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
