### PR TITLE
Added sort to reminders

### DIFF
--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -15,7 +15,7 @@ const EstimatedLandDateReminders = () => {
     <Resource
       name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
       id={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
-      payload={{ page }}
+      payload={{ page, sortby: qsParams.sortby }}
     >
       {({ results, count }) => (
         <RemindersCollection

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -15,7 +15,7 @@ const NoRecentInteractionReminders = () => {
     <Resource
       name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
       id={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
-      payload={{ page }}
+      payload={{ page, sortby: qsParams.sortby }}
     >
       {({ results, count }) => (
         <RemindersCollection

--- a/src/client/modules/Reminders/RemindersCollection.jsx
+++ b/src/client/modules/Reminders/RemindersCollection.jsx
@@ -17,6 +17,7 @@ import { BLUE, GREY_2 } from 'govuk-colours'
 import urls from '../../../lib/urls'
 import {
   CollectionHeaderRow,
+  CollectionSort,
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
@@ -121,9 +122,26 @@ const RemindersHeaderRow = ({ totalItems }) => {
   )
 }
 
+const sortOptions = [
+  {
+    name: 'Most recent',
+    value: '-created_on',
+  },
+  {
+    name: 'Oldest',
+    value: 'created_on',
+  },
+]
+const maxItemsToPaginate = 10000
+const itemsPerPage = 10
+
 const RemindersCollection = ({ subject, results, count, page }) => {
   const location = useLocation()
   const title = `Reminders for ${subject}`
+  const totalPages = Math.ceil(
+    Math.min(count, maxItemsToPaginate) / itemsPerPage
+  )
+
   return (
     <DefaultLayout
       pageTitle={title}
@@ -167,6 +185,7 @@ const RemindersCollection = ({ subject, results, count, page }) => {
         </GridCol>
         <GridCol>
           <RemindersHeaderRow totalItems={count} />
+          <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
           <RemindersList data-test="reminders-list">
             {results.map(({ id, created_on, event, project }) => (
               <RemindersListItem key={id} data-test="reminders-list-item">

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -62,19 +62,24 @@ export const saveNriSubscriptions = (payload) =>
     payload
   )
 
-export const getEstimatedLandDateReminders = ({ page = 1, limit = 10 } = {}) =>
+export const getEstimatedLandDateReminders = ({
+  sortby = '-created_on',
+  page = 1,
+  limit = 10,
+} = {}) =>
   apiProxyAxios
     .get('/v4/reminder/estimated-land-date', {
-      params: { limit, offset: getPageOffset({ page, limit }) },
+      params: { sortby, limit, offset: getPageOffset({ page, limit }) },
     })
     .then(({ data }) => data)
 
 export const getNoRecentInteractionReminders = ({
+  sortby = '-created_on',
   page = 1,
   limit = 10,
 } = {}) =>
   apiProxyAxios
     .get('/v4/reminder/no-recent-investment-interaction', {
-      params: { limit, offset: getPageOffset({ page, limit }) },
+      params: { sortby, limit, offset: getPageOffset({ page, limit }) },
     })
     .then(({ data }) => data)

--- a/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
@@ -2,9 +2,10 @@ import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { reminderFaker, reminderListFaker } from '../../fakers/reminders'
 
-const remindersEndpoint = '/api-proxy/v4/reminder/estimated-land-date'
+const remindersEndpoint =
+  '/api-proxy/v4/reminder/no-recent-investment-interaction'
 
-describe('Estimated Land Date Reminders', () => {
+describe('No Recent Interaction Reminders', () => {
   const reminders = [
     reminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -49,21 +50,21 @@ describe('Estimated Land Date Reminders', () => {
   context('Reminders List', () => {
     before(() => {
       interceptApiCalls()
-      cy.visit(urls.reminders.estimatedLandDate())
+      cy.visit(urls.reminders.noRecentInteraction())
       cy.wait('@remindersApiRequest')
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
         Home: '/',
-        'Reminders for approaching estimated land dates': null,
+        'Reminders for projects with no recent interaction': null,
       })
     })
 
     it('should render the heading', () => {
       cy.get('[data-test="heading"]').should(
         'have.text',
-        'Reminders for approaching estimated land dates'
+        'Reminders for projects with no recent interaction'
       )
     })
 
@@ -133,7 +134,7 @@ describe('Estimated Land Date Reminders', () => {
   context('Pagination', () => {
     beforeEach(() => {
       interceptApiCalls()
-      cy.visit(urls.reminders.estimatedLandDate())
+      cy.visit(urls.reminders.noRecentInteraction())
       cy.wait('@remindersApiRequest')
     })
 
@@ -164,7 +165,7 @@ describe('Estimated Land Date Reminders', () => {
   context('Sort', () => {
     beforeEach(() => {
       cy.intercept('GET', `${remindersEndpoint}*`).as('remindersApiRequest')
-      cy.visit(urls.reminders.estimatedLandDate())
+      cy.visit(urls.reminders.noRecentInteraction())
     })
 
     it('should apply the default sort', () => {


### PR DESCRIPTION
**Marked as DO NOT MERGE until relevant API release is made**

## Description of change

Adds sort by to reminders lists

## Test instructions

Reminders pages should now have the ability to sort by most recent / oldest - default sort should show most recent first.

## Screenshots

![image](https://user-images.githubusercontent.com/1234577/174833650-433222ad-2721-4957-8fe4-92c728855c11.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
