### PR TITLE
Update semver-regex override to 3.1.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32971,9 +32971,9 @@
       }
     },
     "node_modules/semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "optional": true,
       "engines": {
         "node": ">=8"
@@ -53371,7 +53371,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "optional": true,
       "requires": {
-        "semver-regex": "3.1.3"
+        "semver-regex": "3.1.4"
       }
     },
     "find-webpack": {
@@ -63270,9 +63270,9 @@
       }
     },
     "semver-regex": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.3.tgz",
-      "integrity": "sha512-Aqi54Mk9uYTjVexLnR67rTyBusmwd04cLkHy9hNvk3+G3nT2Oyg7E0l4XVbOaNwIvQ3hHeYxGcyEy+mKreyBFQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "optional": true
     },
     "semver-truncate": {

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "prismjs": "1.27.0",
     "set-value": "4.0.1",
     "trim": "0.0.3",
-    "semver-regex": "3.1.3",
+    "semver-regex": "3.1.4",
     "ansi-regex": "5.0.1",
     "glob-parent": "5.1.2",
     "async": "^3.2.3"


### PR DESCRIPTION
## Description of change

This PR updates the version of the semver-regex package override to 3.1.4.

## Test instructions

No changes.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
