### PR TITLE
Resolve division deprecation warning

### DIFF
--- a/assets/stylesheets/_deprecated/_dashboard.scss
+++ b/assets/stylesheets/_deprecated/_dashboard.scss
@@ -16,7 +16,7 @@
 
   .dashboard-list {
     li + li {
-      padding-top: $default-spacing-unit / 2;
+      padding-top: $default-spacing-unit * 0.5;
     }
   }
 

--- a/assets/stylesheets/_deprecated/_shame.scss
+++ b/assets/stylesheets/_deprecated/_shame.scss
@@ -9,5 +9,5 @@ strong {
 }
 
 .column-three-quarters {
-  @include grid-column(3 / 4, tablet);
+  @include grid-column(3 * 0.25, tablet);
 }

--- a/assets/stylesheets/_deprecated/components/_table.scss
+++ b/assets/stylesheets/_deprecated/components/_table.scss
@@ -33,7 +33,7 @@
   }
 
   div + ul {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 }
 
@@ -79,7 +79,7 @@ table.table--key-value.table--small {
   color: $secondary-text-colour;
 
   .table__details-name {
-    padding-top: $default-spacing-unit / 4;
+    padding-top: $default-spacing-unit * 0.25;
   }
 
   .table__details-content {
@@ -110,5 +110,5 @@ table.table--key-value.table--small {
 }
 
 .table__action {
-  padding-left: $default-spacing-unit / 2;
+  padding-left: $default-spacing-unit * 0.5;
 }

--- a/assets/stylesheets/components/_.example.scss
+++ b/assets/stylesheets/components/_.example.scss
@@ -6,8 +6,8 @@
 }
 
 .example__header {
-  padding-top: $default-spacing-unit / 4;
-  padding-bottom: $default-spacing-unit / 4;
+  padding-top: $default-spacing-unit * 0.25;
+  padding-bottom: $default-spacing-unit * 0.25;
 
   &::before {
     content: attr(data-tab-title);
@@ -17,8 +17,8 @@
     font-size: 16px;
     line-height: 32px;
     font-weight: 600;
-    padding: 0 ($default-spacing-unit / 2);
-    margin-right: $default-spacing-unit / 2;
+    padding: 0 ($default-spacing-unit * 0.5);
+    margin-right: $default-spacing-unit * 0.5;
     display: inline-block;
     vertical-align: top;
   }

--- a/assets/stylesheets/components/_action-bar.scss
+++ b/assets/stylesheets/components/_action-bar.scss
@@ -2,5 +2,5 @@
 
 .action-bar {
   text-align: right;
-  margin-bottom: $gutter / 2;
+  margin-bottom: $gutter * 0.5;
 }

--- a/assets/stylesheets/components/_answers-summary.scss
+++ b/assets/stylesheets/components/_answers-summary.scss
@@ -13,7 +13,7 @@
   @include bold-font(24);
   border-bottom: 1px solid $grey-2;
   margin: 0;
-  padding: 0 0 $default-spacing-unit / 4;
+  padding: 0 0 $default-spacing-unit * 0.25;
   position: relative;
 }
 
@@ -39,7 +39,7 @@
   border-bottom: 0;
   display: block;
   margin: 0;
-  padding: ($default-spacing-unit / 2) 0;
+  padding: ($default-spacing-unit * 0.5) 0;
 
   @include media(tablet) {
     border-bottom: 1px solid $grey-2;
@@ -82,7 +82,7 @@
 
   .govuk-button--secondary {
     @include core-font(16);
-    margin-bottom: $default-spacing-unit / 2;
+    margin-bottom: $default-spacing-unit * 0.5;
 
     @include media(tablet) {
       margin-bottom: 0;

--- a/assets/stylesheets/components/_badge.scss
+++ b/assets/stylesheets/components/_badge.scss
@@ -34,7 +34,7 @@
 
 .c-badge {
   @include _style-badge($green);
-  padding: ($baseline-grid-unit / 2) $baseline-grid-unit;
+  padding: ($baseline-grid-unit * 0.5) $baseline-grid-unit;
   text-decoration: none;
   font-weight: 600;
 

--- a/assets/stylesheets/components/_data-table.scss
+++ b/assets/stylesheets/components/_data-table.scss
@@ -54,7 +54,7 @@
     border: 0;
     color: $grey-5;
     font-size: inherit;
-    padding: $default-spacing-unit/4 0;
+    padding: $default-spacing-unit*0.25 0;
     @include media (mobile) {
       display:block;
     }

--- a/assets/stylesheets/components/_details-list.scss
+++ b/assets/stylesheets/components/_details-list.scss
@@ -14,21 +14,21 @@
 
 .details-list__item-section {
   @include grid-row;
-  margin-bottom: $gutter / 4;
+  margin-bottom: $gutter * 0.25;
 }
 
 .details-list__item-heading {
   display: block;
-  margin-bottom: $gutter / 2;
+  margin-bottom: $gutter * 0.5;
 }
 
 .details-list__item-title {
-  @include grid-column(1 / 4);
+  @include grid-column(1 * 0.25);
   color: $grey-1;
 }
 
 .details-list__item-description {
-  @include grid-column(3 / 4);
+  @include grid-column(3 * 0.25);
   display: inline;
 }
 
@@ -36,7 +36,7 @@
   .details-list__item-heading {
     &::before {
       font-family: "FontAwesome";
-      width: $gutter / 2;
+      width: $gutter * 0.5;
       display: inline-block;
       content: "\f0da";
     }

--- a/assets/stylesheets/components/_entity-list.scss
+++ b/assets/stylesheets/components/_entity-list.scss
@@ -14,7 +14,7 @@
   border: 1px solid $grey-2;
   display: block;
   margin-top: -1px;
-  padding: 0 ($gutter / 2) ($gutter / 2);
+  padding: 0 ($gutter * 0.5) ($gutter * 0.5);
   text-decoration: none;
 
   &:hover,
@@ -29,6 +29,6 @@
 
   .c-entity-list__item {
     border-top: 0;
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 }

--- a/assets/stylesheets/components/_entity.scss
+++ b/assets/stylesheets/components/_entity.scss
@@ -28,7 +28,7 @@
   @include core-font(16);
 
   * + & {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 }
 

--- a/assets/stylesheets/components/_local-header.scss
+++ b/assets/stylesheets/components/_local-header.scss
@@ -128,7 +128,7 @@
 }
 
 * + .c-local-header__heading-after {
-  margin-top: $default-spacing-unit / 2;
+  margin-top: $default-spacing-unit * 0.5;
   margin-bottom: $default-spacing-unit * 0.75;
 }
 
@@ -160,12 +160,12 @@
   margin: 0;
 
   & + & {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 }
 
 .c-local-header__description {
-  padding: $default-spacing-unit / 2;
+  padding: $default-spacing-unit * 0.5;
   background-color: $grey-3;
 
   * + & {
@@ -177,11 +177,11 @@
     margin-bottom: 0;
 
     &:not(:last-child) {
-      margin-bottom: $default-spacing-unit / 2;
+      margin-bottom: $default-spacing-unit * 0.5;
     }
 
     a {
-      margin-left: $default-spacing-unit / 2;
+      margin-left: $default-spacing-unit * 0.5;
     }
   }
 

--- a/assets/stylesheets/components/_local-nav.scss
+++ b/assets/stylesheets/components/_local-nav.scss
@@ -5,8 +5,8 @@
 
 .c-local-nav {
   @include core-font(20);
-  margin-left: -($gutter / 2);
-  margin-right: -($gutter / 2);
+  margin-left: -($gutter * 0.5);
+  margin-right: -($gutter * 0.5);
 
   @include media(tablet) {
     padding-right: 0;
@@ -17,7 +17,7 @@
 
 .c-local-nav__link {
   display: block;
-  padding: ($default-spacing-unit / 2) $default-spacing-unit;
+  padding: ($default-spacing-unit * 0.5) $default-spacing-unit;
 
   &:link,
   &:visited {

--- a/assets/stylesheets/components/_meta-list.scss
+++ b/assets/stylesheets/components/_meta-list.scss
@@ -3,7 +3,7 @@
 
 .c-meta-list__item {
   & + & {
-    margin-top: $default-spacing-unit / 4;
+    margin-top: $default-spacing-unit * 0.25;
   }
 }
 
@@ -34,7 +34,7 @@
 
 .c-meta-list--inline {
   display: inline-block;
-  margin-top: -($default-spacing-unit / 2);
+  margin-top: -($default-spacing-unit * 0.5);
 
   .c-meta-list__item-label {
     display: inline-block;
@@ -43,7 +43,7 @@
   .c-meta-list__item {
     display: inline-block;
     margin-right: $default-spacing-unit * 2;
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
 
     &:last-child {
       margin-right: 0;
@@ -53,7 +53,7 @@
 
 .c-meta-list--condensed {
   &.c-meta-list--inline .c-meta-list__item {
-    margin-right: $default-spacing-unit / 4;
+    margin-right: $default-spacing-unit * 0.25;
 
     &:last-child {
       margin-right: 0;
@@ -65,7 +65,7 @@
   display: block;
 
   & + & {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 
   .c-meta-list__item-label {
@@ -75,12 +75,12 @@
 
 .c-meta-list--split {
   @include clearfix;
-  margin-top: -($default-spacing-unit / 4);
+  margin-top: -($default-spacing-unit * 0.25);
   width: 100%;
 
   .c-meta-list__item {
     display: block;
-    margin-top: $default-spacing-unit / 4;
+    margin-top: $default-spacing-unit * 0.25;
   }
 
   @include media(tablet) {

--- a/assets/stylesheets/components/_pagination.scss
+++ b/assets/stylesheets/components/_pagination.scss
@@ -39,7 +39,7 @@
 .c-pagination__label {
   @include bold-font(16);
   display: inline-block;
-  padding: ($default-spacing-unit / 2) $default-spacing-unit;
+  padding: ($default-spacing-unit * 0.5) $default-spacing-unit;
   background-color: $grey-4;
 
   &:link,
@@ -69,8 +69,8 @@
 
 .c-pagination__label--truncation {
   background-color: transparent;
-  padding-right: $default-spacing-unit / 2;
-  padding-left: $default-spacing-unit / 2;
+  padding-right: $default-spacing-unit * 0.5;
+  padding-left: $default-spacing-unit * 0.5;
   color: $grey-1;
 }
 

--- a/assets/stylesheets/components/_phase-badge.scss
+++ b/assets/stylesheets/components/_phase-badge.scss
@@ -12,7 +12,7 @@ span.phase-badge {
   font-weight: 600;
   letter-spacing: 1px;
   line-height: 1;
-  margin: 0 ($default-spacing-unit / 2) 0 0;
+  margin: 0 ($default-spacing-unit * 0.5) 0 0;
   padding: 3px 5px;
   vertical-align: top;
 

--- a/assets/stylesheets/components/_progress.scss
+++ b/assets/stylesheets/components/_progress.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../settings";
 @import "../tools";
 
@@ -9,14 +11,14 @@
 $_section-width: 25%;
 
 .c-progress {
-  margin-left: $default-spacing-unit / 2;
-  margin-right: $default-spacing-unit / 2;
+  margin-left: $default-spacing-unit * 0.5;
+  margin-right: $default-spacing-unit * 0.5;
 
   @include media(tablet) {
     margin-left: $default-spacing-unit * 2;
     margin-right: $default-spacing-unit * 2;
-    padding-bottom: $default-spacing-unit / 2;
-    padding-top: $default-spacing-unit / 3;
+    padding-bottom: $default-spacing-unit * 0.5;
+    padding-top: math.div($default-spacing-unit, 3);
   }
 }
 

--- a/assets/stylesheets/components/_stack-trace.scss
+++ b/assets/stylesheets/components/_stack-trace.scss
@@ -8,7 +8,7 @@
 
 .stack-trace__heading {
   @include core-font(24);
-  margin-bottom: $gutter / 2;
+  margin-bottom: $gutter * 0.5;
 }
 
 .stack-trace__details {

--- a/assets/stylesheets/components/form/_entity-search.scss
+++ b/assets/stylesheets/components/form/_entity-search.scss
@@ -4,7 +4,7 @@
 $search-button-width: 50px;
 
 .c-entity-search__input {
-  padding-right: $search-button-width + ($default-spacing-unit / 2);
+  padding-right: $search-button-width + ($default-spacing-unit * 0.5);
 }
 
 .c-entity-search__button {
@@ -35,7 +35,7 @@ $search-button-width: 50px;
 
 .c-entity-search__aggregations-item {
   display: inline-block;
-  padding: $default-spacing-unit / 2;
+  padding: $default-spacing-unit * 0.5;
   white-space: nowrap;
   cursor: default;
 }

--- a/assets/stylesheets/components/form/_form-control.scss
+++ b/assets/stylesheets/components/form/_form-control.scss
@@ -8,7 +8,7 @@
   background-color: $white;
   display: inline-block;
   height: 2em;
-  padding: 0 ($default-spacing-unit / 2);
+  padding: 0 ($default-spacing-unit * 0.5);
   font-size: 1em;
   outline: 0;
 
@@ -62,8 +62,8 @@
 textarea.c-form-control {
   min-height: 8em;
   max-height: 50vh;
-  padding-top: $default-spacing-unit / 2;
-  padding-bottom: $default-spacing-unit / 2;
+  padding-top: $default-spacing-unit * 0.5;
+  padding-bottom: $default-spacing-unit * 0.5;
   width: 100%;
   max-width: 100%;
 }

--- a/assets/stylesheets/components/form/_form-fieldset.scss
+++ b/assets/stylesheets/components/form/_form-fieldset.scss
@@ -10,13 +10,13 @@
 }
 
 .c-form-fieldset__legend {
-  margin-left: -$default-spacing-unit / 2;
+  margin-left: -$default-spacing-unit * 0.5;
   font-size: 24px;
   color: $grey-1;
 }
 
 .c-form-fieldset__legend-text {
-  margin: 0 $default-spacing-unit / 2;
+  margin: 0 $default-spacing-unit * 0.5;
 }
 
 .c-form-fieldset__hint {

--- a/assets/stylesheets/components/form/_form-group.scss
+++ b/assets/stylesheets/components/form/_form-group.scss
@@ -125,7 +125,7 @@ fieldset.c-form-group.c-form-fieldset--subfield {
 
     .c-form-group__label:not(legend) {
       display: inline-block;
-      margin-right: $default-spacing-unit / 2;
+      margin-right: $default-spacing-unit * 0.5;
     }
 
     .c-form-control {
@@ -173,7 +173,7 @@ fieldset.c-form-group.c-form-fieldset--subfield {
 
 .c-form-group--filter {
   background: $grey-3;
-  padding: $default-spacing-unit / 2;
+  padding: $default-spacing-unit * 0.5;
   margin-top: $default-spacing-unit;
 }
 
@@ -182,7 +182,7 @@ fieldset.c-form-group.c-form-fieldset--subfield {
 }
 
 .c-form-group--filter.c-form-group--hide-label {
-  padding-top: ($default-spacing-unit / 2) - 3;
+  padding-top: ($default-spacing-unit * 0.5) - 3;
 }
 
 .c-form-group--hide-label {

--- a/assets/stylesheets/components/form/_multiple-choice.scss
+++ b/assets/stylesheets/components/form/_multiple-choice.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @import "../../settings";
 @import "../../tools";
 
@@ -20,8 +22,8 @@
       border-width: 0 0 5px 5px;
     }
 
-    width: round($input-size / 1.7);
-    height: round($input-size / 3);
+    width: round(math.div($input-size, 1.7));
+    height: round(math.div($input-size, 3));
   }
 
   & + .c-multiple-choice__label {
@@ -31,9 +33,9 @@
     }
 
     &::after {
-      border: ceil($font-size / 2) solid $text-colour;
-      left: floor($font-size / 2);
-      top: floor($font-size / 2);
+      border: ceil($font-size * 0.5) solid $text-colour;
+      left: floor($font-size * 0.5);
+      top: floor($font-size * 0.5);
     }
   }
 }
@@ -98,7 +100,7 @@
   cursor: pointer;
   vertical-align: middle;
   display: inline-block;
-  padding: ($default-spacing-unit / 2) ($default-spacing-unit / 2) ($default-spacing-unit / 2) ($default-spacing-unit * 3);
+  padding: ($default-spacing-unit * 0.5) ($default-spacing-unit * 0.5) ($default-spacing-unit * 0.5) ($default-spacing-unit * 3);
   line-height: 1.2;
 }
 
@@ -127,7 +129,7 @@
   }
 
   .c-multiple-choice__label {
-    padding-left: round($default-spacing-unit * 3 * (16 / 19));
+    padding-left: round($default-spacing-unit * 3 * math.div(16, 19));
     line-height: 16px;
   }
 }
@@ -138,7 +140,7 @@
   }
 
   .c-multiple-choice__label {
-    padding-left: round($default-spacing-unit * 3 * (10 / 19));
+    padding-left: round($default-spacing-unit * 3 * math.div(10, 19));
     line-height: 18px;
   }
 }
@@ -155,21 +157,21 @@
   }
 
   .c-multiple-choice__input {
-    left: $default-spacing-unit / 2;
-    top: $default-spacing-unit / 2;
+    left: $default-spacing-unit * 0.5;
+    top: $default-spacing-unit * 0.5;
 
     + .c-multiple-choice__label {
       &:after,
       &:before {
-        margin-left: $default-spacing-unit / 2;
-        margin-top: $default-spacing-unit / 2;
+        margin-left: $default-spacing-unit * 0.5;
+        margin-top: $default-spacing-unit * 0.5;
       }
     }
   }
 
   .c-multiple-choice__label {
     display: block;
-    padding-left: round($default-spacing-unit * 3 * (10 / 19) + ($default-spacing-unit / 2));
+    padding-left: round($default-spacing-unit * 3 * math.div(10, 19) + ($default-spacing-unit * 0.5));
 
     &:hover {
       background-color: $grey-4;

--- a/assets/stylesheets/components/form/_typeahead.scss
+++ b/assets/stylesheets/components/form/_typeahead.scss
@@ -32,7 +32,7 @@
   border: 1px solid $black;
   border-radius: 0;
   font-size: 1em;
-  padding: 0 $default-spacing-unit / 2;
+  padding: 0 $default-spacing-unit * 0.5;
   min-height: auto;
 }
 
@@ -41,7 +41,7 @@
   background: $highlight-colour;
   border-radius: 0;
   color: $text-colour;
-  margin: 0 $default-spacing-unit / 2 0 0;
+  margin: 0 $default-spacing-unit * 0.5 0 0;
   overflow: initial;
   white-space: normal;
   line-height: 1.4;
@@ -89,7 +89,7 @@
 }
 
 .multiselect__option-label {
-  margin-bottom: $default-spacing-unit / 4;
+  margin-bottom: $default-spacing-unit * 0.25;
 }
 
 .c-form-group--no-filter .multiselect__tags {

--- a/assets/stylesheets/elements/_headings.scss
+++ b/assets/stylesheets/elements/_headings.scss
@@ -7,7 +7,7 @@ h3,
 h4,
 h5,
 h6 {
-  margin-bottom: ($gutter / 2);
+  margin-bottom: ($gutter * 0.5);
 }
 
 h3 {

--- a/assets/stylesheets/layout/_assemblies.scss
+++ b/assets/stylesheets/layout/_assemblies.scss
@@ -23,7 +23,7 @@
 
   .c-multiple-choice,
   .c-meta-list {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 
   .c-meta-container,
@@ -32,7 +32,7 @@
   }
 
   .metadata-list {
-    margin-top: $default-spacing-unit / 4;
+    margin-top: $default-spacing-unit * 0.25;
   }
 
   .c-form-fieldset--subfield,

--- a/assets/stylesheets/objects/_list.scss
+++ b/assets/stylesheets/objects/_list.scss
@@ -15,7 +15,7 @@
 
 .list-lined li {
   border-bottom: 1px solid $border-colour;
-  padding: ($gutter / 2) ($gutter / 2) ($gutter / 2) 0;
+  padding: ($gutter * 0.5) ($gutter * 0.5) ($gutter * 0.5) 0;
 
   &:first-child {
     border-top: 1px solid $border-colour;
@@ -33,7 +33,7 @@
   }
 
   li + li {
-    margin-top: $default-spacing-unit / 2;
+    margin-top: $default-spacing-unit * 0.5;
   }
 }
 

--- a/assets/stylesheets/tools/mixins/_conditionals.scss
+++ b/assets/stylesheets/tools/mixins/_conditionals.scss
@@ -18,6 +18,8 @@
 ///       float: left;
 ///     }
 ///   }
+@use "sass:list";
+
 @mixin media($size: false, $max-width: false, $min-width: false) {
   @if $size == desktop {
     @media (min-width: 925px) {
@@ -49,7 +51,7 @@
 @mixin device-pixel-ratio($ratio: 2) {
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
   only screen and (min--moz-device-pixel-ratio: $ratio),
-  only screen and (  -o-min-device-pixel-ratio: #{($ratio*10)}/10),
+  only screen and (  -o-min-device-pixel-ratio: list.slash(($ratio*10), 10)),
   only screen and (     min-device-pixel-ratio: $ratio),
   only screen and (             min-resolution: #{($ratio*96)}dpi),
   only screen and (             min-resolution: #{$ratio}dppx) {

--- a/assets/stylesheets/tools/mixins/_layout.scss
+++ b/assets/stylesheets/tools/mixins/_layout.scss
@@ -32,7 +32,7 @@
 ///   }
 @mixin grid-column($width, $full-width: desktop, $float: left) {
   display: block;
-  padding: 0 ($gutter / 2);
+  padding: 0 ($gutter * 0.5);
 
   @include media($full-width) {
     float: $float;
@@ -43,7 +43,7 @@
 
 @mixin grid-row {
   @include clearfix;
-  margin: 0 (-($gutter / 2));
+  margin: 0 (-($gutter * 0.5));
 
   @include media(desktop) {
     .page-section &,
@@ -56,7 +56,7 @@
 }
 
 @mixin site-width-container {
-  margin: 0 ($gutter / 2);
+  margin: 0 ($gutter * 0.5);
   max-width: $site-width;
 
   @include media(desktop) {

--- a/src/templates/_macros/collection-header/_collection-header.scss
+++ b/src/templates/_macros/collection-header/_collection-header.scss
@@ -4,14 +4,14 @@
 .c-collection__header-row {
   @include clearfix;
   @include core-font(16);
-  padding-bottom: ($default-spacing-unit / 2);
+  padding-bottom: ($default-spacing-unit * 0.5);
 
   &:first-child {
     border-bottom: 5px solid $text-colour;
   }
 
   &:not(first-child) {
-    padding-top: ($default-spacing-unit / 2);
+    padding-top: ($default-spacing-unit * 0.5);
     border-bottom: 1px solid $grey-2;
   }
 }
@@ -59,9 +59,9 @@
   background-color: #F3F2F1;
   border-width: 1px;
   border-radius: 5px;
-  margin-right: $default-spacing-unit / 2;
-  margin-top: $default-spacing-unit / 2;
-  padding: 0 ($default-spacing-unit / 2);
+  margin-right: $default-spacing-unit * 0.5;
+  margin-top: $default-spacing-unit * 0.5;
+  padding: 0 ($default-spacing-unit * 0.5);
   cursor: default;
 }
 
@@ -99,8 +99,8 @@
 .c-collection__filter-remove-all {
   display: inline-block;
   line-height: 1.2;
-  margin-top: $default-spacing-unit / 2;
-  margin-bottom: $default-spacing-unit / 2;
+  margin-top: $default-spacing-unit * 0.5;
+  margin-bottom: $default-spacing-unit * 0.5;
 
   &:link,
   &:visited {
@@ -114,7 +114,7 @@
 }
 
 .c-collection__sort-form {
-  margin-top: $default-spacing-unit / 2;
+  margin-top: $default-spacing-unit * 0.5;
   display: flex;
 
   .c-form-group--inline {
@@ -124,7 +124,7 @@
 
   .c-form-group__label {
     margin-bottom: 0;
-    margin-right: $default-spacing-unit / 2;
+    margin-right: $default-spacing-unit * 0.5;
   }
 
   @include media(tablet) {
@@ -133,13 +133,13 @@
   }
 
   .govuk-button {
-    margin-left: $default-spacing-unit / 2;
+    margin-left: $default-spacing-unit * 0.5;
     margin-bottom: 2px;
   }
 }
 
 .c-collection__total-cost {
-  padding-top: $default-spacing-unit / 2;
+  padding-top: $default-spacing-unit * 0.5;
 
   .c-collection__total-cost__value{
     font-weight: 600;


### PR DESCRIPTION
## Description of change

When bringing up the frontend this morning I noticed that there were hundreds of SASS deprecation warnings related to the `/` division operator, as well as a [link to an automatic migration tool.](https://sass-lang.com/documentation/breaking-changes/slash-div)

<img width="696" alt="Screenshot 2022-01-10 at 11 36 47" src="https://user-images.githubusercontent.com/36161814/148760939-77c8450d-bd71-42dc-b654-708e69cba43d.png">

After running the migration tool, the number of SASS warnings dropped from over 100 to 63 (the remaining warnings are coming from CSS files in `node_modules` or are unrelated).

## Test instructions

Everything should work as normal. When running the frontend locally, the number of deprecation warnings should be much lower).

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
