### PR TITLE
Update skeleton placeholders to match structure of actual filters

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -11,7 +11,8 @@ import {
 
 import {
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
+  CheckboxPlaceholder,
+  ToggleHeadingPlaceholder,
 } from '../../../../client/components/SkeletonPlaceholder'
 
 import {
@@ -58,7 +59,14 @@ const ProjectsCollection = ({
     name: TASK_GET_INVESTMENTS_PROJECTS_METADATA,
     id: INVESTMENT_PROJECTS_ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder(),
+    renderProgress: () => (
+      <>
+        <ToggleHeadingPlaceholder />
+        <CheckboxPlaceholder count={5} />
+        <CheckboxPlaceholder count={5} />
+        <ToggleHeadingPlaceholder count={4} />
+      </>
+    ),
     startOnRender: {
       payload: {
         projectStageOptions: urls.metadata.investmentProjectStage(),

--- a/src/client/components/SkeletonPlaceholder/CollectionListFiltersPlaceholder.jsx
+++ b/src/client/components/SkeletonPlaceholder/CollectionListFiltersPlaceholder.jsx
@@ -10,7 +10,7 @@ const CheckboxHeading = styled('div')`
   height: ${SPACING.SCALE_4};
 `
 const CheckboxList = styled('ul')`
-  margin-bottom: 75px;
+  margin-bottom: 40px;
 `
 
 const CheckboxListItem = styled('li')`
@@ -31,7 +31,7 @@ const CheckboxLabel = styled('div')`
   margin-left: ${SPACING.SCALE_2};
 `
 
-const FilterCheckboxes = ({ count }) =>
+export const CheckboxPlaceholder = ({ count = 1 }) =>
   count ? (
     <>
       <CheckboxHeading />
@@ -49,7 +49,7 @@ const FilterCheckboxes = ({ count }) =>
   ) : null
 
 const InputList = styled('ul')`
-  ${({ marginTop }) => marginTop && `margin-top: ${marginTop}px;`};
+  margin-bottom: 30px;
 `
 
 const InputListItem = styled('li')`
@@ -74,9 +74,9 @@ const InputListItemField = styled('div')`
   margin-top: ${SPACING.SCALE_1};
 `
 
-const FilterInputs = ({ inputCount }) => (
+export const InputPlaceholder = ({ count = 1 }) => (
   <InputList>
-    {Array.from(Array(inputCount).keys()).map((el, i) => (
+    {Array.from(Array(count).keys()).map((el, i) => (
       <InputListItem key={i}>
         <InputListItemLabel />
         <InputListItemField />
@@ -85,14 +85,17 @@ const FilterInputs = ({ inputCount }) => (
   </InputList>
 )
 
-const collectionListFilters =
-  ({ filterCheckboxCount = 6, filterInputCount = 10 } = {}) =>
-  () =>
-    (
-      <>
-        <FilterCheckboxes count={filterCheckboxCount} />
-        <FilterInputs inputCount={filterInputCount} />
-      </>
-    )
+const ToggleHeadingText = styled('div')`
+  ${animation};
+  width: 250px;
+  height: ${SPACING.SCALE_5};
+  margin-bottom: ${SPACING.SCALE_4};
+`
 
-export default collectionListFilters
+export const ToggleHeadingPlaceholder = ({ count = 1 }) => (
+  <>
+    {Array.from(Array(count).keys()).map((el, i) => (
+      <ToggleHeadingText key={i} />
+    ))}
+  </>
+)

--- a/src/client/components/SkeletonPlaceholder/index.jsx
+++ b/src/client/components/SkeletonPlaceholder/index.jsx
@@ -1,2 +1,6 @@
 export { default as listSkeletonPlaceholder } from './CollectionListPlaceholder'
-export { default as filterSkeletonPlaceholder } from './CollectionListFiltersPlaceholder'
+export {
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
+} from './CollectionListFiltersPlaceholder'

--- a/src/client/modules/Companies/CollectionList/index.jsx
+++ b/src/client/modules/Companies/CollectionList/index.jsx
@@ -17,8 +17,10 @@ import {
 
 import {
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
-} from '../../../components/SkeletonPlaceholder/'
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
+} from '../../../components/SkeletonPlaceholder'
 
 import { LABELS } from './constants'
 
@@ -52,7 +54,17 @@ const CompaniesCollection = ({
     name: TASK_GET_COMPANIES_METADATA,
     id: ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder({ filterCheckboxCount: 3 }),
+    renderProgress: () => (
+      <>
+        <ToggleHeadingPlaceholder />
+        <InputPlaceholder />
+        <CheckboxPlaceholder count={3} />
+        <InputPlaceholder />
+        <CheckboxPlaceholder count={2} />
+        <InputPlaceholder />
+        <ToggleHeadingPlaceholder count={2} />
+      </>
+    ),
     startOnRender: {
       onSuccessDispatch: COMPANIES__METADATA_LOADED,
     },

--- a/src/client/modules/Contacts/CollectionList/index.jsx
+++ b/src/client/modules/Contacts/CollectionList/index.jsx
@@ -14,7 +14,9 @@ import {
 
 import {
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
 import {
@@ -45,10 +47,14 @@ const ContactsCollection = ({
     name: TASK_GET_CONTACTS_METADATA,
     id: CONTACTS_LIST_ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder({
-      filterCheckboxCount: 0,
-      filterInputFields: 6,
-    }),
+    renderProgress: () => (
+      <>
+        <ToggleHeadingPlaceholder />
+        <InputPlaceholder count={3} />
+        <CheckboxPlaceholder count={2} />
+        <ToggleHeadingPlaceholder />
+      </>
+    ),
     startOnRender: {
       onSuccessDispatch: CONTACTS__METADATA_LOADED,
     },

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -16,7 +16,9 @@ import {
 
 import {
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
 import { LABELS } from './constants'
@@ -51,10 +53,14 @@ const EventsCollection = ({
     name: TASK_GET_EVENTS_METADATA,
     id: ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder({
-      filterCheckboxCount: 0,
-      filterInputFields: 6,
-    }),
+    renderProgress: () => (
+      <>
+        <ToggleHeadingPlaceholder />
+        <InputPlaceholder count={4} />
+        <CheckboxPlaceholder count={8} />
+        <ToggleHeadingPlaceholder />
+      </>
+    ),
     startOnRender: {
       onSuccessDispatch: EVENTS__METADATA_LOADED,
     },

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -22,7 +22,9 @@ import {
 
 import {
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
 import {
@@ -71,10 +73,17 @@ const InteractionCollection = ({
     name: TASK_GET_INTERACTIONS_METADATA,
     id: ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder({
-      filterCheckboxCount: 3,
-      filterInputFields: 4,
-    }),
+    renderProgress: () => (
+      <>
+        <CheckboxPlaceholder count={1} />
+        <CheckboxPlaceholder count={2} />
+        <ToggleHeadingPlaceholder />
+        <InputPlaceholder count={5} />
+        <CheckboxPlaceholder count={1} />
+        <CheckboxPlaceholder count={7} />
+        <ToggleHeadingPlaceholder count={2} />
+      </>
+    ),
     startOnRender: {
       onSuccessDispatch: INTERACTIONS__METADATA_LOADED,
     },

--- a/src/client/modules/Omis/CollectionList/index.jsx
+++ b/src/client/modules/Omis/CollectionList/index.jsx
@@ -18,8 +18,9 @@ import {
 } from '../../../components'
 
 import {
+  CheckboxPlaceholder,
+  InputPlaceholder,
   listSkeletonPlaceholder,
-  filterSkeletonPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
 import {
@@ -63,7 +64,12 @@ const OrdersCollection = ({
     name: TASK_GET_ORDERS_METADATA,
     id: ORDERS_LIST_ID,
     progressMessage: 'Loading filters',
-    renderProgress: filterSkeletonPlaceholder(),
+    renderProgress: () => (
+      <>
+        <CheckboxPlaceholder count={6} />
+        <InputPlaceholder count={10} />
+      </>
+    ),
     startOnRender: {
       payload: {},
       onSuccessDispatch: ORDERS__METADATA_LOADED,


### PR DESCRIPTION
## Description of change

Updates the skeleton placeholders for filters on the collection list pages to more closely resemble the structure of the actual filters.

## Test instructions

Skeleton placeholders should look like the actual filters.


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
