### PR TITLE
Fix for event services dropdown

### DIFF
--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -32,6 +32,13 @@ async function getMetadataOptions(
     : data.map(transformMetadataOption)
 }
 
+/**
+ * Get an alphabetically sorted list of metadata options filtered by disabled on and context
+ * @url the metadata endpoint
+ * @context the service context for which to filter on
+ * @filterDisabled whether to filter each option based on its
+ * disabled_on key, defaulting to true
+ */
 async function getMetadataWithContextOptions(
   url,
   context,
@@ -47,6 +54,7 @@ async function getMetadataWithContextOptions(
   return filteringDisabledOptions
     .filter((service) => service.contexts.includes(context))
     .map(transformMetadataOption)
+    .sort((service1, service2) => (service1.label > service2.label ? 1 : -1))
 }
 
 /**

--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -9,10 +9,9 @@ const HQ_TYPE_LABELS = {
 const filterDisabledOption = ({ disabled_on }) =>
   disabled_on ? Date.parse(disabled_on) > Date.now() : true
 
-const transformMetadataOption = ({ id, name, contexts }) => ({
+const transformMetadataOption = ({ id, name }) => ({
   value: id,
   label: name,
-  contexts: contexts,
 })
 
 /**
@@ -33,6 +32,23 @@ async function getMetadataOptions(
     : data.map(transformMetadataOption)
 }
 
+async function getMetadataWithContextOptions(
+  url,
+  context,
+  { filterDisabled = true, params = {} } = {}
+) {
+  const { data } = await axios.get(url, {
+    params,
+  })
+  const filteringDisabledOptions = filterDisabled
+    ? data.filter(filterDisabledOption)
+    : data
+
+  return filteringDisabledOptions
+    .filter((service) => service.contexts.includes(context))
+    .map(transformMetadataOption)
+}
+
 /**
  * Get the hq type options as a list of values and labels
  */
@@ -46,4 +62,8 @@ const getHeadquarterTypeOptions = (url) =>
       .sort((item1, item2) => (item1.label > item2.label ? 1 : -1))
   )
 
-export { getMetadataOptions, getHeadquarterTypeOptions }
+export {
+  getMetadataOptions,
+  getHeadquarterTypeOptions,
+  getMetadataWithContextOptions,
+}

--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -9,9 +9,10 @@ const HQ_TYPE_LABELS = {
 const filterDisabledOption = ({ disabled_on }) =>
   disabled_on ? Date.parse(disabled_on) > Date.now() : true
 
-const transformMetadataOption = ({ id, name }) => ({
+const transformMetadataOption = ({ id, name, contexts }) => ({
   value: id,
   label: name,
+  contexts: contexts,
 })
 
 /**

--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -152,7 +152,9 @@ export const EventFormFields = ({ values }) => (
       name="service"
       label="Service"
       required="Select at least one service"
-      options={values?.metadata?.services}
+      options={values?.metadata?.services.filter((service) =>
+        service.contexts.includes('event')
+      )}
       placeholder="Select service"
       aria-label="Select a service"
       noOptionsMessage={() => <span>No service found</span>}

--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -152,9 +152,7 @@ export const EventFormFields = ({ values }) => (
       name="service"
       label="Service"
       required="Select at least one service"
-      options={values?.metadata?.services.filter((service) =>
-        service.contexts.includes('event')
-      )}
+      options={values?.metadata?.services}
       placeholder="Select service"
       aria-label="Select a service"
       noOptionsMessage={() => <span>No service found</span>}

--- a/src/client/modules/Events/EventForm/tasks.js
+++ b/src/client/modules/Events/EventForm/tasks.js
@@ -1,5 +1,8 @@
 import urls from '../../../../lib/urls'
-import { getMetadataOptions } from '../../../../client/metadata'
+import {
+  getMetadataOptions,
+  getMetadataWithContextOptions,
+} from '../../../../client/metadata'
 import { transformResponseToEventForm } from './transformers'
 import {
   catchApiError,
@@ -22,7 +25,7 @@ const getEventFormAndMetadata = (data) => {
     getMetadataOptions(urls.metadata.locationType()),
     getMetadataOptions(urls.metadata.country()),
     getMetadataOptions(urls.metadata.team()),
-    getMetadataOptions(urls.metadata.service()),
+    getMetadataWithContextOptions(urls.metadata.service(), 'event'),
     getMetadataOptions(urls.metadata.programme()),
     getMetadataOptions(urls.metadata.ukRegion()),
     getEventDetails(data.eventId),

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -228,7 +228,7 @@ describe('Event create', () => {
         },
         eventShared: true,
         teams: ['BPI', 'BN America', 'BPI'],
-        service: 'Making Other Introductions : UK Export Finance (UKEF)',
+        service: 'Events : Market Visit',
       })
 
       const expectedBody = {
@@ -246,7 +246,7 @@ describe('Event create', () => {
         address_country: '80756b9a-5d95-e211-a939-e4115bead28a',
         notes: 'Testing a valid form for all fields',
         lead_team: '08c14624-2f50-e311-a56a-e4115bead28a',
-        service: '6fd4b203-8e73-4a39-96ea-188bdb623b69',
+        service: '340bba2b-3499-e211-a939-e4115bead28a',
         organiser: '3442c516-9898-e211-a939-e4115bead28a',
         event_shared: true,
         related_programmes: [


### PR DESCRIPTION
## Description of change
Maintenance ticket: https://uktrade.atlassian.net/jira/software/projects/CPS/boards/228?selectedIssue=CPS-282
This is a fix for the services dropdown list on the Add / Edit Event form. Previously, the dropdown contained 100 + services due it pulling _all_ the services from metadata (i.e. interactions services were displaying too). This PR, filters but 'event' context so only the event services are displayed. 

This should also fix the original bug on the maintenance ticket, where by attendees were not able to be added to Events (this bug was occurring for services that will no longer be in the drop down following this PR being merged).

## Test instructions
- Checkout `bug/cds-282-event-services`
- Go to Events, and click on Add Event. 
- Scroll down and click on Services. You should be able to see 15 services only. 

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/70902973/149753623-bd52e6af-f7fb-446e-9342-44f7f74187eb.png)


### After
![image](https://user-images.githubusercontent.com/70902973/149753526-44960a79-c59b-48eb-8b4d-faa7f1b946ee.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
