### PR TITLE
Aventri events details page display event name in the header

### DIFF
--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -46,7 +46,7 @@ const EventAventriDetails = ({
 
   return (
     <DefaultLayout
-      heading="Events"
+      heading={name}
       pageTitle="Events"
       breadcrumbs={breadcrumbs}
       useReactRouter={true}

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -29,6 +29,13 @@ describe('Event Aventri Details', () => {
         })
       })
 
+      it('should display the event name in the header', () => {
+        cy.get('[data-test="heading"]').should(
+          'contain',
+          'EITA Test Event 2022'
+        )
+      })
+
       it('should display event details', () => {
         assertKeyValueTable('eventAventriDetails', {
           'Type of event': 'dit:aventri:Event',


### PR DESCRIPTION
## Description of change
This PR changes the header on the new Aventri Events Details page to display whatever the Event name is instead of hardcoding the word "Events" as is the current behaviour.  

## Test instructions
- In Django dev API, add the user feature flag user-event-activities to your adviser profile.
- Go to the new [Aventri events details page](http://localhost:3000/events/aventri/1111/details?featureTesting=user-event-activities).
- The event title should be the header.
- You can repeat this with other Aventri test events by changing the event id to '2222' or '3333' in the url.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/70902973/176918022-fb5a67db-06e3-44b9-a226-6ab723577c24.png)

### After
![image](https://user-images.githubusercontent.com/70902973/176918095-04d30a0b-c1c7-4d2c-a375-b6c35cdf4227.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
