### PR TITLE
Only collect analytics on search entities with an index and category

### DIFF
--- a/src/templates/_macros/entity/entity-list.njk
+++ b/src/templates/_macros/entity/entity-list.njk
@@ -16,7 +16,7 @@
           isBlockLink: hasBlockLinks,
           preventDoubleClick: props.preventDoubleClick,
           features: props.features,
-          index: loop.index0
+          index: loop.index
         })) }}
       </li>
     {% endfor %}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -53,7 +53,7 @@
           {% if props.id and not props.isBlockLink %}
             <a
               href="{{ url }}"
-              class="c-entity__link js-search-entity"
+              class="c-entity__link{% if props.index and props.type %} js-search-entity{% endif %}"
               data-search-result-rank="{{ props.index }}"
               data-search-category="{{ props.type }}"
             >


### PR DESCRIPTION
## Description of change

Fixes search analsytics by not pushing search entities without an index / category

## Test instructions

Analytics should not send any events with an undefined search index or category

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
