### PR TITLE
Add GTM data analytics for details accordion to company activity feed 

### DIFF
--- a/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
@@ -6,7 +6,11 @@ import { Card, CardDetails, CardHeader, CardTable } from './card'
 
 import CardUtils from './card/CardUtils'
 import { currencyGBP } from '../../../utils/number-utils'
-import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
+import {
+  ACTIVITY_TYPE,
+  ANALYTICS_ACCORDION_TYPE,
+  SOURCE_TYPES,
+} from '../constants'
 
 const { format } = require('../../../utils/date')
 
@@ -61,6 +65,7 @@ export default class CompaniesHouseAccount extends React.PureComponent {
           summaryVisuallyHidden={`${summary} in Companies House`}
           link={{ taxonomy, text: 'Go to the Companies House accounts page' }}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.COMPANIES_HOUSE}
         >
           <CardTable
             rows={[

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
@@ -13,7 +13,11 @@ import {
 import { DefaultItemRenderer } from './card/item-renderers'
 
 import CardUtils from './card/CardUtils'
-import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
+import {
+  ACTIVITY_TYPE,
+  ANALYTICS_ACCORDION_TYPE,
+  SOURCE_TYPES,
+} from '../constants'
 
 const { format } = require('../../../utils/date')
 
@@ -80,6 +84,7 @@ export default class CompaniesHouseCompany extends React.PureComponent {
           summary="View key details for this company"
           summaryVisuallyHidden={`${summary} from Companies House`}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.COMPANIES_HOUSE}
         >
           <CardTable
             rows={[
@@ -100,7 +105,10 @@ export default class CompaniesHouseCompany extends React.PureComponent {
                 header: 'Returns last made up date',
                 content: returnsLastMadeUpDate,
               },
-              { header: 'Returns next due date', content: returnsNextDueDate },
+              {
+                header: 'Returns next due date',
+                content: returnsNextDueDate,
+              },
               {
                 header: 'SIC code(s)',
                 content: (

--- a/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
+++ b/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
@@ -13,7 +13,11 @@ import {
 import { DefaultItemRenderer } from './card/item-renderers'
 
 import CardUtils from './card/CardUtils'
-import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
+import {
+  ACTIVITY_TYPE,
+  ANALYTICS_ACCORDION_TYPE,
+  SOURCE_TYPES,
+} from '../constants'
 
 export default class HmrcExporter extends React.PureComponent {
   static propTypes = {
@@ -56,6 +60,7 @@ export default class HmrcExporter extends React.PureComponent {
           summary="View key export details"
           summaryVisuallyHidden={` for ${reference}`}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.HMRC}
         >
           <CardTable
             rows={[

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -16,7 +16,7 @@ import {
   AdviserActivityRenderer,
   AdviserItemRenderer,
 } from './card/item-renderers'
-import { ACTIVITY_TYPE } from '../constants'
+import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
 import InteractionUtils from './InteractionUtils'
@@ -194,7 +194,6 @@ export default class Interaction extends React.PureComponent {
           startTime={transformed.startTime}
           badge={transformed.badge}
         />
-
         <CardDetails
           summary={`View ${transformed.typeText} details`}
           summaryVisuallyHidden={` for ${transformed.subject}`}
@@ -203,6 +202,7 @@ export default class Interaction extends React.PureComponent {
             text: `You can view more on the ${transformed.typeText} detail page`,
           }}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY}
         >
           <CardTable
             rows={[

--- a/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
+++ b/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
@@ -12,7 +12,7 @@ import {
 } from './card'
 
 import { AdviserItemRenderer, ContactItemRenderer } from './card/item-renderers'
-import { ACTIVITY_TYPE } from '../constants'
+import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
 import { currencyGBP, decimal } from '../../../utils/number-utils'
@@ -77,6 +77,7 @@ export default class InvestmentProject extends React.PureComponent {
           summaryVisuallyHidden={` ${name}`}
           link={{ url, text: 'Go to the investment project detail page' }}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY}
         >
           <CardTable
             rows={[

--- a/src/client/components/ActivityFeed/activities/Omis.jsx
+++ b/src/client/components/ActivityFeed/activities/Omis.jsx
@@ -12,7 +12,7 @@ import {
 } from './card'
 
 import { AdviserItemRenderer, ContactItemRenderer } from './card/item-renderers'
-import { ACTIVITY_TYPE } from '../constants'
+import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
 
@@ -53,6 +53,7 @@ export default class Omis extends React.PureComponent {
           summaryVisuallyHidden={` reference ${reference}`}
           link={{ url, text: 'Go to the order detail page' }}
           showDetails={showDetails}
+          analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY}
         >
           <CardTable
             rows={[

--- a/src/client/components/ActivityFeed/activities/card/CardDetails.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardDetails.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { SPACING, MEDIA_QUERIES, FONT_SIZE } from '@govuk-react/constants'
 import { VisuallyHidden } from 'govuk-react'
 import PropTypes from 'prop-types'
+import Analytics from '../../../Analytics'
 
 const GovUkDetails = styled(Details)`
   font-size: ${FONT_SIZE.SIZE_16};
@@ -35,6 +36,7 @@ export default class CardDetails extends React.PureComponent {
       text: PropTypes.string,
     }),
     children: PropTypes.node.isRequired,
+    analyticsAccordionType: PropTypes.string,
   }
 
   static defaultProps = {
@@ -50,8 +52,14 @@ export default class CardDetails extends React.PureComponent {
   }
 
   render() {
-    const { summary, showDetails, link, children, summaryVisuallyHidden } =
-      this.props
+    const {
+      summary,
+      showDetails,
+      link,
+      children,
+      summaryVisuallyHidden,
+      analyticsAccordionType,
+    } = this.props
 
     const SummaryWithHiddenContent = (
       <>
@@ -61,13 +69,26 @@ export default class CardDetails extends React.PureComponent {
     )
 
     return (
-      <GovUkDetails
-        summary={summaryVisuallyHidden ? SummaryWithHiddenContent : summary}
-        open={showDetails}
-      >
-        {children}
-        {this.renderLink(link)}
-      </GovUkDetails>
+      <Analytics>
+        {(pushAnalytics) => (
+          <GovUkDetails
+            summary={summaryVisuallyHidden ? SummaryWithHiddenContent : summary}
+            open={showDetails}
+            onClick={() => {
+              pushAnalytics({
+                event: 'viewInteractionEngagement',
+                extra: {
+                  accordionEngagement: 'clicked',
+                  accordionType: analyticsAccordionType,
+                },
+              })
+            }}
+          >
+            {children}
+            {this.renderLink(link)}
+          </GovUkDetails>
+        )}
+      </Analytics>
     )
   }
 }

--- a/src/client/components/ActivityFeed/constants.js
+++ b/src/client/components/ActivityFeed/constants.js
@@ -79,6 +79,12 @@ export const ACTIVITY_TYPE_FILTERS = {
   },
 }
 
+export const ANALYTICS_ACCORDION_TYPE = {
+  HMRC: 'HMRC',
+  COMPANIES_HOUSE: 'Companies House',
+  DATA_HUB_ACTIVITY: 'Data Hub Activity',
+}
+
 export const INTERACTION_SERVICES = {
   'Account Management': 'Account Management',
   'A Specific Service': 'Specific Service',
@@ -100,6 +106,7 @@ export const INTERACTION_SERVICES = {
 export default {
   ACTIVITY_TYPE,
   ACTIVITY_TYPE_FILTERS,
+  ANALYTICS_ACCORDION_TYPE,
   SOURCE_TYPES,
   STATUS,
   BADGES,


### PR DESCRIPTION
## Description of change

The performance analysts have asked us to add analytics tracking to the 'View interaction details' accordion to show when users are interacting with it.

## Test instructions

Same as [this PR](https://github.com/uktrade/data-hub-frontend/pull/4549). You can view the analytics by going to a company and opening the details accordion.

## Screenshots

<img width="882" alt="Screenshot 2022-05-03 at 11 03 20" src="https://user-images.githubusercontent.com/36161814/166435761-8e8eedf5-34fc-412f-b505-3e36865a1b59.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
