### PR TITLE
Reduce functional test parallelism from 9 to 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
       docker_layer_caching: false
-    parallelism: 7
+    parallelism: 3
     resource_class: 2xlarge
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
       docker_layer_caching: false
-    parallelism: 9
+    parallelism: 7
     resource_class: 2xlarge
     steps:
       - checkout


### PR DESCRIPTION
## Description of change

To improve the reliability of the functional suite whilst the Google Cloud issues are ongoing, the parallelism for the functional suite has been reduced. This is because of numerous occurences of single runs crashing silently.

When everything has gone back to normal, we'll be able to go back to 9.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
