### PR TITLE
Add analytics on search results etc

### DIFF
--- a/assets/javascripts/modules/search-analytics.js
+++ b/assets/javascripts/modules/search-analytics.js
@@ -1,13 +1,35 @@
 const searchEntitySelector = '.js-search-entity'
+const searchResultsSelector = '.js-search-results'
 
 const SearchAnalytics = {
   init() {
+    window.dataLayer = window.dataLayer || []
+
     this.pageNumber =
       new URLSearchParams(window.location.search).get('page') || 1
     const entities = document.querySelectorAll(searchEntitySelector)
     if (entities) {
       for (let i = 0; i < entities.length; i++) {
         entities[i].addEventListener('click', this.onClickHandler.bind(this))
+      }
+    }
+    const searchResults = document.querySelectorAll(searchResultsSelector)
+    if (searchResults?.length) {
+      if (!sessionStorage.getItem('searchCount')) {
+        sessionStorage.setItem('searchCount', 1)
+      } else if (this.pageNumber == 1) {
+        // Only increment search count when visiting first page of results
+        sessionStorage.setItem(
+          'searchCount',
+          parseInt(sessionStorage.getItem('searchCount')) + 1
+        )
+      }
+      for (let i = 0; i < searchResults.length; i++) {
+        window.dataLayer.push({
+          searchCategory: searchResults[i].dataset.searchCategory,
+          resultsReturned: searchResults[i].dataset.resultsReturned,
+          countOfSearch: sessionStorage.getItem('searchCount'),
+        })
       }
     }
   },
@@ -17,7 +39,6 @@ const SearchAnalytics = {
     searchResultPageNumber,
     searchCategory,
   }) {
-    window.dataLayer = window.dataLayer || []
     window.dataLayer.push({
       event: 'searchResultClick',
       searchResultPageNumber,

--- a/src/templates/_macros/collection-header/template.njk
+++ b/src/templates/_macros/collection-header/template.njk
@@ -8,7 +8,11 @@
 
 <header class="c-collection__header">
   <div class="c-collection__header-row">
-    <h2 class="c-collection__header-intro">
+    <h2
+      class="c-collection__header-intro js-search-results"
+      data-results-returned="{{ count }}"
+      data-search-category="{{ props.type }}"
+    >
       <span class="c-collection__result-count">{{ count | formatNumber }}</span>
       {{ countLabel | pluralise(count) }}
       {% if props.highlightTerm or selectedFilters | length %}


### PR DESCRIPTION
## Description of change

Adds extra search analytics regarding the number of results returned and how many searches have been carried out in a session.

## Test instructions

The number of search results and the count of searches made in a session should be pushed to the data layer after making a new search.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
