### PR TITLE
Stop interactions with no service breaking the company activity feed

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -166,11 +166,14 @@ export default class Interaction extends React.PureComponent {
           </StyledNotes>
         )}
         <StyledMetadata>
-          {metadata.map(({ label, value }) => (
-            <div>
-              <span style={{ fontWeight: 'bold' }}>{label}:</span> {value}
-            </div>
-          ))}
+          {metadata.map(
+            ({ label, value }) =>
+              value && (
+                <div>
+                  <span style={{ fontWeight: 'bold' }}>{label}:</span> {value}
+                </div>
+              )
+          )}
         </StyledMetadata>
       </ItemWrapper>
     )

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -61,7 +61,7 @@ export default class Interaction extends React.PureComponent {
     const service = transformed.serviceText
     const kind = transformed.typeText
 
-    const serviceName = activityObject['dit:service'].name
+    const serviceName = activityObject['dit:service']?.name
     const serviceNotes = activityObject.content
     const MAX_NOTE_LENGTH = 255
 

--- a/src/client/components/ActivityFeed/activities/InteractionUtils.js
+++ b/src/client/components/ActivityFeed/activities/InteractionUtils.js
@@ -24,17 +24,20 @@ const isServiceDelivery = (activity) => {
 
 const getServiceText = (activity) => {
   const service = get(activity, 'object.dit:service.name')
-  const serviceType = service.includes(' : ')
-    ? service.split(' : ')[0]
-    : service
+  if (service) {
+    const serviceType = service.includes(' : ')
+      ? service.split(' : ')[0]
+      : service
 
-  const serviceText =
-    service.includes('Making') && service.includes('Introductions')
-      ? 'Introduction'
-      : service.includes('Advice & Information')
-      ? 'Advice & Information'
-      : INTERACTION_SERVICES[serviceType]
-  return serviceText
+    const serviceText =
+      service.includes('Making') && service.includes('Introductions')
+        ? 'Introduction'
+        : service.includes('Advice & Information')
+        ? 'Advice & Information'
+        : INTERACTION_SERVICES[serviceType]
+    return serviceText
+  }
+  return null
 }
 
 const getThemeText = (activity) => {

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -85,12 +85,6 @@ describe('Contact activity', () => {
           )
         })
 
-        it('should display the communication channel', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            'Communication channel:'
-          )
-        })
-
         it('should display the advisers with email', () => {
           cy.get('[data-test=interaction-activity]')
             .contains(
@@ -103,6 +97,13 @@ describe('Contact activity', () => {
         it('should display the service', () => {
           cy.get('[data-test=interaction-activity]').contains(
             'Service: Making Export Introductions : Someone else in DIT'
+          )
+        })
+
+        it('should not display entries for missing data', () => {
+          cy.get('[data-test=interaction-activity]').should(
+            'not.have.text',
+            'Communication channel:'
           )
         })
       })


### PR DESCRIPTION
## Description of change

There is currently a live issue where the company activity feed breaks if an interaction without a service comes through [(example in dev](https://www.datahub.dev.uktrade.io/companies/b570f2de-1638-4308-9149-5ff17b64d18e/activity)). This is because some of the transformers for the new interactions card (which run regardless of whether the feature flag is active or not) are reliant on a service being present.

The relevant functions now only run if a service exists, and return `null` if it doesn't. In addition to this, service information no longer renders on the new contact activity feed where interactions have no service.

## Test instructions

With your local FE pointing to dev, go to [the example company listed above](http://localhost:3000/companies/b570f2de-1638-4308-9149-5ff17b64d18e/activity). The page should render properly.

If you want to inspect the contact activity feed changes, enable the `user-contact-activities` feature flag and go to [this contact](http://localhost:3000/contacts/715e8a58-6515-4d52-a4b5-84cb49566b01/interactions?featureTesting=user-contact-activities). You should see an interaction with no service information.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
