### PR TITLE
When country is null on the address, do not break

### DIFF
--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -230,7 +230,7 @@ const filters = {
       address.county,
       address.postcode,
       address.area && featureFlag ? address.area.name : null,
-      address.country.name,
+      address.country?.name,
     ]).join(join)
   },
 


### PR DESCRIPTION
## Description of change

Search results were breking when the country was null in an address - this is now fixed by using blank for the country if nothing is set.

Socrates Software is set up without a country on the registered address, so if you search for that it should now not fail.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
