### PR TITLE
Abstract the ELD header for reusability across reminders/settings

### DIFF
--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -53,7 +53,7 @@ const DefaultLayout = ({
 }
 
 DefaultLayout.propTypes = {
-  heading: PropTypes.string.isRequired,
+  heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
   pageTitle: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,
 }

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -111,7 +111,7 @@ LocalHeader.propTypes = {
       PropTypes.arrayOf(PropTypes.string).isRequired,
     ]),
   }),
-  heading: PropTypes.string,
+  heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   headingLink: PropTypes.shape({
     url: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -21,6 +21,7 @@ import {
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
+import Heading from './Heading'
 import Resource from '../../components/Resource'
 import { DARK_GREY } from '../../utils/colors'
 import { formatMediumDate } from '../../utils/date'
@@ -99,12 +100,6 @@ const StyledCollectionHeaderRow = styled(CollectionHeaderRow)({
   alignItems: 'flex-end',
 })
 
-const PreHeading = styled('span')({
-  display: 'block',
-  fontWeight: FONT_WEIGHTS.regular,
-  marginBottom: SPACING.SCALE_1,
-})
-
 const SettingsLink = styled(Link)({
   fontSize: FONT_SIZE.SIZE_19,
 })
@@ -135,16 +130,14 @@ const EstimatedLandDateReminders = () => {
   const qsParams = qs.parse(location.search.slice(1))
   const page = parseInt(qsParams.page, 10)
   const title = 'Reminders for approaching estimated land dates'
-  const heading = (
-    <>
-      <PreHeading>Reminders for </PreHeading>approaching estimated land dates
-    </>
-  )
-
   return (
     <DefaultLayout
       pageTitle={title}
-      heading={heading}
+      heading={
+        <Heading preHeading="Reminders for">
+          approaching estimated land dates
+        </Heading>
+      }
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
       <Resource

--- a/src/client/modules/Reminders/Heading.jsx
+++ b/src/client/modules/Reminders/Heading.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import styled from 'styled-components'
+import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
+
+const PreHeading = styled('span')({
+  display: 'block',
+  fontWeight: FONT_WEIGHTS.regular,
+  marginBottom: SPACING.SCALE_1,
+})
+
+const Heading = ({ preHeading, children }) => (
+  <>
+    <PreHeading>{preHeading}</PreHeading> {children}
+  </>
+)
+
+export default Heading

--- a/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
@@ -48,7 +48,7 @@ describe('Estimated Land Date Reminders', () => {
 
     it('should render the heading', () => {
       cy.get('[data-test="heading"]').should(
-        'contain',
+        'have.text',
         'Reminders for approaching estimated land dates'
       )
     })


### PR DESCRIPTION
## Description of change

A simple refactor so we can reuse the header across reminders/settings and fixes a number of React warnings in the browser console.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
