### PR TITLE
Revert "DET-85 Use API proxy for Activity Feed"

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/repos.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/repos.test.js
@@ -1,12 +1,9 @@
+const config = require('../../../../../config')
 const activityFeedRawFixture = require('../../../../../../test/unit/data/activity-feed/activity-feed-from-es.json')
 const { DATA_HUB_ACTIVITY } = require('../constants')
 
 describe('Activity feed repos', () => {
-  const BASE_URL = 'https://example.com'
-  const stubRequest = {
-    session: { token: 'abcd' },
-    res: { locals: { BASE_URL } },
-  }
+  const stubRequest = { session: { token: 'abcd' } }
 
   describe('#fetchActivityFeed', () => {
     const authorisedRequestStub = sinon.stub().resolves(activityFeedRawFixture)
@@ -57,7 +54,7 @@ describe('Activity feed repos', () => {
       it('should make a request including the filters', () => {
         expect(authorisedRequestStub).to.be.calledOnceWith(stubRequest, {
           body,
-          url: `${BASE_URL}/api-proxy/v4/activity-feed`,
+          url: `${config.apiRoot}/v4/activity-feed`,
         })
       })
 

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -1,8 +1,9 @@
+const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
 
-async function fetchActivityFeed(req, body) {
+function fetchActivityFeed(req, body) {
   return authorisedRequest(req, {
-    url: `${req.res.locals.BASE_URL}/api-proxy/v4/activity-feed`,
+    url: `${config.apiRoot}/v4/activity-feed`,
     body,
   })
 }

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -52,7 +52,6 @@ const ALLOWLIST = [
   '/v3/omis/order/:id/assignee',
   '/v3/omis/order/:id/subscriber-list',
   '/v3/investment/:id/team-member',
-  '/v4/activity-feed',
 ]
 
 module.exports = (app) => {


### PR DESCRIPTION
## Description of change

This reverts commit dd5dd7c343760979c357393195fc6abf0ae5e9b5.
Using the express api-proxy endpoint broke things on remote envs.

## Test instructions

Activity Stream calls should be authorised now.

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
