### PR TITLE
Add 3 more fields to data hub events in the Events Collection List

### DIFF
--- a/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
@@ -11,7 +11,7 @@ import ActivityCardMetadata from './card/ActivityCardMetadata'
 
 export default function DataHubEvent({ activity: event }) {
   const eventObject = event.object
-  const name = eventObject.name
+  const eventName = eventObject.name
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
   const organiser = eventObject['dit:organiser'].name
   const serviceType = eventObject['dit:service'].name
@@ -20,13 +20,25 @@ export default function DataHubEvent({ activity: event }) {
   return (
     <ActivityCardWrapper dataTest="data-hub-event">
       <ActivityCardSubject dataTest="data-hub-event-name">
-        {name}
+        {eventName}
       </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[
           {
             label: 'Event date',
             value: date,
+          },
+          {
+            label: 'Organiser',
+            value: organiser,
+          },
+          {
+            label: 'Service type',
+            value: serviceType,
+          },
+          {
+            label: 'Lead team',
+            value: leadTeam,
           },
         ]}
       />

--- a/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
@@ -13,6 +13,9 @@ export default function DataHubEvent({ activity: event }) {
   const eventObject = event.object
   const name = eventObject.name
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
+  const organiser = eventObject['dit:organiser'].name
+  const serviceType = eventObject['dit:service'].name
+  const leadTeam = eventObject['dit:leadTeam'].name
 
   return (
     <ActivityCardWrapper dataTest="data-hub-event">

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -159,6 +159,21 @@ describe('Event Collection List Page - React', () => {
         .should('exist')
         .should('contain', '30 May to 14 Jun 2022')
     })
+    it('should display the event organiser', () => {
+      cy.get('[data-test="organiser-label"]')
+        .should('exist')
+        .should('contain', 'Joe Bloggs')
+    })
+    it('should display the service type', () => {
+      cy.get('[data-test="service-type-label"]')
+        .should('exist')
+        .should('contain', 'Best service')
+    })
+    it('should display the lead team', () => {
+      cy.get('[data-test="lead-team-label"]')
+        .should('exist')
+        .should('contain', 'Digital Data Hub - Live Service')
+    })
     context(
       'viewing the events collection page when there is an error loading events',
       () => {


### PR DESCRIPTION
## Description of change

Following the work done on [DET-191]( https://uktrade.atlassian.net/browse/DET-191) & [DET-190](https://uktrade.atlassian.net/browse/DET-190), we now want to display more events data from Data Hub, which we will get from Activity Stream and not the Data Hub API. 

We will pull through additional data and add the correct styling.

The additional fields to pull through will be:
- Organiser
- Service Type (Service Name)
- Lead Team

## Test instructions

- In Django dev API, add the user feature flag `user-event-activities` to your adviser profile.
- Go to the [Events Collection page](http://localhost:3000/events?page=1&sortby=modified_on%3Adesc&featureTesting=user-event-activities).
- You should see 10 events displayed on the page, with event name event date, organiser, service type and lead team visible.


## Screenshots
### Before

![image](https://user-images.githubusercontent.com/83657534/175959997-6d4754b5-279e-4837-a1cd-950b28eae11c.png)

### After

![image](https://user-images.githubusercontent.com/83657534/175960049-44a82c7f-6878-448b-b001-477201858d80.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
