### PR TITLE
Add script to simplify Storybook updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
   - dependency-name: "@storybook/react"
     versions:
     - ">= 0"
+  - dependency-name: "@storybook/builder-webpack5"
+    versions:
+    - ">= 0"
+  - dependency-name: "@storybook/manager-webpack5"
+    versions:
+    - ">= 0"
   # ignore all GitHub linguist patch updates
   - dependency-name: "github-linguist"
     update-types: ["version-update:semver-patch"]

--- a/docs/Dependabot.md
+++ b/docs/Dependabot.md
@@ -36,4 +36,6 @@ The `react-dom` and `react` packages should, where possible, be kept at the same
 
 ### Storybook / Nivo
 
-When one of the `@storybook` dependencies is updated, the others need to be updated so they are all on the same version. The same principle applies to the `@nivo` dependencies.
+When one of the `@storybook` dependencies is updated, the others need to be updated so they are all on the same version. This can be done with the script `storybook:update-dependencies`, which will set all Storybook dependencies to the latest version.
+
+The same principle applies to the `@nivo` dependencies.

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "storybook": "start-storybook",
     "storybook:build": "rimraf storybook-static && build-storybook --quiet",
     "storybook:release": "npm run storybook:build && cp -R ./.circleci ./storybook-static/.circleci && git-directory-deploy --directory storybook-static --branch gh-pages",
+    "storybook:update-dependencies": "npm install --save-dev @storybook/addon-a11y@latest @storybook/addon-actions@latest @storybook/addon-controls@latest @storybook/addons@latest @storybook/builder-webpack5@latest @storybook/manager-webpack5@latest @storybook/react@latest",
     "clean": "del .build cypress-coverage",
     "start": "node --use-strict src/server.js",
     "start:coverage": "nyc --silent npm run start",


### PR DESCRIPTION
## Description of change

As part of the Dependabot process, we need to keep all the Storybook dependencies at the same version. However, doing this manually is time consuming and can be prone to error. In order to improve this I have added a script (`storybook:update-dependencies`) that will bump all Storybook dependencies to the latest version.

I've also added the two new Storybook dependencies to the Dependabot ignore list.

## Test instructions

If you want to test the new script out, first run the command below to downgrade the Storybook dependencies.
```bash
npm install --save-dev @storybook/addon-a11y@6.4.1 @storybook/addon-actions@6.4.1 @storybook/addon-controls@6.4.1 @storybook/addons@6.4.1 @storybook/builder-webpack5@6.4.1 @storybook/manager-webpack5@6.4.1 @storybook/react@6.4.1
``` 
Running the new script will reinstall them at the latest `6.4.22` version.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
