### PR TITLE
Bring datahub-header code into repository

### DIFF
--- a/assets/javascripts/app.js
+++ b/assets/javascripts/app.js
@@ -1,4 +1,4 @@
-require('@uktrade/datahub-header/component/header')
+require('./modules/header.js')
 require('element-closest')
 require('classlist.js')
 

--- a/assets/javascripts/modules/header.js
+++ b/assets/javascripts/modules/header.js
@@ -1,0 +1,140 @@
+;(function (doc, helpers) {
+  if (!(helpers.toggleClass && helpers.hasListenerSupport)) {
+    return
+  }
+
+  var HEADER_JS_ENABLED_CLASS = 'js-datahub-header-enabled'
+  var HEADER_CONTAINER_CLASS = 'js-datahub-header'
+  var TOGGLE_BUTTON_CLASS = 'js-datahub-header-toggle'
+  var CONTAINER_OPEN_CLASS = 'datahub-header--open'
+  var TOGGLE_BUTTON_OPEN_CLASS = 'datahub-header__menu-button--open'
+
+  function DatahubHeader($module) {
+    // Check for module
+    if (!$module) {
+      return
+    }
+    // Check for button
+    var $toggleButton = helpers.getByClass($module, TOGGLE_BUTTON_CLASS)
+
+    if (!$toggleButton) {
+      return
+    }
+
+    var toggleIds = $toggleButton.getAttribute('aria-controls').split(' ')
+
+    if (!toggleIds.length) {
+      return
+    }
+
+    this.$module = $module
+    this.$toggleButton = $toggleButton
+    this.toggleElems = []
+
+    helpers.addClass($module, HEADER_JS_ENABLED_CLASS)
+
+    var i = 0
+    var l = toggleIds.length
+    var toggleElem
+
+    for (; i < l; i++) {
+      toggleElem = doc.getElementById(toggleIds[i])
+      if (toggleElem) {
+        this.toggleElems.push(toggleElem)
+      }
+    }
+
+    // Handle $toggleButton click events
+    $toggleButton.addEventListener('click', this.handleClick.bind(this))
+  }
+
+  DatahubHeader.prototype.handleClick = function () {
+    var i = 0
+    var l = this.toggleElems.length
+    var isAriaHidden =
+      this.toggleElems[0].getAttribute('aria-hidden') === 'false'
+
+    helpers.toggleClass(this.$module, CONTAINER_OPEN_CLASS)
+    helpers.toggleClass(this.$toggleButton, TOGGLE_BUTTON_OPEN_CLASS)
+
+    this.$toggleButton.setAttribute(
+      'aria-expanded',
+      this.$toggleButton.getAttribute('aria-expanded') !== 'true'
+    )
+
+    for (; i < l; i++) {
+      this.toggleElems[i].setAttribute('aria-hidden', isAriaHidden)
+    }
+  }
+
+  var container = helpers.getByClass(doc, HEADER_CONTAINER_CLASS)
+
+  if (container) {
+    new DatahubHeader(container)
+  }
+})(
+  document,
+  (function (doc) {
+    //helpers taken from: https://github.com/cinsoft/jessie
+
+    var helpers = {}
+
+    function isHostObjectProperty(object, property) {
+      var objectProperty = object[property]
+      return typeof objectProperty == 'object' && null !== objectProperty
+    }
+
+    function isHostMethod(object, method) {
+      var objectMethod = object[method]
+      var type = typeof objectMethod
+      return (
+        type == 'function' ||
+        (type == 'object' && null !== objectMethod) ||
+        type == 'unknown'
+      )
+    }
+
+    var html =
+      isHostObjectProperty(doc, 'documentElement') && doc.documentElement
+    var hasClassListSupport = html && isHostObjectProperty(html, 'classList')
+
+    if (hasClassListSupport && isHostMethod(html.classList, 'remove')) {
+      helpers.removeClass = function (el, className) {
+        return el.classList.remove(className)
+      }
+    }
+
+    if (hasClassListSupport && isHostMethod(html.classList, 'contains')) {
+      helpers.hasClass = function (el, className) {
+        return el.classList.contains(className)
+      }
+    }
+
+    if (hasClassListSupport && isHostMethod(html.classList, 'add')) {
+      helpers.addClass = function (el, className) {
+        return el.classList.add(className)
+      }
+    }
+
+    if (helpers.hasClass && helpers.addClass && helpers.removeClass) {
+      helpers.toggleClass = function (el, className) {
+        var toggle = helpers.hasClass(el, className)
+          ? 'removeClass'
+          : 'addClass'
+        helpers[toggle](el, className)
+      }
+    }
+
+    helpers.hasListenerSupport = html && isHostMethod(html, 'addEventListener')
+
+    helpers.getByClass = function (parent, className) {
+      var elem = parent.getElementsByClassName(className)
+
+      if (elem && elem.length > 0) {
+        return elem[0]
+      }
+    }
+
+    return helpers
+  })(document)
+)

--- a/assets/stylesheets/_components.scss
+++ b/assets/stylesheets/_components.scss
@@ -18,6 +18,7 @@
 @import "components/progress";
 @import "components/stack-trace";
 @import "components/tabbed-local-nav";
+@import 'components/header';
 
 // Style examples on components page
 @import "components/.example";

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -2,7 +2,6 @@ $images-dir: '/images/';
 
 $govuk-canvas-background-colour: #f3f2f1;
 $govuk-font-family: Arial, sans-serif;
-@import '../../node_modules/@uktrade/datahub-header/component/header.css';
 @import '../../node_modules/govuk-frontend/all';
 
 $toolkit-font-stack: $govuk-font-family;

--- a/assets/stylesheets/components/_header.scss
+++ b/assets/stylesheets/components/_header.scss
@@ -1,0 +1,370 @@
+$govuk-black: #0b0c0c;
+$govuk-grey-1: #6f777b;
+$govuk-grey-2: #bfc1c3;
+$govuk-grey-3: #dee0e2;
+$govuk-grey-4: #f8f8f8;
+$govuk-blue: #005EA5;
+$govuk-light-blue: #5694CA;
+$govuk-yellow: #ffbf47;
+$govuk-focus: #ffdd01;
+
+$tablet: 40.0625em;
+
+@function iff($condition, $if-true) {
+	@return if($condition, $if-true, null);
+}
+
+@mixin govuk-visually-hidden($important: true) {
+	position: absolute iff($important, !important);
+
+	width: 1px iff($important, !important);
+	height: 1px iff($important, !important);
+	// If margin is set to a negative value it can cause text to be announced in the wrong order in VoiceOver for OSX
+	margin: 0 iff($important, !important);
+	padding: 0 iff($important, !important);
+
+	overflow: hidden iff($important, !important);
+	clip: rect(0 0 0 0) iff($important, !important);
+	-webkit-clip-path: inset(50%) iff($important, !important);
+	clip-path: inset(50%) iff($important, !important);
+
+	border: 0 iff($important, !important);
+
+	// For long content, line feeds are not interpreted as spaces and small width
+	// causes content to wrap 1 word per line:
+	// https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+	white-space: nowrap iff($important, !important);
+}
+
+@mixin tablet-padding() {
+	@media ( min-width: $tablet ) {
+		padding-left: 30px;
+		padding-right: 30px;
+	}
+}
+
+@mixin underline($color: inherit) {
+	position: relative;
+	&::after {
+		content: "";
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		border-bottom: 5px solid;
+		border-color: $color;
+	}
+}
+
+@mixin focus() {
+	outline: none;
+	// We are increasing specificity here because of color
+	&#{&}:focus {
+		color: $govuk-black;
+		background: $govuk-focus;
+	}
+}
+
+@mixin underline-focus() {
+	@include focus;
+	&:focus {
+		@include underline;
+	}
+}
+
+.datahub-header {
+	font-family: Arial,"Helvetica Neue",Helvetica,sans-serif;
+	line-height: 1.5;
+	background-color: black;
+	position: relative; //contain button
+
+	// Prevent apps to add an outline to the header's links
+	a {
+		box-shadow: none !important;
+		outline: none !important;
+	}
+
+	&__logo {
+		font-size: 30px;
+		font-weight: bold;
+		display: inline-block;
+		padding-right: 2em;
+
+		&__site-name {
+			@include govuk-visually-hidden;
+		}
+
+		&__link {
+			@include focus;
+		}
+
+		&__text {
+			-webkit-font-smoothing: initial; /* makes the font bolder */
+		}
+		
+		&__tag {
+			-webkit-font-smoothing: initial; /* makes the font bolder */
+			font-weight: 700;
+			font-size: 14px;
+			line-height: 1.25;
+			display: inline-block;
+			padding: 4px 8px 2px 8px;
+			outline: 2px solid transparent;
+			outline-offset: -2px;
+			color: white;
+			background-color: $govuk-blue;
+			letter-spacing: 1px;
+			text-decoration: none;
+			text-transform: uppercase;
+			position: relative;
+			top: -5px;
+		}
+
+		&-container {
+			color: white;
+			overflow: hidden;
+			font-weight: 700;
+			padding: 2px 15px;
+			box-sizing: content-box;
+			-moz-osx-font-smoothing: grayscale;
+			@include tablet-padding;
+		
+			a,
+			a:visited,
+			a:link {
+				color: white;
+				text-decoration: none;
+			}
+		}
+	}
+
+	&__menu-button {
+		font-weight: 400;
+		font-size: 14px;
+		line-height: 1.14286;
+		display: none;
+		position: absolute;
+		top: 20px;
+		right: 30px;
+		margin: 0;
+		padding: 0;
+		border: 0;
+		color: white;
+		background: 0 0;
+		@include focus;
+
+		@media print {
+			font-family: sans-serif;
+			font-size: 14pt;
+			line-height: 1.2;
+		}
+
+		@media ( min-width: $tablet ){
+			font-size:16px;
+			line-height: 1.25;
+			top: 15px;
+		}
+
+		&:hover {
+			text-decoration: underline;
+		}
+
+		&::after {
+			display: inline-block;
+			width: 0;
+			height: 0;
+			border-style: solid;
+			border-color: transparent;
+			-webkit-clip-path: polygon( 0 0,50% 100%,100% 0 );
+			clip-path: polygon( 0 0,50% 100%,100% 0 );
+			border-width: 8.66px 5px 0 5px;
+			border-top-color: inherit;
+			content: "";
+			margin-left: 5px;
+		}
+
+		&--open::after {
+			display: inline-block;
+			width: 0;
+			height: 0;
+			border-style: solid;
+			border-color: transparent;
+			-webkit-clip-path: polygon( 50% 0,0 100%,100% 100% );
+			clip-path: polygon( 50% 0,0 100%,100% 100% );
+			border-width: 0 5px 8.66px 5px;
+			border-bottom-color: inherit;
+		}
+	}
+
+	&__links {
+		display: block;
+		font-size: 16px;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		outline: 3px solid transparent;
+		font-weight: 700;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+
+		@media ( min-width: $tablet ) {
+			float: right;
+
+			&__item {
+				display: inline-block;
+				padding: 5px 10px;
+				border-bottom: 0;
+
+				&:last-of-type {
+					padding-right: 0;
+				}
+			}
+		}
+
+		&__item {
+			display: block;
+			border-bottom: 1px solid $govuk-grey-1;
+
+			:hover {
+				text-decoration: underline;
+			}
+
+			&:last-of-type {
+				border-bottom: 0;
+			}
+
+			&__text {
+				display: inline-block;
+				padding: 5px 0;
+				width: 100%;
+				@include focus;
+
+				// Is this ever used?
+				&--active {
+					color: $govuk-blue;
+					&:link,
+					&:visited {
+						color: $govuk-light-blue;
+					}
+				}
+			}
+		}
+	}
+
+	&__navigation {
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		padding: 0 15px;
+		box-sizing: content-box;
+		@include tablet-padding;
+
+		&-wrapper {
+			background-color: $govuk-grey-3;
+			font-weight: 700;
+
+			&--sub {
+				background-color: $govuk-grey-4;
+				font-weight: normal;
+				border-bottom: 1px solid $govuk-grey-3;
+			}
+		}
+
+		&__item {
+			display: block;
+			padding-right: 20px;
+
+			@media ( min-width: $tablet ) {
+				display: inline-block;
+			}
+
+			&:last-of-type {
+				padding-right: 0;
+			}
+
+			&__link {
+				display: block;
+				padding: 5px 0;
+				margin: 0;
+				font-size: 16px;
+				line-height: 23px;
+				text-decoration: none;
+				color: $govuk-black;
+
+				@media ( min-width: $tablet ) {
+					display: inline-block;
+					padding: 8px 0;
+				}
+
+				&:visited,
+				&:link {
+					color: $govuk-black;
+				}
+
+				&:hover {
+					@media ( max-width: $tablet ) {
+						color: $govuk-blue;
+					}
+					@media ( min-width: $tablet ) {
+						@include underline($govuk-blue);
+					}
+				}
+
+				&--active {
+					color: $govuk-blue;
+
+					@media ( min-width: $tablet ) {
+						@include underline;
+					}
+
+					&:visited,
+					&:link {
+						color: $govuk-blue;
+					}
+				}
+
+				@include underline-focus;
+			}
+		}
+	}
+
+	$grandparent: &;
+	&--max-width {
+		#{$grandparent} {
+			&__navigation,
+			&__logo-container {
+				max-width: 960px;
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
+	}
+}
+
+.js-datahub-header-enabled {
+	.datahub-header {
+		&__menu-button {
+			display: block;
+			@media ( min-width: $tablet ){
+				display: none;
+			}
+		}
+
+		&__navigation,
+		&__links {
+			display: none;
+			@media ( min-width: $tablet ){
+				display: block;
+			}
+		}
+	}
+
+	&.datahub-header--open {
+		.datahub-header {
+			&__navigation,
+			&__links {
+				display: block;
+			}
+		}
+	}
+ }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@nivo/pie": "^0.79.0",
         "@nivo/tooltip": "^0.79.0",
         "@sentry/browser": "^6.18.2",
-        "@uktrade/datahub-header": "^1.5.0",
         "autoprefixer": "^10.4.4",
         "axios": "^0.26.1",
         "basic-auth": "^2.0.1",
@@ -2471,6 +2470,7 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
       "dependencies": {
         "@emotion/memoize": "0.7.4"
       }
@@ -4684,13 +4684,13 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "node_modules/@sentry/browser": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.1.tgz",
-      "integrity": "sha512-nU73PecOoMwrsw2WRJW+oQSSfgGkcY3So3JH7qwRHnnk4Gx56TkDfS0AOrNRsSpIQXj1UbSFIWKzz6ajsOg9OA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.2.tgz",
+      "integrity": "sha512-5VC44p5Vu2eJhVT39nLAJFgha5MjHDYCyZRR1ieeZt3a++otojPGBBAKNAtrEMGV+A2Z9AoneD6ZnDVlyb3GKg==",
       "dependencies": {
-        "@sentry/core": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/core": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4698,14 +4698,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.1.tgz",
-      "integrity": "sha512-ZSIFnwYCzABK1jX1iMwUbaAoWbbJear0wM+gSZvJpSUJ1dAXV1OZyL7kXtEJRtATahIlcrMou5ewIoeJizeWAw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.2.tgz",
+      "integrity": "sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==",
       "dependencies": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/minimal": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/hub": "6.19.2",
+        "@sentry/minimal": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4713,12 +4713,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.1.tgz",
-      "integrity": "sha512-BgUwdxxXntGohAYrXtYrYBA6QzOeRz3NINuS838n7SRTkGf9gBJ/Rd3dyOWUrzJciKty7rmvYIwTA0oo91AMkw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.2.tgz",
+      "integrity": "sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==",
       "dependencies": {
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4726,12 +4726,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.1.tgz",
-      "integrity": "sha512-Xre3J6mjWEcQhDmQ3j4g71J8f0nDgg2p7K41SngibfZVYSOe8jAowxSI9JuWD7juuwT5GVRVCqLs+Y6mWDBaoQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.2.tgz",
+      "integrity": "sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==",
       "dependencies": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
+        "@sentry/hub": "6.19.2",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4739,19 +4739,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-ovmNYdqD2MKLmru4calxetX1xjJdYim+HEI/GzwvVUYshsaXRq4EiQ17h3DAy90MV7JH279PmMoPGDTOpufq+Q==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+      "integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.1.tgz",
-      "integrity": "sha512-mWcQbQ1yO7PooLpJpQK84+wOfxGeb8iUKRb8inO+2Eg6VksDbXRuJ89Yd4APBTRxBj5Wihy48bPuVfKtovtm8g==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.2.tgz",
+      "integrity": "sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==",
       "dependencies": {
-        "@sentry/types": "6.19.1",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -11270,9 +11270,9 @@
       "devOptional": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -11471,11 +11471,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@uktrade/datahub-header": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.5.0.tgz",
-      "integrity": "sha512-JDNyXFsH9ZyWrVb5q9ud1NITDJed/yFXzsjqY3prq0MtqHRZ33iX5ZPvKQ5BWR0GeuU+EKu2a1z9PXTRQ1KNTQ=="
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -14705,9 +14700,9 @@
       "dev": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==",
+      "version": "1.0.30001320",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
+      "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
       "funding": [
         {
           "type": "opencollective",
@@ -16539,9 +16534,9 @@
       }
     },
     "node_modules/cypress-recurse": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.18.0.tgz",
-      "integrity": "sha512-gtWjwrzA3zTcEMe60SyCLbR+0WiyueaVuD+ZLm5hMvS0zGHAJv3ZL/t4ZVaxUj9ommlc0lGFetlnTpmgwHy9QQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.20.0.tgz",
+      "integrity": "sha512-8/gqot/XnVkSF8ssgn3zLRTfPw7Bum2tMIOxf6NO+Wqk0MBQdd4NPNVCObllZmmviLsGmF6ZXwlbXZ8TYvD6dw==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -17996,9 +17991,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "node_modules/elastic-apm-http-client": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.0.tgz",
-      "integrity": "sha512-HB6+O0C4GGj9k5bd6yL3QK5prGKh+Rf8Tc5iW0T7FCdh2HliICfGmB6wmdQ2XkClblLtISh7tKYgVr9YgdXl3Q==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.1.tgz",
+      "integrity": "sha512-5AOWlhs2WlZpI+DfgGqY/8Rk7KF8WeevaO8R961eBylavU6GWhLRNiJncohn5jsvrqhmeT19azBvy/oYRN7bJw==",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
         "breadth-filter": "^2.0.0",
@@ -18029,9 +18024,9 @@
       }
     },
     "node_modules/elastic-apm-node": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.30.0.tgz",
-      "integrity": "sha512-KumRBDGIE+MGgJfteAi9BDqeGxpAYpbovWjNdB5x8T3/zpnQRJkDMSblliEsMwD6uKf2+Nkxzmyq9UZdh5MbGQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.31.0.tgz",
+      "integrity": "sha512-0OulazfhkXYbOaGkHncqjwOfxtcvzsDyzUKr6Y1k95HwKrjf1Vi+xPutZv4p/WfDdO+JadphI0U2Uu5ncGB2iA==",
       "dependencies": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",
@@ -18040,7 +18035,7 @@
         "basic-auth": "^2.0.1",
         "cookie": "^0.4.0",
         "core-util-is": "^1.0.2",
-        "elastic-apm-http-client": "11.0.0",
+        "elastic-apm-http-client": "11.0.1",
         "end-of-stream": "^1.4.4",
         "error-callsites": "^2.0.4",
         "error-stack-parser": "^2.0.6",
@@ -18125,9 +18120,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.90.tgz",
-      "integrity": "sha512-ZwKgSA0mQMyEhz+NR0F8dRzkrCLeHLzLkjx/CWf16+zV85hQ6meXPQbKanvhnpkYb7b2uJNj+enQJ/N877ND4Q=="
+      "version": "1.4.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.93.tgz",
+      "integrity": "sha512-ywq9Pc5Gwwpv7NG767CtoU8xF3aAUQJjH9//Wy3MBCg4w5JSLbJUq2L8IsCdzPMjvSgxuue9WcVaTOyyxCL0aQ=="
     },
     "node_modules/element-closest": {
       "version": "3.0.2",
@@ -26542,12 +26537,12 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -30203,9 +30198,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
+      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -35272,13 +35267,14 @@
       }
     },
     "node_modules/styled-components": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
+      "hasInstallScript": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/is-prop-valid": "^1.1.0",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1.12.0",
@@ -35298,6 +35294,14 @@
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
         "react-is": ">= 16.8.0"
+      }
+    },
+    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+      "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.7.4"
       }
     },
     "node_modules/stylis": {
@@ -36266,9 +36270,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "peer": true,
       "bin": {
@@ -40369,6 +40373,7 @@
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
       "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
       "requires": {
         "@emotion/memoize": "0.7.4"
       }
@@ -42128,59 +42133,59 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@sentry/browser": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.1.tgz",
-      "integrity": "sha512-nU73PecOoMwrsw2WRJW+oQSSfgGkcY3So3JH7qwRHnnk4Gx56TkDfS0AOrNRsSpIQXj1UbSFIWKzz6ajsOg9OA==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.19.2.tgz",
+      "integrity": "sha512-5VC44p5Vu2eJhVT39nLAJFgha5MjHDYCyZRR1ieeZt3a++otojPGBBAKNAtrEMGV+A2Z9AoneD6ZnDVlyb3GKg==",
       "requires": {
-        "@sentry/core": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/core": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.1.tgz",
-      "integrity": "sha512-ZSIFnwYCzABK1jX1iMwUbaAoWbbJear0wM+gSZvJpSUJ1dAXV1OZyL7kXtEJRtATahIlcrMou5ewIoeJizeWAw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.19.2.tgz",
+      "integrity": "sha512-yu1R3ewBT4udmB4v7sc4biQZ0Z0rfB9+TzB5ZKoCftbe6kqXjFMMaFRYNUF9HicVldKAsBktgkWw3+yfqGkw/A==",
       "requires": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/minimal": "6.19.1",
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/hub": "6.19.2",
+        "@sentry/minimal": "6.19.2",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.1.tgz",
-      "integrity": "sha512-BgUwdxxXntGohAYrXtYrYBA6QzOeRz3NINuS838n7SRTkGf9gBJ/Rd3dyOWUrzJciKty7rmvYIwTA0oo91AMkw==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.19.2.tgz",
+      "integrity": "sha512-W7KCgNBgdBIMagOxy5J5KQPe+maYxSqfE8a5ncQ3R8BcZDQEKnkW/1FplNbfRLZqA/tL/ndKb7pTPqVtzsbARw==",
       "requires": {
-        "@sentry/types": "6.19.1",
-        "@sentry/utils": "6.19.1",
+        "@sentry/types": "6.19.2",
+        "@sentry/utils": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.1.tgz",
-      "integrity": "sha512-Xre3J6mjWEcQhDmQ3j4g71J8f0nDgg2p7K41SngibfZVYSOe8jAowxSI9JuWD7juuwT5GVRVCqLs+Y6mWDBaoQ==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.19.2.tgz",
+      "integrity": "sha512-ClwxKm77iDHET7kpzv1JvzDx1er5DoNu+EUjst0kQzARIrXvu9xuZuE2/CnBWycQWqw8o3HoGoKz65uIhsUCzQ==",
       "requires": {
-        "@sentry/hub": "6.19.1",
-        "@sentry/types": "6.19.1",
+        "@sentry/hub": "6.19.2",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.1.tgz",
-      "integrity": "sha512-ovmNYdqD2MKLmru4calxetX1xjJdYim+HEI/GzwvVUYshsaXRq4EiQ17h3DAy90MV7JH279PmMoPGDTOpufq+Q=="
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.19.2.tgz",
+      "integrity": "sha512-XO5qmVBdTs+7PdCz7fAwn1afWxSnRE2KLBFg5/vOdKosPSSHsSHUURSkxiEZc2QsR+JpRB4AeQ26AkIRX38qTg=="
     },
     "@sentry/utils": {
-      "version": "6.19.1",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.1.tgz",
-      "integrity": "sha512-mWcQbQ1yO7PooLpJpQK84+wOfxGeb8iUKRb8inO+2Eg6VksDbXRuJ89Yd4APBTRxBj5Wihy48bPuVfKtovtm8g==",
+      "version": "6.19.2",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.19.2.tgz",
+      "integrity": "sha512-2DQQ2OJaxjtyxGq5FmMlqb6hptsqMs2xoBiVRMkTS/rvyTrk1oQdKZ8ePwjtgX3nJ728ni3IXIyXV+vfGp4EBw==",
       "requires": {
-        "@sentry/types": "6.19.1",
+        "@sentry/types": "6.19.2",
         "tslib": "^1.9.3"
       }
     },
@@ -47443,9 +47448,9 @@
       "devOptional": true
     },
     "@types/react": {
-      "version": "17.0.42",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.42.tgz",
-      "integrity": "sha512-nuab3x3CpJ7VFeNA+3HTUuEkvClYHXqWtWd7Ud6AZYW7Z3NH9WKtgU+tFB0ZLcHq+niB/HnzLcaZPqMJ95+k5Q==",
+      "version": "17.0.43",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz",
+      "integrity": "sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==",
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -47643,11 +47648,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@uktrade/datahub-header": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@uktrade/datahub-header/-/datahub-header-1.5.0.tgz",
-      "integrity": "sha512-JDNyXFsH9ZyWrVb5q9ud1NITDJed/yFXzsjqY3prq0MtqHRZ33iX5ZPvKQ5BWR0GeuU+EKu2a1z9PXTRQ1KNTQ=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -50266,9 +50266,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001319",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz",
-      "integrity": "sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw=="
+      "version": "1.0.30001320",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
+      "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA=="
     },
     "case": {
       "version": "1.6.3",
@@ -51762,9 +51762,9 @@
       }
     },
     "cypress-recurse": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.18.0.tgz",
-      "integrity": "sha512-gtWjwrzA3zTcEMe60SyCLbR+0WiyueaVuD+ZLm5hMvS0zGHAJv3ZL/t4ZVaxUj9ommlc0lGFetlnTpmgwHy9QQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/cypress-recurse/-/cypress-recurse-1.20.0.tgz",
+      "integrity": "sha512-8/gqot/XnVkSF8ssgn3zLRTfPw7Bum2tMIOxf6NO+Wqk0MBQdd4NPNVCObllZmmviLsGmF6ZXwlbXZ8TYvD6dw==",
       "dev": true
     },
     "d3-array": {
@@ -52851,9 +52851,9 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elastic-apm-http-client": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.0.tgz",
-      "integrity": "sha512-HB6+O0C4GGj9k5bd6yL3QK5prGKh+Rf8Tc5iW0T7FCdh2HliICfGmB6wmdQ2XkClblLtISh7tKYgVr9YgdXl3Q==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/elastic-apm-http-client/-/elastic-apm-http-client-11.0.1.tgz",
+      "integrity": "sha512-5AOWlhs2WlZpI+DfgGqY/8Rk7KF8WeevaO8R961eBylavU6GWhLRNiJncohn5jsvrqhmeT19azBvy/oYRN7bJw==",
       "requires": {
         "agentkeepalive": "^4.2.1",
         "breadth-filter": "^2.0.0",
@@ -52880,9 +52880,9 @@
       }
     },
     "elastic-apm-node": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.30.0.tgz",
-      "integrity": "sha512-KumRBDGIE+MGgJfteAi9BDqeGxpAYpbovWjNdB5x8T3/zpnQRJkDMSblliEsMwD6uKf2+Nkxzmyq9UZdh5MbGQ==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/elastic-apm-node/-/elastic-apm-node-3.31.0.tgz",
+      "integrity": "sha512-0OulazfhkXYbOaGkHncqjwOfxtcvzsDyzUKr6Y1k95HwKrjf1Vi+xPutZv4p/WfDdO+JadphI0U2Uu5ncGB2iA==",
       "requires": {
         "@elastic/ecs-pino-format": "^1.2.0",
         "after-all-results": "^2.0.0",
@@ -52891,7 +52891,7 @@
         "basic-auth": "^2.0.1",
         "cookie": "^0.4.0",
         "core-util-is": "^1.0.2",
-        "elastic-apm-http-client": "11.0.0",
+        "elastic-apm-http-client": "11.0.1",
         "end-of-stream": "^1.4.4",
         "error-callsites": "^2.0.4",
         "error-stack-parser": "^2.0.6",
@@ -52963,9 +52963,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.90",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.90.tgz",
-      "integrity": "sha512-ZwKgSA0mQMyEhz+NR0F8dRzkrCLeHLzLkjx/CWf16+zV85hQ6meXPQbKanvhnpkYb7b2uJNj+enQJ/N877ND4Q=="
+      "version": "1.4.93",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.93.tgz",
+      "integrity": "sha512-ywq9Pc5Gwwpv7NG767CtoU8xF3aAUQJjH9//Wy3MBCg4w5JSLbJUq2L8IsCdzPMjvSgxuue9WcVaTOyyxCL0aQ=="
     },
     "element-closest": {
       "version": "3.0.2",
@@ -59226,12 +59226,12 @@
       "integrity": "sha512-DCfg/T8fcrhrRKTPjRrw/5LLvdGV7BHySf/1LOZx7TzWZdYRjogNtyNq885z3nNallwr3QUKARjqvHqX1/7t+w=="
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "miller-rabin": {
@@ -62047,9 +62047,9 @@
       "devOptional": true
     },
     "prettier": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
-      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.1.tgz",
+      "integrity": "sha512-8UVbTBYGwN37Bs9LERmxCPjdvPxlEowx2urIL6urHzdb3SDq4B/Z6xLFCblrSnE4iKWcS6ziJ3aOYrc1kz/E2A==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -66022,13 +66022,13 @@
       }
     },
     "styled-components": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.3.tgz",
-      "integrity": "sha512-++4iHwBM7ZN+x6DtPPWkCI4vdtwumQ+inA/DdAsqYd4SVgUKJie5vXyzotA00ttcFdQkCng7zc6grwlfIfw+lw==",
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.5.tgz",
+      "integrity": "sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.8",
+        "@emotion/is-prop-valid": "^1.1.0",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1.12.0",
@@ -66036,6 +66036,16 @@
         "hoist-non-react-statics": "^3.0.0",
         "shallowequal": "^1.1.0",
         "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "@emotion/is-prop-valid": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.1.2.tgz",
+          "integrity": "sha512-3QnhqeL+WW88YjYbQL5gUIkthuMw7a0NGbZ7wfFVk2kg/CK5w8w5FFa0RzWjyY1+sujN0NWbtSHH6OJmWHtJpQ==",
+          "requires": {
+            "@emotion/memoize": "^0.7.4"
+          }
+        }
       }
     },
     "stylis": {
@@ -66787,9 +66797,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "@nivo/pie": "^0.79.0",
     "@nivo/tooltip": "^0.79.0",
     "@sentry/browser": "^6.18.2",
-    "@uktrade/datahub-header": "^1.5.0",
     "autoprefixer": "^10.4.4",
     "axios": "^0.26.1",
     "basic-auth": "^2.0.1",

--- a/src/config/nunjucks/index.js
+++ b/src/config/nunjucks/index.js
@@ -81,7 +81,6 @@ module.exports = (app, config) => {
       `${config.root}/src/templates`,
       `${config.root}/node_modules/govuk-frontend`,
       `${config.root}/node_modules/govuk-frontend/components`,
-      `${config.root}/node_modules/@uktrade`,
     ],
     {
       autoescape: true,

--- a/src/templates/_components/header.njk
+++ b/src/templates/_components/header.njk
@@ -1,0 +1,160 @@
+{% macro datahubHeader(permittedApps, params) %}
+
+	{%- set crmApps = params.crmApps %}
+	{%- set datahubDomain = ( params.domains.datahub or 'https://www.datahub.trade.gov.uk/' ) %}
+	{%- set miDomain = ( params.domains.mi or 'https://mi.exportwins.service.trade.gov.uk/' ) %}
+	{%- set findExportersDomain = ( params.domains.findExporters or 'https://data.trade.gov.uk/datasets/a70a3967-2352-4230-b556-61bf875dc28c' ) %}
+	{%- set marketAcessDomain = ( params.domains.marketAccess or 'https://market-access.trade.gov.uk/' ) %}
+	{%- set dataWorkspaceDomain = (params.domains.dataWorkspaceDomain or 'https://data.trade.gov.uk' ) %}
+
+	{%- set datahubCrmKey = 'datahub-crm' %}
+	{%- set hasCrmPermission = false %}
+	{%- for permitted in permittedApps %}
+		{%- if permitted.key === datahubCrmKey %}
+			{%- set hasCrmPermission = true %}
+		{%- endif %}
+	{%- endfor %}
+	{%- set companiesKey = 'datahub-companies' %}
+	{%- set contactsKey = 'datahub-contacts' %}
+	{%- set eventsKey = 'datahub-events' %}
+	{%- set interactionsKey = 'datahub-interactions' %}
+	{%- set investmentsKey = 'datahub-investments' %}
+	{%- set ordersKey = 'datahub-orders' %}
+	{%- set supportApp = {
+    activeKey: 'support',
+    name: 'Support',
+    href: ( datahubDomain + 'support' ),
+    active: ( 'datahub-support' === params.active )
+} %}
+	{%- set apps = [
+	{
+		permittedKey: datahubCrmKey,
+		activeKey: companiesKey,
+		canShow: ( companiesKey in crmApps ) if crmApps else true,
+		name: 'Companies',
+		href: ( datahubDomain + 'companies?archived[0]=false&sortby=modified_on:desc&page=1' )
+	}, {
+		permittedKey: datahubCrmKey,
+		activeKey: contactsKey,
+		canShow: ( contactsKey in crmApps ) if crmApps else true,
+		name: 'Contacts',
+		href: ( datahubDomain + 'contacts?archived[0]=false&sortby=modified_on:desc&page=1' )
+	}, {
+		permittedKey: datahubCrmKey,
+		activeKey: eventsKey,
+		canShow: ( eventsKey in crmApps ) if crmApps else true,
+		name: 'Events',
+		href: ( datahubDomain + 'events?page=1&sortby=modified_on:desc' )
+	}, {
+		permittedKey: datahubCrmKey,
+		activeKey: interactionsKey,
+		canShow: ( interactionsKey in crmApps ) if crmApps else true,
+		name: 'Interactions',
+		href: ( datahubDomain + 'interactions?sortby=date:desc&page=1' )
+	}, {
+		permittedKey: datahubCrmKey,
+		activeKey: investmentsKey,
+		canShow: ( investmentsKey in crmApps ) if crmApps else true,
+		name: 'Investments',
+		href: ( datahubDomain + 'investments?page=1&sortby=created_on:desc' )
+	}, {
+		permittedKey: datahubCrmKey,
+		activeKey: ordersKey,
+		canShow: ( ordersKey in crmApps ) if crmApps else true,
+		name: 'Orders',
+		href: ( datahubDomain + 'omis?page=1&sortby=created_on:desc' )
+	}, {
+		permittedKey: 'find-exporters',
+		activeKey: 'find-exporters',
+		canShow: true,
+		name: 'Find exporters',
+		href: findExportersDomain
+	}, {
+		permittedKey: 'market-access',
+		activeKey: 'market-access',
+		canShow: true,
+		name: 'Market Access',
+		href: marketAcessDomain
+	}
+] %}
+
+	{%- set headerLinks = [
+	{
+		text: 'Switch to Data Workspace',
+		href: dataWorkspaceDomain
+	}
+] -%}
+
+	<header class="datahub-header js-datahub-header{% if params.fluid == false %} datahub-header--max-width{% endif %}" role="banner" data-module="header"
+	{%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+		<div class="datahub-header__logo-container">
+			<div class="datahub-header__logo">
+				<span class="datahub-header__logo__site-name">Department for International Trade</span>
+				{%- set logoText %}
+				<span class="datahub-header__logo__text">Data Hub</span>{% endset %}
+				{%- if hasCrmPermission %}
+					<a href="{{ datahubDomain }}" class="datahub-header__logo__link">{{ logoText | safe }}</a>
+				{%- else %}
+					{{ logoText | safe }}
+				{%- endif %}
+				<strong class="datahub-header__logo__tag">beta</strong>
+			</div>
+			<ul id="logo-navigation" class="datahub-header__links" aria-label="Header links">
+				{%- for link in headerLinks %}
+					{%- if link.text -%}
+						<li class="datahub-header__links__item">
+							{%- if link.href %}
+								<a class="datahub-header__links__item__text{{ ' datahub-header__links__item__text--active' if link.active }}" href="{{ link.href }}">{{ link.text }}</a>
+							{%- else %}
+								<span class="datahub-header__links__item__text{{ ' datahub-header__links__item__text--active' if link.active }}">{{ link.text }}</span>
+							{%- endif %}
+						</li>
+					{%- endif %}
+				{%- endfor %}
+			</ul>
+		</div>
+		<button role="button" class="datahub-header__menu-button js-datahub-header-toggle" aria-controls="navigation sub-navigation logo-navigation" aria-label="Show or hide navigation">Menu</button>
+		<div class="datahub-header__navigation-container">
+			<nav class="datahub-header__navigation-wrapper" aria-labelledby="navigation">
+				<ul id="navigation" class="datahub-header__navigation {{ params.navigationClasses if params.navigationClasses }}" aria-label="Top Level Navigation">
+					{%- for item in apps %}
+
+						{%- set allowed = false %}
+
+						{%- if item.canShow %}
+							{%- for permitted in permittedApps %}
+								{%- if permitted.key === item.permittedKey %}
+									{%- set allowed = true %}
+								{%- endif %}
+							{%- endfor %}
+						{%- endif %}
+
+						{%- if allowed -%}
+							<li class="datahub-header__navigation__item">
+								<a class="datahub-header__navigation__item__link{{ ' datahub-header__navigation__item__link--active' if item.activeKey == params.active }}" href="{{ item.href }}">
+									{{- item.name -}}
+								</a>
+							</li>
+						{%- endif %}
+					{%- endfor %}
+					<li class="datahub-header__navigation__item">
+						<a class="datahub-header__navigation__item__link{{ ' datahub-header__navigation__item__link--active' if supportApp.active }}" href="{{ supportApp.href }}">
+							{{- supportApp.name -}}
+						</a>
+					</li>
+				</ul>
+			</nav>
+			{%- if params.subNavigation %}
+				<nav class="datahub-header__navigation-wrapper datahub-header__navigation-wrapper--sub" aria-labelledby="sub-navigation">
+					<ul id="sub-navigation" class="datahub-header__navigation" aria-label="Second Level Navigation">
+						{%- for item in params.subNavigation %}
+							<li class="datahub-header__navigation__item">
+								<a class="datahub-header__navigation__item__link{{ ' datahub-header__navigation__item__link--active' if item.active }}" href="{{ item.href }}">{{ item.text }}</a>
+							</li>
+						{%- endfor %}
+					</ul>
+				</nav>
+			{%- endif %}
+		</div>
+	</header>
+{%- endmacro %}

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -8,7 +8,7 @@
 {% from "_macros/common.njk" import Message, MessageList, Pagination, LocalNav, Progress, FromNow, AnswersSummary, HiddenContent, TabbedLocalNav %}
 {% from "_macros/collection.njk" import CollectionContent, CollectionFilters %}
 {% from "_macros/entity.njk" import MetaList %}
-{% from "datahub-header/component/header.njk" import datahubHeader %}
+{% from "_components/header.njk" import datahubHeader %}
 
 {% if IS_XHR %}
   {% extends "./xhr.njk" %}


### PR DESCRIPTION
## Description of change

This PR copies the code for the global header from the [datahub-header](https://github.com/uktrade/datahub-header) repository into the frontend and removes the dependency on the datahub-header npm package.

The code for the header consists of:
- A nunjucks template
- A sass file with styling for the header
- A javascript file which makes the header responsive on smaller screen sizes

As datahub frontend is the last application using the datahub-header package, this will enable us to deprecate the package and save developer time maintaining it/fixing vulnerabilities.

## Test instructions

1. The global header should work as expected on the homepage and other pages not using react (e.g. investment pages after the collection list).
2. It should show a collapsed menu in mobile view.

**NOTE** - the links to Find Exporters and Market Access only show locally if you have the env var `OAUTH2_BYPASS_SSO=false`

## Screenshots

**Desktop view**
![Screenshot 2022-03-25 at 17 00 13](https://user-images.githubusercontent.com/22460823/160167093-05a31a78-b1f5-43de-b1d7-6dc5d6e28ed2.png)

**Mobile view collapsed**
![Screenshot 2022-03-25 at 17 00 29](https://user-images.githubusercontent.com/22460823/160167130-55a2f33c-f230-4344-b166-91ae2e94cead.png)

**Mobile view expanded**
![Screenshot 2022-03-25 at 17 00 44](https://user-images.githubusercontent.com/22460823/160167172-4d7ffee1-6fb8-4419-bab3-4019b4d68e4d.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
