### PR TITLE
Fix investor cleared options failing to save

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/client/transformers.js
+++ b/src/apps/companies/apps/investments/large-capital-profile/client/transformers.js
@@ -34,6 +34,8 @@ export const transformInvestorDetailsToApi = ({
     notes_on_locations: investor_notes,
     required_checks_conducted: required_checks,
     required_checks_conducted_on: transformDateObjectToDateString(date),
-    required_checks_conducted_by: transformOption(adviser),
+    required_checks_conducted_by: adviser
+      ? transformOption(adviser)
+      : undefined,
   }
 }

--- a/src/client/transformers/index.js
+++ b/src/client/transformers/index.js
@@ -3,8 +3,13 @@ import { OPTION_NO, OPTION_YES } from '../../common/constants'
 import { format, isDateValid } from '../../client/utils/date'
 
 export const transformDateObjectToDateString = (value) => {
-  const dateString = `${value?.year}-${value?.month}-${value?.day}`
-  return dateString === '--' ? null : dateString
+  if (value) {
+    const dateString = `${value?.year ?? ''}-${value?.month ?? ''}-${
+      value?.day ?? ''
+    }`
+    return dateString === '--' ? null : dateString
+  }
+  return null
 }
 
 export const transformOption = (option) => {

--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -213,6 +213,37 @@ describe('View large capital investor details page', () => {
         assertFlashMessage('Investor details changes saved')
       })
     })
+
+    it('should save new investment with not yet checked', () => {
+      const expectedBody = {}
+
+      assertInvestorType().then((element) => {
+        selectFirstTypeaheadOption({ element, input: 'Asset manager' })
+      })
+      assertGlobalAssetsAmount().then((element) => {
+        clearAndTypeInput({ element, value: '500' })
+      })
+      assertCapitalValue().then((element) => {
+        clearAndTypeInput({ element, value: '700' })
+      })
+      assertInvestorDescription().then((element) => {
+        clearAndTypeTextArea({ element, value: 'Notes about investment' })
+      })
+      assertRequiredChecks().then((element) => {
+        clickRadioGroupOption({
+          element,
+          label: 'Not yet checked',
+        })
+      })
+
+      clickButton('Save and return')
+
+      assertAPIRequest(EDIT_INVESTOR_INTERCEPT, (xhr) => {
+        assertRequestBody(xhr, expectedBody)
+        assertUrl(urls.companies.investments.largeCapitalProfile(newCompany.id))
+        assertFlashMessage('Investor details changes saved')
+      })
+    })
   })
 
   context('when successfully saved', () => {

--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -136,7 +136,7 @@ describe('View large capital investor details page', () => {
   })
 
   context('when the company is new ', () => {
-    before(() => {
+    beforeEach(() => {
       gotoEditInvestorDetails(newCompany.id)
     })
 

--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -215,7 +215,16 @@ describe('View large capital investor details page', () => {
     })
 
     it('should save new investment with not yet checked', () => {
-      const expectedBody = {}
+      const expectedBody = {
+        id: 'a84f8405-c419-40a6-84c8-642b7c3209b2',
+        investor_company_id: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+        investor_type: '80168d31-fa91-494e-9ad5-b9255e01b5da',
+        global_assets_under_management: '500',
+        investable_capital: '700',
+        notes_on_locations: 'Notes about investment',
+        required_checks_conducted: '81fafe5a-ed32-4f46-bdc5-2cafedf828e8',
+        required_checks_conducted_on: null,
+      }
 
       assertInvestorType().then((element) => {
         selectFirstTypeaheadOption({ element, input: 'Asset manager' })


### PR DESCRIPTION
## Description of change

Fails to save investor details when the options do not have extra details. 

## Test instructions

Actual: Fails to save investor details when the options do not have extra details. 
Expected: Should save with no error

## Screenshots
<img width="976" alt="image" src="https://user-images.githubusercontent.com/19926221/157229119-d82e3aa8-83d9-4e3d-9a91-bbdbe2ec02fc.png">

_Add a screenshot_

### After

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/19926221/157229478-582332b4-f4cf-4860-9c87-c301bd4eb5fd.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
