### PR TITLE
Correct search onclick event delegation by using currentTarget

### DIFF
--- a/assets/javascripts/modules/search-analytics.js
+++ b/assets/javascripts/modules/search-analytics.js
@@ -27,7 +27,7 @@ const SearchAnalytics = {
   },
 
   onClickHandler(e) {
-    const target = e.target
+    const target = e.currentTarget
     if (target) {
       this.pushAnalyticsEvent({
         searchResultRank: target.dataset.searchResultRank,


### PR DESCRIPTION
## Description of change

When clicking a search result, we often get 'undefined' for rank and category - I believe this is due to bad event delegation. Using `e.currentTarget` instead of `e.target` should fix this.

## Test instructions

Click a search result and the correct data should get pushed to the data layer.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
