### PR TITLE
Fix deprecates res commands in sandbox routes

### DIFF
--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -63,7 +63,7 @@ var getInteractionById = function (req, res) {
 
 var createInteraction = function (req, res) {
   if (_.isEqual(req.body.companies, ['4e6a4edb-55e3-4461-a88d-84d329ee7eb8'])) {
-    return res.json(400, interactionValidationError)
+    return res.status(400).json(interactionValidationError)
   }
 
   if (req.body.subject) {
@@ -73,13 +73,13 @@ var createInteraction = function (req, res) {
   }
 
   if (req.body.were_countries_discussed === 'true') {
-    return res.json(201, {
+    return res.status(201).json({
       ...interactionCreate,
       were_countries_discussed: true,
     })
   }
 
-  res.json(201, interactionCreate)
+  res.status(201).json(interactionCreate)
 }
 
 var archiveInteraction = function (req, res) {

--- a/test/sandbox/routes/v3/investment/investment-projects.js
+++ b/test/sandbox/routes/v3/investment/investment-projects.js
@@ -40,7 +40,7 @@ exports.patchInvestmentProject = function (req, res) {
     }
   }
 
-  return res.json(400, {
+  return res.status(400).json({
     client_requirements: ['required'],
   })
 }

--- a/test/sandbox/routes/v4/company-list/companyList.js
+++ b/test/sandbox/routes/v4/company-list/companyList.js
@@ -29,7 +29,7 @@ exports.getCompanyList = function (req, res) {
     return
   }
 
-  res.send(404)
+  res.sendStatus(404)
 }
 
 exports.getCompanyListItems = function (req, res) {
@@ -44,31 +44,31 @@ exports.getCompanyListItems = function (req, res) {
 }
 
 exports.createCompanyList = function (req, res) {
-  res.send(201)
+  res.sendStatus(201)
 }
 
 exports.deleteCompanyList = function (req, res) {
   if (req.params.listId === multipleItemCompanyList.id) {
-    res.send(204)
+    res.sendStatus(204)
     return
   }
 
-  res.send(404)
+  res.sendStatus(404)
 }
 
 exports.editCompanyList = function (req, res) {
   if (req.params.listId === multipleItemCompanyList.id) {
-    res.send(204)
+    res.sendStatus(204)
     return
   }
 
-  res.send(404)
+  res.sendStatus(404)
 }
 
 exports.addCompanyToList = function (req, res) {
-  res.send(204)
+  res.sendStatus(204)
 }
 
 exports.removeCompanyFromList = function (req, res) {
-  res.send(204)
+  res.sendStatus(204)
 }

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -76,7 +76,7 @@ exports.largeInvestorProfilePatched = function (req, res) {
 
 exports.largeInvestorProfilePostCreate = function (req, res) {
   if (req.body.investor_company === '400094ac-f79a-43e5-9c88-059a7baa17f3') {
-    return res.json(400, largeCapitalProfileCreateError)
+    return res.status(400).json(largeCapitalProfileCreateError)
   }
 
   res.json(largeCapitalProfileCreateSuccess)
@@ -183,7 +183,7 @@ exports.getCompanyList = function (req, res) {
 }
 
 exports.manageAdviser = function (req, res) {
-  return res.json(204, {})
+  return res.status(204).json({})
 }
 
 exports.companyAudit = function (req, res) {

--- a/test/sandbox/routes/v4/event/event.js
+++ b/test/sandbox/routes/v4/event/event.js
@@ -11,7 +11,7 @@ function getEventById(res, req) {
     '8253a4d2-0a61-4928-80cb-ebd70cce9971': eventById,
     '777f73a6-5d95-e211-aaaa-e4115bead28b': missingTeams,
   }
-  return res.json(200, events[req.params.eventId] || eventById)
+  return res.status(200).json(events[req.params.eventId] || eventById)
 }
 
 exports.eventById = function (req, res) {
@@ -19,7 +19,7 @@ exports.eventById = function (req, res) {
 }
 
 exports.createEvent = function (req, res) {
-  return res.json(201, eventCreate)
+  return res.status(201).json(eventCreate)
 }
 
 exports.patchEvent = function (req, res) {

--- a/test/sandbox/routes/v4/interaction/interaction.js
+++ b/test/sandbox/routes/v4/interaction/interaction.js
@@ -60,7 +60,7 @@ var getInteractionById = function (req, res) {
 
 var createInteraction = function (req, res) {
   if (_.isEqual(req.body.companies, ['4e6a4edb-55e3-4461-a88d-84d329ee7eb8'])) {
-    return res.json(400, interactionValidationError)
+    return res.status(400).json(interactionValidationError)
   }
 
   if (req.body.subject) {
@@ -70,13 +70,13 @@ var createInteraction = function (req, res) {
   }
 
   if (req.body.were_countries_discussed === 'true') {
-    return res.json(201, {
+    return res.status(201).json({
       ...interactionCreate,
       were_countries_discussed: true,
     })
   }
 
-  res.json(201, interactionCreate)
+  res.status(201).json(interactionCreate)
 }
 
 var archiveInteraction = function (req, res) {


### PR DESCRIPTION
## Description of change

We've recently had a few deprecation warnings appearing in CircleCI related to some of the sandbox routes.

## Test instructions

Everything should work as normal. Warnings related to 'GMT express res.json / res.send' shouldn't appear anymore.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
