### PR TITLE
Update celery command to version 5 syntax

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -35,7 +35,7 @@ services:
       - es
       - redis
     entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
-    command: celery worker -A config -l info -Q celery -B
+    command: celery -A config worker -l info -Q celery -B
 
   postgres:
     image: postgres:12


### PR DESCRIPTION
## Description of change

This PR updates the celery command used when building the back end containers in docker for our e2e tests.

This command uses the API's version of celery, which has been updated to version 5.2.2. In version 5, the `-A` app flag is applied to the celery command, rather than any sub commands.

## Test instructions

E2e tests should be passing

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
