### PR TITLE
Revert "Update celery command to version 5 syntax"

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -35,7 +35,7 @@ services:
       - es
       - redis
     entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 5m
-    command: celery -A config worker -l info -Q celery -B
+    command: celery worker -A config -l info -Q celery -B
 
   postgres:
     image: postgres:12


### PR DESCRIPTION
Reverts uktrade/data-hub-frontend#4280

Now that the Celery version has been rolled back to v4, the e2e commands need to be rolled back as well.