### PR TITLE
Use get param for step in multi-step forms

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -123,6 +123,7 @@ const InteractionDetailsForm = ({
                     )
                   }
                   scrollToTopOnStep={true}
+                  showStepInUrl={true}
                 >
                   {({ values, currentStep }) => (
                     <>

--- a/src/client/actions.js
+++ b/src/client/actions.js
@@ -72,6 +72,7 @@ export const FORM__STEP_REGISTER = 'FORM__STEP_REGISTER'
 export const FORM__STEP_DEREGISTER = 'FORM__STEP_DEREGISTER'
 export const FORM__FORWARD = 'FORM__FORWARD'
 export const FORM__BACK = 'FORM__BACK'
+export const FORM__GO_TO_STEP = 'FORM__GO_TO_STEP'
 export const FORM__VALIDATE = 'FORM__VALIDATE'
 export const FORM__RESOLVED = 'FORM__RESOLVED'
 

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -12,6 +12,7 @@ import {
   FORM__STEP_REGISTER,
   FORM__VALIDATE,
   FORM__FIELD_TOUCHED,
+  FORM__GO_TO_STEP,
 } from '../../actions'
 
 export default (
@@ -101,6 +102,16 @@ export default (
       return {
         ...state,
         currentStep: state.currentStep - 1,
+        previousValues: state.values,
+      }
+    case FORM__GO_TO_STEP:
+      const nextCurrentStep = action.stepName
+        ? state.steps.indexOf(action.stepName)
+        : 0
+      return {
+        ...state,
+        currentStep: nextCurrentStep,
+
         previousValues: state.values,
       }
     case FORM__STEP_REGISTER:

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -498,6 +498,22 @@ describe('Interaction theme', () => {
         }
       )
     })
+
+    it('should persist form fields after navigating back', () => {
+      cy.url().should('include', '?step=interaction_details')
+      cy.contains(ELEMENT_SUBJECT.label)
+        .next()
+        .find('input')
+        .type('Persisting subject')
+      cy.go('back')
+      cy.url().should('include', '?step=interaction_type')
+      cy.contains('button', 'Continue').click()
+      cy.url().should('include', '?step=interaction_details')
+      cy.contains(ELEMENT_SUBJECT.label)
+        .next()
+        .find('input')
+        .should('have.attr', 'value', 'Persisting subject')
+    })
   })
 })
 
@@ -864,7 +880,9 @@ describe('Contact loop', () => {
       cy.contains('a', 'Cancel').should(
         'have.attr',
         'href',
-        urls.companies.interactions.create(company.id)
+        `${urls.companies.interactions.create(
+          company.id
+        )}?step=interaction_details`
       )
 
       cy.contains('div', 'First name').find('input').type('John')


### PR DESCRIPTION
## Description of change

Uses a get param to keep track of the step on multistep forms - this has been applied to the create interaction form

## Test instructions

Go to a company and select "create interaction" - the url should contain a get paramater with the step name. Clicking the browser nav back / forwards should allow you to navigate between steps without losing form data.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
