### PR TITLE
Expose search results to assistive technologies

### DIFF
--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -63,7 +63,7 @@ const CollectionList = ({
               entityNamePlural={entityNamePlural}
             />
           )}
-          <ol>
+          <ol aria-live="polite">
             {items.map(
               (
                 { headingText, headingUrl, subheading, badges, metadata },

--- a/src/client/components/EntityList/index.jsx
+++ b/src/client/components/EntityList/index.jsx
@@ -15,7 +15,7 @@ const StyledEntityListItem = styled('li')`
 `
 
 const EntityList = ({ entities, entityRenderer: EntityRenderer }) => (
-  <StyledEntityList data-test="entity-list">
+  <StyledEntityList aria-live="polite" data-test="entity-list">
     {entities.map((entity) => (
       <StyledEntityListItem
         data-test="entity-list-item"

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -101,7 +101,7 @@ const FilteredCollectionList = ({
                 <Task.Status {...taskProps}>
                   {() =>
                     isComplete && (
-                      <ol>
+                      <ol aria-live="polite">
                         {results.map((item) => (
                           <Analytics>
                             {(pushAnalytics) => (


### PR DESCRIPTION
## Description of change

Ensure users of assistive technologies are made aware of search results. Previously, users of this technology would be unaware of changes to the page.

## Test instructions
On macOS start the screen reader with `CTRL + (quickly press Touch ID 3 times)` or `CMD-F5` for machines that do not have Touch ID. Once Voiceover is enabled, simply perform a search on any CollectionList page (Companies, Contacts, Events... ) by applying a filter, the screen reader will now read the search results. The same applies when searching for a company that a user wishes to add to Data Hub.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
