### PR TITLE
Add ContactInformation component to Interaction Form

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -3,7 +3,6 @@ import _ from 'lodash'
 import qs from 'qs'
 import { H3 } from '@govuk-react/heading'
 import InsetText from '@govuk-react/inset-text'
-import Link from '@govuk-react/link'
 import PropTypes from 'prop-types'
 import { GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
@@ -25,6 +24,7 @@ import {
   FieldSelect,
   FieldTextarea,
   FieldTypeahead,
+  ContactInformation,
 } from '../../../../../client/components'
 import Resource from '../../../../../client/components/Resource'
 
@@ -278,26 +278,15 @@ const StepInteractionDetails = ({
 
       <FieldTypeahead
         name="contacts"
-        label="Contact(s)"
-        placeholder="-- Select contact --"
+        label="Contacts"
+        placeholder="Select contact"
         required="Select at least one contact"
         options={contacts}
         isMulti={true}
-        hint={
-          <>
-            If the contact you are looking for is not listed you can{' '}
-            <Link
-              onClick={onOpenContactForm}
-              href={urls.contacts.create(companyId, {
-                origin_url: window.location.pathname,
-                origin_type: 'interaction',
-              })}
-            >
-              add a new contact
-            </Link>
-            .
-          </>
-        }
+      />
+      <ContactInformation
+        onOpenContactForm={onOpenContactForm}
+        companyId={companyId}
       />
 
       <FieldAdvisersTypeahead

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -16,6 +16,7 @@ const {
   assertFieldTypeahead,
   assertFormActions,
   assertFormFields,
+  assertDetails,
 } = require('../../support/assertions')
 
 const {
@@ -81,9 +82,19 @@ const ELEMENT_PARTICIPANTS_HEADER = {
   assert: assertHeader,
 }
 const ELEMENT_CONTACT = {
-  label: 'Contact(s)',
-  placeholder: '-- Select contact --',
+  label: 'Contacts',
+  placeholder: 'Select contact',
   assert: assertFieldTypeahead,
+}
+const ELEMENT_ADD_CONTACT_LINK = {
+  assert: ({ element }) => cy.wrap(element).contains('add a new contact'),
+}
+const ELEMENT_CONTACT_INFO_DETAILS = {
+  summary: "Information you'll need to add a contact",
+  content:
+    "You need to give the new contact's:full namejob titleemail" +
+    ' addressphone numberwork address if different to the company address',
+  assert: assertDetails,
 }
 const ELEMENT_ADVISER = {
   label: 'Adviser(s)',
@@ -213,7 +224,6 @@ function fillCommonFields({
 
   if (contact) {
     cy.contains(ELEMENT_CONTACT.label)
-      .next()
       .next()
       .selectTypeaheadOption(contact)
       .should('contain', contact)
@@ -418,6 +428,8 @@ describe('Interaction theme', () => {
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
+        ELEMENT_ADD_CONTACT_LINK,
+        ELEMENT_CONTACT_INFO_DETAILS,
         ELEMENT_ADVISER,
         ELEMENT_DETAILS_HEADER,
         ELEMENT_DATE,
@@ -432,8 +444,7 @@ describe('Interaction theme', () => {
     })
 
     it('should only show non-archived contacts in the contacts field', () => {
-      cy.contains(ELEMENT_CONTACT.label)
-        .next()
+      cy.contains(ELEMENT_PARTICIPANTS_HEADER.text)
         .next()
         .click()
         .find('[data-test="typeahead-menu-option"]')
@@ -536,6 +547,8 @@ describe('Service delivery theme', () => {
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
+        ELEMENT_ADD_CONTACT_LINK,
+        ELEMENT_CONTACT_INFO_DETAILS,
         ELEMENT_ADVISER,
         ELEMENT_DETAILS_HEADER,
         ELEMENT_DATE,
@@ -629,6 +642,8 @@ describe('Investment theme', () => {
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
+        ELEMENT_ADD_CONTACT_LINK,
+        ELEMENT_CONTACT_INFO_DETAILS,
         ELEMENT_ADVISER,
         ELEMENT_DETAILS_HEADER,
         ELEMENT_DATE,
@@ -744,6 +759,8 @@ describe('Trade Agreement theme', () => {
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
+        ELEMENT_ADD_CONTACT_LINK,
+        ELEMENT_CONTACT_INFO_DETAILS,
         ELEMENT_ADVISER,
         ELEMENT_DETAILS_HEADER,
         ELEMENT_DATE,


### PR DESCRIPTION
## Description of change

!!!This PR is ready for reviews but must not be merged until the User Enhancements Team are ready!!!

This PR adds the `<ContactInformation>` component to the Interaction form. The component includes the link to add a new contact and some additional information on what is needed to add a contact. This is to match the new design already implemented in the Investments form. 

## Test instructions

Go to a company, click add interaction. Fill out the first question. You should see the below visual changes on the second page around the Contact details field. 

## Screenshots
### Before

<img width="1106" alt="Screenshot 2022-03-16 at 15 42 01" src="https://user-images.githubusercontent.com/46787754/158629796-aae415bc-958f-4863-9919-7debed1637c2.png">

### After

<img width="1040" alt="Screenshot 2022-03-16 at 15 41 16" src="https://user-images.githubusercontent.com/46787754/158629632-8ed1a599-5596-422b-9c0a-6257a2303816.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
