### PR TITLE
Remove the 'Add investment project' button feature flag

### DIFF
--- a/src/apps/companies/apps/investments/projects/controllers/list.js
+++ b/src/apps/companies/apps/investments/projects/controllers/list.js
@@ -1,9 +1,7 @@
 const urls = require('../../../../../../lib/urls')
 
 function renderProjects(req, res) {
-  const { company, returnUrl, dnbRelatedCompaniesCount, features } = res.locals
-  const hideAddInvestmentButtonEnabled =
-    features['company-hide-add-investment-button-for-uk'] ?? false
+  const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
   res.locals.title = `Investments - ${company.name} - Companies`
 
   res.render('companies/apps/investments/projects/views/list', {
@@ -20,7 +18,6 @@ function renderProjects(req, res) {
       ],
       returnUrl,
       dnbRelatedCompaniesCount,
-      hideAddInvestmentButtonEnabled,
     },
   })
 }

--- a/src/apps/investments/client/projects/CompanyProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/CompanyProjectsCollection.jsx
@@ -18,7 +18,6 @@ const CompanyProjectsCollection = ({
   payload,
   optionMetadata,
   selectedFilters,
-  hideAddInvestmentButtonEnabled,
   ...props
 }) => {
   const collectionListTask = {
@@ -55,7 +54,7 @@ const CompanyProjectsCollection = ({
         taskProps={collectionListTask}
         selectedFilters={selectedFilters}
         addItemUrl={
-          company.archived || (hideAddInvestmentButtonEnabled && isUkCompany)
+          company.archived || isUkCompany
             ? null
             : `/investments/projects/create/${company.id}`
         }

--- a/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+++ b/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
@@ -2,9 +2,5 @@
   {
     "code": "cfe1",
     "is_active": true
-  },
-  {
-    "code": "company-hide-add-investment-button-for-uk",
-    "is_active": true
   }
 ]


### PR DESCRIPTION
## Description of change
We removed the 'Add investment project' button from all UK companies (you can't add an investment to a UK company) on the 13th January, some three weeks ago. Today, we remove the code supporting the feature flag.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
