### PR TITLE
Remove Yarn removal warning from sandbox

### DIFF
--- a/test/sandbox/package-lock.json
+++ b/test/sandbox/package-lock.json
@@ -14,8 +14,7 @@
         "nodemon": "^2.0.12"
       },
       "engines": {
-        "node": "16.14.0",
-        "yarn": "YARN NO LONGER USED - use npm instead."
+        "node": "16.14.0"
       }
     },
     "node_modules/@sindresorhus/is": {

--- a/test/sandbox/package.json
+++ b/test/sandbox/package.json
@@ -10,7 +10,6 @@
     "nodemon": "^2.0.12"
   },
   "engines": {
-    "yarn": "YARN NO LONGER USED - use npm instead.",
     "node": "16.14.0"
   },
   "overrides": {


### PR DESCRIPTION
## Description of change

Yarn was removed from the codebase almost two years ago (see #2794), so this warning is not relevant anymore.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
