### PR TITLE
Hide Events Collection behind feature flag 

### DIFF
--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -1,4 +1,5 @@
 const CONTACT_ACTIVITY_FEATURE_FLAG = 'user-contact-activities'
+const EVENT_ACTIVITY_FEATURE_FLAG = 'user-event-activities'
 
 const FILTER_KEYS = {
   dataHubAndExternalActivity: 'dataHubAndExternalActivity',
@@ -59,6 +60,7 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
 
 module.exports = {
   CONTACT_ACTIVITY_FEATURE_FLAG,
+  EVENT_ACTIVITY_FEATURE_FLAG,
   FILTER_KEYS,
   FILTER_ITEMS,
   DATA_HUB_ACTIVITY,

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -1,3 +1,5 @@
+const CONTACT_ACTIVITY_FEATURE_FLAG = 'user-contact-activities'
+
 const FILTER_KEYS = {
   dataHubAndExternalActivity: 'dataHubAndExternalActivity',
   myActivity: 'myActivity',
@@ -56,6 +58,7 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
 ]
 
 module.exports = {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
   FILTER_KEYS,
   FILTER_ITEMS,
   DATA_HUB_ACTIVITY,

--- a/src/apps/contacts/controllers/audit.js
+++ b/src/apps/contacts/controllers/audit.js
@@ -4,6 +4,9 @@ const {
 } = require('../../../modules/api/transformers')
 const { transformAuditLogToListItem } = require('../../audit/transformers')
 const { contactAuditLabels } = require('../labels')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../../companies/apps/activity-feed/constants')
 
 async function getAudit(req, res, next) {
   try {
@@ -12,7 +15,7 @@ async function getAudit(req, res, next) {
     const page = req.query.page || 1
 
     const isContactActivitiesFeatureOn = res.locals?.userFeatures?.includes(
-      'user-contact-activities'
+      CONTACT_ACTIVITY_FEATURE_FLAG
     )
 
     const auditLog = await getContactAuditLog(req, contactId, page).then(

--- a/src/apps/contacts/controllers/details.js
+++ b/src/apps/contacts/controllers/details.js
@@ -1,5 +1,8 @@
 const contactsRepository = require('../repos')
 const companyRepository = require('../../companies/repos')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../../companies/apps/activity-feed/constants')
 
 async function getCommon(req, res, next) {
   try {
@@ -33,7 +36,7 @@ function getDetails(req, res, next) {
     const contact = res.locals.contact
     const companyAddress = res.locals.company.address
     const isContactActivitiesFeatureOn = res.locals.userFeatures?.includes(
-      'user-contact-activities'
+      CONTACT_ACTIVITY_FEATURE_FLAG
     )
 
     res.render('contacts/views/details', {

--- a/src/apps/contacts/controllers/documents.js
+++ b/src/apps/contacts/controllers/documents.js
@@ -1,8 +1,12 @@
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../../companies/apps/activity-feed/constants')
+
 function renderDocuments(req, res) {
   const contactId = req.params.contactId
   const contact = res.locals.contact
   const isContactActivitiesFeatureOn = res.locals.userFeatures?.includes(
-    'user-contact-activities'
+    CONTACT_ACTIVITY_FEATURE_FLAG
   )
   const { ARCHIVED_DOCUMENT_BASE_URL } = res.locals
 

--- a/src/apps/contacts/router.js
+++ b/src/apps/contacts/router.js
@@ -27,6 +27,9 @@ const {
   fetchActivitiesForContact,
 } = require('../companies/apps/activity-feed/controllers')
 const userFeatures = require('../../middleware/user-features')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../companies/apps/activity-feed/constants')
 
 router.get(urls.contacts.index(), renderContactsView)
 router.get(['/create', '/:contactId/edit'], createAndEdit)
@@ -43,7 +46,7 @@ router.use(
 router.get('/:contactId', redirectToFirstNavItem)
 router.get(
   '/:contactId/details',
-  userFeatures('user-contact-activities'),
+  userFeatures(CONTACT_ACTIVITY_FEATURE_FLAG),
   getDetails
 )
 
@@ -51,13 +54,13 @@ router.get('/:id/unarchive', unarchiveContact)
 
 router.get(
   '/:contactId/audit',
-  userFeatures('user-contact-activities'),
+  userFeatures(CONTACT_ACTIVITY_FEATURE_FLAG),
   getAudit
 )
 
 router.get(
   '/:contactId/documents',
-  userFeatures('user-contact-activities'),
+  userFeatures(CONTACT_ACTIVITY_FEATURE_FLAG),
   renderDocuments
 )
 

--- a/src/apps/interactions/controllers/list.js
+++ b/src/apps/interactions/controllers/list.js
@@ -7,6 +7,9 @@ const { transformAdviserToOption } = require('../../adviser/transformers')
 const { saveSession } = require('../../../lib/session-helper')
 
 const FILTER_CONSTANTS = require('../../../lib/filter-constants')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../../companies/apps/activity-feed/constants')
 
 const QUERY_STRING = FILTER_CONSTANTS.INTERACTIONS.SECTOR.PRIMARY.QUERY_STRING
 const SECTOR = FILTER_CONSTANTS.INTERACTIONS.SECTOR.NAME
@@ -106,7 +109,7 @@ function renderInteractionsForEntity(req, res, next) {
     const contact = res.locals.contact
 
     const isContactActivitiesFeatureOn = res.locals.userFeatures?.includes(
-      'user-contact-activities'
+      CONTACT_ACTIVITY_FEATURE_FLAG
     )
 
     const breadcrumbTitle = isContactActivitiesFeatureOn

--- a/src/apps/interactions/router.sub-app.js
+++ b/src/apps/interactions/router.sub-app.js
@@ -13,6 +13,9 @@ const {
 const userFeatures = require('../../middleware/user-features')
 
 const detailsFormRouter = require('./apps/details-form/router')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../companies/apps/activity-feed/constants')
 
 router.param('interactionId', getInteractionDetails)
 
@@ -21,7 +24,7 @@ router.get(
   getInteractionsRequestBody,
   getInteractionCollectionForEntity,
   getInteractionSortForm,
-  userFeatures('user-contact-activities'),
+  userFeatures(CONTACT_ACTIVITY_FEATURE_FLAG),
   renderInteractionsForEntity
 )
 

--- a/src/client/components/CheckUserFeatureFlags/index.jsx
+++ b/src/client/components/CheckUserFeatureFlags/index.jsx
@@ -1,7 +1,9 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
+import qs from 'qs'
 import Resource from '../Resource'
 import { ID, TASK_GET_USER_FEATURE_FLAGS } from './state'
+import { useHistory, useLocation } from 'react-router-dom'
 
 /** 
 This component enables the checking of a particular user feature flag in React.
@@ -18,13 +20,33 @@ export default function CheckUserFeatureFlag({
   children,
   userFeatureFlagName,
 }) {
+  const location = useLocation()
+  const history = useHistory()
+  const existingParams = qs.parse(location.search.slice(1))
+
+  const [isFlagOn, setFlagOn] = useState(false)
+
+  useEffect(() => {
+    if (isFlagOn) {
+      history.replace({
+        search: qs.stringify({
+          ...existingParams,
+          ['featureTesting']: userFeatureFlagName,
+        }),
+      })
+    }
+  }, [isFlagOn])
+
   return (
     <Resource
       name={TASK_GET_USER_FEATURE_FLAGS}
       id={ID}
       payload={userFeatureFlagName}
     >
-      {(isFeatureFlagEnabled) => children(isFeatureFlagEnabled)}
+      {(isFeatureFlagEnabled) => {
+        setFlagOn(isFeatureFlagEnabled)
+        return children(isFeatureFlagEnabled)
+      }}
     </Resource>
   )
 }

--- a/src/client/modules/Contacts/ContactActivity/ContactActivity.jsx
+++ b/src/client/modules/Contacts/ContactActivity/ContactActivity.jsx
@@ -15,7 +15,10 @@ import {
   RoutedPagination,
 } from '../../../components'
 import { ACTIVITIES_PER_PAGE } from '../../../../apps/contacts/constants'
-import { CONTACT_ACTIVITY_SORT_SELECT_OPTIONS } from '../../../../apps/companies/apps/activity-feed/constants'
+import {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+  CONTACT_ACTIVITY_SORT_SELECT_OPTIONS,
+} from '../../../../apps/companies/apps/activity-feed/constants'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
 const ContactActivityList = styled('ol')`
@@ -73,7 +76,9 @@ const ContactActivity = ({
                   sortOptions={CONTACT_ACTIVITY_SORT_SELECT_OPTIONS}
                   totalPages={totalPages}
                 />
-                <CheckUserFeatureFlag userFeatureFlagName="user-contact-activities">
+                <CheckUserFeatureFlag
+                  userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}
+                >
                   {(isContactActivitiesFeatureOn) => (
                     <ContactActivityList>
                       {activities.map((activity, index) => (

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -35,7 +35,6 @@ import {
 
 const EventsCollection = ({
   payload,
-  currentAdviserId,
   optionMetadata,
   selectedFilters,
   ...props

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 
 import {
   EVENTS__LOADED,
@@ -13,6 +14,7 @@ import {
   FilterToggleSection,
   DefaultLayout,
 } from '../../../components'
+import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
 import {
   listSkeletonPlaceholder,
@@ -77,93 +79,99 @@ const EventsCollection = ({
 
   return (
     <DefaultLayout heading="Events" pageTitle="Events">
-      <FilteredCollectionList
-        {...props}
-        collectionName="event"
-        sortOptions={optionMetadata.sortOptions}
-        taskProps={collectionListTask}
-        selectedFilters={selectedFilters}
-        entityName="event"
-        entityNamePlural="events"
-        addItemUrl="/events/create"
-        useReactRouter={true}
-      >
-        <CollectionFilters taskProps={collectionListMetadataTask}>
-          <FilterToggleSection
-            id="EventCollection.event-details-filters"
-            label="Event details"
-            isOpen={true}
-          >
-            <Filters.Input
-              id="EventsCollection.name"
-              qsParam="name"
-              name="name"
-              label={LABELS.eventName}
-              placeholder="Search event name"
-              data-test="event-name-filter"
-            />
-            <Filters.AdvisersTypeahead
-              isMulti={true}
-              taskProps={organisersTask}
-              label={LABELS.organiser}
-              name="organiser"
-              qsParam="organiser"
-              placeholder="Search organiser"
-              noOptionsMessage="No organisers found"
-              selectedOptions={selectedFilters.organisers.options}
-              data-test="organiser-filter"
-            />
-            <Filters.Date
-              label={LABELS.startDateAfter}
-              name="start_date_after"
-              qsParamName="start_date_after"
-              data-test="start-date-after-filter"
-            />
-            <Filters.Date
-              label={LABELS.startDateBefore}
-              name="start_date_before"
-              qsParamName="start_date_before"
-              data-test="start-date-before-filter"
-            />
-            <Filters.CheckboxGroup
-              maxScrollHeight={345}
-              legend={LABELS.eventType}
-              name="event_type"
-              qsParam="event_type"
-              options={optionMetadata.eventTypeOptions}
-              selectedOptions={selectedFilters.eventTypes.options}
-              data-test="event-type-filter"
-              groupId="event-type-filter"
-            />
-          </FilterToggleSection>
-          <FilterToggleSection
-            id="EventCollection.event-location-details-filters"
-            label="Event location details"
-            isOpen={false}
-          >
-            <Filters.Typeahead
-              isMulti={true}
-              label={LABELS.country}
-              name="address_country"
-              qsParam="address_country"
-              placeholder="Search country"
-              options={optionMetadata.countryOptions}
-              selectedOptions={selectedFilters.countries.options}
-              data-test="country-filter"
-            />
-            <Filters.Typeahead
-              isMulti={true}
-              label={LABELS.ukRegion}
-              name="uk_region"
-              qsParam="uk_region"
-              placeholder="Search UK region"
-              options={optionMetadata.ukRegionOptions}
-              selectedOptions={selectedFilters.ukRegions.options}
-              data-test="uk-region-filter"
-            />
-          </FilterToggleSection>
-        </CollectionFilters>
-      </FilteredCollectionList>
+      <CheckUserFeatureFlag userFeatureFlagName={EVENT_ACTIVITY_FEATURE_FLAG}>
+        {(isFeatureFlagOn) =>
+          !isFeatureFlagOn && (
+            <FilteredCollectionList
+              {...props}
+              collectionName="event"
+              sortOptions={optionMetadata.sortOptions}
+              taskProps={collectionListTask}
+              selectedFilters={selectedFilters}
+              entityName="event"
+              entityNamePlural="events"
+              addItemUrl="/events/create"
+              useReactRouter={true}
+            >
+              <CollectionFilters taskProps={collectionListMetadataTask}>
+                <FilterToggleSection
+                  id="EventCollection.event-details-filters"
+                  label="Event details"
+                  isOpen={true}
+                >
+                  <Filters.Input
+                    id="EventsCollection.name"
+                    qsParam="name"
+                    name="name"
+                    label={LABELS.eventName}
+                    placeholder="Search event name"
+                    data-test="event-name-filter"
+                  />
+                  <Filters.AdvisersTypeahead
+                    isMulti={true}
+                    taskProps={organisersTask}
+                    label={LABELS.organiser}
+                    name="organiser"
+                    qsParam="organiser"
+                    placeholder="Search organiser"
+                    noOptionsMessage="No organisers found"
+                    selectedOptions={selectedFilters.organisers.options}
+                    data-test="organiser-filter"
+                  />
+                  <Filters.Date
+                    label={LABELS.startDateAfter}
+                    name="start_date_after"
+                    qsParamName="start_date_after"
+                    data-test="start-date-after-filter"
+                  />
+                  <Filters.Date
+                    label={LABELS.startDateBefore}
+                    name="start_date_before"
+                    qsParamName="start_date_before"
+                    data-test="start-date-before-filter"
+                  />
+                  <Filters.CheckboxGroup
+                    maxScrollHeight={345}
+                    legend={LABELS.eventType}
+                    name="event_type"
+                    qsParam="event_type"
+                    options={optionMetadata.eventTypeOptions}
+                    selectedOptions={selectedFilters.eventTypes.options}
+                    data-test="event-type-filter"
+                    groupId="event-type-filter"
+                  />
+                </FilterToggleSection>
+                <FilterToggleSection
+                  id="EventCollection.event-location-details-filters"
+                  label="Event location details"
+                  isOpen={false}
+                >
+                  <Filters.Typeahead
+                    isMulti={true}
+                    label={LABELS.country}
+                    name="address_country"
+                    qsParam="address_country"
+                    placeholder="Search country"
+                    options={optionMetadata.countryOptions}
+                    selectedOptions={selectedFilters.countries.options}
+                    data-test="country-filter"
+                  />
+                  <Filters.Typeahead
+                    isMulti={true}
+                    label={LABELS.ukRegion}
+                    name="uk_region"
+                    qsParam="uk_region"
+                    placeholder="Search UK region"
+                    options={optionMetadata.ukRegionOptions}
+                    selectedOptions={selectedFilters.ukRegions.options}
+                    data-test="uk-region-filter"
+                  />
+                </FilterToggleSection>
+              </CollectionFilters>
+            </FilteredCollectionList>
+          )
+        }
+      </CheckUserFeatureFlag>
     </DefaultLayout>
   )
 }

--- a/test/component/cypress/specs/CheckUserFeatureFlags.test.jsx
+++ b/test/component/cypress/specs/CheckUserFeatureFlags.test.jsx
@@ -4,6 +4,10 @@ import DataHubProvider from './provider'
 import CheckUserFeatureFlag from '../../../../src/client/components/CheckUserFeatureFlags'
 import { TASK_GET_USER_FEATURE_FLAGS } from '../../../../src/client/components/CheckUserFeatureFlags/state'
 import { getUserFeatureFlags } from '../../../../src/client/components/CheckUserFeatureFlags/tasks'
+import {
+  assertNotQueryParams,
+  assertQueryParams,
+} from '../../../functional/cypress/support/assertions'
 
 describe('CheckUserFeatureFlags', () => {
   const Component = ({ userFeatureFlagName }) => (
@@ -23,6 +27,7 @@ describe('CheckUserFeatureFlags', () => {
   )
 
   const enabledFlag = 'flag-enabled'
+  const disabledFlag = 'flag-disabled'
 
   beforeEach(() => {
     cy.intercept('GET', '/api-proxy/whoami/', {
@@ -30,7 +35,21 @@ describe('CheckUserFeatureFlags', () => {
     })
   })
 
-  context('when the feature flag is  enabled', () => {
+  context('when the feature flag is not enabled', () => {
+    beforeEach(() => {
+      mount(<Component userFeatureFlagName={disabledFlag} />)
+    })
+
+    it('should pass false to its children', () => {
+      cy.contains('feature flag is not enabled')
+    })
+
+    it('should not set the flag in the url', () => {
+      assertNotQueryParams('featureTesting', disabledFlag)
+    })
+  })
+
+  context('when the feature flag is enabled', () => {
     beforeEach(() => {
       mount(<Component userFeatureFlagName={enabledFlag} />)
     })
@@ -38,15 +57,9 @@ describe('CheckUserFeatureFlags', () => {
     it('should pass true to the children', () => {
       cy.contains('feature flag is enabled')
     })
-  })
 
-  context('when the feature flag is not enabled', () => {
-    beforeEach(() => {
-      mount(<Component userFeatureFlagName={'disabled-flag'} />)
-    })
-
-    it('should pass false to its children', () => {
-      cy.contains('feature flag is not enabled')
+    it('should set the flag in the url', () => {
+      assertQueryParams('featureTesting', enabledFlag)
     })
   })
 })

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -2,13 +2,16 @@ const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 const dataHubActivities = require('../../../../sandbox/fixtures/v4/activity-feed/data-hub-activities.json')
 const { assertErrorDialog } = require('../../support/assertions')
+const {
+  CONTACT_ACTIVITY_FEATURE_FLAG,
+} = require('../../../../../src/apps/companies/apps/activity-feed/constants')
 
 describe('Contact activity', () => {
   const contactId = fixtures.contact.deanCox.id
 
-  context('when the feature flag user-contact-activities is enabled', () => {
+  context('when the feature flag for activity stream is on', () => {
     before(() => {
-      cy.setUserFeatures(['user-contact-activities'])
+      cy.setUserFeatures([CONTACT_ACTIVITY_FEATURE_FLAG])
     })
 
     context('when viewing a contact with no activity', () => {

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -2,6 +2,7 @@ import { assertBreadcrumbs } from '../../support/assertions'
 import { events } from '../../../../../src/lib/urls'
 
 import { eventFaker, eventListFaker } from '../../fakers/events'
+import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../../src/apps/companies/apps/activity-feed/constants'
 
 describe('Event Collection List Page - React', () => {
   const event1 = eventFaker({
@@ -131,5 +132,15 @@ describe('Event Collection List Page - React', () => {
       .find('[data-test="metadata"]')
       .should('contain', 'Organiser')
       .and('contain', 'Hannibal Smith')
+  })
+
+  context('when the activity stream flag is on', () => {
+    beforeEach(() => {
+      cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
+      cy.visit(events.index())
+    })
+    it('should not display the data hub API collection list', () => {
+      cy.get('@collectionList').should('not.exist')
+    })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -594,6 +594,18 @@ const assertQueryParams = (key, value) => {
 }
 
 /**
+ * Asserts the key-value pair are defined within the query params
+ */
+const assertNotQueryParams = (key, value) => {
+  cy.url().should(
+    'not.include',
+    qs.stringify({
+      [key]: value,
+    })
+  )
+}
+
+/**
  * Assert the expected payload to the API
  */
 
@@ -736,6 +748,7 @@ module.exports = {
   assertChipsEmpty,
   assertFieldEmpty,
   assertQueryParams,
+  assertNotQueryParams,
   assertPayload,
   assertDateInput,
   assertErrorSummary,

--- a/test/sandbox/fixtures/whoami.json
+++ b/test/sandbox/fixtures/whoami.json
@@ -95,5 +95,6 @@
     "company.change_one_list_tier_and_global_account_manager",
     "company.change_one_list_core_team_member"
   ],
-  "features": []
+  "features": [],
+  "active_features": []
 }


### PR DESCRIPTION
## Description of change

We are going to be user testing a feature where we show Events via Activity Stream, rather than the Data Hub API. This is so we can return Aventri Event objects as well as Data Hub events. 
The first step in this is checking whether the user feature flag is on, and turning off the old collection list if it is. 

## Test instructions

- add the `user-event-activities` flag to your adviser in the django admin
- visit the Events tab and see that it's a blank page
- when the flag is off everything should be as normal

## Screenshots
### Before
![Screenshot 2022-06-10 at 15 42 10](https://user-images.githubusercontent.com/16647486/173090833-4d0fb244-8dfe-47af-9526-1e9ffe7c1497.png)


### After

![Screenshot 2022-06-10 at 15 44 55](https://user-images.githubusercontent.com/16647486/173090860-8c79287a-4776-409a-805a-8bf0549b6e1d.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
