### PR TITLE
Fix annoying Webpack warnings

### DIFF
--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
 import { H3 } from '@govuk-react/heading'
-import { LINK_COLOUR, RED, TEXT } from 'govuk-colours'
+import { LINK_COLOUR, RED, TEXT_COLOUR } from 'govuk-colours'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
@@ -42,7 +42,7 @@ const StyledProjectCode = styled('div')`
 
 const StyledDueDate = styled('span')`
   font-size: ${FONT_SIZE.SIZE_16};
-  color: ${TEXT};
+  color: ${TEXT_COLOUR};
 `
 
 const StyledDueCountdown = styled('span')`
@@ -50,7 +50,7 @@ const StyledDueCountdown = styled('span')`
   text-align: right;
   white-space: nowrap;
   font-size: ${FONT_SIZE.SIZE_16};
-  color: ${TEXT};
+  color: ${TEXT_COLOUR};
 `
 
 const StyledList = styled('ul')`


### PR DESCRIPTION
## Description of change

Removes two annoying Webpack warnings:

<img width="1099" alt="before" src="https://user-images.githubusercontent.com/964268/158403454-facd3a85-fc3a-4d01-af87-fd75845cc592.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
