### PR TITLE
Display Aventri events attended status

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import CardUtils from './card/CardUtils'
 import { ACTIVITY_TYPE } from '../constants'
 import { formatStartAndEndDate } from '../../../utils/date'
+import { GREY_1 } from 'govuk-colours'
+import styled from 'styled-components'
 
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -18,6 +20,12 @@ const transformAventriAttendee = (activity) => ({
     activity.object['dit:aventri:virtual_event_attendance'] == 'Yes',
 })
 
+const StyledSpan = styled('span')`
+  & > span {
+    color: ${GREY_1};
+  }
+`
+
 export default function AventriAttendee({ activity }) {
   const { eventName, date, isVirtualAttendanceConfirmed } =
     transformAventriAttendee(activity)
@@ -28,9 +36,9 @@ export default function AventriAttendee({ activity }) {
       <ActivityCardSubject>
         {eventName}
         {isVirtualAttendanceConfirmed && (
-          <span>
+          <StyledSpan>
             : <span>{VIRTUAL_EVENT_ATTENDANCE_STATUS}</span>
-          </span>
+          </StyledSpan>
         )}
       </ActivityCardSubject>
       <ActivityCardMetadata

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -9,14 +9,15 @@ import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 import ActivityCardLabels from './card/ActivityCardLabels'
 
+const VIRTUAL_EVENT_ATTENDANCE_STATUS = 'Attended'
+
 const transformAventriAttendee = (activity) => ({
   eventName: activity.eventName,
   date: formatStartAndEndDate(activity.startDate, activity.endDate),
   isVirtualAttendanceConfirmed:
-    activity.object['dit:aventri:virtual_event_attendance'],
+    activity.object['dit:aventri:virtual_event_attendance'] == 'Yes',
 })
 
-const VIRTUAL_EVENT_ATTENDANCE_STATUS = 'Attended'
 export default function AventriAttendee({ activity }) {
   const { eventName, date, isVirtualAttendanceConfirmed } =
     transformAventriAttendee(activity)
@@ -25,13 +26,12 @@ export default function AventriAttendee({ activity }) {
     <ActivityCardWrapper dataTest="aventri-activity">
       <ActivityCardLabels service="event" kind="aventri service delivery" />
       <ActivityCardSubject>
-        {/* TODO: This initial/plain presentation of event name with attendance status ATM, 
-                    styling and link will be apply when aventri details page is available */}
-        {`${eventName}${
-          isVirtualAttendanceConfirmed == 'Yes'
-            ? `: ${VIRTUAL_EVENT_ATTENDANCE_STATUS}`
-            : ''
-        }`}
+        {eventName}
+        {isVirtualAttendanceConfirmed && (
+          <span>
+            : <span>{VIRTUAL_EVENT_ATTENDANCE_STATUS}</span>
+          </span>
+        )}
       </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[{ label: 'Event date', value: date || 'Unknown' }]}

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -17,7 +17,7 @@ const transformAventriAttendee = (activity) => ({
   eventName: activity.eventName,
   date: formatStartAndEndDate(activity.startDate, activity.endDate),
   isVirtualAttendanceConfirmed:
-    activity.object['dit:aventri:virtual_event_attendance'] == 'Yes',
+    activity.object['dit:aventri:virtual_event_attendance'] === 'Yes',
 })
 
 const StyledSpan = styled('span')`

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -12,14 +12,19 @@ import ActivityCardLabels from './card/ActivityCardLabels'
 const transformAventriAttendee = (activity) => ({
   eventName: activity.eventName,
   date: formatStartAndEndDate(activity.startDate, activity.endDate),
+  virtualAttendanceConfirmed:
+    activity.object['dit:aventri:virtual_attendance_confirmed'],
 })
 export default function AventriAttendee({ activity }) {
-  const { eventName, date } = transformAventriAttendee(activity)
+  const { eventName, date, virtualAttendanceConfirmed } =
+    transformAventriAttendee(activity)
 
   return (
     <ActivityCardWrapper dataTest="aventri-activity">
       <ActivityCardLabels service="event" kind="aventri service delivery" />
-      <ActivityCardSubject>{eventName}</ActivityCardSubject>
+      <ActivityCardSubject>
+        {`${eventName}: ${virtualAttendanceConfirmed == 'Yes' && 'Attended'}`}
+      </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[{ label: 'Event date', value: date || 'Unknown' }]}
       />

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -12,18 +12,26 @@ import ActivityCardLabels from './card/ActivityCardLabels'
 const transformAventriAttendee = (activity) => ({
   eventName: activity.eventName,
   date: formatStartAndEndDate(activity.startDate, activity.endDate),
-  virtualAttendanceConfirmed:
-    activity.object['dit:aventri:virtual_attendance_confirmed'],
+  isVirtualAttendanceConfirmed:
+    activity.object['dit:aventri:virtual_event_attendance'],
 })
+
+const VIRTUAL_EVENT_ATTENDANCE_STATUS = 'Attended'
 export default function AventriAttendee({ activity }) {
-  const { eventName, date, virtualAttendanceConfirmed } =
+  const { eventName, date, isVirtualAttendanceConfirmed } =
     transformAventriAttendee(activity)
 
   return (
     <ActivityCardWrapper dataTest="aventri-activity">
       <ActivityCardLabels service="event" kind="aventri service delivery" />
       <ActivityCardSubject>
-        {`${eventName}: ${virtualAttendanceConfirmed == 'Yes' && 'Attended'}`}
+        {/* TODO: This initial/plain presentation of event name with attendance status ATM, 
+                    styling and link will be apply when aventri details page is available */}
+        {`${eventName}${
+          isVirtualAttendanceConfirmed == 'Yes'
+            ? `: ${VIRTUAL_EVENT_ATTENDANCE_STATUS}`
+            : ''
+        }`}
       </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[{ label: 'Event date', value: date || 'Unknown' }]}

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
-import { BLUE, GREY_1 } from 'govuk-colours'
+import { BLUE } from 'govuk-colours'
 import styled from 'styled-components'
 
 const StyledActivitySubject = styled('h3')`
@@ -17,17 +17,10 @@ const StyledActivitySubject = styled('h3')`
     text-decoration: none;
     color: ${BLUE};
   }
-  & > span > span {
-    color: ${GREY_1};
-  }
 `
 
 const ActivityCardSubject = ({ children }) => {
-  return (
-    <span>
-      <StyledActivitySubject>{children}</StyledActivitySubject>
-    </span>
-  )
+  return <StyledActivitySubject>{children}</StyledActivitySubject>
 }
 
 ActivityCardSubject.propTypes = {

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
-import { BLUE } from 'govuk-colours'
+import { BLUE, GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
 
 const StyledActivitySubject = styled('h3')`
@@ -17,10 +17,17 @@ const StyledActivitySubject = styled('h3')`
     text-decoration: none;
     color: ${BLUE};
   }
+  & > span > span {
+    color: ${GREY_1};
+  }
 `
 
 const ActivityCardSubject = ({ children }) => {
-  return <StyledActivitySubject>{children}</StyledActivitySubject>
+  return (
+    <span>
+      <StyledActivitySubject>{children}</StyledActivitySubject>
+    </span>
+  )
 }
 
 ActivityCardSubject.propTypes = {

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -139,9 +139,9 @@ describe('Contact activity', () => {
       })
 
       context('when viewing a Contact with Aventri activity', () => {
-        it('should diplay event name from Aventri ', () => {
+        it('should display event name and virtual event attendance from Aventri ', () => {
           cy.get('[data-test="aventri-activity"]').contains(
-            'EITA Test Event 2022'
+            'EITA Test Event 2022: Attended'
           )
         })
         it('should display event date from Aventri', () => {

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -138,33 +138,47 @@ describe('Contact activity', () => {
         })
       })
 
-      context('when viewing a Contact with Aventri activity', () => {
-        it('should display event name and virtual event attendance from Aventri ', () => {
-          cy.get('[data-test="aventri-activity"]').contains(
-            'EITA Test Event 2022: Attended'
-          )
-        })
-        it('should display event date from Aventri', () => {
-          cy.get('[data-test="aventri-activity"]').contains(
-            'Event date: 02 Mar 2021 to 04 May 2022'
-          )
-        })
-        it('should display the Events label', () => {
-          cy.get('[data-test="aventri-activity"]').within(() => {
-            cy.get('[data-test="activity-service-label"]').contains('event', {
-              matchCase: false,
-            })
-          })
-        })
-        it('should display the Kind label', () => {
-          cy.get('[data-test="aventri-activity"]').within(() => {
-            cy.get('[data-test="activity-kind-label"]').contains(
-              'aventri service delivery',
-              { matchCase: false }
+      context(
+        'when viewing a Contact with confirmed virtual event attendance from Aventri activity',
+        () => {
+          it('should display event name and with confirmed virtual event attendance', () => {
+            cy.get('[data-test="aventri-activity"]').contains(
+              'EITA Test Event 2022: Attended'
             )
           })
-        })
-      })
+          it('should display event date from Aventri', () => {
+            cy.get('[data-test="aventri-activity"]').contains(
+              'Event date: 02 Mar 2021 to 04 May 2022'
+            )
+          })
+          it('should display the Events label', () => {
+            cy.get('[data-test="aventri-activity"]').within(() => {
+              cy.get('[data-test="activity-service-label"]').contains('event', {
+                matchCase: false,
+              })
+            })
+          })
+          it('should display the Kind label', () => {
+            cy.get('[data-test="aventri-activity"]').within(() => {
+              cy.get('[data-test="activity-kind-label"]').contains(
+                'aventri service delivery',
+                { matchCase: false }
+              )
+            })
+          })
+        }
+      )
+
+      context(
+        'when viewing a Contact with unconfirmed virtual event attendance from Aventri activity',
+        () => {
+          it('should display event name with unconfirmed virtual event attendance', () => {
+            cy.get('[data-test="aventri-activity"]')
+              .contains('EITA Test Event 2 2022')
+              .should('not.contain', ': Attended')
+          })
+        }
+      )
 
       context('when there are more than 10 activities', () => {
         it('should be possible to page through', () => {

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-events.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-events.json
@@ -75,6 +75,64 @@
         {
           "_index" : "activities__feed_id_dummy-data-feed__date_2022-05-03__timestamp_1651585823__batch_id_jaedyooq__",
           "_type" : "_doc",
+          "_id" : "dit:aventri:Event:1113:Create",
+          "_score" : 1.3122244,
+          "_source" : {
+            "dit:application" : "aventri",
+            "id" : "dit:aventri:Event:1113:Create",
+            "object" : {
+              "attributedTo" : {
+                "id" : "dit:aventri:Folder:EITA Event 2 2022",
+                "type" : "dit:aventri:Folder"
+              },
+              "content" : "<p>This is some content about event</p>",
+              "dit:aventri:approval_required" : "0",
+              "dit:aventri:approval_status" : "0",
+              "dit:aventri:city" : "Online",
+              "dit:aventri:clientcontact" : "",
+              "dit:aventri:closedate" : "2022-01-23T23:45:00",
+              "dit:aventri:code" : "EITA Code",
+              "dit:aventri:contactinfo" : "contact2@example.host",
+              "dit:aventri:country" : "",
+              "dit:aventri:createdby" : "1234",
+              "dit:aventri:defaultlanguage" : "eng",
+              "dit:aventri:folderid" : "1113",
+              "dit:aventri:live_date" : null,
+              "dit:aventri:location_address1" : "",
+              "dit:aventri:location_address2" : "",
+              "dit:aventri:location_address3" : "",
+              "dit:aventri:location_city" : "Online",
+              "dit:aventri:location_country" : "",
+              "dit:aventri:location_name" : "",
+              "dit:aventri:location_postcode" : "",
+              "dit:aventri:location_state" : "",
+              "dit:aventri:locationname" : "",
+              "dit:aventri:max_reg" : "0",
+              "dit:aventri:modifiedby" : "firstname1.lastname1@example.host",
+              "dit:aventri:modifieddatetime" : "2022-01-23T20:53:38",
+              "dit:aventri:price_type" : "net",
+              "dit:aventri:standardcurrency" : "Sterling",
+              "dit:aventri:state" : "",
+              "dit:aventri:timezone" : "Europe/London",
+              "dit:public" : true,
+              "dit:status" : "Pre-Event",
+              "endTime" : "2022-05-04T20:09:14",
+              "id" : "dit:aventri:Event:1113",
+              "name" : "EITA Test Event 2 2022",
+              "published" : "2022-01-23T20:09:14",
+              "startTime" : "2021-03-02T20:09:14",
+              "type" : [
+                "dit:aventri:Event"
+              ],
+              "url" : ""
+            },
+            "published" : "2022-01-23T20:09:14",
+            "type" : "dit:aventri:Event"
+          }
+        },
+        {
+          "_index" : "activities__feed_id_dummy-data-feed__date_2022-05-03__timestamp_1651585823__batch_id_jaedyooq__",
+          "_type" : "_doc",
           "_id" : "dit:aventri:Event:1112:Create",
           "_score" : 1.3122244,
           "_source" : {

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
@@ -37,7 +37,7 @@
             "dit:aventri:lastname": "Lastname1",
             "dit:aventri:modifiedby": "attendee",
             "dit:aventri:registrationstatus": "Confirmed",
-            "dit:aventri:virtual_attendance_confirmed": "Yes",
+            "dit:aventri:virtual_event_attendance": "Yes",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": ["dit:aventri:Attendee"]

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
@@ -28,13 +28,13 @@
               "type": "dit:aventri:Event"
             },
             "dit:aventri:approvalstatus": null,
-            "dit:aventri:companyname": "Acme Ltd",
+            "dit:aventri:companyname": "Acme2 Ltd",
             "dit:aventri:createdby": "attendee",
-            "dit:aventri:email": "firstname1.lastname1@example.host",
-            "dit:aventri:firstname": "Firstname1",
+            "dit:aventri:email": "firstname2.lastname1@example.host",
+            "dit:aventri:firstname": "Firstname2",
             "dit:aventri:language": "eng",
             "dit:aventri:lastmodified": "2022-01-24T11:12:13",
-            "dit:aventri:lastname": "Lastname1",
+            "dit:aventri:lastname": "Lastname2",
             "dit:aventri:modifiedby": "attendee",
             "dit:aventri:registrationstatus": "Confirmed",
             "dit:aventri:virtual_event_attendance": "Yes",
@@ -47,6 +47,39 @@
         },
         "sort": [1645702137000]
       },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-03-11__timestamp_1646998003__batch_id_kc0ew8vl__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:1113:Create",
+        "_score": null,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1113:Attendee:1113:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1113",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": null,
+            "dit:aventri:companyname": "Acme Ltd",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "firstname1.lastname1@example.host",
+            "dit:aventri:firstname": "Firstname1",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Lastname1",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "",
+            "id": "dit:aventri:Attendee:1234",
+            "published": "1970-01-01T00:00:00",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        },
+        "sort": [1645702137000]
+    },
       {
         "_index": "activities__feed_id_datahub-interactions__date_2019-06-20__timestamp_1561034480__batch_id_xputyeio__",
         "_type": "_doc",

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
@@ -37,6 +37,7 @@
             "dit:aventri:lastname": "Lastname1",
             "dit:aventri:modifiedby": "attendee",
             "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_attendance_confirmed": "Yes",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": ["dit:aventri:Attendee"]


### PR DESCRIPTION
## Description of change

This PR pulls through a field from Activity Stream called `virtual_event_attendance` which is set to "Yes" when virtual attendance has been confirmed, or an empty string if it hasn't been/ the information is unknown.

If virtual attendance has been confirmed, the 'Attended' status will be shown at the end of the event name. If not, then nothing will be shown. 

## Test instructions
- Go to Data Hub dev django admin and turn on the user feature flag `user-contact-activities` on your adviser profile.
- Using branch `feature/DET-181-display-aventri-attended-status` and the dev api go to the contact John Doe http://localhost:3000/contacts/68be55fc-544d-4d9c-a264-977b917f1fd3/interactions?featureTesting=user-contact-activities
- If you scroll down, you should be able to see three events. One with nothing at the end, and two with the Attended status. 

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/28296624/170244863-e18dc1d7-418a-4454-9f23-878dc1b91c62.png)


**After**
![image](https://user-images.githubusercontent.com/28296624/170244708-5e5f75c6-572e-4eb4-bc23-6df54f2492fa.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [X] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
