### PR TITLE
DET-85 refactor Contact Interaction task to handle errors properly

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -160,7 +160,7 @@ async function fetchActivitiesForContact(req, res, next) {
       next(error)
     })
 
-    let activities = results?.hits.hits.map((hit) => hit._source)
+    let activities = results.hits.hits.map((hit) => hit._source)
 
     res.json({ activities })
   } catch (error) {

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -160,9 +160,7 @@ async function fetchActivitiesForContact(req, res, next) {
       next(error)
     })
 
-    let activities = results
-      ? results.hits.hits.map((hit) => hit._source)
-      : { error: 'error' }
+    let activities = results?.hits.hits.map((hit) => hit._source)
 
     res.json({ activities })
   } catch (error) {

--- a/src/apps/contacts/client/ContactInteractionsApp.jsx
+++ b/src/apps/contacts/client/ContactInteractionsApp.jsx
@@ -30,15 +30,11 @@ const ContactInteractionsApp = ({ contactId, activities }) => (
     {() =>
       activities && (
         <ContactInteractionsList>
-          {activities?.error ? (
-            <div>Error occurred while loading activities.</div>
-          ) : (
-            activities.map((activity, index) => (
-              <li key={`activity-${index}`}>
-                <Activity activity={activity} />
-              </li>
-            ))
-          )}
+          {activities.map((activity, index) => (
+            <li key={`activity-${index}`}>
+              <Activity activity={activity} />
+            </li>
+          ))}
         </ContactInteractionsList>
       )
     }

--- a/src/apps/contacts/client/tasks.js
+++ b/src/apps/contacts/client/tasks.js
@@ -2,4 +2,7 @@ import axios from 'axios'
 import urls from '../../../lib/urls'
 
 export const getContactInteractions = (contactId) =>
-  axios.get(urls.contacts.activity.data(contactId)).then(({ data }) => data)
+  axios
+    .get(urls.contacts.activity.data(contactId))
+    .then(({ data }) => data)
+    .catch(() => Promise.reject('Unable to load Contact Interactions'))


### PR DESCRIPTION
## Description of change

The `Task` component [does not handle generic Errors](https://github.com/uktrade/data-hub-frontend/blob/99d66f94319bb6cfcae5f33a027d8c645ce0cea2/src/client/components/Task/saga.js#L42) as we originally assumed. It looks like we have to handle them by rejecting the Task's Promise and returning a message string.

It doesn't look particularly user-friendly atm, so I expect in future we'll want to render a nice-looking error component

## Test instructions

_What should I see?_

## Screenshots
### Before

The Task would fail in the background and the 'loading' component shown continuously.

### After

If `fetchActivityFeed` throws an error:
![Screenshot 2022-03-29 at 11 42 45](https://user-images.githubusercontent.com/16647486/160594541-eff2fcc5-0f8e-49f7-bdf2-1f2c499034e4.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
