### PR TITLE
Add `userFeatureFlags` to global React store

### DIFF
--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -26,7 +26,7 @@ const interactionsRouter = require('../interactions/router.sub-app')
 const {
   fetchActivitiesForContact,
 } = require('../companies/apps/activity-feed/controllers')
-const userFeatures = require('../../middleware/user-features')
+const { checkUserFeatures } = require('../../middleware/user-features')
 
 router.get(urls.contacts.index(), renderContactsView)
 router.get(['/create', '/:contactId/edit'], createAndEdit)
@@ -43,7 +43,7 @@ router.use(
 router.get('/:contactId', redirectToFirstNavItem)
 router.get(
   '/:contactId/details',
-  userFeatures('user-contact-activities'),
+  checkUserFeatures('user-contact-activities'),
   getDetails
 )
 
@@ -51,13 +51,13 @@ router.get('/:id/unarchive', unarchiveContact)
 
 router.get(
   '/:contactId/audit',
-  userFeatures('user-contact-activities'),
+  checkUserFeatures('user-contact-activities'),
   getAudit
 )
 
 router.get(
   '/:contactId/documents',
-  userFeatures('user-contact-activities'),
+  checkUserFeatures('user-contact-activities'),
   renderDocuments
 )
 

--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -2,7 +2,7 @@ const router = require('express').Router()
 const urls = require('../../lib/urls')
 const { renderDashboard } = require('./controllers')
 const spaBasePath = require('../../middleware/spa-base-path')
-const userFeatures = require('../../middleware/user-features')
+const { checkUserFeatures } = require('../../middleware/user-features')
 
 module.exports = {
   router: router.get(
@@ -16,7 +16,7 @@ module.exports = {
       urls.pipeline.won(),
     ],
     spaBasePath(urls.dashboard.route),
-    userFeatures('personalised-dashboard'),
+    checkUserFeatures('personalised-dashboard'),
     renderDashboard
   ),
 }

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -10,7 +10,7 @@ const {
   getInteractionCollectionForEntity,
   getInteractionSortForm,
 } = require('./middleware/collection')
-const userFeatures = require('../../middleware/user-features')
+const { checkUserFeatures } = require('../../middleware/user-features')
 
 const detailsFormRouter = require('./apps/details-form/router')
 
@@ -21,7 +21,7 @@ router.get(
   getInteractionsRequestBody,
   getInteractionCollectionForEntity,
   getInteractionSortForm,
-  userFeatures('user-contact-activities'),
+  checkUserFeatures('user-contact-activities'),
   renderInteractionsForEntity
 )
 

--- a/src/apps/investments/router-projects.js
+++ b/src/apps/investments/router-projects.js
@@ -81,11 +81,15 @@ const {
 
 const interactionsRouter = require('../interactions/router.sub-app')
 const propositionsRouter = require('../propositions/router.sub-app')
-const userFeatures = require('../../middleware/user-features')
+const { checkUserFeatures } = require('../../middleware/user-features')
 
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
-router.use('/:investmentId', userFeatures('notifications'), setLocalNavigation)
+router.use(
+  '/:investmentId',
+  checkUserFeatures('notifications'),
+  setLocalNavigation
+)
 router.param('investmentId', shared.getInvestmentDetails)
 router.param('companyId', shared.getCompanyDetails)
 

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -136,6 +136,7 @@ const parseProps = (domNode) => {
     return {
       modulePermissions: [],
       currentAdviserId: '',
+      userFeatureFlags: {},
     }
   }
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
@@ -143,11 +144,13 @@ const parseProps = (domNode) => {
 
 const appWrapper = document.getElementById('react-app')
 
-const { modulePermissions, currentAdviserId } = parseProps(appWrapper)
+const { modulePermissions, currentAdviserId, userFeatureFlags } =
+  parseProps(appWrapper)
 
 const reducer = {
   currentAdviserId: () => currentAdviserId,
   modulePermissions: () => modulePermissions,
+  userFeatureFlags: () => userFeatureFlags,
   router: connectRouter(history),
   tasks,
   [FLASH_MESSAGE_ID]: flashMessageReducer,

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -17,6 +17,7 @@ module.exports = () => {
         ...res.locals.PERMITTED_APPLICATIONS.map(({ key }) => key),
       ]),
       currentAdviserId: req.session?.user?.id,
+      userFeatureFlags: res.locals.userFeatures,
     }
     next()
   }

--- a/src/middleware/user-features.js
+++ b/src/middleware/user-features.js
@@ -3,6 +3,13 @@ const { get, isEmpty } = require('lodash')
 const config = require('../config')
 const { authorisedRequest } = require('../lib/authorised-request')
 
+const setUserFeatures = async (req, res, next) => {
+  if (!res.locals.userFeatures) {
+    const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
+    res.locals.userFeatures = get(user, 'active_features', [])
+  }
+  next()
+}
 /**
  * Allows users with the given feature flag to trial a new feature.
  *
@@ -20,12 +27,7 @@ const { authorisedRequest } = require('../lib/authorised-request')
 
 const HTTP_GET = 'GET'
 
-module.exports = (feature) => async (req, res, next) => {
-  if (!res.locals.userFeatures) {
-    const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
-    res.locals.userFeatures = get(user, 'active_features', [])
-  }
-
+const checkUserFeatures = (feature) => async (req, res, next) => {
   res.locals.isFeatureTesting = res.locals.userFeatures.includes(feature)
 
   if (
@@ -41,4 +43,9 @@ module.exports = (feature) => async (req, res, next) => {
   } else {
     next()
   }
+}
+
+module.exports = {
+  checkUserFeatures,
+  setUserFeatures,
 }

--- a/src/middleware/user-features.js
+++ b/src/middleware/user-features.js
@@ -5,8 +5,12 @@ const { authorisedRequest } = require('../lib/authorised-request')
 
 const setUserFeatures = async (req, res, next) => {
   if (!res.locals.userFeatures) {
-    const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
-    res.locals.userFeatures = get(user, 'active_features', [])
+    try {
+      const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
+      res.locals.userFeatures = get(user, 'active_features', [])
+    } catch {
+      res.locals.userFeatures = undefined
+    }
   }
   next()
 }

--- a/src/server.js
+++ b/src/server.js
@@ -47,6 +47,7 @@ const helpCentreApiProxy = require('./middleware/help-centre-api-proxy')
 const fixSlashes = require('./middleware/fix-slashes')
 
 const routers = require('./apps/routers')
+const { setUserFeatures } = require('./middleware/user-features')
 
 const app = express()
 
@@ -133,6 +134,7 @@ app.use(auth)
 app.use(user)
 app.use(permissions)
 app.use(features)
+app.use(setUserFeatures)
 app.use(userLocals)
 app.use(headers)
 app.use(store())


### PR DESCRIPTION
## Description of change

We have a story coming up where we will need to check a user's feature
flags on the Events collection page. Because the current function for
checking [user feature flags is done via the Express routing middleware](https://github.com/uktrade/data-hub-frontend/blob/master/src/middleware/user-features.js#L43-L44),
we need a way to check the flags when routing is done via React.

I noticed that the `userFeatures` middleware was doing two things - setting the `userFeatures` in `res.locals` if it was not already set, and then adding the specified user feature flag to the path. I also noticed that we are setting environment-level feature flags at [the server level by default](https://github.com/uktrade/data-hub-frontend/blob/71e5139bfb7c8c42e75a738830f7fa4baf65f6a7/src/server.js#L135) and that we have a function for adding global props to the redux store - for things [like `modulePermissions` and `clientAdviserId`](https://github.com/uktrade/data-hub-frontend/blob/master/src/middleware/react-global-props.js#L11)

I'm proposing that we 
1. decouple the checking and setting of userFeatures in `res.locals` so that they are always set
2. add the user feature flags to the react global store, so that we will be able to access them in React-land
e.g. a `mapState2Props` function would look in the state and pass the value to component props like so:

```
...

 const isContactActivitiesFeatureOn =
    state.userFeatureFlags.includes(
        'user-contact-activities'
      )

return {
 ...state[ID],
 isContactActivitiesFeauteOn,
}

```

## Feedback

* I feel like there must be a simpler approach - in previous projects I've worked on this would have been done in a hook or context provider purely in React land, but I'm not sure I really grasp how to do it in this repo. I guess another way could be having a component that runs a Task to get the user features and passes them to children... 
* testing - the e2e tests were failing because they weren't able to make an authorisedrequrest to the `whoami` endpoint, so I'm failing the function silently, not sure how to put a test framework around this, or if it's needed, as we will test in functional tests when user feature flag is implemented? like we are doing here: https://github.com/uktrade/data-hub-frontend/blob/master/test/functional/cypress/specs/contacts/activity-spec.js#L11 
* I'm not an expert on Express, is this the right way to use middleware?
* naming - I notice I'm not really following the existing naming convention in the app for middleware - e.g. `features` instead of `setFeatures` but went with more verbose as it seemed better to be explicit

## Test instructions

_What should I see?_


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
