### PR TITLE
Improve the error message for this assertion.

### DIFF
--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -668,7 +668,15 @@ const assertParamNotContainedInUrl = (xhr, param) => {
  * Assert that the body of an intercepted request is as expected
  */
 const assertRequestBody = (xhr, expectedBody) => {
-  expect(xhr.request.body).to.deep.equal(expectedBody)
+  const printableXhr = JSON.stringify(xhr)
+  const printableExpectedBody = JSON.stringify(expectedBody)
+  expect(xhr.request.body).to.deep.equal(
+    expectedBody,
+    'Expected the request body to deep equal\n\n' +
+      printableExpectedBody +
+      '\n\nbut got\n\n' +
+      printableXhr
+  )
 }
 
 /**


### PR DESCRIPTION
It's involved in a flaky test, and it'd be nice to see what is wrong.