### PR TITLE
Adding a test for error messaging in Contact Interactions

### DIFF
--- a/src/apps/contacts/client/tasks.js
+++ b/src/apps/contacts/client/tasks.js
@@ -5,4 +5,4 @@ export const getContactInteractions = (contactId) =>
   axios
     .get(urls.contacts.activity.data(contactId))
     .then(({ data }) => data)
-    .catch(() => Promise.reject('Unable to load Contact Interactions'))
+    .catch(() => Promise.reject('Unable to load Contact Interactions.'))

--- a/test/functional/cypress/specs/contacts/interactions-spec.js
+++ b/test/functional/cypress/specs/contacts/interactions-spec.js
@@ -1,26 +1,49 @@
 const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 
+const { assertErrorDialog } = require('../../support/assertions')
+
 describe('Contact interactions', () => {
   const contactId = fixtures.contact.deanCox.id
 
-  context(
-    'when viewing a contact with data on Activity Stream with the feature flag enabled',
-    () => {
+  context('when the feature flag user-contact-activities is enabled', () => {
+    before(() => {
+      cy.setUserFeatures(['user-contact-activities'])
+    })
+
+    context('when viewing a contact with activities', () => {
       before(() => {
-        cy.setUserFeatures(['user-contact-activities'])
         cy.visit(urls.contacts.contactInteractions(contactId))
       })
 
       it('should display the Activity Stream activities', () => {
         cy.get('[data-test=aventri-activity]').should('be.visible')
       })
+    })
 
-      after(() => {
-        cy.resetUser()
-      })
-    }
-  )
+    context(
+      'viewing a contact when there is an error loading activities',
+      () => {
+        before(() => {
+          cy.intercept('GET', urls.contacts.activity.data(contactId), {
+            statusCode: 500,
+          })
+          cy.visit(urls.contacts.contactInteractions(contactId))
+        })
+
+        it('should render an error message', () => {
+          assertErrorDialog(
+            'TASK_GET_CONTACT_INTERACTIONS',
+            'Unable to load Contact Interactions.'
+          )
+        })
+      }
+    )
+
+    after(() => {
+      cy.resetUser()
+    })
+  })
   context('when viewing a contact with the feature flag disabled', () => {
     before(() => {
       cy.visit(urls.contacts.contactInteractions(contactId))


### PR DESCRIPTION
Co-Authored-By: Edmond De Los Reyes <28296624+dredmonds@users.noreply.github.com>
Co-Authored-By: Harriet H-W <16647486+Harriethw@users.noreply.github.com>
Co-Authored-By: Onyela Ogah <83657534+onyela-o@users.noreply.github.com>
Co-Authored-By: Christopher Sunkel <36161814+cgsunkel@users.noreply.github.com>

## Description of change
Adding a test for error added in #4491

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
