### PR TITLE
Reactify investment project documents page

### DIFF
--- a/src/apps/investments/client/projects/ProjectDocuments.jsx
+++ b/src/apps/investments/client/projects/ProjectDocuments.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import InvestmentResource from '../../../../client/components/Resource/Investment'
+import DocumentsSection from '../../../../client/components/DocumentsSection'
+
+const InvestmentDocuments = ({ projectId, archivedDocumentPath }) => {
+  return (
+    <InvestmentResource id={projectId}>
+      {(project) => (
+        <DocumentsSection
+          fileBrowserRoot={archivedDocumentPath}
+          documentPath={project.archivedDocumentsUrlPath}
+        />
+      )}
+    </InvestmentResource>
+  )
+}
+
+export default InvestmentDocuments

--- a/src/apps/investments/controllers/documents.js
+++ b/src/apps/investments/controllers/documents.js
@@ -1,13 +1,12 @@
-const { get } = require('lodash')
-
 async function renderDocuments(req, res) {
-  const archivedDocumentPath = get(
-    res.locals,
-    'investment.archived_documents_url_path'
-  )
+  const { id } = res.locals.investment
+  const { ARCHIVED_DOCUMENT_BASE_URL } = res.locals
 
   return res.breadcrumb('Documents').render('investments/views/documents', {
-    archivedDocumentPath,
+    props: {
+      projectId: id,
+      archivedDocumentPath: ARCHIVED_DOCUMENT_BASE_URL,
+    },
   })
 }
 

--- a/src/apps/investments/views/documents.njk
+++ b/src/apps/investments/views/documents.njk
@@ -1,17 +1,8 @@
 {% extends "./template.njk" %}
 
 {% block main_grid_right_column %}
-  <h2 class="govuk-heading-m">Documents</h2>
-  <p>
-    {% if archivedDocumentPath %}
-      <a href="{{ ARCHIVED_DOCUMENT_BASE_URL }}{{ archivedDocumentPath }}" aria-labelledby="external-link-label">
-        View files and documents
-      </a>
-      <br>
-      <span id="external-link-label">(will open another website)</span>
-    {% else %}
-      There are no files or documents
-    {% endif %}
-  </p>
-
+  {% component 'react-slot', {
+      id: 'investment-documents',
+      props: props
+    } %}
 {% endblock %}

--- a/src/client/components/DocumentsSection/index.jsx
+++ b/src/client/components/DocumentsSection/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+import { typography } from '@govuk-react/lib'
+
+import NewWindowLink from '../NewWindowLink'
+
+const StyledSectionHeader = styled('div')`
+  ${typography.font({ size: 24, weight: 'bold' })};
+  margin-bottom: ${SPACING.SCALE_4};
+`
+
+const DocumentsSection = ({ fileBrowserRoot, documentPath }) => {
+  return (
+    <>
+      <StyledSectionHeader data-test="document-heading">
+        Documents
+      </StyledSectionHeader>
+      {documentPath ? (
+        <NewWindowLink
+          href={fileBrowserRoot + documentPath}
+          data-test="document-link"
+        >
+          View files and documents
+        </NewWindowLink>
+      ) : (
+        <p data-test="no-documents-message">There are no files or documents</p>
+      )}
+    </>
+  )
+}
+
+DocumentsSection.propTypes = {
+  fileBrowserRoot: PropTypes.string.isRequired,
+  documentPath: PropTypes.string.isRequired,
+}
+
+export default DocumentsSection

--- a/src/client/components/Resource/Investment.js
+++ b/src/client/components/Resource/Investment.js
@@ -1,0 +1,3 @@
+import { createEntityResource } from '.'
+
+export default createEntityResource('Investment', (id) => `v3/investment/${id}`)

--- a/src/client/components/Resource/tasks.js
+++ b/src/client/components/Resource/tasks.js
@@ -14,6 +14,7 @@ import OpportunityValueType from './OpportunityValueType'
 import PipelineItem from './PipelineItem'
 import OrderAssignees from './OrderAssignees'
 import OrderSubscribers from './OrderSubscribers'
+import Investment from './Investment'
 
 export default {
   ...Advisers.tasks,
@@ -32,4 +33,5 @@ export default {
   ...PipelineItem.tasks,
   ...OrderAssignees.tasks,
   ...OrderSubscribers.tasks,
+  ...Investment.tasks,
 }

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -61,6 +61,7 @@ import ContactActivity from './modules/Contacts/ContactActivity/ContactActivity'
 import ContactLocalHeader from './components/ContactLocalHeader'
 import ContactDetails from './modules/Contacts/ContactDetails/ContactDetails'
 import ContactDocuments from './modules/Contacts/ContactDocuments/ContactDocuments'
+import InvestmentDocuments from '../apps/investments/client/projects/ProjectDocuments'
 
 import * as companyListsTasks from './components/CompanyLists/tasks'
 import * as referralTasks from '../apps/companies/apps/referrals/details/client/tasks'
@@ -645,6 +646,9 @@ function App() {
       </Mount>
       <Mount selector="#contact-documents">
         {(props) => <ContactDocuments {...props} />}
+      </Mount>
+      <Mount selector="#investment-documents">
+        {(props) => <InvestmentDocuments {...props} />}
       </Mount>
 
       <Mount selector="#react-app">

--- a/src/client/modules/Contacts/ContactDocuments/ContactDocuments.jsx
+++ b/src/client/modules/Contacts/ContactDocuments/ContactDocuments.jsx
@@ -1,37 +1,16 @@
 import React from 'react'
-import styled from 'styled-components'
-import { SPACING } from '@govuk-react/constants'
-import { typography } from '@govuk-react/lib'
 
 import ContactResource from '../../../components/Resource/Contact'
-import { NewWindowLink } from '../../../components'
-
-const StyledSectionHeader = styled('div')`
-  ${typography.font({ size: 24, weight: 'bold' })};
-  margin-bottom: ${SPACING.SCALE_4};
-`
+import DocumentsSection from '../../../components/DocumentsSection'
 
 const ContactDocuments = ({ contactId, archivedDocumentPath }) => {
   return (
     <ContactResource id={contactId}>
       {(contact) => (
-        <>
-          <StyledSectionHeader data-test="document-heading">
-            Documents
-          </StyledSectionHeader>
-          {contact.archivedDocumentsUrlPath ? (
-            <NewWindowLink
-              href={archivedDocumentPath + contact.archivedDocumentsUrlPath}
-              data-test="document-link"
-            >
-              View files and documents
-            </NewWindowLink>
-          ) : (
-            <p data-test="no-documents-message">
-              There are no files or documents
-            </p>
-          )}
-        </>
+        <DocumentsSection
+          fileBrowserRoot={archivedDocumentPath}
+          documentPath={contact.archivedDocumentsUrlPath}
+        />
       )}
     </ContactResource>
   )

--- a/test/functional/cypress/specs/investments/project-document-spec.js
+++ b/test/functional/cypress/specs/investments/project-document-spec.js
@@ -1,5 +1,4 @@
 const fixtures = require('../../fixtures')
-const selectors = require('../../../../selectors')
 const { assertBreadcrumbs } = require('../../support/assertions')
 const { dashboard, investments } = require('../../../../../src/lib/urls')
 
@@ -26,14 +25,10 @@ describe('Investment Project Documents', () => {
     })
 
     it('should display appropriate message when there is a link to a document', () => {
-      cy.get(selectors.document.documentHeader).should('contain', 'Document')
-      cy.get(selectors.document.documentContent).should(
+      cy.get('[data-test=document-heading]').should('contain', 'Document')
+      cy.get('[data-test=document-link]').should(
         'contain',
         'View files and documents'
-      )
-      cy.get(selectors.document.documentContent).should(
-        'contain',
-        '(will open another website)'
       )
     })
   })
@@ -60,8 +55,9 @@ describe('Investment Project Documents', () => {
     })
 
     it('should display appropriate message when there is not a link to a document', () => {
-      cy.get(selectors.document.documentHeader).should('contain', 'Document')
-      cy.get(selectors.document.documentContent).should(
+      cy.get('[data-test=document-heading]').should('contain', 'Document')
+      cy.get('[data-test=document-link]').should('not.exist')
+      cy.get('[data-test=no-documents-message]').should(
         'contain',
         'There are no files or documents'
       )

--- a/test/selectors/document.js
+++ b/test/selectors/document.js
@@ -1,4 +1,0 @@
-module.exports = {
-  documentContent: 'article > p',
-  documentHeader: 'article > h2',
-}

--- a/test/selectors/index.js
+++ b/test/selectors/index.js
@@ -41,7 +41,6 @@ exports.omisWorkOrder = require('./omis/work-order')
 
 exports.breadcrumbs = require('./breadcrumbs')
 exports.detailsContainer = require('./details-container')
-exports.document = require('./document')
 exports.editHistory = require('./edit-history')
 exports.entityCollection = require('./entity-collection')
 exports.filter = require('./filter')


### PR DESCRIPTION
## Description of change

As the investments documents page is identical to the contacts one I have reactified it using the same logic as in #4606. I've also created a reusable component to contain all the shared logic.

## Test instructions

The functionality for viewing investment project documents should work as before.

## Screenshots
See the screenshots in #4606 (the page content is identical)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
