### PR TITLE
Remove progress indication from filter typeaheads and fix teams filter

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-
 import urls from '../../../../lib/urls'
 import {
   CollectionFilters,
@@ -49,7 +48,6 @@ const ProjectsCollection = ({
   const adviserListTask = {
     name: TASK_GET_INVESTMENTS_PROJECTS_ADVISER_NAME,
     id: INVESTMENT_PROJECTS_ID,
-    progressMessage: 'Loading advisers',
     startOnRender: {
       payload: payload.adviser,
       onSuccessDispatch: INVESTMENTS__PROJECTS_SELECTED_ADVISERS,

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -32,7 +32,7 @@ const RoutedAdvisersTypeahead = ({
   loadOptions = fetchAdvisers(onlyShowActiveAdvisers),
   ...props
 }) => (
-  <Task.Status {...taskProps}>
+  <Task.Status {...taskProps} progressOverlay={true}>
     {() => (
       <RoutedTypeahead
         loadOptions={loadOptions}

--- a/src/client/components/RoutedTeamsTypeahead/index.jsx
+++ b/src/client/components/RoutedTeamsTypeahead/index.jsx
@@ -35,7 +35,7 @@ const RoutedTeamsTypeahead = ({
   loadOptions = fetchTeams(),
   ...props
 }) => (
-  <Task.Status {...taskProps}>
+  <Task.Status {...taskProps} progressOverlay={true}>
     {() => (
       <RoutedTypeahead
         loadOptions={loadOptions}

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -7,10 +7,17 @@ import { get } from 'lodash'
 import PropTypes from 'prop-types'
 import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
+import { LoadingBox } from 'govuk-react'
 
 import { TASK__START, TASK__DISMISS_ERROR, TASK__CANCEL } from '../../actions'
 import Err from './Error'
 import ProgressIndicator from '../ProgressIndicator'
+
+import styled from 'styled-components'
+
+const StyledLoadingBox = styled(LoadingBox)({
+  paddingBottom: 0,
+})
 
 const nameIdPropTypes = {
   name: PropTypes.string.isRequired,
@@ -218,6 +225,7 @@ Task.Status = ({
   progressMessage,
   renderError = Err,
   renderProgress = ProgressIndicator,
+  progressOverlay = false,
   dismissable = true,
   children = () => null,
 }) => (
@@ -239,7 +247,9 @@ Task.Status = ({
           {!!startOnRender && (
             <Task.StartOnRender {...startOnRender} {...{ name, id }} />
           )}
-          {progress && renderProgress({ message: progressMessage })}
+          {!progressOverlay &&
+            progress &&
+            renderProgress({ message: progressMessage })}
           {error &&
             renderError({
               noun,
@@ -248,7 +258,9 @@ Task.Status = ({
               dismiss: dismissError,
               dismissable,
             })}
-          {!status && children()}
+          <StyledLoadingBox loading={progress && progressOverlay}>
+            {(!status || progressOverlay) && children()}
+          </StyledLoadingBox>
         </>
       )
     }}
@@ -259,6 +271,7 @@ Task.Status.propTypes = {
   ...nameIdPropTypes,
   noun: PropTypes.string,
   progressMessage: PropTypes.string,
+  progressOverlay: PropTypes.bool,
   startOnRender: PropTypes.shape(startOnRenderPropTypes),
   renderProgress: PropTypes.elementType,
   renderError: PropTypes.elementType,

--- a/src/client/components/ToggleSection/FilterToggleSection.jsx
+++ b/src/client/components/ToggleSection/FilterToggleSection.jsx
@@ -17,6 +17,9 @@ export const FilterToggleSection = styled(ToggleSection)({
     '> *:last-child': {
       marginBottom: 0,
     },
+    '> *:last-child div:last-child': {
+      marginBottom: 0,
+    },
   },
 })
 

--- a/src/client/components/Typeahead/SelectedChips.jsx
+++ b/src/client/components/Typeahead/SelectedChips.jsx
@@ -61,7 +61,7 @@ const SelectedChips = ({ name, selectedOptions, onOptionRemove }) => (
             onOptionRemove(option)
           }}
         >
-          {option.label}
+          {option.chipLabel || option.label}
         </ChipButton>
       </Chip>
     ))}

--- a/src/client/modules/Companies/CollectionList/index.jsx
+++ b/src/client/modules/Companies/CollectionList/index.jsx
@@ -73,7 +73,6 @@ const CompaniesCollection = ({
   const leadItaGlobalAccountManagerTask = {
     name: TASK_GET_COMPANIES_LEAD_ITA_OR_GLOBAL_ACCOUNT_MANAGER_NAME,
     id: ID,
-    progressMessage: 'Loading advisers',
     startOnRender: {
       payload: payload.one_list_group_global_account_manager,
       onSuccessDispatch: COMPANIES__SELECTED_LEAD_ITA_OR_GLOBAL_ACCOUNT_MANAGER,

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -69,7 +69,6 @@ const EventsCollection = ({
   const organisersTask = {
     name: TASK_GET_EVENTS_ORGANISER_NAME,
     id: ID,
-    progressMessage: 'Loading organisers',
     startOnRender: {
       payload: payload.organiser,
       onSuccessDispatch: EVENTS__SELECTED_ORGANISER,

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -62,7 +62,6 @@ const InteractionCollection = ({
   const adviserListTask = {
     name: TASK_GET_INTERACTIONS_ADVISER_NAME,
     id: ID,
-    progressMessage: 'Loading advisers',
     startOnRender: {
       payload: payload.dit_participants__adviser,
       onSuccessDispatch: INTERACTIONS_SELECTED_ADVISERS,
@@ -101,7 +100,6 @@ const InteractionCollection = ({
   const teamListTask = {
     name: TASK_GET_INTERACTIONS_TEAM_NAME,
     id: ID,
-    progressMessage: 'Loading teams',
     startOnRender: {
       payload: payload.dit_participants__team,
       onSuccessDispatch: INTERACTIONS_SELECTED_TEAMS,

--- a/src/client/teams.js
+++ b/src/client/teams.js
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import urls from '../lib/urls'
 import { apiProxyAxios } from './components/Task/utils'
 
@@ -8,14 +9,14 @@ export const getTeamNames = (team) => {
 
   const teams = Array.isArray(team) ? team : [team]
 
-  return apiProxyAxios
+  return axios
     .all(
       teams.map((teamId) =>
         apiProxyAxios.get(`${urls.metadata.team()}?id=${teamId}`)
       )
     )
     .then(
-      apiProxyAxios.spread((...responses) =>
+      axios.spread((...responses) =>
         responses.map(({ data }) => ({
           teams: data[0],
         }))

--- a/src/common/formatAdviser.js
+++ b/src/common/formatAdviser.js
@@ -3,6 +3,7 @@ const parseAdviserData = (advisers) => {
     .filter((adviser) => adviser.name && adviser.name.trim().length)
     .map(({ id, name, dit_team }) => ({
       label: `${name}${dit_team ? ', ' + dit_team.name : ''}`,
+      chipLabel: name,
       value: id,
     }))
 }

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -684,6 +684,7 @@ describe('Add company form', () => {
         .parent()
         .parent()
         .parent()
+        .parent()
         .next()
         .contains('DIT sector')
         .next()

--- a/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-details-spec.js
@@ -30,7 +30,7 @@ describe('Referral details', () => {
     })
 
     it('should render the content and elements in order', () => {
-      cy.get('#referral-details > table')
+      cy.get('#referral-details > div > table')
         .eq(0)
         .find('caption')
         .should('have.text', 'I am a subject')
@@ -127,7 +127,7 @@ describe('Referral details', () => {
     })
 
     it('should render the content and elements in order', () => {
-      cy.get('#referral-details > table')
+      cy.get('#referral-details > div > table')
         .eq(0)
         .find('caption')
         .should('have.text', 'I am a subject')


### PR DESCRIPTION
## Description of change

This fixes a visual bug where filter typeaheads in collection pages would briefly disappear showing "Loading advisers" or "Loading teams" progress indicator after selecting a filter. Since the progress is also shown in the main collection list, it is not necessary to show it in individual filters. An option to bypass showing progress has been added to `Task.Status` component.

Additionally it fixes Teams collection filter, where `getTeamNames` used axios incorrectly causing component to crash.

## Test instructions

Go to Investment collection page and select an Adviser. The adviser typeahead shouldn't be disappearing.

Go to Interaction collection page and select a Team. The team typeahead shouldn't be disappearing and component no longer crashes after making a selection.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
