### PR TITLE
Pull Aventri data into Aventri Event Details page

### DIFF
--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -6,11 +6,29 @@ import urls from '../../../../lib/urls'
 import { TASK_GET_EVENT_AVENTRI_DETAILS, ID, state2props } from './state'
 import { EVENTS__AVENTRI_DETAILS_LOADED } from '../../../actions'
 import Task from '../../../components/Task'
-import { DefaultLayout } from '../../../components'
+import {
+  DefaultLayout,
+  LocalNav,
+  LocalNavLink,
+  SummaryTable,
+} from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
+import { GridCol, GridRow } from 'govuk-react'
+import styled from 'styled-components'
+import { isEmpty } from 'lodash'
 
-const EventAventriDetails = ({ name }) => {
+const StyledSummaryTable = styled(SummaryTable)({
+  marginTop: 0,
+})
+
+const EventAventriDetails = ({
+  name,
+  type,
+  eventDate,
+  location,
+  fullAddress,
+}) => {
   const { aventriEventId } = useParams()
   const breadcrumbs = [
     {
@@ -47,8 +65,42 @@ const EventAventriDetails = ({ name }) => {
             >
               {() => {
                 return (
-                  <></>
-                  // TODO: Implements events aventri details here
+                  name && (
+                    <GridRow data-test="eventAventriDetails">
+                      <GridCol setWidth="one-quarter">
+                        <LocalNav data-test="event-aventri-details-nav">
+                          <LocalNavLink
+                            data-test="event-aventri-details-link"
+                            href={urls.events.aventri.details(aventriEventId)}
+                          >
+                            Details
+                          </LocalNavLink>
+                        </LocalNav>
+                      </GridCol>
+                      <GridCol setWidth="three-quarters">
+                        <StyledSummaryTable>
+                          <SummaryTable.Row
+                            heading="Type of event"
+                            children={type}
+                          />
+                          <SummaryTable.Row
+                            heading="Event date"
+                            children={eventDate}
+                          />
+                          <SummaryTable.Row
+                            heading="Event location type"
+                            children={isEmpty(location) ? 'Not set' : location}
+                          />
+                          <SummaryTable.Row
+                            heading="Address"
+                            children={
+                              isEmpty(fullAddress) ? 'Not set' : fullAddress
+                            }
+                          />
+                        </StyledSummaryTable>
+                      </GridCol>
+                    </GridRow>
+                  )
                 )
               }}
             </Task.Status>

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -7,6 +7,7 @@ import {
   formatMediumDateTime,
   getDifferenceInDays,
   formatLongDate,
+  formatStartAndEndDate,
 } from '../../utils/date'
 
 import { transformIdNameToValueLabel } from '../../transformers'
@@ -132,9 +133,19 @@ const transformResponseToEventDetails = ({
   disabledOn: disabled_on,
 })
 
-const transformResponseToEventAventriDetails = ({ id, object }) => ({
+const transformResponseToEventAventriDetails = ({ id, object, type }) => ({
   id,
   name: object?.name,
+  type,
+  eventDate: formatStartAndEndDate(object?.startTime, object?.endTime),
+  location: object['dit:aventri:locationname'],
+  fullAddress: compact([
+    object['dit:aventri:location_address1'],
+    object['dit:aventri:location_address2'],
+    object['dit:aventri:location_city'],
+    object['dit:aventri:location_postcode'],
+    object['dit:aventri:location_country'],
+  ]),
 })
 
 export {

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -2,6 +2,7 @@ const urls = require('../../../../../src/lib/urls')
 const {
   assertBreadcrumbs,
   assertErrorDialog,
+  assertKeyValueTable,
 } = require('../../support/assertions')
 const {
   CONTACT_ACTIVITY_FEATURE_FLAG,
@@ -20,6 +21,13 @@ describe('Event Aventri Details', () => {
         Home: urls.dashboard.route,
         Events: urls.events.index(),
         'EITA Test Event 2022': null,
+      })
+
+      assertKeyValueTable('eventAventriDetails', {
+        'Type of event': 'dit:aventri:Event',
+        'Event date': '02 Mar 2021 to 04 May 2022',
+        'Event location type': 'Not set',
+        Address: 'Online',
       })
     })
   })


### PR DESCRIPTION
## Description of change

As part of bringing new Datahub features, I pull Aventri data to newly created Aventri Event Details page.

## Test instructions

- Add user feature flag from Django admin in order to view Aventri event details
- Manually enter in the browser address bar e.g. http://localhost:3000/events/aventri/{id}/details

**Where:**
id replace with 1111, 2222 or 3333 as Aventri test id.

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/28296624/175515971-3fd6ea8b-acba-4616-a409-a1579d4e83b8.png)

### After
![image](https://user-images.githubusercontent.com/28296624/175515546-b07ee569-11a0-440d-aec8-44bd8e8e0abb.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
