### PR TITLE
Scroll to top when navigating between add interaction form steps

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -6,9 +6,9 @@ import { Route } from 'react-router-dom'
 
 import StepInteractionType from './StepInteractionType'
 import StepInteractionDetails from './StepInteractionDetails'
-import Step from '../../../../../client/components/Form/elements/Step.jsx'
+import Step from '../../../../../client/components/Form/elements/Step'
 import Task from '../../../../../client/components/Task'
-import Form from '../../../../../client/components/Form/index.jsx'
+import Form from '../../../../../client/components/Form'
 import {
   ID as STATE_ID,
   TASK_SAVE_INTERACTION,
@@ -122,6 +122,7 @@ const InteractionDetailsForm = ({
                       data.was_policy_feedback_provided
                     )
                   }
+                  scrollToTopOnStep={true}
                 >
                   {({ values, currentStep }) => (
                     <>

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -63,6 +63,7 @@ const _Form = ({
   children,
   initialValues,
   redirectMode = 'hard',
+  scrollToTopOnStep = false,
   // TODO: Allow for react router redirection
   reactRouterRedirect,
   transformInitialValues = (x) => x,
@@ -84,6 +85,9 @@ const _Form = ({
   useEffect(() => {
     onLoad(initialValues, initialStepIndex)
   }, [])
+  useEffect(() => {
+    scrollToTopOnStep && window.scrollTo(0, 0)
+  }, [scrollToTopOnStep, props.currentStep])
 
   // TODO: Clean up this mess
   const contextProps = {
@@ -477,6 +481,8 @@ const dispatchToProps = (dispatch) => ({
  * representing the index of the step which the user will land on when the form
  * is rendered, if the form has multiple steps. This is then set as the currentStep
  * property in the form's state.
+ * @param {Props['scrollToTopOnStep']} [props.scrollToTopOnStep] - Whether or not page
+ * should scroll to the top when navigating between steps.
  * */
 const Form = multiInstance({
   name: 'Form',
@@ -500,6 +506,7 @@ Form.propTypes = {
   transformInitialValues: PropTypes.func,
   transformPayload: PropTypes.func,
   initialStepIndex: PropTypes.number,
+  scrollToTopOnStep: PropTypes.bool,
 }
 
 export default Form


### PR DESCRIPTION
## Description of change

Scrolls the page to the stop when navigating between the add interaction form steps.

https://uktrade.atlassian.net/browse/RR-314

## Test instructions

Step 1:  Go to companies & choose a company

Step 2:  Click add interaction button 

Step 3: Select other & standard interaction

Step 4: The page should start at the top and show the ‘Service’ sub-title.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
