### PR TITLE
Log output and errors from `node.js` server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ const StartServerAfterBuild = () => {
         } else {
           server = spawn(
             "npx nodemon --inspect --ignore 'src/**/__test__/**/*'",
-            { stdio: 'pipe', shell: true }
+            { stdio: ['pipe', 'inherit', 'inherit'], shell: true }
           )
         }
       })


### PR DESCRIPTION
## Description of change

We want to be able to see console logs and errors from the `node.js`
server, which is started when the webpack build is done.

This commit sets the `stdout` and `stderr` of the child
process[1] spawned in `StartServerAfterBuild` to inherit from the
parent.

[1] https://nodejs.org/api/child_process.html#optionsstdio


## Test instructions

After running `npm run develop`:
1. Console log something in a controller function and you should see it in your terminal. 
2. Cause a compilation error to happen in a controller and you should see that in the terminal.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari) 
