### PR TITLE
Update Ubuntu image in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ ignore_ghpages: &ignore_ghpages
 jobs:
   lint:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout
@@ -22,6 +23,7 @@ jobs:
 
   unit_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout
@@ -48,6 +50,7 @@ jobs:
 
   unit_client_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout
@@ -65,6 +68,7 @@ jobs:
 
   functional_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     parallelism: 9
     resource_class: xlarge
@@ -87,6 +91,7 @@ jobs:
 
   a11y_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout
@@ -98,6 +103,7 @@ jobs:
 
   visual_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout
@@ -111,6 +117,7 @@ jobs:
 
   visual_component_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     resource_class: xlarge
     steps:
@@ -125,6 +132,7 @@ jobs:
 
   e2e_tests_dit:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     parallelism: 3
     resource_class: xlarge
@@ -140,6 +148,7 @@ jobs:
 
   e2e_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     parallelism: 1
     resource_class: xlarge
@@ -155,6 +164,7 @@ jobs:
 
   component_tests:
     machine:
+      image: ubuntu-2004:202201-02
       docker_layer_caching: false
     steps:
       - checkout


### PR DESCRIPTION
## Description of change

CircleCI are planning on [deprecating their Ubuntu 14.04 image](https://circleci.com/blog/ubuntu-14-16-image-deprecation) in May (as Canonical won't be supporting it anymore). As there will be several planned outages before this date (with the first one coming up on the 29th), I've updated the image the FE suite uses to the latest available version.

## Test instructions

CircleCI should run as normal. The warning that is displayed about this issue shouldn't appear anymore.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
