### PR TITLE
Stop using React history hook to change search params

### DIFF
--- a/src/client/components/CheckUserFeatureFlags/index.jsx
+++ b/src/client/components/CheckUserFeatureFlags/index.jsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import qs from 'qs'
 import Resource from '../Resource'
 import { ID, TASK_GET_USER_FEATURE_FLAGS } from './state'
-import { useHistory, useLocation } from 'react-router-dom'
 
 /** 
 This component enables the checking of a particular user feature flag in React.
@@ -20,22 +18,11 @@ export default function CheckUserFeatureFlag({
   children,
   userFeatureFlagName,
 }) {
-  const location = useLocation()
-  const history = useHistory()
-  const existingParams = qs.parse(location.search.slice(1))
-
-  const [isFlagOn, setFlagOn] = useState(false)
-
-  useEffect(() => {
-    if (isFlagOn) {
-      history.replace({
-        search: qs.stringify({
-          ...existingParams,
-          ['featureTesting']: userFeatureFlagName,
-        }),
-      })
-    }
-  }, [isFlagOn])
+  const setSearchParams = () => {
+    const url = new URL(window.location)
+    url.searchParams.set('featureTesting', userFeatureFlagName)
+    window.history.replaceState(null, '', url.toString())
+  }
 
   return (
     <Resource
@@ -44,7 +31,9 @@ export default function CheckUserFeatureFlag({
       payload={userFeatureFlagName}
     >
       {(isFeatureFlagEnabled) => {
-        setFlagOn(isFeatureFlagEnabled)
+        if (isFeatureFlagEnabled) {
+          setSearchParams()
+        }
         return children(isFeatureFlagEnabled)
       }}
     </Resource>


### PR DESCRIPTION
## Description of change

Previously we needed to call a set state hook to change the params for
this user feature flag component, and that was causing some console errors
around the rendering cycle[1] 

This commit uses the URL constructor[2] and the regular window history
to add the param... as I don't think  the react router ever needs to
know about this I think it's fine?

[1]
https://github.com/uktrade/data-hub-frontend/pull/4611/commits/09f86a4c017f2fd0127b691edb2c133ee898a190
[2] https://developer.mozilla.org/en-US/docs/Web/API/URL/URL note: not
supported by Internet Explorer...

## Test instructions

No errors in the console related to the `CheckUserFeatureFlag` component when it is used. (e.g. on `http://localhost:3000/events`) 

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
