### PR TITLE
Only redirect when the request is a HTTP GET

### DIFF
--- a/src/middleware/user-features.js
+++ b/src/middleware/user-features.js
@@ -18,6 +18,8 @@ const { authorisedRequest } = require('../lib/authorised-request')
  * @param {String} feature - the feature to toggle layout for.
  */
 
+const HTTP_GET = 'GET'
+
 module.exports = (feature) => async (req, res, next) => {
   if (!res.locals.userFeatures) {
     const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
@@ -26,7 +28,11 @@ module.exports = (feature) => async (req, res, next) => {
 
   res.locals.isFeatureTesting = res.locals.userFeatures.includes(feature)
 
-  if (res.locals.isFeatureTesting && !req.query.featureTesting) {
+  if (
+    res.locals.isFeatureTesting &&
+    !req.query.featureTesting &&
+    req.method == HTTP_GET
+  ) {
     res.redirect(
       `${req.originalUrl}${
         isEmpty(req.query) ? '?' : '&'


### PR DESCRIPTION
## Description of change

Fixes a bug within our feature testing mechanism. This small fix ensures we only redirect the user to a different url when the request is a `HTTP GET`.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
