### PR TITLE
wait for api request in typeahead action

### DIFF
--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -10,8 +10,9 @@ export const selectFirstAdvisersTypeaheadOption = ({ element, input }) =>
       'adviserResults'
     )
     cy.get('input').clear().type(input)
-    cy.wait('@adviserResults')
-    cy.get('input').type('{downarrow}{enter}{esc}')
+    cy.wait('@adviserResults').then(() => {
+      cy.get('input').type('{downarrow}{enter}{esc}')
+    })
   })
 
 /**


### PR DESCRIPTION
Looking at the documentation for `cy.wait` it looks like we should put
actions we want to take after the request in a `then` block. Tests may
have been failing because they were trying to use the UI before the
request had completed.

https://docs.cypress.io/api/commands/wait#Alias

## Description of change

_Document what the PR does and why the change is needed_

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
