### PR TITLE
Allow additional query params when feature testing

### DIFF
--- a/src/middleware/user-features.js
+++ b/src/middleware/user-features.js
@@ -23,10 +23,15 @@ module.exports = (feature) => async (req, res, next) => {
     const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
     res.locals.userFeatures = get(user, 'active_features', [])
   }
+
   res.locals.isFeatureTesting = res.locals.userFeatures.includes(feature)
 
-  if (res.locals.isFeatureTesting && isEmpty(req.query)) {
-    return res.redirect(`${req.originalUrl}?featureTesting=${feature}`)
+  if (res.locals.isFeatureTesting && !req.query.featureTesting) {
+    res.redirect(
+      `${req.originalUrl}${
+        isEmpty(req.query) ? '?' : '&'
+      }featureTesting=${feature}`
+    )
   } else {
     next()
   }


### PR DESCRIPTION
## Description of change

Improves our feature testing by allowing additional query parameters. This change enables us to track users coming from email notifications we've sent them.

## Test instructions

**Existing behaviour is unchanged**
`/` redirects to `/?featureTesting=personalised-dashboard`

**New behaviour allows additional query params when feature testing**
`/?foo=bar` redirects to `/?foo=bar&featureTesting=personalised-dashboard`

**Investments**
`/investments/projects/<investment-uuid>/notifications/estimated-land-date?foo=bar` redirects to: 
`/investments/projects/<investment-uuid>/notifications/estimated-land-date?foo=bar&featureTesting=notifications`

`/investments/projects/<investment-uuid>/details?foo=bar` redirects to:
`/investments/projects/investment-uuid>/details?foo=bar&featureTesting=notifications`

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
