### PR TITLE
Fix flaky OMIS assignees/subscribers tests

### DIFF
--- a/test/functional/cypress/specs/omis/edit-assignees-spec.js
+++ b/test/functional/cypress/specs/omis/edit-assignees-spec.js
@@ -88,13 +88,9 @@ describe('View edit assignees page', () => {
       assertAPIRequest(OMIS_ASSIGNEES_INTERCEPT, (xhr) => {
         assertParamContainedInUrl(xhr, 'force-delete=1')
         assertRequestBody(xhr, expectedBody)
-        assertRedirectToOmisWorkOrder()
-        assertFlashMessage('Changes saved')
-
-        function assertRedirectToOmisWorkOrder() {
-          assertUrl(urls.omis.workOrder(draftOrder.id))
-        }
       })
+      assertRedirectToOmisWorkOrder()
+      assertFlashMessage('Changes saved')
     })
 
     it('should redirect back to work order when cancelled', () => {
@@ -176,6 +172,10 @@ describe('View edit assignees page', () => {
     })
   })
 })
+
+function assertRedirectToOmisWorkOrder() {
+  assertUrl(urls.omis.workOrder(draftOrder.id))
+}
 
 function assertApiPreventsDeletions(orderId) {
   cy.visit(urls.omis.edit.assignees(orderId))

--- a/test/functional/cypress/specs/omis/edit-subscribers-spec.js
+++ b/test/functional/cypress/specs/omis/edit-subscribers-spec.js
@@ -88,13 +88,9 @@ describe('View edit subscribers page', () => {
       assertAPIRequest(OMIS_SUBSCRIBERS_INTERCEPT, (xhr) => {
         assertParamContainedInUrl(xhr, 'force-delete=1')
         assertRequestBody(xhr, expectedBody)
-        assertRedirectToOmisWorkOrder()
-        assertFlashMessage('Changes saved')
-
-        function assertRedirectToOmisWorkOrder() {
-          assertUrl(urls.omis.workOrder(draftOrder.id))
-        }
       })
+      assertRedirectToOmisWorkOrder()
+      assertFlashMessage('Changes saved')
     })
 
     it('should redirect back to work order when cancelled', () => {
@@ -170,6 +166,10 @@ describe('View edit subscribers page', () => {
     })
   })
 })
+
+function assertRedirectToOmisWorkOrder() {
+  assertUrl(urls.omis.workOrder(draftOrder.id))
+}
 
 function assertApiPreventsDeletions(orderId) {
   cy.visit(urls.omis.edit.subscribers(orderId))


### PR DESCRIPTION
## Description of change

Fix flaky OMIS assignees/subscribers tests

## Test instructions

No issues with these tests on the run


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
