### PR TITLE
Add marked to resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32073,6 +32073,14 @@
       "requires": {
         "loader-utils": "^1.2.3",
         "marked": "^0.7.0"
+      },
+      "dependencies": {
+        "marked": {
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+          "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+          "dev": true
+        }
       }
     },
     "markdown-to-jsx": {
@@ -32084,12 +32092,6 @@
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
       }
-    },
-    "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
-      "dev": true
     },
     "md5": {
       "version": "2.2.1",
@@ -45380,6 +45382,12 @@
         "vuex": "^3.1.0"
       },
       "dependencies": {
+        "marked": {
+          "version": "4.0.10",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.10.tgz",
+          "integrity": "sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==",
+          "dev": true
+        },
         "prismjs": {
           "version": "1.25.0",
           "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",

--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "nth-check": "2.0.1",
     "json-schema": "0.4.0",
     "jsonpointer": ">=5.0.0",
-    "node-forge": ">=1.0.0"
+    "node-forge": ">=1.0.0",
+    "marked": "4.0.10"
   }
 }


### PR DESCRIPTION
## Description of change

We currently have a high severity vulnerability for the `marked` dependency. This is a deep dependency of one of our Storybook addons, which isn't being maintained anymore. In order to prevent this from going critical I have added this to resolutions until a suitable replacement is found (I have already attempted adding the official Storybook docs addon but couldn't get it working).

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
