### PR TITLE
Fix failing Large Capital Profile test

### DIFF
--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -272,14 +272,14 @@ describe('View large capital investor details page', () => {
         required_checks_conducted: '02d6fc9b-fbb9-4621-b247-d86f2487898e',
         required_checks_conducted_on: `${lastMonth.getFullYear()}-${(
           lastMonth.getMonth() + 1
-        ).toString()}-${lastMonth.getDay().toString()}`,
+        ).toString()}-${lastMonth.getDate().toString()}`,
         required_checks_conducted_by: null,
       }
       assertRequiredCheckDate().then((element) => {
         clearAndInputDateValueObject({
           element,
           value: {
-            day: lastMonth.getDay().toString(),
+            day: lastMonth.getDate().toString(),
             month: (lastMonth.getMonth() + 1).toString(),
             year: lastMonth.getFullYear().toString(),
           },


### PR DESCRIPTION
## Description of change

This test was failing due to an issue with the dynamic date. The date was set to be the 3rd day of the previous month which was extracted using the `getDay` function (which returns the numerical day of the week).

As the 3rd April happened to be a Sunday, the `getDay` function returned zero which was entered in the form, which raised an error that prevented the form of being submitted. I've replaced it with the `getDate` function, which will always return a non-zero number and prevent this issue from occuring again.

## Test instructions

The `investment-large-capital-investor-details-spec` should pass.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
