### PR TITLE
DET-208 Modify Aventri event details feature flag

### DIFF
--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -13,7 +13,7 @@ import {
   SummaryTable,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
+import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import { GridCol, GridRow } from 'govuk-react'
 import styled from 'styled-components'
 import { isEmpty } from 'lodash'
@@ -51,7 +51,7 @@ const EventAventriDetails = ({
       breadcrumbs={breadcrumbs}
       useReactRouter={true}
     >
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
+      <CheckUserFeatureFlag userFeatureFlagName={EVENT_ACTIVITY_FEATURE_FLAG}>
         {(isFeatureFlagEnabled) =>
           isFeatureFlagEnabled && (
             <Task.Status

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -5,7 +5,7 @@ const {
   assertKeyValueTable,
 } = require('../../support/assertions')
 const {
-  CONTACT_ACTIVITY_FEATURE_FLAG,
+  EVENT_ACTIVITY_FEATURE_FLAG,
 } = require('../../../../../src/apps/companies/apps/activity-feed/constants')
 
 describe('Event Aventri Details', () => {
@@ -15,7 +15,7 @@ describe('Event Aventri Details', () => {
 
   context('when the feature flag is on', () => {
     before(() => {
-      cy.setUserFeatures([CONTACT_ACTIVITY_FEATURE_FLAG])
+      cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
     })
 
     context('when it is a valid event', () => {


### PR DESCRIPTION
## Description of change

As part of creating new feature for Datahub, I modify the feature flag being used from `CONTACT_ACTIVITY_FEATURE_FLAG` to `EVENT_ACTIVITY_FEATURE_FLAG`



## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [X] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
