### PR TITLE
Small design amendements to the Contacts form

### DIFF
--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -72,6 +72,7 @@ const _ContactForm = ({
   duplicateEmail,
   dispatch,
   id,
+  notes: moreDetails,
   ...props
 }) => {
   const findAdministrativeAreas = useAdministrativeAreaLookup()
@@ -160,6 +161,7 @@ const _ContactForm = ({
                       addressSameAsCompany,
                       primary,
                       email,
+                      moreDetails,
                       ...values
                     }) => ({
                       contactId,
@@ -167,6 +169,7 @@ const _ContactForm = ({
                       values: {
                         ...keysToSnakeCase(values),
                         email,
+                        notes: moreDetails,
                         accepts_dit_email_marketing:
                           acceptsDitEmailMarketing.includes(YES),
                         primary,
@@ -226,6 +229,7 @@ const _ContactForm = ({
                     }
                     initialValues={{
                       ...props,
+                      moreDetails,
                       postcode,
                       county,
                       city,
@@ -336,7 +340,10 @@ const _ContactForm = ({
                             },
                           ]}
                         />
-                        <FieldTextarea label="Notes (optional)" name="notes" />
+                        <FieldTextarea
+                          label="More details (optional)"
+                          name="moreDetails"
+                        />
                       </>
                     )}
                   </Form>

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -315,7 +315,7 @@ const _ContactForm = ({
                           ]}
                         />
                         <FieldRadios
-                          legend="Is the contact’s address the same as the company address?"
+                          legend="Is this contact’s work address the same as the company address?"
                           name="addressSameAsCompany"
                           required="Select yes if the contact's address is the same as the company address"
                           options={[

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -336,17 +336,6 @@ const _ContactForm = ({
                             },
                           ]}
                         />
-                        <FieldInput
-                          label="Alternative telephone number (optional)"
-                          name="telephoneAlternative"
-                          type="text"
-                        />
-                        <FieldInput
-                          label="Alternative email (optional)"
-                          name="emailAlternative"
-                          type="email"
-                          validate={(x) => x && validators.email(x)}
-                        />
                         <FieldTextarea label="Notes (optional)" name="notes" />
                       </>
                     )}
@@ -401,8 +390,6 @@ ContactForm.propTypes = {
   addressTown: PropTypes.string,
   addressCounty: PropTypes.string,
   addressPostcode: PropTypes.string,
-  telephoneAlternative: PropTypes.string,
-  emailAlternative: PropTypes.string,
   notes: PropTypes.string,
 }
 

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -297,7 +297,7 @@ const _ContactForm = ({
                           }
                         />
                         <FieldInput
-                          label="Email"
+                          label="Email address"
                           name="email"
                           type="email"
                           required="Enter an email"

--- a/src/client/components/Resource/__stories__/tasks.js
+++ b/src/client/components/Resource/__stories__/tasks.js
@@ -32,8 +32,6 @@ export default {
             addressCounty: 'County',
             addressPostcode: null,
             addressCountry: '87756b9a-5d95-e211-a939-e4115bead28a',
-            telephoneAlternative: '33333',
-            emailAlternative: 'alternative@email.keket',
             notes: 'Notes',
           }),
         2000
@@ -101,8 +99,6 @@ export default {
                 addressCounty: null,
                 addressCountry: null,
                 addressPostcode: null,
-                telephoneAlternative: null,
-                emailAlternative: null,
                 notes: null,
                 acceptsDitEmailMarketing: false,
                 archived: false,

--- a/test/end-to-end/cypress/specs/DIT/contacts-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/contacts-spec.js
@@ -40,7 +40,7 @@ describe('Contacts', () => {
     cy.visit(contacts.create(company.pk))
 
     cy.checkRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'Yes'
     )
     cy.checkRadioGroup('Is this person a primary contact?', 'Yes')
@@ -58,7 +58,7 @@ describe('Contacts', () => {
     cy.visit(contacts.create(company.pk))
 
     cy.checkRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'Yes'
     )
     cy.checkRadioGroup('Is this person a primary contact?', 'Yes')

--- a/test/end-to-end/cypress/support/user-actions/contacts.js
+++ b/test/end-to-end/cypress/support/user-actions/contacts.js
@@ -10,7 +10,7 @@ const fillOut = (data) => {
 const create = (data) => {
   fillOut(data)
   cy.checkRadioGroup(
-    'Is the contact’s address the same as the company address?',
+    'Is this contact’s work address the same as the company address?',
     'Yes'
   )
   cy.getSubmitButtonByLabel('Add contact').click()
@@ -19,7 +19,7 @@ const create = (data) => {
 const createWithNewAddress = (data) => {
   fillOut(data)
   cy.checkRadioGroup(
-    'Is the contact’s address the same as the company address?',
+    'Is this contact’s work address the same as the company address?',
     'No'
   )
   cy.contains('Address line 1').type(data.address1)

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -366,7 +366,7 @@ describe('Contact loop', () => {
       cy.contains('div', 'Telephone number').find('input').type('123 567 789')
       cy.contains('div', 'Email').find('input').type('john@new.com')
       cy.checkRadioGroup(
-        'Is the contact’s address the same as the company address?',
+        'Is this contact’s work address the same as the company address?',
         'Yes'
       )
       cy.getSubmitButtonByLabel('Add contact').click()

--- a/test/functional/cypress/specs/contacts/create-and-edit.jsx
+++ b/test/functional/cypress/specs/contacts/create-and-edit.jsx
@@ -76,8 +76,6 @@ describe('Create contact form', () => {
       'Job title': '',
       'Telephone number': '',
       Email: '',
-      'Alternative telephone number (optional)': '',
-      'Alternative email (optional)': '',
     })
   })
 
@@ -299,8 +297,6 @@ describe('Edit contact', () => {
       'Job title': 'Dog master',
       'Telephone number': '222 3453454',
       Email: 'contact@bob.com',
-      'Alternative telephone number (optional)': '',
-      'Alternative email (optional)': '',
     })
   })
 })

--- a/test/functional/cypress/specs/contacts/create-and-edit.jsx
+++ b/test/functional/cypress/specs/contacts/create-and-edit.jsx
@@ -75,7 +75,7 @@ describe('Create contact form', () => {
       'Last name': '',
       'Job title': '',
       'Telephone number': '',
-      Email: '',
+      'Email address': '',
     })
   })
 
@@ -89,7 +89,7 @@ describe('Create contact form', () => {
       'Is this person a primary contact?':
         'Select yes if this person is a primary contact',
       'Telephone number': 'Enter a telephone number',
-      Email: 'Enter an email',
+      'Email address': 'Enter an email',
       'Is this contact’s work address the same as the company address?':
         "Select yes if the contact's address is the same as the company address",
     })
@@ -110,7 +110,7 @@ describe('Create contact form', () => {
       'Is this person a primary contact?':
         'Select yes if this person is a primary contact',
       'Telephone number': 'Enter a telephone number',
-      Email: 'Enter an email',
+      'Email address': 'Enter an email',
       'Address line 1': 'Enter an address line 1',
       'Town or city': 'Enter a town or city',
     })
@@ -154,13 +154,13 @@ describe('Create contact form', () => {
       'Last name': 'Pipkin',
       'Job title': 'On dole',
       'Telephone number': '12345',
-      Email: 'foo',
+      'Email address': 'foo',
     })
 
     cy.clickSubmitButton('Add contact')
 
     assertErrors({
-      Email: 'Enter a valid email address',
+      'Email address': 'Enter a valid email address',
     })
   })
 
@@ -176,7 +176,7 @@ describe('Create contact form', () => {
       'Last name': 'Pipkin',
       'Job title': 'On dole',
       'Telephone number': '456789',
-      Email: 'andy@new.email',
+      'Email address': 'andy@new.email',
     })
 
     cy.clickSubmitButton('Add contact')
@@ -296,7 +296,7 @@ describe('Edit contact', () => {
       'Last name': 'Woof',
       'Job title': 'Dog master',
       'Telephone number': '222 3453454',
-      Email: 'contact@bob.com',
+      'Email address': 'contact@bob.com',
     })
   })
 })

--- a/test/functional/cypress/specs/contacts/create-and-edit.jsx
+++ b/test/functional/cypress/specs/contacts/create-and-edit.jsx
@@ -67,7 +67,7 @@ describe('Create contact form', () => {
 
     assertRadioGroupNoOptionChecked('Is this person a primary contact?')
     assertRadioGroupNoOptionChecked(
-      'Is the contact’s address the same as the company address?'
+      'Is this contact’s work address the same as the company address?'
     )
 
     assertInputValuesByLabels({
@@ -90,14 +90,14 @@ describe('Create contact form', () => {
         'Select yes if this person is a primary contact',
       'Telephone number': 'Enter a telephone number',
       Email: 'Enter an email',
-      'Is the contact’s address the same as the company address?':
+      'Is this contact’s work address the same as the company address?':
         "Select yes if the contact's address is the same as the company address",
     })
   })
 
   it('Should show errors when only the same as company address is checked', () => {
     cy.checkRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'No'
     )
 
@@ -119,7 +119,7 @@ describe('Create contact form', () => {
   describe('country specific address fields', () => {
     beforeEach(() => {
       cy.checkRadioGroup(
-        'Is the contact’s address the same as the company address?',
+        'Is this contact’s work address the same as the company address?',
         'No'
       )
     })
@@ -144,7 +144,7 @@ describe('Create contact form', () => {
 
   it('Should show errors for invalid field values', () => {
     cy.checkRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'Yes'
     )
     cy.checkRadioGroup('Is this person a primary contact?', 'Yes')
@@ -167,7 +167,7 @@ describe('Create contact form', () => {
   it('Should redirect to the new contact page when required fields are filled out', () => {
     cy.checkRadioGroup('Is this person a primary contact?', 'Yes')
     cy.checkRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'Yes'
     )
 
@@ -287,7 +287,7 @@ describe('Edit contact', () => {
 
     assertRadioGroup('Is this person a primary contact?', 'Yes')
     assertRadioGroup(
-      'Is the contact’s address the same as the company address?',
+      'Is this contact’s work address the same as the company address?',
       'No'
     )
 

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -912,7 +912,7 @@ describe('Contact loop', () => {
       cy.contains('div', 'Email').find('input').type('john@new.com')
       cy.contains(
         'fieldset',
-        'Is the contact’s address the same as the company address?'
+        'Is this contact’s work address the same as the company address?'
       )
         .contains('label', 'Yes')
         .click()


### PR DESCRIPTION
## Description of change

!!! This PR is ready for reviews but must not be merged until the User Enhancements Team are ready to merge it!!!

This PR makes a couple of design changes to the Contacts form. In particular it: 
- Removes the alternative email and telephone fields as it's intended that the user will add these to the notes.
- Renames the "Notes (optional)" field to "More details (optional)". 
- Renames the "Email" field to "Email address"
- Rewords the question about the contact address being the same as their company's address. 

## Test instructions

Click on a company, go to their contacts, and either add a new one or edit an existing one. You should see the changes listed above reflected on the page. 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
