### PR TITLE
Add component test for new interaction card

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -100,10 +100,12 @@ export default class Interaction extends React.PureComponent {
       <ActivityCardWrapper dataTest="interaction-activity">
         <ActivityCardLabels theme={theme} service={service} kind={kind} />
         <ActivityCardSubject>
-          <Link href={transformed.url}>{transformed.subject}</Link>
+          <Link data-test="interaction-subject" href={transformed.url}>
+            {transformed.subject}
+          </Link>
         </ActivityCardSubject>
         {serviceNotes && (
-          <Notes>
+          <Notes data-test="interaction-notes">
             {serviceNotes.length < MAX_NOTE_LENGTH
               ? serviceNotes
               : serviceNotes

--- a/src/client/components/ActivityFeed/activities/InteractionUtils.js
+++ b/src/client/components/ActivityFeed/activities/InteractionUtils.js
@@ -22,22 +22,21 @@ const isServiceDelivery = (activity) => {
   return includes(activityTypes, 'dit:ServiceDelivery')
 }
 
-const getServiceText = (activity) => {
-  const service = get(activity, 'object.dit:service.name')
-  if (service) {
-    const serviceType = service.includes(' : ')
-      ? service.split(' : ')[0]
-      : service
+export const getServiceText = (service) => {
+  const serviceType = service.includes(' : ')
+    ? service.split(' : ')[0]
+    : service
 
-    const serviceText =
-      service.includes('Making') && service.includes('Introductions')
-        ? 'Introduction'
-        : service.includes('Advice & Information')
-        ? 'Advice & Information'
-        : INTERACTION_SERVICES[serviceType]
-    return serviceText
-  }
-  return null
+  const serviceText =
+    service.includes('Making') && service.includes('Introductions')
+      ? 'Introduction'
+      : service.includes('Advice & Information')
+      ? 'Advice & Information'
+      : service.includes('Investment Enquiry')
+      ? 'Enquiry'
+      : INTERACTION_SERVICES[serviceType]
+
+  return serviceText
 }
 
 const getThemeText = (activity) => {
@@ -67,7 +66,9 @@ export default class InteractionUtils {
       ? 'service delivery'
       : 'interaction'
 
-    const serviceText = getServiceText(activity)
+    const service = get(activity, 'object.dit:service.name')
+    const serviceText = service ? getServiceText(service) : null
+
     const themeText = getThemeText(activity)
     const communicationChannel = get(
       activity,

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
@@ -45,7 +45,7 @@ const ActivityCardLabels = ({ theme, service, kind }) => (
 ActivityCardLabels.propTypes = {
   theme: PropTypes.string,
   service: PropTypes.string,
-  kind: PropTypes.string,
+  kind: PropTypes.string.isRequired,
 }
 
 export default ActivityCardLabels

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
@@ -35,11 +35,9 @@ const ActivityCardLabels = ({ theme, service, kind }) => (
       )}
     </TagColumn>
     <TagColumn>
-      {kind && (
-        <Tag data-test="activity-kind-label" colour="grey">
-          {kind}
-        </Tag>
-      )}
+      <Tag data-test="activity-kind-label" colour="grey">
+        {kind}
+      </Tag>
     </TagColumn>
   </TagRow>
 )

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardMetadata.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardMetadata.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { FONT_SIZE } from '@govuk-react/constants'
 import { GREY_1 } from 'govuk-colours'
 import styled from 'styled-components'
+import { kebabCase } from 'lodash'
 
 const StyledCardMetadata = styled('div')`
   color: ${GREY_1};
@@ -15,7 +16,10 @@ const ActivityCardMetadata = ({ metadata }) => (
     {metadata.map(
       ({ label, value }, index) =>
         value && (
-          <div key={`${label}-${index}`}>
+          <div
+            key={`${label}-${index}`}
+            data-test={kebabCase(`${label}-'label'`)}
+          >
             <span style={{ fontWeight: 'bold' }}>{label}:</span> {value}
           </div>
         )

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -1,0 +1,709 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+
+import Interaction from '../../../../../src/client/components/ActivityFeed/activities/Interaction'
+import urls from '../../../../../src/lib/urls'
+import { getServiceText } from '../../../../../src/client/components/ActivityFeed/activities/InteractionUtils'
+
+const subject = 'An interaction with a company'
+const typeInteraction = 'dit:Interaction'
+const typeServiceDelivery = 'dit:ServiceDelivery'
+const interactionUrl = urls.interactions.detail(
+  'accf9d98-93c5-48ad-adf5-d71757cdeb44'
+)
+const shortNotes = 'Labore\nculpa\nquas\ncupiditate\nvoluptatibus\nmagni.'
+const longNotes =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ornare, nisi eget consequat convallis, risus lacus egestas lorem, et tincidunt quam tortor sed libero. Aliquam hendrerit mi a orci cursus congue. Mauris justo sapien, tristique sed mollis ultricies, porta a lorem. Sed ut augue vel velit luctus blandit. Integer convallis nunc vitae ante pharetra laoreet. Pellentesque sodales convallis blandit. Quisque a vehicula lectus. Nulla et est luctus, accumsan quam id, semper risus. Suspendisse facilisis dignissim rutrum. Proin elementum lacinia lectus in pharetra. Ut interdum diam ut tortor imperdiet, in tempus mauris lobortis. Aenean magna orci, dignissim congue enim vel, suscipit interdum arcu.'
+const truncatedNotes =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ornare, nisi eget consequat convallis, risus lacus egestas lorem, et tincidunt quam tortor sed libero. Aliquam hendrerit mi a orci cursus congue. Mauris justo sapien, tristique sed mollis ...'
+const oneAdviserText =
+  'Adviser(s): Bernard Harris-Patel  bernardharrispatel@test.com, Test Team  '
+const twoAdvisersText =
+  'Adviser(s): Bernard Harris-Patel  bernardharrispatel@test.com, Test Team  Puck Head  puckhead@test.com, Test Team  '
+const date = '2058-11-25T00:00:00Z'
+
+const adviser1 = {
+  'dit:emailAddress': 'bernardharrispatel@test.com',
+  'dit:team': {
+    id: 'dit:DataHubTeam:0b08839e-654d-4d10-8318-83acc6f32809',
+    name: 'Test Team',
+    type: ['Group', 'dit:Team'],
+  },
+  id: 'dit:DataHubAdviser:09091b75-31ec-479f-9088-67de8745c0fc',
+  name: 'Bernard Harris-Patel',
+  type: ['Person', 'dit:Adviser'],
+}
+
+const adviser2 = {
+  'dit:emailAddress': 'puckhead@test.com',
+  'dit:team': {
+    id: 'dit:DataHubTeam:0b08839e-654d-4d10-8318-83acc6f32809',
+    name: 'Test Team',
+    type: ['Group', 'dit:Team'],
+  },
+  id: 'dit:DataHubAdviser:09091b75-31ec-479f-9088-67de8745c9uf',
+  name: 'Puck Head',
+  type: ['Person', 'dit:Adviser'],
+}
+
+const interactionThemes = ['export', 'investment', 'trade_agreement', 'other']
+
+const interactionServices = {
+  specificDITService:
+    'A Specific DIT Export Service or Funding : Enhanced International Support Services',
+  specificService: 'A Specific Service : Digital Trade Advisers One-to-One',
+  accountManagement: 'Account Management : Midlands Engine',
+  cop26: 'COP26 : Participation at Glasgow/getting involved with COP26',
+  enquiry:
+    'Enquiry received : HPO High Potential Opportunity Investment Enquiry via IST Target Company',
+  enquiryOrReferral: 'Enquiry or Referral Received : Combined Authorities',
+  event: 'Events : Outward Mission',
+  exportWin: 'Export Win',
+  gis2021: 'Global Investment Summit (2021)',
+  istAftercare: 'Investment - IST Aftercare Offered (IST use only)',
+  investmentServices: 'Investment - Services',
+  investmentEnquiry: 'Investment Enquiry – Assigned to HQ (IST use only)',
+  istSpecificService:
+    'IST Specific Service : Abandoned - No Investor Response (ERU Use)',
+  propDevelopment: 'Proposition Development',
+  tradeAgreementImplementation:
+    'Trade Agreement Implementation Activity : Civil Society meetings',
+  exportIntros: 'Making Export Introductions : Another Government Department',
+  investmentIntros:
+    'Making Investment Introductions : Another Government Department',
+  exportAI: 'Providing Export Advice & Information',
+  investmentAI: 'Providing Investment Advice & Information',
+}
+
+// The notes render with a single space at the end
+const buildActualNotes = (notes) => {
+  return notes + ' '
+}
+
+const buildServiceLabel = (service) => {
+  return 'Service: ' + service
+}
+
+const buildAttributedTo = (numberOfAdvisers) => {
+  const noAdvisers = [
+    {
+      'dit:companiesHouseNumber': null,
+      'dit:dunsNumber': null,
+      id: 'dit:DataHubCompany:bbab3b56-d2bb-4d5e-bb2f-dd159e5439dc',
+      name: 'Test Limited',
+      type: ['Organization', 'dit:Company'],
+    },
+  ]
+  const oneAdviser = noAdvisers.concat(adviser1)
+
+  if (numberOfAdvisers === 1) {
+    return oneAdviser
+  }
+
+  if (numberOfAdvisers === 2) {
+    return oneAdviser.concat(adviser2)
+  }
+
+  return noAdvisers
+}
+
+const buildAndMountActivity = (
+  service,
+  theme,
+  communicationChannel,
+  type,
+  notes,
+  date,
+  numberOfAdvisers = 1
+) => {
+  const interactionTheme = 'dit:datahub:theme:' + theme
+  const attributedTo = buildAttributedTo(numberOfAdvisers)
+
+  const activity = {
+    generator: {
+      name: 'dit:dataHub',
+      type: 'Application',
+    },
+    id: 'dit:DataHubInteraction:accf9d98-93c5-48ad-adf5-d71757cdeb44:Announce',
+    object: {
+      attributedTo: attributedTo,
+      content: notes,
+      'dit:communicationChannel': {
+        name: communicationChannel,
+      },
+      'dit:service': {
+        name: service,
+      },
+      'dit:subject': subject,
+      id: 'dit:DataHubInteraction:accf9d98-93c5-48ad-adf5-d71757cdeb44',
+      startTime: date,
+      type: ['dit:Event', type, interactionTheme],
+      url: interactionUrl,
+    },
+    published: '2021-10-29T08:49:25.175367Z',
+    type: 'Announce',
+  }
+
+  return mount(
+    <Interaction
+      activity={activity}
+      isContactActivitiesFeatureOn={true}
+      showDetails={false}
+      showDnbHierarchy={false}
+      filter={[]}
+    />
+  )
+}
+
+const buildAndMountWithCustomTheme = (theme) => {
+  buildAndMountActivity(
+    interactionServices.specificDITService,
+    theme,
+    'Email/Fax',
+    typeInteraction,
+    shortNotes,
+    date
+  )
+}
+
+const buildAndMountWithCustomService = (service) => {
+  buildAndMountActivity(
+    service,
+    interactionThemes[0],
+    'Email/Fax',
+    typeInteraction,
+    shortNotes,
+    date
+  )
+}
+
+describe('Interaction activity card', () => {
+  context('When the card is rendered with a complete interaction', () => {
+    beforeEach(() => {
+      buildAndMountActivity(
+        interactionServices.specificDITService,
+        interactionThemes[0],
+        'Email/Fax',
+        typeInteraction,
+        shortNotes,
+        date
+      )
+      cy.get('[data-test=interaction-activity]').should('exist')
+    })
+
+    it('should render the theme label', () => {
+      assertThemeLabel()
+    })
+
+    it('should render the service label', () => {
+      assertServiceLabel()
+    })
+
+    it('should render the kind label', () => {
+      assertKindLabel()
+    })
+
+    it('should render the interaction subject', () => {
+      assertInteractionSubject()
+    })
+
+    it('should render the interaction notes', () => {
+      assertNotes()
+    })
+
+    it('should render the date label', () => {
+      assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+    })
+
+    it('should render the communication channel label', () => {
+      assertCommunicationChannelLabel()
+    })
+
+    it('should render the advisers label', () => {
+      assertText('[data-test=adviser-s-label]', oneAdviserText)
+    })
+
+    it('should render the full service label', () => {
+      assertBottomServiceLabel()
+    })
+
+    context('When the interaction has lengthy notes', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          longNotes,
+          date
+        )
+      })
+
+      it('should render the truncated interaction notes', () => {
+        assertNotes(truncatedNotes)
+      })
+    })
+
+    context('When there are multiple advisers', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date,
+          2
+        )
+      })
+
+      it('should render both advisers', () => {
+        assertText('[data-test=adviser-s-label]', twoAdvisersText)
+      })
+    })
+
+    context('When the kind is set to service delivery', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeServiceDelivery,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct kind', () => {
+        assertKindLabel('service delivery')
+      })
+    })
+  })
+
+  context('When the card is rendered with an incomplete interaction', () => {
+    context('When the theme is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          null,
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should not render the theme label', () => {
+        cy.get('[data-test=activity-theme-label]').should('not.exist')
+      })
+
+      it('should render the service label', () => {
+        assertServiceLabel()
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      })
+
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
+
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
+      })
+
+      it('should render the service label', () => {
+        assertBottomServiceLabel()
+      })
+    })
+
+    context('When the service is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          null,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should render the theme label', () => {
+        assertThemeLabel()
+      })
+
+      it('should not render the service label', () => {
+        cy.get('[data-test=activity-service-label]').should('not.exist')
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      })
+
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
+
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
+      })
+
+      it('should not render the full service label', () => {
+        cy.get('[data-test=service-label]').should('not.exist')
+      })
+    })
+
+    context('When the date is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          null
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should render the theme label', () => {
+        assertThemeLabel()
+      })
+
+      it('should render the service label', () => {
+        assertServiceLabel()
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should not render the date label', () => {
+        cy.get('[data-test=date-label]').should('not.exist')
+      })
+
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
+
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
+      })
+
+      it('should render the full service label', () => {
+        assertBottomServiceLabel()
+      })
+    })
+
+    context('When the advisers are missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date,
+          0
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should render the theme label', () => {
+        assertThemeLabel()
+      })
+
+      it('should render the service label', () => {
+        assertServiceLabel()
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      })
+
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
+
+      it('should not render the advisers label', () => {
+        cy.get('[data-test=adviser-s-label]').should('not.exist')
+      })
+
+      it('should render the full service label', () => {
+        assertBottomServiceLabel()
+      })
+    })
+
+    context('When the communication channel is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          null,
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should render the theme label', () => {
+        assertThemeLabel()
+      })
+
+      it('should render the service label', () => {
+        assertServiceLabel()
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      })
+
+      it('should not render the communication channel label', () => {
+        cy.get('[data-test=communication-channel-label]').should('not.exist')
+      })
+
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
+      })
+
+      it('should render the full service label', () => {
+        assertBottomServiceLabel()
+      })
+    })
+  })
+
+  context('When the interaction has a different theme', () => {
+    context('When the theme is Investment', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[1])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel(interactionThemes[1])
+      })
+    })
+
+    context('When the theme is Trade Agreement', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[2])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel('trade agreement')
+      })
+    })
+
+    context('When the theme is Other', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[3])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel(interactionThemes[3])
+      })
+    })
+  })
+
+  context('When the interaction has a different service', () => {
+    context('When the service is A Specific Service', () => {
+      assertService(interactionServices.specificService)
+    })
+
+    context('When the service is Account Management', () => {
+      assertService(interactionServices.accountManagement)
+    })
+
+    context('When the service is COP26', () => {
+      assertService(interactionServices.cop26)
+    })
+
+    context('When the service is a recieved enquiry', () => {
+      assertService(interactionServices.enquiry)
+    })
+
+    context('When the service is an Enquiry/Referral', () => {
+      assertService(interactionServices.enquiryOrReferral)
+    })
+
+    context('When the service is an Event', () => {
+      assertService(interactionServices.event)
+    })
+
+    context('When the service is an Export Win', () => {
+      assertService(interactionServices.exportWin)
+    })
+
+    context('When the service is Global Investment Summit (2021)', () => {
+      assertService(interactionServices.gis2021)
+    })
+
+    context('When the service is IST Aftercare', () => {
+      assertService(interactionServices.istAftercare)
+    })
+
+    context('When the service is an Investment Service', () => {
+      assertService(interactionServices.investmentServices)
+    })
+
+    context('When the service is an Investment Enquiry', () => {
+      assertService(interactionServices.investmentEnquiry)
+    })
+
+    context('When the service is an IST Specific Service', () => {
+      assertService(interactionServices.istSpecificService)
+    })
+
+    context('When the service is Proposition Development', () => {
+      assertService(interactionServices.propDevelopment)
+    })
+
+    context(
+      'When the service is a Trade Agreement Implementation Activity',
+      () => {
+        assertService(interactionServices.tradeAgreementImplementation)
+      }
+    )
+
+    context('When the service is Making Introductions', () => {
+      context('When the service is Making Export Introductions', () => {
+        assertService(interactionServices.exportIntros)
+      })
+
+      context('When the service is Making Investment Introductions', () => {
+        assertService(interactionServices.investmentIntros)
+      })
+    })
+
+    context('When the service is Providing Information', () => {
+      context('When the service is Providing Export Information', () => {
+        assertService(interactionServices.exportAI)
+      })
+
+      context('When the service is Providing Investment Information', () => {
+        assertService(interactionServices.investmentAI)
+      })
+    })
+  })
+})
+
+const assertText = (label, expectedText) => {
+  cy.get(label).should('exist').should('have.text', expectedText)
+}
+
+const assertThemeLabel = (expectedText = interactionThemes[0]) => {
+  assertText('[data-test=activity-theme-label]', expectedText)
+}
+
+const assertKindLabel = (expectedText = 'interaction') => {
+  assertText('[data-test=activity-kind-label]', expectedText)
+}
+
+const assertServiceLabel = (
+  service = interactionServices.specificDITService
+) => {
+  assertText('[data-test=activity-service-label]', getServiceText(service))
+}
+
+const assertNotes = (notes = shortNotes) => {
+  assertText('[data-test=interaction-notes]', buildActualNotes(notes))
+}
+
+const assertCommunicationChannelLabel = () => {
+  assertText(
+    '[data-test=communication-channel-label]',
+    'Communication channel: Email/Fax'
+  )
+}
+
+const assertBottomServiceLabel = (
+  service = interactionServices.specificDITService
+) => {
+  assertText('[data-test=service-label]', buildServiceLabel(service))
+}
+
+const assertInteractionSubject = () => {
+  cy.get('[data-test=interaction-subject]')
+    .should('exist')
+    .should('have.text', subject)
+    .should('have.attr', 'href', interactionUrl)
+}
+
+function assertService(service) {
+  beforeEach(() => {
+    buildAndMountWithCustomService(service)
+    cy.get('[data-test=interaction-activity]').should('exist')
+  })
+
+  it('should display the correct service', () => {
+    assertServiceLabel(service)
+  })
+
+  it('should render the full service label', () => {
+    assertBottomServiceLabel(service)
+  })
+}

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -306,30 +306,6 @@ describe('Interaction activity card', () => {
       it('should render the kind label', () => {
         assertKindLabel()
       })
-
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
-      })
-
-      it('should render the interaction notes', () => {
-        assertNotes()
-      })
-
-      it('should render the date label', () => {
-        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
-      })
-
-      it('should render the communication channel label', () => {
-        assertCommunicationChannelLabel()
-      })
-
-      it('should render the advisers label', () => {
-        assertText('[data-test=adviser-s-label]', oneAdviserText)
-      })
-
-      it('should render the service label', () => {
-        assertBottomServiceLabel()
-      })
     })
 
     context('When the service is missing', () => {
@@ -356,30 +332,6 @@ describe('Interaction activity card', () => {
       it('should render the kind label', () => {
         assertKindLabel()
       })
-
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
-      })
-
-      it('should render the interaction notes', () => {
-        assertNotes()
-      })
-
-      it('should render the date label', () => {
-        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
-      })
-
-      it('should render the communication channel label', () => {
-        assertCommunicationChannelLabel()
-      })
-
-      it('should render the advisers label', () => {
-        assertText('[data-test=adviser-s-label]', oneAdviserText)
-      })
-
-      it('should not render the full service label', () => {
-        cy.get('[data-test=service-label]').should('not.exist')
-      })
     })
 
     context('When the date is missing', () => {
@@ -393,26 +345,6 @@ describe('Interaction activity card', () => {
           null
         )
         cy.get('[data-test=interaction-activity]').should('exist')
-      })
-
-      it('should render the theme label', () => {
-        assertThemeLabel()
-      })
-
-      it('should render the service label', () => {
-        assertServiceLabel()
-      })
-
-      it('should render the kind label', () => {
-        assertKindLabel()
-      })
-
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
-      })
-
-      it('should render the interaction notes', () => {
-        assertNotes()
       })
 
       it('should not render the date label', () => {
@@ -446,26 +378,6 @@ describe('Interaction activity card', () => {
         cy.get('[data-test=interaction-activity]').should('exist')
       })
 
-      it('should render the theme label', () => {
-        assertThemeLabel()
-      })
-
-      it('should render the service label', () => {
-        assertServiceLabel()
-      })
-
-      it('should render the kind label', () => {
-        assertKindLabel()
-      })
-
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
-      })
-
-      it('should render the interaction notes', () => {
-        assertNotes()
-      })
-
       it('should render the date label', () => {
         assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
       })
@@ -494,26 +406,6 @@ describe('Interaction activity card', () => {
           date
         )
         cy.get('[data-test=interaction-activity]').should('exist')
-      })
-
-      it('should render the theme label', () => {
-        assertThemeLabel()
-      })
-
-      it('should render the service label', () => {
-        assertServiceLabel()
-      })
-
-      it('should render the kind label', () => {
-        assertKindLabel()
-      })
-
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
-      })
-
-      it('should render the interaction notes', () => {
-        assertNotes()
       })
 
       it('should render the date label', () => {


### PR DESCRIPTION
## Description of change

This PR adds a component test for the new interaction `ActivityFeed` card introduced in #4536.

The bulk of this PR is made up of [very similar tests](https://github.com/uktrade/data-hub-frontend/blob/675231ec759b4ebc2323828baab5cd4aaccd5c71/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx#L284) I was unable to abstract, and if/when the remaining activity cards are switched to the new card design some of the assertions can be reused.

## Test instructions

The new test should pass. Nothing else should change.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
