### PR TITLE
Add GTM data analytics to company activity type drop-down filter

### DIFF
--- a/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 
 import SelectFilter from './filters/SelectFilter'
 import ActivityFeedCheckbox from './ActivityFeedCheckbox'
+import Analytics from '../Analytics'
 
 const ActivityFeedFiltersRow = styled('div')`
   padding: ${SPACING.SCALE_2};
@@ -33,6 +34,14 @@ const StyledTitle = styled('div')`
   white-space: nowrap;
 `
 
+const getDropDownOptionLabel = (options, selectEvent) => {
+  const { label } = options.find(
+    (option) => option.value == selectEvent.target.value
+  )
+
+  return label
+}
+
 const ActivityFeedFilters = ({
   activityTypeFilters,
   activityTypeFilter,
@@ -55,11 +64,28 @@ const ActivityFeedFilters = ({
           </ActivityFeedCheckbox>
         </StyledCheckboxContainer>
       )}
-      <SelectFilter
-        filters={activityTypeFilters}
-        onActivityTypeFilterChange={onActivityTypeFilterChange}
-        value={activityTypeFilter}
-      />
+      <Analytics>
+        {(pushAnalytics) => (
+          <SelectFilter
+            filters={activityTypeFilters}
+            onActivityTypeFilterChange={
+              (onActivityTypeFilterChange,
+              (selectEvent) => {
+                pushAnalytics({
+                  event: 'activityTypeDropDown',
+                  extra: {
+                    dropDownOptionSelected: getDropDownOptionLabel(
+                      activityTypeFilters,
+                      selectEvent
+                    ),
+                  },
+                })
+              })
+            }
+            value={activityTypeFilter}
+          />
+        )}
+      </Analytics>
     </ActivityFeedFiltersRow>
   )
 }

--- a/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
@@ -34,6 +34,17 @@ const StyledTitle = styled('div')`
   white-space: nowrap;
 `
 
+const trackAnalytics = (e, pushAnalytics) => {
+  const { options, selectedIndex } = e.target
+  const dropDownOptionSelected = options[selectedIndex].text
+  pushAnalytics({
+    event: 'activityTypeDropDown',
+    extra: {
+      dropDownOptionSelected,
+    },
+  })
+}
+
 const ActivityFeedFilters = ({
   activityTypeFilters,
   activityTypeFilter,
@@ -60,17 +71,10 @@ const ActivityFeedFilters = ({
         {(pushAnalytics) => (
           <SelectFilter
             filters={activityTypeFilters}
-            onActivityTypeFilterChange={
-              (onActivityTypeFilterChange,
-              ({ target: { options, selectedIndex } }) => {
-                pushAnalytics({
-                  event: 'activityTypeDropDown',
-                  extra: {
-                    dropDownOptionSelected: options[selectedIndex].text,
-                  },
-                })
-              })
-            }
+            onActivityTypeFilterChange={(e) => {
+              onActivityTypeFilterChange(e)
+              trackAnalytics(e, pushAnalytics)
+            }}
             value={activityTypeFilter}
           />
         )}

--- a/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedFilters.jsx
@@ -34,14 +34,6 @@ const StyledTitle = styled('div')`
   white-space: nowrap;
 `
 
-const getDropDownOptionLabel = (options, selectEvent) => {
-  const { label } = options.find(
-    (option) => option.value == selectEvent.target.value
-  )
-
-  return label
-}
-
 const ActivityFeedFilters = ({
   activityTypeFilters,
   activityTypeFilter,
@@ -70,14 +62,11 @@ const ActivityFeedFilters = ({
             filters={activityTypeFilters}
             onActivityTypeFilterChange={
               (onActivityTypeFilterChange,
-              (selectEvent) => {
+              ({ target: { options, selectedIndex } }) => {
                 pushAnalytics({
                   event: 'activityTypeDropDown',
                   extra: {
-                    dropDownOptionSelected: getDropDownOptionLabel(
-                      activityTypeFilters,
-                      selectEvent
-                    ),
+                    dropDownOptionSelected: options[selectedIndex].text,
                   },
                 })
               })


### PR DESCRIPTION
## Description of change

As part of company activities, the performance analysis team would like to track when user filters a company activity type.

## Test instructions
- Set `GOOGLE_TAG_MANAGER_KEY` value to your environment variables
- Add `datalayer checker` plugin to google chrome browser
- Navigate to Data Hub > Companies > "Company Name" > Activity tab
- Select dropdown filter by `Activity types`
- Inspect `datalayer checker` values from developers tools - console to view data being feed to GTM.

Where values are: 
- `dropDownOptionSelected`: `All Data Hub activity` or `All external activity`  etc upon selected
- `event` : `activityTypeDropDown`

<img width="769" alt="image" src="https://user-images.githubusercontent.com/28296624/165794541-833145cd-252e-4ce3-accd-7ef07061e876.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [X] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
