### PR TITLE
Remove antiquated fields from contact details

### DIFF
--- a/src/apps/contacts/__test__/transformers.test.js
+++ b/src/apps/contacts/__test__/transformers.test.js
@@ -164,11 +164,9 @@ describe('Contact transformers', () => {
         expect(this.view).to.have.ordered.keys([
           'Job title',
           'Phone number',
-          'Alternative telephone',
           'Address',
           'Email',
-          'Alternative email',
-          'Notes',
+          'More details',
           'Email marketing',
         ])
       })
@@ -180,23 +178,12 @@ describe('Contact transformers', () => {
         )
       })
 
-      it('should return the alternative phone number', () => {
-        expect(this.view).to.have.property('Alternative telephone', '666555444')
-      })
-
       it('should return the main email', () => {
         expect(this.view).to.have.property('Email', 'Rebecca.Lowe@example.com')
       })
 
-      it('should return the alternative email', () => {
-        expect(this.view).to.have.property(
-          'Alternative email',
-          'Lowe.Rebecca@example.com'
-        )
-      })
-
       it('should return the notes', () => {
-        expect(this.view).to.have.property('Notes', 'ProductRebecca')
+        expect(this.view).to.have.property('More details', 'ProductRebecca')
       })
     })
 

--- a/src/apps/contacts/labels.js
+++ b/src/apps/contacts/labels.js
@@ -1,11 +1,9 @@
 const contactDetailsLabels = {
   job_title: 'Job title',
   full_telephone_number: 'Phone number',
-  telephone_alternative: 'Alternative telephone',
   address: 'Address',
   email: 'Email',
-  email_alternative: 'Alternative email',
-  notes: 'Notes',
+  notes: 'More details',
   email_marketing: 'Email marketing',
 }
 
@@ -17,9 +15,7 @@ const contactAuditLabels = {
   email: 'Email',
   email_marketing: 'Email marketing',
   address: 'Address',
-  telephone_alternative: 'Alternative telephone',
-  email_alternative: 'Alternative email',
-  notes: 'Notes',
+  notes: 'More details',
   address_same_as_company: 'Address same as company',
   first_name: 'First name',
   last_name: 'Last name',

--- a/src/apps/contacts/services/__test__/form.test.js
+++ b/src/apps/contacts/services/__test__/form.test.js
@@ -34,8 +34,6 @@ describe('contact form service', () => {
       email: 'zboasdaan@opasdasdov.com',
       accepts_dit_email_marketing: true,
       address_same_as_company: false,
-      telephone_alternative: '999',
-      email_alternative: 'fred@me.com',
       notes: 'Some notes',
       archived_by: null,
       title: {
@@ -70,8 +68,6 @@ describe('contact form service', () => {
         address_county: 'CA',
         address_postcode: '94043',
         address_country: '81756b9a-5d95-e211-a939-e4115bead28a',
-        telephone_alternative: '999',
-        email_alternative: 'fred@me.com',
         notes: 'Some notes',
       }
 
@@ -110,8 +106,6 @@ describe('contact form service', () => {
         address_county: null,
         address_postcode: null,
         address_country: null,
-        telephone_alternative: '999',
-        email_alternative: 'fred@me.com',
         notes: 'Some notes',
         accepts_dit_email_marketing: true,
       }

--- a/src/apps/contacts/services/form.js
+++ b/src/apps/contacts/services/form.js
@@ -37,8 +37,6 @@ function getContactAsFormData(contact) {
     address_county: contact.address_county,
     address_postcode: contact.address_postcode,
     address_country: getPropertyId(contact, 'address_country'),
-    telephone_alternative: contact.telephone_alternative,
-    email_alternative: contact.email_alternative,
     notes: contact.notes,
   }
 

--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -108,8 +108,6 @@ function transformContactToView(
     address_postcode,
     address_area,
     address_country,
-    telephone_alternative,
-    email_alternative,
     notes,
     address_same_as_company,
   },
@@ -118,8 +116,6 @@ function transformContactToView(
   const viewRecord = {
     job_title,
     email,
-    telephone_alternative,
-    email_alternative,
     notes,
     full_telephone_number,
     email_marketing: accepts_dit_email_marketing


### PR DESCRIPTION
## Description of change

Removed antiquated fields and renamed `Notes` to `More details`

## Test instructions

Go to `/contacts/<contact-uuid>/details` 

## Screenshots
### Before
<img width="989" alt="before" src="https://user-images.githubusercontent.com/964268/162961681-2256179e-cccd-4fca-92d4-828ba93f22c6.png">

### After
<img width="989" alt="after" src="https://user-images.githubusercontent.com/964268/162961721-f7d1d5c9-29fd-48f5-bc18-f3397ddeda44.png">
## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
