### PR TITLE
Add an `npm` command to run selected unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "lint:js": "npx eslint --ext .jsx,.js ./test ./src ./assets",
     "lint:js:fix": "npx eslint --ext .jsx,.js ./test ./src ./assets --fix",
     "test": "run-s test:*",
+    "test:unit:files": "f() { NODE_ENV=test API_ROOT=http://test LOG_LEVEL=silent MOCHA_FILE=junit/test-results.xml npx mocha \"${@:-./src/**/*.test.js}\"; }; f",
     "test:unit": "NODE_ENV=test API_ROOT=http://test LOG_LEVEL=silent MOCHA_FILE=junit/test-results.xml npx mocha ./src/**/*.test.js",
     "test:functional": "CYPRESS_retries=3 nyc cypress run --browser chrome",
     "test:a11y": "CYPRESS_pluginsFile=test/a11y/plugins/index.js CYPRESS_supportFile=test/a11y/support/index.js CYPRESS_coverage=false CYPRESS_integrationFolder=test/a11y/cypress/specs cypress run --browser chrome",


### PR DESCRIPTION
## Description of change

I would like to be able to run selected unit tests rather than the whole
suite, so that we can do TDD more effectively.

I was going to edit the existing `test:unit` command but as this is used
by a couple of other commands where variables are passed in, it seems
like we need a new command.

## feedback

Maybe it's possible to do this already with the existing command? 
I'm not a master at shell commands so mainly copied this from [SO](https://stackoverflow.com/questions/51401352/if-else-on-arguments-in-npm-run-script) -
maybe there's a nicer way of doing it? 
Is there a nicer name for the command?

## Test instructions

run `npm run test:unit:files ./src/apps/events/attendees/controllers/__test__/create.test.js ./src/apps/omis/controllers/__test__/create.test.js` and you should see tests running for just those files


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
