### PR TITLE
Make investment project notifications visible for other types of users

### DIFF
--- a/src/apps/investments/middleware/local-navigation.js
+++ b/src/apps/investments/middleware/local-navigation.js
@@ -18,8 +18,19 @@ const filterNotificationNavItem = (
   investment,
   isFeatureTesting
 ) => {
+  const isProjectManager = user?.id === investment?.project_manager?.id
+  const isProjectAssuranceAdviser =
+    user?.id === investment?.project_assurance_adviser?.id
+  const isClientRelationshipManager =
+    user?.id === investment?.client_relationship_manager?.id
+  const isReferralSourceAdviser =
+    user?.id === investment?.referral_source_adviser?.id
   const hasNotifications =
-    user?.id === investment?.project_manager?.id && isFeatureTesting
+    (isProjectManager ||
+      isProjectAssuranceAdviser ||
+      isClientRelationshipManager ||
+      isReferralSourceAdviser) &&
+    isFeatureTesting
 
   if (!hasNotifications) {
     return items.filter(({ path }) => !(path === NOTIFICATIONS))

--- a/test/functional/cypress/fixtures/investment/notification-settings-all.json
+++ b/test/functional/cypress/fixtures/investment/notification-settings-all.json
@@ -1,4 +1,18 @@
 {
-  "id": "39588dd2-e643-43fa-9141-6e7beb52c140",
-  "name": "Wig factory"
+  "project_manager": {
+    "id": "39588dd2-e643-43fa-9141-6e7beb52c140",
+    "name": "Wig factory"
+  },
+  "project_assurance_adviser": {
+    "id": "9e4e3ead-4a5c-4c3a-ab1d-76baeb4d2b54",
+    "name": "Wig factory"
+  },
+  "client_relationship_manager": {
+    "id": "24b87b77-d12a-4509-8651-dd9267b06dbc",
+    "name": "Wig factory"
+  },
+  "referral_source_adviser": {
+    "id": "b41448d3-5f46-4f01-bd27-ca745dbe4925",
+    "name": "Wig factory"
+  }
 }

--- a/test/functional/cypress/specs/investments/notifications-spec.js
+++ b/test/functional/cypress/specs/investments/notifications-spec.js
@@ -12,7 +12,7 @@ describe('Notification settings with all options', () => {
       cy.resetUser()
       cy.visit(
         urls.investments.notificationSettings.index(
-          fixtures.investment.notificationSettingsAll.id
+          fixtures.investment.notificationSettingsAll.project_manager.id
         ),
         { failOnStatusCode: false }
       )
@@ -29,7 +29,7 @@ describe('Notification settings with all options', () => {
       cy.setUserFeatures(['notifications'])
       cy.visit(
         urls.investments.notificationSettings.index(
-          fixtures.investment.notificationSettingsAll.id
+          fixtures.investment.notificationSettingsAll.project_manager.id
         )
       )
     })
@@ -44,7 +44,7 @@ describe('Notification settings with all options', () => {
         Investments: urls.investments.index(),
         Projects: urls.investments.projects.index(),
         'Wig factory': urls.investments.projects.project(
-          fixtures.investment.notificationSettingsAll.id
+          fixtures.investment.notificationSettingsAll.project_manager.id
         ),
         Notifications: null,
       })
@@ -71,7 +71,7 @@ describe('Notification settings with all options', () => {
           'have.attr',
           'href',
           urls.investments.notificationSettings.estimatedLandDate(
-            fixtures.investment.notificationSettingsAll.id
+            fixtures.investment.notificationSettingsAll.project_manager.id
           )
         )
     })
@@ -105,7 +105,7 @@ describe('Notification settings with no options', () => {
       })
     })
 
-    it('should display the notificaion options', () => {
+    it('should display the notification options', () => {
       cy.get('[data-test="notifications-estimated-land-date"]').should(
         'have.text',
         'None'
@@ -134,7 +134,7 @@ describe('Notification details option visible', () => {
         cy.resetUser()
         cy.visit(
           urls.investments.projects.details(
-            fixtures.investment.notificationSettingsAll.id
+            fixtures.investment.notificationSettingsAll.project_manager.id
           )
         )
       })
@@ -149,7 +149,7 @@ describe('Notification details option visible', () => {
       cy.setUserFeatures(['notifications'])
       cy.visit(
         urls.investments.projects.details(
-          fixtures.investment.notificationSettingsAll.id
+          fixtures.investment.notificationSettingsAll.project_manager.id
         )
       )
     })
@@ -161,9 +161,49 @@ describe('Notification details option visible', () => {
       cy.url().should(
         'contain',
         urls.investments.notificationSettings.index(
-          fixtures.investment.notificationSettingsAll.id
+          fixtures.investment.notificationSettingsAll.project_manager.id
         )
       )
+    })
+  })
+
+  describe('Notification details option for different types of users', () => {
+    ;[
+      [
+        fixtures.investment.notificationSettingsAll.project_manager.id,
+        'project manager',
+      ],
+      [
+        fixtures.investment.notificationSettingsAll.project_assurance_adviser
+          .id,
+        'project assurance adviser',
+      ],
+      [
+        fixtures.investment.notificationSettingsAll.client_relationship_manager
+          .id,
+        'client relationship manager',
+      ],
+      [
+        fixtures.investment.notificationSettingsAll.referral_source_adviser.id,
+        'referral source adviser',
+      ],
+    ].forEach(([projectId, userType]) => {
+      context('When viewing a project details page as ' + userType, () => {
+        before(() => {
+          cy.setUserFeatures(['notifications'])
+          cy.visit(urls.investments.projects.details(projectId))
+        })
+        it('should display the notifications button', () => {
+          cy.get(nav.sideNav).should('contain', 'Notifications')
+        })
+        it('should render the notifications page when the Notifications tab is clicked', () => {
+          cy.get(nav.sideNav).contains('Notifications').click()
+          cy.url().should(
+            'contain',
+            urls.investments.notificationSettings.index(projectId)
+          )
+        })
+      })
     })
   })
 

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -3122,6 +3122,570 @@
       "stage_log": []
     },
     {
+      "id": "9e4e3ead-4a5c-4c3a-ab1d-76baeb4d2b54",
+      "incomplete_fields": [
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town",
+        "address_postcode",
+        "actual_uk_regions",
+        "delivery_partners"
+      ],
+      "name": "Wig factory",
+      "project_code": "DHP-00000554",
+      "description": "Notifications all - project assurance adviser",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": false,
+      "estimated_land_date": "2020-01-01",
+      "actual_land_date": null,
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Active",
+        "id": "7606cc19-20da-4b74-aba1-2cec0d753ad8"
+      },
+      "status": "lost",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": "Low demand.",
+      "date_lost": "2018-01-01",
+      "country_lost_to": {
+        "name": "Marshall Islands",
+        "id": "0950bdb8-5d95-e211-a939-e4115bead28a"
+      },
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-03-05T12:00:00Z",
+      "modified_on": "2017-05-05T10:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": null,
+      "r_and_d_budget": null,
+      "non_fdi_r_and_d_budget": null,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": null,
+      "export_revenue": null,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": null,
+      "address_2": null,
+      "address_town": null,
+      "address_postcode": null,
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": false,
+      "uk_region_locations": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "actual_uk_regions": [],
+      "delivery_partners": [],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": null,
+      "requirements_complete": false,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_assurance_adviser": {
+        "name": "DIT Staff",
+        "first_name": "DIT",
+        "last_name": "Staff",
+        "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
+      "id": "24b87b77-d12a-4509-8651-dd9267b06dbc",
+      "incomplete_fields": [
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town",
+        "address_postcode",
+        "actual_uk_regions",
+        "delivery_partners"
+      ],
+      "name": "Wig factory",
+      "project_code": "DHP-00000554",
+      "description": "Notifications all - client relationship manager",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": false,
+      "estimated_land_date": "2020-01-01",
+      "actual_land_date": null,
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Active",
+        "id": "7606cc19-20da-4b74-aba1-2cec0d753ad8"
+      },
+      "status": "lost",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": "Low demand.",
+      "date_lost": "2018-01-01",
+      "country_lost_to": {
+        "name": "Marshall Islands",
+        "id": "0950bdb8-5d95-e211-a939-e4115bead28a"
+      },
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "DIT Staff",
+        "first_name": "DIT",
+        "last_name": "Staff",
+        "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-03-05T12:00:00Z",
+      "modified_on": "2017-05-05T10:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": null,
+      "r_and_d_budget": null,
+      "non_fdi_r_and_d_budget": null,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": null,
+      "export_revenue": null,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": null,
+      "address_2": null,
+      "address_town": null,
+      "address_postcode": null,
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": false,
+      "uk_region_locations": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "actual_uk_regions": [],
+      "delivery_partners": [],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": null,
+      "requirements_complete": false,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_assurance_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
+      "id": "b41448d3-5f46-4f01-bd27-ca745dbe4925",
+      "incomplete_fields": [
+        "number_safeguarded_jobs",
+        "r_and_d_budget",
+        "non_fdi_r_and_d_budget",
+        "new_tech_to_uk",
+        "export_revenue",
+        "address_1",
+        "address_town",
+        "address_postcode",
+        "actual_uk_regions",
+        "delivery_partners"
+      ],
+      "name": "Wig factory",
+      "project_code": "DHP-00000555",
+      "description": "Notifications all - referral source adviser",
+      "anonymous_description": "",
+      "allow_blank_estimated_land_date": false,
+      "estimated_land_date": "2020-01-01",
+      "actual_land_date": null,
+      "quotable_as_public_case_study": null,
+      "likelihood_to_land": null,
+      "priority": null,
+      "approved_commitment_to_invest": null,
+      "approved_fdi": null,
+      "approved_good_value": null,
+      "approved_high_value": null,
+      "approved_landed": null,
+      "approved_non_fdi": null,
+      "investment_type": {
+        "name": "FDI",
+        "id": "3e143372-496c-4d1e-8278-6fdd3da9b48b"
+      },
+      "stage": {
+        "name": "Active",
+        "id": "7606cc19-20da-4b74-aba1-2cec0d753ad8"
+      },
+      "status": "lost",
+      "reason_delayed": null,
+      "reason_abandoned": null,
+      "date_abandoned": null,
+      "reason_lost": "Low demand.",
+      "date_lost": "2018-01-01",
+      "country_lost_to": {
+        "name": "Marshall Islands",
+        "id": "0950bdb8-5d95-e211-a939-e4115bead28a"
+      },
+      "investor_company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+      },
+      "investor_type": null,
+      "investor_company_country": {
+        "name": "United Kingdom",
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a"
+      },
+      "intermediate_company": null,
+      "level_of_involvement": null,
+      "specific_programme": null,
+      "client_contacts": [
+        {
+          "name": "Dean Cox",
+          "id": "952232d2-1d25-4c3a-bcac-2f3a30a94da9"
+        }
+      ],
+      "client_relationship_manager": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "client_relationship_manager_team": {
+        "name": "CBBC North EAST",
+        "id": "602b971d-5df6-e511-888e-e4115bead28a"
+      },
+      "referral_source_adviser": {
+        "name": "DIT Staff",
+        "first_name": "DIT",
+        "last_name": "Staff",
+        "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+      },
+      "referral_source_activity": {
+        "name": "None",
+        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0"
+      },
+      "referral_source_activity_website": null,
+      "referral_source_activity_marketing": null,
+      "referral_source_activity_event": null,
+      "fdi_type": {
+        "name": "Creation of new site or activity",
+        "id": "f8447013-cfdc-4f35-a146-6619665388b3"
+      },
+      "sector": {
+        "name": "Renewable Energy : Wind : Onshore",
+        "id": "034be3be-5329-e511-b6bc-e4115bead28a"
+      },
+      "business_activities": [
+        {
+          "name": "Retail",
+          "id": "a2dbd807-ae52-421c-8d1d-88adfc7a506b"
+        }
+      ],
+      "other_business_activity": null,
+      "archived": false,
+      "archived_documents_url_path": "",
+      "archived_on": null,
+      "archived_reason": null,
+      "archived_by": null,
+      "created_on": "2017-03-05T12:00:00Z",
+      "modified_on": "2017-05-05T10:00:00Z",
+      "comments": "",
+      "country_investment_originates_from": null,
+      "level_of_involvement_simplified": "unspecified",
+      "fdi_value": null,
+      "total_investment": "1000000",
+      "foreign_equity_investment": "200000",
+      "government_assistance": true,
+      "some_new_jobs": null,
+      "number_new_jobs": 20,
+      "will_new_jobs_last_two_years": null,
+      "average_salary": {
+        "name": "Below £25,000",
+        "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"
+      },
+      "number_safeguarded_jobs": null,
+      "r_and_d_budget": null,
+      "non_fdi_r_and_d_budget": null,
+      "associated_non_fdi_r_and_d_project": null,
+      "new_tech_to_uk": null,
+      "export_revenue": null,
+      "value_complete": false,
+      "client_cannot_provide_total_investment": false,
+      "client_cannot_provide_foreign_investment": false,
+      "client_requirements": "Anywhere",
+      "site_decided": false,
+      "address_1": null,
+      "address_2": null,
+      "address_town": null,
+      "address_postcode": null,
+      "competitor_countries": [],
+      "allow_blank_possible_uk_regions": false,
+      "uk_region_locations": [
+        {
+          "name": "North East",
+          "id": "814cd12a-6095-e211-a939-e4115bead28a"
+        }
+      ],
+      "actual_uk_regions": [],
+      "delivery_partners": [],
+      "strategic_drivers": [
+        {
+          "name": "Access to market",
+          "id": "382aa6d1-a362-4166-a09d-f579d9f3be75"
+        }
+      ],
+      "client_considering_other_countries": false,
+      "uk_company_decided": null,
+      "uk_company": null,
+      "requirements_complete": false,
+      "project_manager_requested_on": null,
+      "project_manager_request_status": null,
+      "project_manager": {
+        "name": "Paula Churing",
+        "first_name": "Paula",
+        "last_name": "Churing",
+        "id": "5a644146-5298-4741-91f3-d5d7558adf47"
+      },
+      "project_assurance_adviser": {
+        "name": "Puck Head",
+        "first_name": "Puck",
+        "last_name": "Head",
+        "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+      },
+      "project_manager_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "project_assurance_team": {
+        "name": "Marketing - Marketing Team",
+        "id": "8248318c-9698-e211-a939-e4115bead28a"
+      },
+      "team_complete": true,
+      "team_members": [],
+      "project_arrived_in_triage_on": null,
+      "proposal_deadline": null,
+      "stage_log": []
+    },
+    {
       "id": "161c7f52-662b-45c3-8ade-8e9a04aaf3c1",
       "incomplete_fields": [
         "number_safeguarded_jobs",

--- a/test/sandbox/routes/v3/investment/investment-projects.js
+++ b/test/sandbox/routes/v3/investment/investment-projects.js
@@ -4,8 +4,12 @@ var projectAudit = require('../../../fixtures/v3/investment/project-audit.json')
 var notificationSettings = require('../../../fixtures/v3/investment/notification.json')
 var notificationSettingsEmpty = require('../../../fixtures/v3/investment/notification-empty.json')
 
-const NOTIFICATION_SETTINGS_ALL_PROJECT_ID =
-  '39588dd2-e643-43fa-9141-6e7beb52c140'
+const NOTIFICATION_SETTINGS_ALL_PROJECT_ID = [
+  '39588dd2-e643-43fa-9141-6e7beb52c140',
+  '9e4e3ead-4a5c-4c3a-ab1d-76baeb4d2b54',
+  '24b87b77-d12a-4509-8651-dd9267b06dbc',
+  'b41448d3-5f46-4f01-bd27-ca745dbe4925',
+]
 const NOTIFICATION_SETTINGS_EMPTY_PROJECT_ID =
   '161c7f52-662b-45c3-8ade-8e9a04aaf3c1'
 
@@ -54,7 +58,7 @@ exports.postInvestmentProjectEditTeams = function (req, res) {
 }
 
 exports.getInvestmentNotificationSettings = function (req, res) {
-  if (req.params.id == NOTIFICATION_SETTINGS_ALL_PROJECT_ID) {
+  if (NOTIFICATION_SETTINGS_ALL_PROJECT_ID.includes(req.params.id)) {
     res.json(notificationSettings)
     return
   }


### PR DESCRIPTION
## Description of change

This makes investment project notifications tab visible also for project assurance adviser, client relationship manager and referral source adviser.

## Test instructions

Visit investment project details page as its project manager, project assurance adviser, client relationship manager or referral source adviser. You should see a Notifications tab on the left hand side.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
