### PR TITLE
Fix broken table header within notifications

### DIFF
--- a/src/apps/investments/client/projects/notifications/InvestmentNotificationSettings.jsx
+++ b/src/apps/investments/client/projects/notifications/InvestmentNotificationSettings.jsx
@@ -27,13 +27,18 @@ const InvestmentNotificationSettings = ({ investment }) => (
   >
     {({ estimatedLandDate }) => (
       <>
-        <p>Change your email preferences for: {investment.name}</p>
-        <Table>
-          <Table.Row>
-            <Table.Header>Notification type</Table.Header>
-            <Table.Header>Subscriptions</Table.Header>
-            <Table.Header>&nbsp;</Table.Header>
-          </Table.Row>
+        <p data-test="notification-preferences">
+          Change your email notification preferences for: {investment.name}
+        </p>
+        <Table
+          head={
+            <Table.Row>
+              <Table.CellHeader>Notification type</Table.CellHeader>
+              <Table.CellHeader>Subscriptions</Table.CellHeader>
+              <Table.CellHeader>&nbsp;</Table.CellHeader>
+            </Table.Row>
+          }
+        >
           <Table.Row>
             <Table.Cell>Estimated land date</Table.Cell>
             <Table.Cell data-test="notifications-estimated-land-date">

--- a/test/functional/cypress/specs/investments/notifications-spec.js
+++ b/test/functional/cypress/specs/investments/notifications-spec.js
@@ -50,6 +50,13 @@ describe('Notification settings with all options', () => {
       })
     })
 
+    it('should display text above the table', () => {
+      cy.get('[data-test="notification-preferences"]').should(
+        'have.text',
+        'Change your email notification preferences for: Wig factory'
+      )
+    })
+
     it('should display the notificaion options', () => {
       cy.get('[data-test="notifications-estimated-land-date"]').should(
         'have.text',


### PR DESCRIPTION
## Description of change

Fixes a table header issue on the notifications settings page.

## Test instructions

Go to `/investments/projects/<investment-uuid>/notifications`

## Screenshots
### Before
![MicrosoftTeams-image](https://user-images.githubusercontent.com/964268/169778719-89d6413b-a0b0-42b0-9ed6-45cb54bb206c.png)

### After
<img width="1072" alt="Screenshot 2022-05-23 at 09 15 31" src="https://user-images.githubusercontent.com/964268/169778597-05f4c8d5-aa30-43cf-ada1-b411999bb0fb.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
