### PR TITLE
Add checkbox exclusive selection between the last checkbox and all checkboxes that precede it

### DIFF
--- a/src/client/components/Form/elements/FieldCheckboxes/usage.md
+++ b/src/client/components/Form/elements/FieldCheckboxes/usage.md
@@ -43,6 +43,7 @@ Checkboxes for use in forms and filters.
 | `legend`       | false    | null                                                                    | node                           | Node for legend element                       |
 | `hint`         | false    | null                                                                    | node                           | Node for hint element                         |
 | `validate`     | false    | null                                                                    | function or array of functions | Validate functions for input                  |
-| `required`     | false    | `` | Boolean | Text 'required' sets wether the input is required or not |
-| `initialValue` | false    | `` | Text | Sets initial value of the input                             |
-| `options` | true | empty array | array | Defines the checkbox labels and values                     |
+| `required`     | false    | `` | boolean | Text 'required' sets wether the input is required or not |
+| `initialValue` | false    | [] | array of strings | Sets initial value of the input                 |
+| `options` | true | [] | array | Defines the checkbox labels and values                              |
+| `exclusive` | false | false | boolean | Splits the last checkbox from the others where the choice is exclusive between them|

--- a/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
@@ -98,3 +98,42 @@ storiesOf('Form/Form Elements/Checkboxes', module)
       )}
     </Form>
   ))
+  .add('Checkboxes - exclusive', () => (
+    <Form
+      id="fieldCheckboxExample"
+      analyticsFormName="fieldCheckboxExample"
+      submissionTaskName="Submit Form example"
+    >
+      {(form) => (
+        <>
+          <FieldCheckboxes
+            name="countries"
+            label="Estimated land date notification preferences"
+            hint="Select all that apply"
+            required="Select at least one country or select 'No, ...'"
+            exclusive={true}
+            initialValue={['no']}
+            options={[
+              {
+                label: 'France',
+                value: 'fr',
+              },
+              {
+                label: 'Portugal',
+                value: 'pr',
+              },
+              {
+                label: 'Spain',
+                value: 'sp',
+              },
+              {
+                label: 'No, I will not be travelling to any of these countries',
+                value: 'no',
+              },
+            ]}
+          />
+          <pre>{JSON.stringify(form, null, 2)}</pre>
+        </>
+      )}
+    </Form>
+  ))


### PR DESCRIPTION
## Description of change

Adding a new feature to the `Checkboxes.jsx` component that allows exclusive selection between the last checkbox and all checkboxes that precede it. To enable the new functionality simply set the `exclusive` prop on the component to `true`, the default is `false`.
 
<img width="558" alt="Screenshot 2022-02-28 at 09 02 04" src="https://user-images.githubusercontent.com/964268/155956267-cbd491b8-df36-42e4-9434-7dd1f06b1f50.png">

## Test instructions

`npm run storybook`

<img width="280" alt="Screenshot 2022-02-28 at 09 18 35" src="https://user-images.githubusercontent.com/964268/155956947-74284191-99fb-4ba9-a969-710cadb791dd.png">

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
