### PR TITLE
Chore/dependencies 2022 06 29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -90,7 +90,7 @@
         "style-loader": "^3.3.1",
         "styled-components": "^5.3.5",
         "uuid": "^8.3.2",
-        "winston": "^3.6.0"
+        "winston": "^3.8.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.5",
@@ -37715,9 +37715,9 @@
       "dev": true
     },
     "node_modules/winston": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
-      "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.0.tgz",
+      "integrity": "sha512-Iix1w8rIq2kBDkGvclO0db2CVOHYVamCIkVWcUbs567G9i2pdB+gvqLgDgxx4B4HXHYD6U4Zybh6ojepUOqcFQ==",
       "dependencies": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",
@@ -67018,9 +67018,9 @@
       "dev": true
     },
     "winston": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
-      "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.8.0.tgz",
+      "integrity": "sha512-Iix1w8rIq2kBDkGvclO0db2CVOHYVamCIkVWcUbs567G9i2pdB+gvqLgDgxx4B4HXHYD6U4Zybh6ojepUOqcFQ==",
       "requires": {
         "@dabh/diagnostics": "^2.0.2",
         "async": "^3.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -127,7 +127,7 @@
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-mocha": "^10.0.3",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-prettier": "^4.0.0",
+        "eslint-plugin-prettier": "^4.1.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react": "^7.30.1",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -18290,15 +18290,15 @@
       }
     },
     "node_modules/eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.1.0.tgz",
+      "integrity": "sha512-A3AXIEfTnq3D5qDFjWJdQ9c4BLhw/TqhSR+6+SVaoPJBAWciFEuJiNQh275OnjRrAi7yssZzuWBRw66VG2g6UA==",
       "dev": true,
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=12.0.0"
       },
       "peerDependencies": {
         "eslint": ">=7.28.0",
@@ -52334,9 +52334,9 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz",
-      "integrity": "sha512-98MqmCJ7vJodoQK359bqQWaxOE0CS8paAz/GgjaZLyex4TTk3g9HugoO89EqWCrFiOqn9EVvcoo7gZzONCWVwQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.1.0.tgz",
+      "integrity": "sha512-A3AXIEfTnq3D5qDFjWJdQ9c4BLhw/TqhSR+6+SVaoPJBAWciFEuJiNQh275OnjRrAi7yssZzuWBRw66VG2g6UA==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "@babel/core": "^7.18.5",
         "@babel/eslint-parser": "^7.17.0",
         "@babel/helper-call-delegate": "^7.12.13",
-        "@babel/plugin-proposal-class-properties": "7.17.12",
+        "@babel/plugin-proposal-class-properties": "7.18.6",
         "@babel/plugin-proposal-object-rest-spread": "^7.17.3",
         "@babel/plugin-proposal-optional-chaining": "^7.16.7",
         "@babel/preset-env": "7.18.2",
@@ -180,11 +180,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -248,11 +248,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.6.tgz",
+      "integrity": "sha512-AIwwoOS8axIC5MZbhNHRLKi3D+DMpvDf9XUcu3pIVAfOHFT45f4AoDAltRbHIQomCipkCZxrNkfpOEHhJz/VKw==",
       "dependencies": {
-        "@babel/types": "^7.18.2",
+        "@babel/types": "^7.18.6",
         "@jridgewell/gen-mapping": "^0.3.0",
         "jsesc": "^2.5.1"
       },
@@ -274,11 +274,11 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -326,18 +326,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.0.tgz",
-      "integrity": "sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.6.tgz",
+      "integrity": "sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-function-name": "^7.18.6",
+        "@babel/helper-member-expression-to-functions": "^7.18.6",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -382,9 +382,9 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
+      "integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -402,35 +402,35 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
+      "integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
-      "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.6.tgz",
+      "integrity": "sha512-CeHxqwwipekotzPDUuJOfIMtcIHBuc7WAzLmTYWctVigqS5RktNMQ5bEwQSuGewzYnCtTWa3BARXeiLxDTv+Ng==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -467,21 +467,21 @@
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
-      "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
+      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -502,16 +502,16 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.2.tgz",
-      "integrity": "sha512-XzAIyxx+vFnrOxiQrToSUOzUOn0e1J2Li40ntddek1Y69AXUTXoDJ40/D5RdjFu7s7qHiaeoTiempZcbuVXh2Q==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.6.tgz",
+      "integrity": "sha512-fTf7zoXnUGl9gF25fXCWE26t7Tvtyn6H4hkLSYhATwJvw2uYxd3aoXplMSe0g9XbwK7bmxNes7+FGO0rB/xC0g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2"
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-member-expression-to-functions": "^7.18.6",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/traverse": "^7.18.6",
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -542,20 +542,20 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -599,11 +599,11 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -612,9 +612,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
-      "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+      "integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -672,13 +672,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.17.12.tgz",
-      "integrity": "sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2035,31 +2035,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.18.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
-      "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.6.tgz",
+      "integrity": "sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.18.5",
-        "@babel/types": "^7.18.4",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-function-name": "^7.18.6",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2068,11 +2068,11 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.6.tgz",
+      "integrity": "sha512-NdBNzPDwed30fZdDQtVR7ZgaO4UKjuaQFH9VArS+HMnurlOY0JWN+4ROlu/iapMFwjRQU4pOG4StZfDmulEwGA==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -38049,11 +38049,11 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
@@ -38097,11 +38097,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.2.tgz",
-      "integrity": "sha512-W1lG5vUwFvfMd8HVXqdfbuG7RuaSrTCCD8cl8fP8wOivdbtbIg2Db3IWUcgvfxKbbn6ZBGYRW/Zk1MIwK49mgw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.6.tgz",
+      "integrity": "sha512-AIwwoOS8axIC5MZbhNHRLKi3D+DMpvDf9XUcu3pIVAfOHFT45f4AoDAltRbHIQomCipkCZxrNkfpOEHhJz/VKw==",
       "requires": {
-        "@babel/types": "^7.18.2",
+        "@babel/types": "^7.18.6",
         "@jridgewell/gen-mapping": "^0.3.0",
         "jsesc": "^2.5.1"
       },
@@ -38119,11 +38119,11 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -38159,18 +38159,18 @@
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.18.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.0.tgz",
-      "integrity": "sha512-Kh8zTGR9de3J63e5nS0rQUdRs/kbtwoeQQ0sriS0lItjC96u8XXZN6lKpuyWd2coKSU13py/y+LTmThLuVX0Pg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.6.tgz",
+      "integrity": "sha512-YfDzdnoxHGV8CzqHGyCbFvXg5QESPFkXlHtvdCkesLjjVMT2Adxe4FGUR5ChIb3DxSaXO12iIOCWoXdsUVwnqw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-function-name": "^7.18.6",
+        "@babel/helper-member-expression-to-functions": "^7.18.6",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
@@ -38200,9 +38200,9 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.2.tgz",
-      "integrity": "sha512-14GQKWkX9oJzPiQQ7/J36FTXcD4kSp8egKjO9nINlSKiHITRA9q/R74qu8S9xlc/b/yjsJItQUeeh3xnGN0voQ=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.6.tgz",
+      "integrity": "sha512-8n6gSfn2baOY+qlp+VSzsosjCVGFqWKmDF0cCWOybh52Dw3SEyoWR1KrhMJASjLwIEkkAufZ0xvr+SxLHSpy2Q=="
     },
     "@babel/helper-explode-assignable-expression": {
       "version": "7.16.7",
@@ -38214,29 +38214,29 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.6.tgz",
+      "integrity": "sha512-0mWMxV1aC97dhjCah5U5Ua7668r5ZmSC2DLfH2EZnf9c3/dHZKiFa5pRLMH5tjSl471tY6496ZWk/kjNONBxhw==",
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
-      "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.6.tgz",
+      "integrity": "sha512-CeHxqwwipekotzPDUuJOfIMtcIHBuc7WAzLmTYWctVigqS5RktNMQ5bEwQSuGewzYnCtTWa3BARXeiLxDTv+Ng==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-imports": {
@@ -38264,18 +38264,18 @@
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
-      "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.6.tgz",
+      "integrity": "sha512-gvZnm1YAAxh13eJdkb9EWHBnF3eAub3XTLCZEehHT2kWxiKVRL64+ae5Y6Ivne0mVHmMYKT+xWgZO+gQhuLUBg==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
@@ -38290,16 +38290,16 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.2.tgz",
-      "integrity": "sha512-XzAIyxx+vFnrOxiQrToSUOzUOn0e1J2Li40ntddek1Y69AXUTXoDJ40/D5RdjFu7s7qHiaeoTiempZcbuVXh2Q==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.6.tgz",
+      "integrity": "sha512-fTf7zoXnUGl9gF25fXCWE26t7Tvtyn6H4hkLSYhATwJvw2uYxd3aoXplMSe0g9XbwK7bmxNes7+FGO0rB/xC0g==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.18.2",
-        "@babel/types": "^7.18.2"
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-member-expression-to-functions": "^7.18.6",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/traverse": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -38321,17 +38321,17 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+      "integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
     },
     "@babel/helper-validator-option": {
       "version": "7.16.7",
@@ -38363,19 +38363,19 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.18.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.5.tgz",
-      "integrity": "sha512-YZWVaglMiplo7v8f1oMQ5ZPQr0vn7HPeZXxXWsxXJRjGVrzUFn9OxFQl1sb5wzfootjA/yChhW84BV+383FSOw=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.6.tgz",
+      "integrity": "sha512-uQVSa9jJUe/G/304lXspfWVpKpK4euFLgGiMQFOCpM/bgcAdeoHwi/OQz23O9GK2osz26ZiXRRV9aV+Yl1O8tw=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.17.12",
@@ -38409,13 +38409,13 @@
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.17.12.tgz",
-      "integrity": "sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-class-static-block": {
@@ -39319,38 +39319,38 @@
       }
     },
     "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+      "integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/traverse": {
-      "version": "7.18.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.5.tgz",
-      "integrity": "sha512-aKXj1KT66sBj0vVzk6rEeAO6Z9aiiQ68wfDgge3nHhA/my6xMM/7HGQUNumKZaoa2qUPQ5whJG9aAifsxUKfLA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.6.tgz",
+      "integrity": "sha512-zS/OKyqmD7lslOtFqbscH6gMLFYOfG1YPqCKfAW5KrTeolKqvB8UelR49Fpr6y93kYkW2Ik00mT1LOGiAGvizw==",
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.18.2",
-        "@babel/helper-environment-visitor": "^7.18.2",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.18.5",
-        "@babel/types": "^7.18.4",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.6",
+        "@babel/helper-function-name": "^7.18.6",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.18.6",
+        "@babel/types": "^7.18.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.18.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
-      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.6.tgz",
+      "integrity": "sha512-NdBNzPDwed30fZdDQtVR7ZgaO4UKjuaQFH9VArS+HMnurlOY0JWN+4ROlu/iapMFwjRQU4pOG4StZfDmulEwGA==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "to-fast-properties": "^2.0.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -42060,7 +42060,7 @@
           "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "5.0.1"
           }
         },
         "style-loader": {
@@ -44773,7 +44773,7 @@
           "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "5.0.1"
           }
         },
         "style-loader": {
@@ -48089,7 +48089,7 @@
           "integrity": "sha512-/dPCrG1s3ePpWm6yBbxZq5Be1dXGLyLn9Z791chDC3NFrpkVbWGzkBwPN1knaciexFXgRJ7hzdnwZ4stHSDmjg==",
           "optional": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         }
       }
@@ -48597,7 +48597,7 @@
         "get-value": "^2.0.6",
         "has-value": "^1.0.0",
         "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
+        "set-value": "4.0.1",
         "to-object-path": "^0.3.0",
         "union-value": "^1.0.0",
         "unset-value": "^1.0.0"
@@ -48849,7 +48849,7 @@
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
         "fsevents": "~2.3.2",
-        "glob-parent": "~5.1.2",
+        "glob-parent": "5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
@@ -49045,7 +49045,7 @@
           "integrity": "sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^6.0.1"
+            "ansi-regex": "5.0.1"
           }
         }
       }
@@ -49644,7 +49644,7 @@
           "requires": {
             "@mrmlnc/readdir-enhanced": "^2.2.1",
             "@nodelib/fs.stat": "^1.1.2",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "5.1.2",
             "is-glob": "^4.0.0",
             "merge2": "^1.2.3",
             "micromatch": "^3.1.10"
@@ -51354,7 +51354,7 @@
             "decompress-response": "^3.2.0",
             "duplexer3": "^0.1.4",
             "get-stream": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
+            "is-plain-obj": "1.1.0",
             "is-retry-allowed": "^1.0.0",
             "is-stream": "^1.0.0",
             "isurl": "^1.0.0-alpha5",
@@ -53025,7 +53025,7 @@
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
+        "glob-parent": "5.1.2",
         "merge2": "^1.3.0",
         "micromatch": "^4.0.4"
       }
@@ -53370,7 +53370,7 @@
       "integrity": "sha512-P8WRou2S+oe222TOCHitLy8zj+SIsVJh52VP4lvXkaFVnOFFdoWv1H1Jjvel1aI6NCFOAaeAVm8qrI0odiLcww==",
       "optional": true,
       "requires": {
-        "semver-regex": "^2.0.0"
+        "semver-regex": "3.1.4"
       }
     },
     "find-webpack": {
@@ -57378,7 +57378,7 @@
       "dev": true,
       "requires": {
         "fault": "^1.0.0",
-        "highlight.js": "~10.7.0"
+        "highlight.js": "11.2.0"
       }
     },
     "lru-cache": {
@@ -58578,7 +58578,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "5.0.1"
           }
         },
         "wrap-ansi": {
@@ -62304,7 +62304,7 @@
         "parse-entities": "^2.0.0",
         "repeat-string": "^1.5.4",
         "state-toggle": "^1.0.0",
-        "trim": "0.0.1",
+        "trim": "0.0.3",
         "trim-trailing-lines": "^1.0.0",
         "unherit": "^1.0.4",
         "unist-util-remove-position": "^2.0.0",
@@ -63284,7 +63284,8 @@
       }
     },
     "semver-regex": {
-      "version": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
       "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
       "optional": true
     },
@@ -63475,7 +63476,8 @@
       "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "set-value": {
-      "version": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-4.0.1.tgz",
       "integrity": "sha512-ayATicCYPVnlNpFmjq2/VmVwhoCQA9+13j8qWp044fmFE3IFphosPtRM+0CJ5xoIx5Uy52fCcwg3XeH2pHbbPQ==",
       "dev": true,
       "requires": {
@@ -63851,7 +63853,7 @@
       "integrity": "sha512-vzn8aSqKgytVik0iwdBEi+zevbTYZogewTUM6dtpmGwEcdzbub/TX4bCzRhebDCRC3QzXgJsLRKB2V/Oof7HXg==",
       "optional": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "sort-keys-length": {
@@ -64326,7 +64328,7 @@
           "dev": true,
           "requires": {
             "fault": "^1.0.2",
-            "highlight.js": "~9.13.0"
+            "highlight.js": "11.2.0"
           }
         },
         "parse-entities": {
@@ -65378,7 +65380,8 @@
       "integrity": "sha512-kdf4JKs8lbARxWdp7RKdNzoJBhGUcIalSYibuGyHJbmk40pOysQ0+QPvlkCOICOivDWU2IJo2rkrxyTK2AH4fw=="
     },
     "trim": {
-      "version": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.3.tgz",
       "integrity": "sha512-h82ywcYhHK7veeelXrCScdH7HkWfbIT1D/CgYO+nmDarz3SGNssVBMws6jU16Ga60AJCRAvPV6w6RLuNerQqjg==",
       "dev": true
     },
@@ -65682,7 +65685,7 @@
         "bail": "^1.0.0",
         "extend": "^3.0.0",
         "is-buffer": "^2.0.0",
-        "is-plain-obj": "^2.0.0",
+        "is-plain-obj": "1.1.0",
         "trough": "^1.0.0",
         "vfile": "^4.0.0"
       },
@@ -65703,7 +65706,7 @@
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "set-value": "4.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -66392,7 +66395,7 @@
             "async-each": "^1.0.1",
             "braces": "^2.3.2",
             "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
+            "glob-parent": "5.1.2",
             "inherits": "^2.0.3",
             "is-binary-path": "^1.0.0",
             "is-glob": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@nivo/tooltip": "^0.79.0",
         "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.8.2",
-        "@sentry/browser": "^7.2.0",
+        "@sentry/browser": "^7.3.1",
         "autoprefixer": "^10.4.4",
         "axios": "^0.27.2",
         "basic-auth": "^2.0.1",
@@ -4229,13 +4229,13 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.2.0.tgz",
-      "integrity": "sha512-QMdRpK7MM8woFOeMTDh7/sXG4lXutgZ/K9SBBMvd5MVaaQnSSE5ZGJMaxMfsiYOISV0UqS7l0V0EaGnv9n3zrQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.3.1.tgz",
+      "integrity": "sha512-x0LhK8hnrGEBBCZVsW9h3USW93agX+axXvUPu72SJMyMnwF+92XjpgOET48OdPNzej/bU8Qv+eXTC/VDh/HXvw==",
       "dependencies": {
-        "@sentry/core": "7.2.0",
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/core": "7.3.1",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4243,13 +4243,13 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-9amsbB9/ePkJRgc0cVXCVW2hQUPImgTqBbnKu4frBXBza+9MBC5W3S8ZyZt2InCK22kuhNVo3z61a8mzCgXoCA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.3.1.tgz",
+      "integrity": "sha512-UYPNDluFtj5w6alh+SjSm9p6kxReKVcKEE+EPE4o44pdowjZ1BFTUY6ipMJhtIiDPr/51eeP8TuYdOAbo0Z9Pg==",
       "dependencies": {
-        "@sentry/hub": "7.2.0",
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/hub": "7.3.1",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4257,12 +4257,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.2.0.tgz",
-      "integrity": "sha512-uzd+GzD++Z4QopRh3AyRc4jz4AzomMnrXTOmdXgud1BH/Du9AYutVlBc5ZYwqCuJH7QPuAW3ySU3P+16UCinIg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.3.1.tgz",
+      "integrity": "sha512-TFewt7zDvVLLrCfKkmvJEO4GPw3oPvR2t+606Z4S2gKiekGXKFGX4YC5u0ytoPfi+NMadXz4HivfrPuxrMy1JQ==",
       "dependencies": {
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -4270,19 +4270,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-e6w62C2AmE5ULr9w/BuVaKTRpKUMGWyw4PhcBlSdDRoS47QgURGgDFIvr3VlaDwkUfCbASwSv49fDhKRX3aoew==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.3.1.tgz",
+      "integrity": "sha512-EZaRLJ8G2aSb7Vlpe1TR9LRZKY5gNpufuu8OXVrnTHiEMLHNUv1NrLQevy2m1SQUkg43oLdTyMKdM+nTESIC+A==",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-uUKIsIXyb6ZXBbl/L8UwG4gy8PBXZl5pGCUFRPbns+vi0U6vtmDRDYa1A/7E17VkBJNRPVNJQr9Pq5Yd0I0MRA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.3.1.tgz",
+      "integrity": "sha512-lrwbyajioWeG/CTFCzRh0Pu+zd/P+A+ASToEy2WIQsRbUORZrOmHSVzP0KR+TSZE0TMNrwxUwjSYZoyWCfZ1wQ==",
       "dependencies": {
-        "@sentry/types": "7.2.0",
+        "@sentry/types": "7.3.1",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -40991,48 +40991,48 @@
       }
     },
     "@sentry/browser": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.2.0.tgz",
-      "integrity": "sha512-QMdRpK7MM8woFOeMTDh7/sXG4lXutgZ/K9SBBMvd5MVaaQnSSE5ZGJMaxMfsiYOISV0UqS7l0V0EaGnv9n3zrQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.3.1.tgz",
+      "integrity": "sha512-x0LhK8hnrGEBBCZVsW9h3USW93agX+axXvUPu72SJMyMnwF+92XjpgOET48OdPNzej/bU8Qv+eXTC/VDh/HXvw==",
       "requires": {
-        "@sentry/core": "7.2.0",
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/core": "7.3.1",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.2.0.tgz",
-      "integrity": "sha512-9amsbB9/ePkJRgc0cVXCVW2hQUPImgTqBbnKu4frBXBza+9MBC5W3S8ZyZt2InCK22kuhNVo3z61a8mzCgXoCA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.3.1.tgz",
+      "integrity": "sha512-UYPNDluFtj5w6alh+SjSm9p6kxReKVcKEE+EPE4o44pdowjZ1BFTUY6ipMJhtIiDPr/51eeP8TuYdOAbo0Z9Pg==",
       "requires": {
-        "@sentry/hub": "7.2.0",
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/hub": "7.3.1",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.2.0.tgz",
-      "integrity": "sha512-uzd+GzD++Z4QopRh3AyRc4jz4AzomMnrXTOmdXgud1BH/Du9AYutVlBc5ZYwqCuJH7QPuAW3ySU3P+16UCinIg==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.3.1.tgz",
+      "integrity": "sha512-TFewt7zDvVLLrCfKkmvJEO4GPw3oPvR2t+606Z4S2gKiekGXKFGX4YC5u0ytoPfi+NMadXz4HivfrPuxrMy1JQ==",
       "requires": {
-        "@sentry/types": "7.2.0",
-        "@sentry/utils": "7.2.0",
+        "@sentry/types": "7.3.1",
+        "@sentry/utils": "7.3.1",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.2.0.tgz",
-      "integrity": "sha512-e6w62C2AmE5ULr9w/BuVaKTRpKUMGWyw4PhcBlSdDRoS47QgURGgDFIvr3VlaDwkUfCbASwSv49fDhKRX3aoew=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.3.1.tgz",
+      "integrity": "sha512-EZaRLJ8G2aSb7Vlpe1TR9LRZKY5gNpufuu8OXVrnTHiEMLHNUv1NrLQevy2m1SQUkg43oLdTyMKdM+nTESIC+A=="
     },
     "@sentry/utils": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.2.0.tgz",
-      "integrity": "sha512-uUKIsIXyb6ZXBbl/L8UwG4gy8PBXZl5pGCUFRPbns+vi0U6vtmDRDYa1A/7E17VkBJNRPVNJQr9Pq5Yd0I0MRA==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.3.1.tgz",
+      "integrity": "sha512-lrwbyajioWeG/CTFCzRh0Pu+zd/P+A+ASToEy2WIQsRbUORZrOmHSVzP0KR+TSZE0TMNrwxUwjSYZoyWCfZ1wQ==",
       "requires": {
-        "@sentry/types": "7.2.0",
+        "@sentry/types": "7.3.1",
         "tslib": "^1.9.3"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "connected-react-router": "^6.9.2",
         "constate": "^3.3.0",
         "cookie-parser": "^1.4.6",
-        "core-js": "^3.23.1",
+        "core-js": "^3.23.3",
         "css-loader": "^6.7.1",
         "csurf": "^1.11.0",
         "cypress-axe": "^0.14.0",
@@ -14851,9 +14851,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.1.tgz",
-      "integrity": "sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w==",
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz",
+      "integrity": "sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -49498,9 +49498,9 @@
       }
     },
     "core-js": {
-      "version": "3.23.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.1.tgz",
-      "integrity": "sha512-wfMYHWi1WQjpgZNC9kAlN4ut04TM9fUTdi7CqIoTVM7yaiOUQTklOzfb+oWH3r9edQcT3F887swuVmxrV+CC8w=="
+      "version": "3.23.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz",
+      "integrity": "sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q=="
     },
     "core-js-compat": {
       "version": "3.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "postcss-loader": "^7.0.0",
         "prop-types": "^15.8.1",
         "pure-uuid": "^1.6.2",
-        "qs": "^6.10.3",
+        "qs": "^6.11.0",
         "raven": "^2.6.4",
         "react": "^17.0.2",
         "react-app-polyfill": "^3.0.0",
@@ -30083,9 +30083,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
-      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -61107,9 +61107,9 @@
       "integrity": "sha512-WQ4xz74ApW6s0BToRuuyuMo9g0VHx1HljY0H2gPng+mqqz/K1yLj7sHZonZZQ2++WfHl/ZzruilWvuz+WtmxjQ=="
     },
     "qs": {
-      "version": "6.10.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
-      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "requires": {
         "side-channel": "^1.0.4"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
         "request-promise": "^4.2.6",
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.53.0",
-        "sass-loader": "^13.0.0",
+        "sass-loader": "^13.0.2",
         "serve-favicon": "^2.5.0",
         "sniffr": "^1.2.0",
         "style-loader": "^3.3.1",
@@ -32833,9 +32833,9 @@
       }
     },
     "node_modules/sass-loader": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
-      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.2.tgz",
+      "integrity": "sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==",
       "dependencies": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"
@@ -63190,9 +63190,9 @@
       }
     },
     "sass-loader": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
-      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.2.tgz",
+      "integrity": "sha512-BbiqbVmbfJaWVeOOAu2o7DhYWtcNmTfvroVgFXa6k2hHheMxNAeDHLNoDy/Q5aoaVlz0LH+MbMktKwm9vN/j8Q==",
       "requires": {
         "klona": "^2.0.4",
         "neo-async": "^2.6.2"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "connected-react-router": "^6.9.2",
     "constate": "^3.3.0",
     "cookie-parser": "^1.4.6",
-    "core-js": "^3.23.1",
+    "core-js": "^3.23.3",
     "css-loader": "^6.7.1",
     "csurf": "^1.11.0",
     "cypress-axe": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "@babel/core": "^7.18.5",
     "@babel/eslint-parser": "^7.17.0",
     "@babel/helper-call-delegate": "^7.12.13",
-    "@babel/plugin-proposal-class-properties": "7.17.12",
+    "@babel/plugin-proposal-class-properties": "7.18.6",
     "@babel/plugin-proposal-object-rest-spread": "^7.17.3",
     "@babel/plugin-proposal-optional-chaining": "^7.16.7",
     "@babel/preset-env": "7.18.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "postcss-loader": "^7.0.0",
     "prop-types": "^15.8.1",
     "pure-uuid": "^1.6.2",
-    "qs": "^6.10.3",
+    "qs": "^6.11.0",
     "raven": "^2.6.4",
     "react": "^17.0.2",
     "react-app-polyfill": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "request-promise": "^4.2.6",
     "resolve-url-loader": "^5.0.0",
     "sass": "^1.53.0",
-    "sass-loader": "^13.0.0",
+    "sass-loader": "^13.0.2",
     "serve-favicon": "^2.5.0",
     "sniffr": "^1.2.0",
     "style-loader": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -184,7 +184,7 @@
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-mocha": "^10.0.3",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-prettier": "^4.0.0",
+    "eslint-plugin-prettier": "^4.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@nivo/tooltip": "^0.79.0",
     "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.8.2",
-    "@sentry/browser": "^7.2.0",
+    "@sentry/browser": "^7.3.1",
     "autoprefixer": "^10.4.4",
     "axios": "^0.27.2",
     "basic-auth": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "style-loader": "^3.3.1",
     "styled-components": "^5.3.5",
     "uuid": "^8.3.2",
-    "winston": "^3.6.0"
+    "winston": "^3.8.0"
   },
   "devDependencies": {
     "@babel/core": "^7.18.5",


### PR DESCRIPTION
## Description of change

Bump core-js from 3.23.1 to 3.23.3
Bump @sentry/browser from 7.2.0 to 7.3.1
Bump eslint-plugin-prettier from 4.0.0 to 4.1.0
Bump qs from 6.10.5 to 6.11.0
Bump @babel/plugin-proposal-class-properties from 7.17.12 to 7.18.6
Bump sass-loader from 13.0.0 to 13.0.2
Bump winston from 3.7.2 to 3.8.0

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
