### PR TITLE
Fix optional data handling for Events from Activity Stream

### DIFF
--- a/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
@@ -13,9 +13,9 @@ export default function DataHubEvent({ activity: event }) {
   const eventObject = event.object
   const eventName = eventObject.name
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
-  const organiser = eventObject['dit:organiser'].name
-  const serviceType = eventObject['dit:service'].name
-  const leadTeam = eventObject['dit:leadTeam'].name
+  const organiser = eventObject['dit:organiser']?.name || 'Not set'
+  const serviceType = eventObject['dit:service']?.name || 'Not set'
+  const leadTeam = eventObject['dit:leadTeam']?.name || 'Not set'
 
   return (
     <ActivityCardWrapper dataTest="data-hub-event">

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -139,41 +139,73 @@ describe('Event Collection List Page - React', () => {
   })
 
   context('when the activity stream flag is on', () => {
-    beforeEach(() => {
+    before(() => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
-      cy.visit(events.index())
     })
-    it('should not display the data hub API collection list', () => {
-      cy.get('[data-test="collection-list"]').should('not.exist')
+
+    context('when there is not an error', () => {
+      beforeEach(() => {
+        cy.visit(events.index())
+        cy.get('[data-test="data-hub-event"]').as('dataHubEvents')
+        cy.get('@dataHubEvents').eq(0).as('firstDataHubEvent')
+        cy.get('@dataHubEvents').eq(1).as('secondDataHubEvent')
+      })
+
+      it('should not display the data hub API collection list', () => {
+        cy.get('[data-test="collection-list"]').should('not.exist')
+      })
+
+      it('should display an event name', () => {
+        cy.get('@firstDataHubEvent')
+          .find('[data-test="data-hub-event-name"]')
+          .should('exist')
+          .should('contain', 'Holiday to the Seaside')
+      })
+
+      it('should display an event date', () => {
+        cy.get('@firstDataHubEvent')
+          .find('[data-test="event-date-label"]')
+          .should('exist')
+          .should('contain', '30 May to 14 Jun 2022')
+      })
+
+      it('should display the event organiser', () => {
+        cy.get('@firstDataHubEvent')
+          .find('[data-test="organiser-label"]')
+          .should('exist')
+          .should('contain', 'Joe Bloggs')
+      })
+
+      it('should display the service type', () => {
+        cy.get('@firstDataHubEvent')
+          .find('[data-test="service-type-label"]')
+          .should('exist')
+          .should('contain', 'Best service')
+      })
+
+      it('should display the lead team', () => {
+        cy.get('@firstDataHubEvent')
+          .find('[data-test="lead-team-label"]')
+          .should('exist')
+          .should('contain', 'Digital Data Hub - Live Service')
+      })
+
+      context('when optional details are missing', () => {
+        it('should display "Not set"', () => {
+          cy.get('@secondDataHubEvent').find('div').find('div').as('labels')
+          cy.get('@labels')
+            .get('[data-test="lead-team-label"]')
+            .should('contain', 'Not set')
+          cy.get('@labels')
+            .get('[data-test="organiser-label"]')
+            .should('contain', 'Not set')
+          cy.get('@labels')
+            .get('[data-test="service-type-label"]')
+            .should('contain', 'Not set')
+        })
+      })
     })
-    it('should display an event', () => {
-      cy.get('[data-test="data-hub-event"]').should('exist')
-    })
-    it('should display an event name', () => {
-      cy.get('[data-test="data-hub-event-name"]')
-        .should('exist')
-        .should('contain', 'Holiday to the Seaside')
-    })
-    it('should display an event date', () => {
-      cy.get('[data-test="event-date-label"]')
-        .should('exist')
-        .should('contain', '30 May to 14 Jun 2022')
-    })
-    it('should display the event organiser', () => {
-      cy.get('[data-test="organiser-label"]')
-        .should('exist')
-        .should('contain', 'Joe Bloggs')
-    })
-    it('should display the service type', () => {
-      cy.get('[data-test="service-type-label"]')
-        .should('exist')
-        .should('contain', 'Best service')
-    })
-    it('should display the lead team', () => {
-      cy.get('[data-test="lead-team-label"]')
-        .should('exist')
-        .should('contain', 'Digital Data Hub - Live Service')
-    })
+
     context(
       'viewing the events collection page when there is an error loading events',
       () => {
@@ -190,6 +222,7 @@ describe('Event Collection List Page - React', () => {
         })
       }
     )
+
     after(() => {
       cy.resetUser()
     })

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-events.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-events.json
@@ -1,82 +1,126 @@
 {
-    "took" : 958,
-    "timed_out" : false,
-    "_shards" : {
-      "total" : 274,
-      "successful" : 274,
-      "skipped" : 151,
-      "failed" : 0
+  "took": 958,
+  "timed_out": false,
+  "_shards": {
+    "total": 274,
+    "successful": 274,
+    "skipped": 151,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 82,
+      "relation": "eq"
     },
-    "hits" : {
-      "total" : {
-        "value" : 82,
-        "relation" : "eq"
-      },
-      "max_score" : 0.036367644,
-      "hits" : [
-        {
-            "_index" : "activities__feed_id_datahub-events__date_2022-06-23__timestamp_1655982198__batch_id_iquvq1ib__",
-            "_type" : "_doc",
-            "_id" : "dit:DataHubEvent:6666:Announce",
-            "_score" : 0.036367644,
-            "_source" : {
-              "generator" : {
-                "name" : "dit:dataHub",
-                "type" : "Application"
-              },
-              "id" : "dit:DataHubEvent:6666:Announce",
-              "object" : {
-                "content" : "",
-                "dit:address_1" : "London",
-                "dit:address_2" : "",
-                "dit:address_country" : {
-                  "name" : "United Kingdom"
-                },
-                "dit:address_county" : "",
-                "dit:address_postcode" : "",
-                "dit:address_town" : "London",
-                "dit:archivedDocumentsUrlPath" : "",
-                "dit:disabledOn" : null,
-                "dit:eventType" : {
-                  "name" : "Account management"
-                },
-                "dit:hasRelatedTradeAgreements" : false,
-                "dit:leadTeam" : {
-                  "name" : "Digital Data Hub - Live Service"
-                },
-                "dit:locationType" : {
-                  "name" : "HQ"
-                },
-                "dit:organiser" : {
-                  "name" : "Joe Bloggs"
-                },
-                "dit:relatedProgrammes" : [ ],
-                "dit:service" : {
-                  "name" : "Best service"
-                },
-                "dit:teams" : [
-                  {
-                    "id" : "dit:DataHubTeam:5555",
-                    "name" : "Digital Data Hub - Live Service",
-                    "type" : [
-                      "Group",
-                      "dit:Team"
-                    ]
-                  }
-                ],
-                "endTime" : "2022-06-14",
-                "id" : "dit:DataHubEvent:6666",
-                "name" : "Holiday to the Seaside",
-                "startTime" : "2022-05-30",
-                "type" : [
-                  "dit:dataHub:Event"
-                ],
-                "url" : ""
-              },
-              "published" : "2021-08-20T10:39:10.184330Z",
-              "type" : "Announce"
-            }
+    "max_score": 0.036367644,
+    "hits": [
+      {
+        "_index": "activities__feed_id_datahub-events__date_2022-06-23__timestamp_1655982198__batch_id_iquvq1ib__",
+        "_type": "_doc",
+        "_id": "dit:DataHubEvent:6666:Announce",
+        "_score": 0.036367644,
+        "_source": {
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "id": "dit:DataHubEvent:6666:Announce",
+          "object": {
+            "content": "",
+            "dit:address_1": "London",
+            "dit:address_2": "",
+            "dit:address_country": {
+              "name": "United Kingdom"
+            },
+            "dit:address_county": "",
+            "dit:address_postcode": "",
+            "dit:address_town": "London",
+            "dit:archivedDocumentsUrlPath": "",
+            "dit:disabledOn": null,
+            "dit:eventType": {
+              "name": "Account management"
+            },
+            "dit:hasRelatedTradeAgreements": false,
+            "dit:leadTeam": {
+              "name": "Digital Data Hub - Live Service"
+            },
+            "dit:locationType": {
+              "name": "HQ"
+            },
+            "dit:organiser": {
+              "name": "Joe Bloggs"
+            },
+            "dit:relatedProgrammes": [],
+            "dit:service": {
+              "name": "Best service"
+            },
+            "dit:teams": [
+              {
+                "id": "dit:DataHubTeam:5555",
+                "name": "Digital Data Hub - Live Service",
+                "type": ["Group", "dit:Team"]
+              }
+            ],
+            "endTime": "2022-06-14",
+            "id": "dit:DataHubEvent:6666",
+            "name": "Holiday to the Seaside",
+            "startTime": "2022-05-30",
+            "type": ["dit:dataHub:Event"],
+            "url": ""
+          },
+          "published": "2021-08-20T10:39:10.184330Z",
+          "type": "Announce"
         }
-      ]
-    }
+      },
+      {
+        "_index": "activities__feed_id_datahub-events__date_2022-06-23__timestamp_1655982198__batch_id_iquvq1ib__",
+        "_type": "_doc",
+        "_id": "dit:DataHubEvent:7777:Announce",
+        "_score": 0.036367644,
+        "_source": {
+          "generator": {
+            "name": "dit:dataHub",
+            "type": "Application"
+          },
+          "id": "dit:DataHubEvent:7777:Announce",
+          "object": {
+            "content": "",
+            "dit:address_1": "London",
+            "dit:address_2": "",
+            "dit:address_country": {
+              "name": "United Kingdom"
+            },
+            "dit:address_county": "",
+            "dit:address_postcode": "",
+            "dit:address_town": "London",
+            "dit:archivedDocumentsUrlPath": "",
+            "dit:disabledOn": null,
+            "dit:eventType": {
+              "name": "Account management"
+            },
+            "dit:hasRelatedTradeAgreements": false,
+            "dit:locationType": {
+              "name": "HQ"
+            },
+            "dit:relatedProgrammes": [],
+            "dit:teams": [
+              {
+                "id": "dit:DataHubTeam:5555",
+                "name": "Digital Data Hub - Live Service",
+                "type": ["Group", "dit:Team"]
+              }
+            ],
+            "endTime": "2022-06-14",
+            "id": "dit:DataHubEvent:6666",
+            "name": "Event with no leader, service or organiser",
+            "startTime": "2022-05-30",
+            "type": ["dit:dataHub:Event"],
+            "url": ""
+          },
+          "published": "2021-07-20T10:39:10.184330Z",
+          "type": "Announce"
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Description of change

For users with the `user-event-activities` feature flag on, the Events collection list is failing, because there are some optional fields not handled when rendering. 

## Test instructions

The Events collection list should load normally.

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
