### PR TITLE
Update read me instructions for running data hub frontend natively

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,13 +60,51 @@ Please view the dedicated [Docker readme](./docs/Docker.md).
     npm install
     ```
 
-4.  Create a copy of the sample `.env` file which points to a mocked API. (Alternatively, check Vault for environment variables that point to other environments, such as staging and dev):
+4.  Create a copy of the `sample.env` file.
 
     ```bash
     cp sample.env .env
     ```
 
-6.  [Install](./docs/Installing%20redis%20natively.md) the redis server and bring it up:
+Steps 5 onwards differ depending on which API you are using.
+
+**Running with the local API**
+5. The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
+    ```
+    API_ROOT=http://localhost:8000
+    REDIS_HOST=localhost
+    REDIS_URL=redis://localhost:6379
+    ```
+
+6. Bring up Data Hub API via the `docker-compose up` command or natively, using the instructions outlined in Data Hub API's `README.md`.
+
+7. Go to [Django Admin](http://localhost:8000/admin/add-access-token/) and get an access token. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
+
+8.  Start the node server
+
+    **In development mode:**
+
+    ```bash
+    npm run develop
+    ```
+
+    The server will watch for changes and rebuild sass or compile js using webpack as
+    needed. Changes to server side code will result in the server autorestarting.
+    The server will run with the node debug flag so you can debug with Webstorm
+    or Visual Studio Code.
+
+
+**Running with other APIs (e.g. staging)**
+
+5. Go to Vault, look in datahub-fe, and add the relevant environment variables specified in the `.env` file for the environment you are interested in developing with.
+
+6. The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
+    ```
+    REDIS_HOST=localhost
+    REDIS_URL=redis://localhost:6379
+    ```
+
+7.  [Install](./docs/Installing%20redis%20natively.md) the redis server and bring it up:
 
     ```bash
     redis-server
@@ -78,21 +116,8 @@ Please view the dedicated [Docker readme](./docs/Docker.md).
     docker run -it -p 6379:6379 redis:3.2
     ```
 
-6.  Start the mocked SSO:
-
-    ```bash
-    docker run -it -p 8080:8080 gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
-    ```
-
-7.  Start the mocked backend (this command is included in `.bin.sample` as `start-sandbox`):
-
-    ```bash
-    cd test/sandbox
-    docker build -t data-hub-sandbox .
-    docker run --rm --name data-hub-sandbox -it -p 8001:8000 data-hub-sandbox
-    ```
-
-8.  Start the node server
+8.
+9.  Start the node server
 
     **In production mode:**
 
@@ -114,9 +139,24 @@ Please view the dedicated [Docker readme](./docs/Docker.md).
     The server will run with the node debug flag so you can debug with Webstorm
     or Visual Studio Code.
 
-### Working with live SSO
+### Working with SSO
 
-To use the live SSO service, add the environment variables from sample.env below the line `To use live SSO` into your `.env` file and uncomment
+**Mock SSO**
+
+To use the mock SSO service, add the environment variables from sample.env below the line `To use mock-SSO` into your `.env` file and uncomment.
+
+  Start the mocked SSO:
+
+    ```bash
+    docker run -it -p 8080:8080 gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
+    ```
+
+
+**Live SSO**
+
+To use the live SSO service, add the environment variables from sample.env below the line `To use live SSO` into your `.env` file and uncomment.
+
+Set SSO_ENABLED=false
 
 Then restart your development environment
 

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ Please view the dedicated [Docker readme](./docs/Docker.md).
     cp sample.env .env
     ```
 
-Steps 5 onwards differ depending on which API you are using.
+Steps 5 onwards differ depending on which API you are using. Skip to section 'Running with the local API' or 'Running with other APIs (e.g. staging)' depending on what you want to do.
 
 **Running with the local API**
+
 5. The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
     ```
     API_ROOT=http://localhost:8000
@@ -96,15 +97,20 @@ Steps 5 onwards differ depending on which API you are using.
 
 **Running with other APIs (e.g. staging)**
 
-5. Go to Vault, look in datahub-fe, and add the relevant environment variables specified in the `.env` file for the environment you are interested in developing with.
+5. Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments) and use the Admin URLs to set the environment variable `API_ROOT`.
+6. Go to Vault, look in datahub-fe, and click on the environment you want to use. Change the following environment variables in your `.env` file to the ones specified in Vault:
+    ``` 
+    DATA_HUB_BACKEND_ACCESS_KEY_ID=frontend-key-id
+    DATA_HUB_BACKEND_SECRET_ACCESS_KEY=frontend-key
+    ```
 
-6. The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
+7. The environment variables copied from Vault and `sample.env` are set up for running both the frontend and the API using the docker. To run the frontend natively, the following variables will need to be changed to:
     ```
     REDIS_HOST=localhost
     REDIS_URL=redis://localhost:6379
     ```
 
-7.  [Install](./docs/Installing%20redis%20natively.md) the redis server and bring it up:
+8.  [Install](./docs/Installing%20redis%20natively.md) the redis server and bring it up:
 
     ```bash
     redis-server
@@ -116,8 +122,9 @@ Steps 5 onwards differ depending on which API you are using.
     docker run -it -p 6379:6379 redis:3.2
     ```
 
-8.
-9.  Start the node server
+9. Go to the Django admin site for your relevant environment and get an access token by adding the following path `/add-access-token/` to the URL. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
+
+10.  Start the node server
 
     **In production mode:**
 
@@ -143,7 +150,9 @@ Steps 5 onwards differ depending on which API you are using.
 
 **Mock SSO**
 
-To use the mock SSO service, add the environment variables from sample.env below the line `To use mock-SSO` into your `.env` file and uncomment.
+To use the mock SSO service, add the environment variables from `sample.env` below the line 'To use mock-SSO' into your `.env` file and uncomment.
+
+Set `SSO_ENABLED=true`
 
   Start the mocked SSO:
 
@@ -154,9 +163,9 @@ To use the mock SSO service, add the environment variables from sample.env below
 
 **Live SSO**
 
-To use the live SSO service, add the environment variables from sample.env below the line `To use live SSO` into your `.env` file and uncomment.
+To use the live SSO service, add the environment variables from `sample.env` below the line 'To use live SSO' into your `.env` file and uncomment.
 
-Set SSO_ENABLED=false
+Set `SSO_ENABLED=true`
 
 Then restart your development environment
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Use this method if you want to make backend changes or run against an API branch
 
 This method is recommended if you are only making frontend changes.
 
-5.  Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments) and use the Admin URLs to set the environment variable `API_ROOT`. You will need to remove `/admin` from the end of the API paths.
+5.  Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments), find the environment you want to use in the Admin URLs section, and set this URL to the environment variable `API_ROOT`. You will need to remove `/admin` from the end of the API path.
 
 6.  Go to Vault, look in datahub-fe, and click on the environment you want to use. Change the following environment variables in your `.env` file to the ones specified in Vault:
     ``` 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
 
 **Running with the local API**
 
+Use this method if you want to make backend changes or run against an API branch which hasn't yet been deployed.
+
 5.  The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
     ```
     API_ROOT=http://localhost:8000
@@ -104,6 +106,8 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
 
 **Running with other APIs (e.g. staging)**
 
+This method is recommended if you are only making frontend changes.
+
 5.  Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments) and use the Admin URLs to set the environment variable `API_ROOT`. You will need to remove `/admin` from the end of the API paths.
 
 6.  Go to Vault, look in datahub-fe, and click on the environment you want to use. Change the following environment variables in your `.env` file to the ones specified in Vault:
@@ -112,7 +116,7 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
     DATA_HUB_BACKEND_SECRET_ACCESS_KEY=frontend-key
     ```
 
-7.  The environment variables copied from Vault and `sample.env` are set up for running both the frontend and the API using the docker. To run the frontend natively, the following variables will need to be changed to:
+7.  The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker. To run the frontend natively, the following variables will need to be changed to:
     ```
     REDIS_HOST=localhost
     REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -70,18 +70,26 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
 
 **Running with the local API**
 
-5. The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
+5.  The environment variables copied from `sample.env` are set up for running both the frontend and the API using the docker set-up outlined [here](./docs/Docker.md). To run the frontend natively, the following variables will need to be changed to:
     ```
     API_ROOT=http://localhost:8000
     REDIS_HOST=localhost
     REDIS_URL=redis://localhost:6379
     ```
 
-6. Bring up Data Hub API via the `docker-compose up` command or natively, using the instructions outlined in Data Hub API's `README.md`.
+6.  Bring up Data Hub API using the instructions outlined in the repository's [`README.md`](https://github.com/uktrade/data-hub-api/blob/develop/README.md).
 
-7. Go to [Django Admin](http://localhost:8000/admin/add-access-token/) and get an access token. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
+7.  Go to http://localhost:8000/admin/add-access-token/ to get an access token. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
 
 8.  Start the node server
+
+    **In production mode:**
+
+    ```bash
+    export NODE_ENV=production
+    npm run build && npm start
+    ```
+    This will build static assets beforehand and then run the app.
 
     **In development mode:**
 
@@ -94,17 +102,17 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
     The server will run with the node debug flag so you can debug with Webstorm
     or Visual Studio Code.
 
-
 **Running with other APIs (e.g. staging)**
 
-5. Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments) and use the Admin URLs to set the environment variable `API_ROOT`.
-6. Go to Vault, look in datahub-fe, and click on the environment you want to use. Change the following environment variables in your `.env` file to the ones specified in Vault:
+5.  Go to the [Playbook](https://readme.trade.gov.uk/docs/playbooks/datahub.html#environments) and use the Admin URLs to set the environment variable `API_ROOT`. You will need to remove `/admin` from the end of the API paths.
+
+6.  Go to Vault, look in datahub-fe, and click on the environment you want to use. Change the following environment variables in your `.env` file to the ones specified in Vault:
     ``` 
     DATA_HUB_BACKEND_ACCESS_KEY_ID=frontend-key-id
     DATA_HUB_BACKEND_SECRET_ACCESS_KEY=frontend-key
     ```
 
-7. The environment variables copied from Vault and `sample.env` are set up for running both the frontend and the API using the docker. To run the frontend natively, the following variables will need to be changed to:
+7.  The environment variables copied from Vault and `sample.env` are set up for running both the frontend and the API using the docker. To run the frontend natively, the following variables will need to be changed to:
     ```
     REDIS_HOST=localhost
     REDIS_URL=redis://localhost:6379
@@ -122,9 +130,9 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
     docker run -it -p 6379:6379 redis:3.2
     ```
 
-9. Go to the Django admin site for your relevant environment and get an access token by adding the following path `/add-access-token/` to the URL. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
+9.  Go to the Django admin site for your relevant environment and get an access token by adding the following path `/add-access-token/` to the URL. Add a frontend environment variable `OAUTH2_DEV_TOKEN` and set this as equal to the access token. 
 
-10.  Start the node server
+10. Start the node server
 
     **In production mode:**
 
@@ -132,7 +140,6 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
     export NODE_ENV=production
     npm run build && npm start
     ```
-
     This will build static assets beforehand and then run the app.
 
     **In development mode:**
@@ -148,28 +155,26 @@ Steps 5 onwards differ depending on which API you are using. Skip to section 'Ru
 
 ### Working with SSO
 
+`SSO_ENABLED` is set to false by default which will bypass any authentication. However, if working on integration with SSO, these sets of instructions can be followed to enable SSO. 
+
 **Mock SSO**
 
 To use the mock SSO service, add the environment variables from `sample.env` below the line 'To use mock-SSO' into your `.env` file and uncomment.
 
-Set `SSO_ENABLED=true`
+Set `SSO_ENABLED=true`  and start the mocked SSO:
 
-  Start the mocked SSO:
-
-    ```bash
-    docker run -it -p 8080:8080 gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
-    ```
+```bash
+docker run -it -p 8080:8080 gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
+```
 
 
 **Live SSO**
 
 To use the live SSO service, add the environment variables from `sample.env` below the line 'To use live SSO' into your `.env` file and uncomment.
 
-Set `SSO_ENABLED=true`
+Set `SSO_ENABLED=true` and then restart your development environment.
 
-Then restart your development environment
-
-These instructions work for both the dockerised environment and the native environment
+These instructions work for both the dockerised environment and the native environment.
 
 ### Environment variables
 


### PR DESCRIPTION
## Description of change

This PR updates and clarifies the read me instructions on how to get Data Hub running natively. Included are instructions on how to use different APIs. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
