### PR TITLE
Scroll to top when there are form api errors

### DIFF
--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -121,6 +121,7 @@ const _Form = ({
           ])
         )
       )
+      window.scrollTo({ top: 0 })
     }
   }, [result])
 


### PR DESCRIPTION
## Description of change

When there is an error with a duplicate email address on the contact form, the page now scrolls to the top so you can read the error messages.

## Test instructions

On submitting the contact form with a duplicate email address (for that company), the page should scroll to the top so you can read the error messages.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
