### PR TITLE
Add search category to search analytics data

### DIFF
--- a/assets/javascripts/modules/search-analytics.js
+++ b/assets/javascripts/modules/search-analytics.js
@@ -12,13 +12,17 @@ const SearchAnalytics = {
     }
   },
 
-  pushAnalyticsEvent({ searchResultRank, searchResultPageNumber }) {
+  pushAnalyticsEvent({
+    searchResultRank,
+    searchResultPageNumber,
+    searchCategory,
+  }) {
     window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
       event: 'searchResultClick',
       searchResultPageNumber,
       searchResultRank,
-      searchCategory: 'Contacts',
+      searchCategory,
     })
   },
 
@@ -28,6 +32,7 @@ const SearchAnalytics = {
       this.pushAnalyticsEvent({
         searchResultRank: target.dataset.searchResultRank,
         searchResultPageNumber: this.pageNumber,
+        searchCategory: target.dataset.searchCategory,
       })
     }
   },

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -55,6 +55,7 @@
               href="{{ url }}"
               class="c-entity__link js-search-entity"
               data-search-result-rank="{{ props.index }}"
+              data-search-category="{{ props.type }}"
             >
               {{ highlightedName }}
             </a>


### PR DESCRIPTION
## Description of change

Adds search ctageory to search analytics data layer

## Test instructions

Category should be added when clicking a search entity from the search results

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
