### PR TITLE
Fix investment project failing to open with http 500 error

### DIFF
--- a/src/apps/investments/transformers/shared.js
+++ b/src/apps/investments/transformers/shared.js
@@ -2,7 +2,7 @@ const { investmentTypes } = require('../types')
 
 const getInvestmentTypeDetails = (investmentType, fdiType) => {
   if (investmentType.name === investmentTypes.FDI) {
-    return `${investmentType.name}, ${fdiType.name}`
+    return `${investmentType.name}, ${fdiType ? fdiType.name : 'None'}`
   }
   return investmentType.name
 }

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -47,6 +47,7 @@ module.exports = {
     investmentWithNoGlobalAccountManager: require('./investment/investment-no-global-account-manager.json'),
     notificationSettingsAll: require('./investment/notification-settings-all'),
     notificationSettingsEmpty: require('./investment/notification-settings-empty'),
+    fdiInvestmentWithNoFDIType: require('./investment/investment-fdi-has-no-fdi-type.json'),
   },
   event: {
     emptyOneDayExhibition: require('./event/empty-one-day-exhibition'),

--- a/test/functional/cypress/fixtures/investment/investment-fdi-has-no-fdi-type.json
+++ b/test/functional/cypress/fixtures/investment/investment-fdi-has-no-fdi-type.json
@@ -1,0 +1,196 @@
+{
+  "id": "1e7c5d2a-c580-48f8-b097-4af3b8841e95",
+  "incomplete_fields": [
+    "actual_land_date",
+    "associated_non_fdi_r_and_d_project"
+  ],
+  "name": "New fruit machine",
+  "project_code": "DHP-00000009",
+  "description": "This is a dummy investment project for testing",
+  "anonymous_description": "",
+  "allow_blank_estimated_land_date": false,
+  "estimated_land_date": "2020-01-01",
+  "actual_land_date": null,
+  "quotable_as_public_case_study": null,
+  "likelihood_to_land": null,
+  "priority": null,
+  "approved_commitment_to_invest": null,
+  "approved_fdi": null,
+  "approved_good_value": null,
+  "approved_high_value": null,
+  "approved_landed": null,
+  "approved_non_fdi": null,
+  "investment_type": {
+    "name": "FDI",
+    "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+  },
+  "stage": {
+    "name": "Verify win",
+    "id": "49b8f6f3-0c50-4150-a965-2c974f3149e3"
+  },
+  "status": "ongoing",
+  "reason_delayed": null,
+  "reason_abandoned": null,
+  "date_abandoned": null,
+  "reason_lost": null,
+  "date_lost": null,
+  "country_lost_to": null,
+  "investor_company": {
+    "name": "Venus Ltd",
+    "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+  },
+  "investor_type": null,
+  "investor_company_country": {
+    "name": "United Kingdom",
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+  },
+  "intermediate_company": null,
+  "level_of_involvement": null,
+  "specific_programme": null,
+  "client_contacts": [
+    {
+      "name": "Dean Cox",
+      "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+    }
+  ],
+  "client_relationship_manager": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "client_relationship_manager_team": {
+    "name": "CBBC North EAST",
+    "id": "602b971d-5df6-e511-888e-e4115bead28a"
+  },
+  "referral_source_adviser": {
+    "name": "Puck Head",
+    "first_name": "Puck",
+    "last_name": "Head",
+    "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+  },
+  "referral_source_activity": {
+    "name": "None",
+    "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+  },
+  "referral_source_activity_website": null,
+  "referral_source_activity_marketing": null,
+  "referral_source_activity_event": null,
+  "fdi_type": null,
+  "sector": {
+    "name": "Renewable Energy : Wind : Onshore",
+    "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+  },
+  "business_activities": [
+    {
+      "name": "Retail",
+      "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+    }
+  ],
+  "other_business_activity": null,
+  "archived": false,
+  "archived_documents_url_path": "",
+  "archived_on": null,
+  "archived_reason": null,
+  "archived_by": null,
+  "created_on": "2017-03-05T12:00:00Z",
+  "modified_on": "2017-03-05T15:00:00Z",
+  "comments": "",
+  "country_investment_originates_from": null,
+  "level_of_involvement_simplified": "unspecified",
+  "fdi_value": null,
+  "total_investment": "1000000",
+  "foreign_equity_investment": "200000",
+  "government_assistance": true,
+  "some_new_jobs": null,
+  "number_new_jobs": 20,
+  "will_new_jobs_last_two_years": null,
+  "average_salary": {
+    "name": "Below £25,000",
+    "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+  },
+  "number_safeguarded_jobs": 1,
+  "r_and_d_budget": false,
+  "non_fdi_r_and_d_budget": true,
+  "associated_non_fdi_r_and_d_project": null,
+  "new_tech_to_uk": true,
+  "export_revenue": true,
+  "value_complete": false,
+  "client_cannot_provide_total_investment": false,
+  "client_cannot_provide_foreign_investment": false,
+  "client_requirements": "Anywhere",
+  "site_decided": true,
+  "address_1": "10 Eastings Road",
+  "address_2": null,
+  "address_town": "London",
+  "address_postcode": "W1 2AA",
+  "competitor_countries": [
+    {
+      "name": "Netherlands",
+      "id": "1950bdb8-5d95-e211-a939-e4115bead28a"
+    }
+  ],
+  "allow_blank_possible_uk_regions": false,
+  "uk_region_locations": [
+    {
+      "name": "North East",
+      "id": "814cd12a-6095-e211-a939-e4115bead28a"
+    }
+  ],
+  "actual_uk_regions": [
+    {
+      "name": "North East",
+      "id": "814cd12a-6095-e211-a939-e4115bead28a"
+    }
+  ],
+  "delivery_partners": [
+    {
+      "name": "New Anglia LEP",
+      "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+    },
+    {
+      "name": "North Eastern LEP",
+      "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+    }
+  ],
+  "strategic_drivers": [
+    {
+      "name": "Access to market",
+      "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+    }
+  ],
+  "client_considering_other_countries": true,
+  "uk_company_decided": null,
+  "uk_company": {
+    "name": "Mercury Ltd",
+    "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+  },
+  "requirements_complete": true,
+  "project_manager_requested_on": null,
+  "project_manager_request_status": null,
+  "project_manager": {
+    "name": "Michael Wining",
+    "first_name": "Michael",
+    "last_name": "Wining",
+    "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
+  },
+  "project_assurance_adviser": {
+    "name": "Paula Churing",
+    "first_name": "Paula",
+    "last_name": "Churing",
+    "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+  },
+  "project_manager_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "project_assurance_team": {
+    "name": "Marketing - Marketing Team",
+    "id": "8248318c-9698-e211-a939-e4115bead28a"
+  },
+  "team_complete": true,
+  "team_members": [],
+  "project_arrived_in_triage_on": null,
+  "proposal_deadline": null,
+  "stage_log": []
+}

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -28,4 +28,30 @@ describe('Investment project details', () => {
       )
     })
   })
+
+  context('When and FDI investment type is missing an FDI Type', () => {
+    before(() => {
+      cy.visit(
+        urls.investments.projects.details(
+          fixtures.investment.fdiInvestmentWithNoFDIType.id
+        )
+      )
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Investments: urls.investments.index(),
+        Projects: urls.investments.projects.index(),
+        [fixtures.investment.fdiInvestmentWithNoFDIType.name]: null,
+      })
+    })
+
+    it('should render a summary containing None FDI type replacing undefined', () => {
+      cy.get("[data-test='summaryContainer-content']").contains(
+        'Investment type'
+      )
+      cy.get("[data-test='summaryContainer-content']").contains('FDI, None')
+    })
+  })
 })

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -1308,10 +1308,7 @@
     },
     {
       "id": "721e2a04-21c3-4172-a321-4368463a4b2d",
-      "incomplete_fields": [
-        "project_manager",
-        "project_assurance_adviser"
-      ],
+      "incomplete_fields": ["project_manager", "project_assurance_adviser"],
       "name": "New hotel (FDI)",
       "project_code": "DHP-00000001",
       "description": "This is a dummy investment project for testing",
@@ -2014,9 +2011,7 @@
     },
     {
       "id": "5d341b34-1fc8-4638-b4b1-a0922ebf401e",
-      "incomplete_fields": [
-        "associated_non_fdi_r_and_d_project"
-      ],
+      "incomplete_fields": ["associated_non_fdi_r_and_d_project"],
       "name": "New metro system (legacy project)",
       "project_code": "DHP-00000010",
       "description": "This is a dummy investment project for testing",
@@ -2202,9 +2197,7 @@
     },
     {
       "id": "3e341b34-1fc8-4638-b4b1-a0922ecf403e",
-      "incomplete_fields": [
-        "associated_non_fdi_r_and_d_project"
-      ],
+      "incomplete_fields": ["associated_non_fdi_r_and_d_project"],
       "name": "Project landing before April 2020",
       "project_code": "DHP-00000010",
       "description": "This is a dummy investment project for testing",
@@ -2390,9 +2383,7 @@
     },
     {
       "id": "6e441b34-1fc8-4638-b4b1-a0922ecf403e",
-      "incomplete_fields": [
-        "associated_non_fdi_r_and_d_project"
-      ],
+      "incomplete_fields": ["associated_non_fdi_r_and_d_project"],
       "name": "Project landing after April 2020",
       "project_code": "DHP-00000010",
       "description": "This is a dummy investment project for testing",
@@ -2577,7 +2568,6 @@
       "stage_log": []
     },
     {
-
       "id": "5e341b34-1fc8-4638-b4b1-a0922ecf403e",
       "incomplete_fields": [],
       "name": "Banner Won Ltd",
@@ -3298,6 +3288,202 @@
         "first_name": "DIT",
         "last_name": "Staff",
         "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+      },
+      "project_assurance_adviser": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
+      "id": "1e7c5d2a-c580-48f8-b097-4af3b8841e95",
+      "incomplete_fields": [
+        "actual_land_date",
+        "associated_non_fdi_r_and_d_project"
+      ],
+      "name": "New fruit machine",
+      "project_code": "DHP-00000009",
+      "description": "This is a dummy investment project for testing",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": false,
+      "estimated_land_date": "2020-01-01",
+      "actual_land_date": null,
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Verify win",
+        "id": "49b8f6f3-0c50-4150-a965-2c974f3149e3"
+      },
+      "status": "ongoing",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": null,
+      "date_lost": null,
+      "country_lost_to": null,
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": null,
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-03-05T12:00:00Z",
+      "modified_on": "2017-03-05T15:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": 1,
+      "r_and_d_budget": false,
+      "non_fdi_r_and_d_budget": true,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": true,
+      "export_revenue": true,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": true,
+      "address_1": "10 Eastings Road",
+      "address_2": null,
+      "address_town": "London",
+      "address_postcode": "W1 2AA",
+      "competitor_countries": [
+        {
+          "name": "Netherlands",
+          "id": "1950bdb8-5d95-e211-a939-e4115bead28a"
+        }
+      ],
+      "allow_blank_possible_uk_regions": false,
+      "uk_region_locations": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "actual_uk_regions": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "delivery_partners": [
+        {
+          "name": "New Anglia LEP",
+          "id": "cdcc392e-0bf1-e511-8ffa-e4115bead28a"
+        },
+        {
+          "name": "North Eastern LEP",
+          "id": "6e85b4e3-0df1-e511-8ffa-e4115bead28a"
+        }
+      ],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": true,
+      "uk_company_decided": null,
+      "uk_company": {
+        "name": "Mercury Ltd",
+        "id": "a73efeba-8499-11e6-ae22-56b6b6499611"
+      },
+      "requirements_complete": true,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Michael Wining",
+        "first_name": "Michael",
+        "last_name": "Wining",
+        "id": "d7493b4e-5d7b-4834-98d9-28b78a74052a"
       },
       "project_assurance_adviser": {
         "name": "Paula Churing",


### PR DESCRIPTION
## Description of change

With very specific investment project data, the page is failing to open. 

## Test instructions

When navigating to https://www.datahub.dev.uktrade.io/investments/projects/fb5b5006-56af-40e0-8615-7aba53e0e4bf/details on dev, this should show no errors and the data that is undefined should show **None** rather than **Undefined**

## Screenshots
### Before

<img width="997" alt="image" src="https://user-images.githubusercontent.com/19926221/168108656-3e95885b-8cd7-499a-8e30-0a722dec2837.png">

### After

<img width="1079" alt="image" src="https://user-images.githubusercontent.com/19926221/168109112-e838b58a-3c18-4e89-8279-ebd8c445e996.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
