### PR TITLE
WIP: Add routing to the Form component

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -123,6 +123,7 @@ const InteractionDetailsForm = ({
                     )
                   }
                   scrollToTopOnStep={true}
+                  showStepInURL={true}
                 >
                   {({ values, currentStep }) => (
                     <>

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -72,6 +72,7 @@ export const FORM__STEP_REGISTER = 'FORM__STEP_REGISTER'
 export const FORM__STEP_DEREGISTER = 'FORM__STEP_DEREGISTER'
 export const FORM__FORWARD = 'FORM__FORWARD'
 export const FORM__BACK = 'FORM__BACK'
+export const FORM__GO_TO_STEP = 'FORM__GO_TO_STEP'
 export const FORM__VALIDATE = 'FORM__VALIDATE'
 export const FORM__RESOLVED = 'FORM__RESOLVED'
 

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -65,6 +65,7 @@ const _Form = ({
   initialValues,
   redirectMode = 'hard',
   scrollToTopOnStep = false,
+  showStepInURL = false,
   reactRouterRedirect,
   transformInitialValues = (x) => x,
   transformPayload = (x) => x,
@@ -95,7 +96,7 @@ const _Form = ({
   }, [scrollToTopOnStep, props.currentStep])
   useEffect(() => {
     goToStep(parseInt(qsParams.step) || 0)
-  }, [qsParams])
+  }, [qsParams.step])
 
   // TODO: Clean up this mess
   const contextProps = {
@@ -157,12 +158,14 @@ const _Form = ({
                     analytics('previous step', {
                       currentStep: props.currentStep,
                     })
-                    history.push({
-                      search: qs.stringify({
-                        ...qsParams,
-                        step: props.currentStep - 1,
-                      }),
-                    })
+                    if (showStepInURL) {
+                      history.push({
+                        search: qs.stringify({
+                          ...qsParams,
+                          step: props.currentStep - 1,
+                        }),
+                      })
+                    }
                   }}
                   validateForm={(fieldNamesToValidate) => {
                     // This method is supposed to validate only the fields whose names
@@ -214,12 +217,14 @@ const _Form = ({
                                   analytics('Next step', {
                                     currentStep: props.currentStep,
                                   })
-                                  history.push({
-                                    search: qs.stringify({
-                                      ...qsParams,
-                                      step: props.currentStep + 1,
-                                    }),
-                                  })
+                                  if (showStepInURL) {
+                                    history.push({
+                                      search: qs.stringify({
+                                        ...qsParams,
+                                        step: props.currentStep + 1,
+                                      }),
+                                    })
+                                  }
                                 }
                               } else {
                                 requestAnimationFrame(() =>

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -87,6 +87,9 @@ const _Form = ({
   const history = useHistory()
   const location = useLocation()
   const qsParams = qs.parse(location.search.slice(1))
+  // Grabs the params from the url.
+
+  const searchy = qs.parse(location.pathname.includes('/create'))
 
   useEffect(() => {
     onLoad(initialValues, initialStepIndex)
@@ -95,17 +98,22 @@ const _Form = ({
     scrollToTopOnStep && window.scrollTo(0, 0)
   }, [scrollToTopOnStep, props.currentStep])
   useEffect(() => {
-    if (qsParams.step) {
-      goToStep(qsParams.step)
-    } else {
-      history.push({
-        search: qs.stringify({
-          ...qsParams,
-          step: steps[initialStepIndex],
-        }),
-      })
+    if (showStepInURL && searchy) {
+      if (qsParams.step) {
+        goToStep(qsParams.step)
+        // if there's a step in the params, use goToStep("")
+      } else {
+        // Otherwise, push the initial step name to the URL as the step.
+        history.push({
+          search: qs.stringify({
+            ...qsParams,
+            step: steps[initialStepIndex],
+          }),
+        })
+      }
     }
   }, [qsParams.step, steps])
+  // Run this code any time the step in the url changes, or the names of the steps.
 
   // TODO: Clean up this mess
   const contextProps = {
@@ -168,6 +176,7 @@ const _Form = ({
                       currentStep: props.currentStep,
                     })
                     if (showStepInURL) {
+                      // if showStepInURL is true, then push the previous step's name to the url.
                       history.push({
                         search: qs.stringify({
                           ...qsParams,
@@ -227,6 +236,7 @@ const _Form = ({
                                     currentStep: props.currentStep,
                                   })
                                   if (showStepInURL) {
+                                    // if showStepInURL is true, then push the next step's name to the url.
                                     history.push({
                                       search: qs.stringify({
                                         ...qsParams,

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -89,8 +89,6 @@ const _Form = ({
   const qsParams = qs.parse(location.search.slice(1))
   // Grabs the params from the url.
 
-  const searchy = qs.parse(location.pathname.includes('/create'))
-
   useEffect(() => {
     onLoad(initialValues, initialStepIndex)
   }, [])
@@ -98,18 +96,20 @@ const _Form = ({
     scrollToTopOnStep && window.scrollTo(0, 0)
   }, [scrollToTopOnStep, props.currentStep])
   useEffect(() => {
-    if (showStepInURL && searchy) {
+    if (showStepInURL) {
       if (qsParams.step) {
         goToStep(qsParams.step)
         // if there's a step in the params, use goToStep("")
       } else {
         // Otherwise, push the initial step name to the URL as the step.
-        history.push({
-          search: qs.stringify({
-            ...qsParams,
-            step: steps[initialStepIndex],
-          }),
-        })
+        if (history.action != 'POP') {
+          history.push({
+            search: qs.stringify({
+              ...qsParams,
+              step: steps[initialStepIndex],
+            }),
+          })
+        }
       }
     }
   }, [qsParams.step, steps])

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -95,8 +95,17 @@ const _Form = ({
     scrollToTopOnStep && window.scrollTo(0, 0)
   }, [scrollToTopOnStep, props.currentStep])
   useEffect(() => {
-    goToStep(parseInt(qsParams.step) || 0)
-  }, [qsParams.step])
+    if (qsParams.step) {
+      goToStep(qsParams.step)
+    } else {
+      history.push({
+        search: qs.stringify({
+          ...qsParams,
+          step: steps[initialStepIndex],
+        }),
+      })
+    }
+  }, [qsParams.step, steps])
 
   // TODO: Clean up this mess
   const contextProps = {
@@ -162,7 +171,7 @@ const _Form = ({
                       history.push({
                         search: qs.stringify({
                           ...qsParams,
-                          step: props.currentStep - 1,
+                          step: steps[props.currentStep - 1],
                         }),
                       })
                     }
@@ -221,7 +230,7 @@ const _Form = ({
                                     history.push({
                                       search: qs.stringify({
                                         ...qsParams,
-                                        step: props.currentStep + 1,
+                                        step: steps[props.currentStep + 1],
                                       }),
                                     })
                                   }
@@ -407,10 +416,10 @@ const dispatchToProps = (dispatch) => ({
     dispatch({
       type: 'FORM__BACK',
     }),
-  goToStep: (stepIndex) => {
+  goToStep: (stepName) => {
     dispatch({
       type: 'FORM__GO_TO_STEP',
-      stepIndex,
+      stepName,
     })
   },
   registerStep: (stepName) =>

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -12,6 +12,7 @@ import {
   FORM__STEP_REGISTER,
   FORM__VALIDATE,
   FORM__FIELD_TOUCHED,
+  FORM__GO_TO_STEP,
 } from '../../actions'
 
 export default (
@@ -23,7 +24,7 @@ export default (
     currentStep: 0,
     steps: [],
   },
-  { type, result, ...action }
+  { type, result, stepIndex, ...action }
 ) => {
   switch (type) {
     case FORM__LOADED:
@@ -101,6 +102,12 @@ export default (
       return {
         ...state,
         currentStep: state.currentStep - 1,
+        previousValues: state.values,
+      }
+    case FORM__GO_TO_STEP:
+      return {
+        ...state,
+        currentStep: stepIndex,
         previousValues: state.values,
       }
     case FORM__STEP_REGISTER:

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -24,7 +24,7 @@ export default (
     currentStep: 0,
     steps: [],
   },
-  { type, result, stepIndex, ...action }
+  { type, result, ...action }
 ) => {
   switch (type) {
     case FORM__LOADED:
@@ -105,9 +105,13 @@ export default (
         previousValues: state.values,
       }
     case FORM__GO_TO_STEP:
+      const nextCurrentStep = action.stepName
+        ? Math.max(state.steps.indexOf(action.stepName), 0)
+        : 0
       return {
         ...state,
-        currentStep: stepIndex,
+        currentStep: nextCurrentStep,
+
         previousValues: state.values,
       }
     case FORM__STEP_REGISTER:

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -106,7 +106,7 @@ export default (
       }
     case FORM__GO_TO_STEP:
       const nextCurrentStep = action.stepName
-        ? Math.max(state.steps.indexOf(action.stepName), 0)
+        ? state.steps.indexOf(action.stepName)
         : 0
       return {
         ...state,


### PR DESCRIPTION
## Description of change

This PR is a record of a spike towards adding the same functionality on the back button in the interactions form, to the browser back and forwards buttons. This is because users predominantly use the browser buttons to go back and forth in the interactions form, but they want to keep the selections they had made in each step as they move back and forth. 

The functionality and rules that need to apply are already implemented on the form's back button, we just need this functionality for browser buttons. 

What's been done? 
- We've added step params to the URLs in the forms so that the previous values can be loaded on each step. 
- We've amended the step params to be the names of the steps rather than the number of the steps. 

What needs to be completed? 
- To counteract a scenario where we don't have a step in the URL, we place in the initial step by default, however, this means any time we click the back button on the first step (aver visiting the second step) we can't leave the page as by default it puts the initial step in. To continue this work, we need to think of some logical conditions for where this default step injection should and shouldn't apply. 
- This PR also needs the tests amended to account for this new behaviour. 


## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
