### PR TITLE
Persist redux store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "redis": "3.1.2",
         "redux": "^4.1.2",
         "redux-devtools-extension": "^2.13.9",
+        "redux-persist": "^6.0.0",
         "redux-saga": "^1.1.3",
         "request": "^2.88.2",
         "request-promise": "^4.2.6",
@@ -31880,6 +31881,14 @@
         "redux": "^3.1.0 || ^4.0.0"
       }
     },
+    "node_modules/redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "peerDependencies": {
+        "redux": ">4.0.0"
+      }
+    },
     "node_modules/redux-saga": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
@@ -43212,7 +43221,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "style-loader": {
@@ -45817,7 +45826,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "style-loader": {
@@ -49585,7 +49594,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "optional": true,
           "requires": {
-            "is-plain-obj": "1.1.0"
+            "is-plain-obj": "^1.0.0"
           }
         }
       }
@@ -50131,7 +50140,7 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": "4.0.1",
+        "set-value": "^2.0.0",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
@@ -50389,7 +50398,7 @@
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
         "fsevents": "~2.3.2",
-        "glob-parent": "5.1.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
@@ -50585,7 +50594,7 @@
           "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1"
+            "ansi-regex": "^6.0.1"
           }
         }
       }
@@ -51206,7 +51215,7 @@
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
             "@nodelib/fs.stat": "^1.1.2",
-            "glob-parent": "5.1.2",
+            "glob-parent": "^3.1.0",
             "is-glob": "^4.0.0",
             "merge2": "^1.2.3",
             "micromatch": "^3.1.10"
@@ -51491,7 +51500,7 @@
         "css-what": "^5.1.0",
         "domhandler": "^4.3.0",
         "domutils": "^2.8.0",
-        "nth-check": "2.0.1"
+        "nth-check": "^2.0.1"
       }
     },
     "css-to-react-native": {
@@ -52659,7 +52668,7 @@
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
             "get-stream": "^3.0.0",
-            "is-plain-obj": "1.1.0",
+            "is-plain-obj": "^1.1.0",
             "is-retry-allowed": "^1.0.0",
             "is-stream": "^1.0.0",
             "isurl": "^1.0.0-alpha5",
@@ -54344,7 +54353,7 @@
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "5.1.2",
+        "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
@@ -54709,7 +54718,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "optional": true,
       "requires": {
-        "semver-regex": "3.1.3"
+        "semver-regex": "^2.0.0"
       }
     },
     "find-webpack": {
@@ -58631,7 +58640,7 @@
       "dev": true,
       "requires": {
         "fault": "^1.0.0",
-        "highlight.js": "11.2.0"
+        "highlight.js": "~10.7.0"
       }
     },
     "lru-cache": {
@@ -59779,7 +59788,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "5.0.1"
+            "ansi-regex": "^4.1.0"
           }
         },
         "wrap-ansi": {
@@ -63329,6 +63338,12 @@
       "integrity": "sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==",
       "requires": {}
     },
+    "redux-persist": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/redux-persist/-/redux-persist-6.0.0.tgz",
+      "integrity": "sha512-71LLMbUq2r02ng2We9S215LtPu3fY0KgaGE0k8WRgl6RkqxtGfl7HUozz1Dftwsb0D/5mZ8dwAaPbtnzfvbEwQ==",
+      "requires": {}
+    },
     "redux-saga": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.1.3.tgz",
@@ -63578,7 +63593,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.3",
+        "trim": "0.0.1",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -64502,7 +64517,7 @@
       "integrity": "sha512-cUdFiCbKoa1mZ6osuJs2uDHrs0k0oprsKveFiiaBKCNq3SYyb5gs2HxhQyDNLCmL51ZZThqi4YNDpCK6GOP1iQ==",
       "dev": true,
       "requires": {
-        "node-forge": ">=1.0.0"
+        "node-forge": "^1.2.0"
       }
     },
     "semver": {
@@ -64520,8 +64535,7 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
+      "version": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
       "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
       "optional": true
     },
@@ -64700,8 +64714,7 @@
       "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "set-value": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
+      "version": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
       "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
       "dev": true,
       "requires": {
@@ -65104,7 +65117,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "optional": true,
       "requires": {
-        "is-plain-obj": "1.1.0"
+        "is-plain-obj": "^1.0.0"
       }
     },
     "sort-keys-length": {
@@ -65591,7 +65604,7 @@
           "dev": true,
           "requires": {
             "fault": "^1.0.2",
-            "highlight.js": "11.2.0"
+            "highlight.js": "~9.13.0"
           }
         },
         "markdown-to-jsx": {
@@ -66635,8 +66648,7 @@
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
     },
     "trim": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+      "version": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
       "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
       "dev": true
     },
@@ -66959,7 +66971,7 @@
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
       },
@@ -66980,7 +66992,7 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "4.0.1"
+        "set-value": "^2.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -67818,7 +67830,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "5.1.2",
+            "glob-parent": "^3.1.0",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "redis": "3.1.2",
     "redux": "^4.1.2",
     "redux-devtools-extension": "^2.13.9",
+    "redux-persist": "^6.0.0",
     "redux-saga": "^1.1.3",
     "request": "^2.88.2",
     "request-promise": "^4.2.6",


### PR DESCRIPTION
## Description of change

Persists the redux store so that filters etc are not lost between page loads.

## Test instructions

Go to the personalised homepage and select some filters - go to another page and come back. The filters you selected previously should persist.

Since this changes the store globally, it makes sense to check all around datahub to make sure this hasn't broken anything.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
