### PR TITLE
Aventri Events Navigation Bar

### DIFF
--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -21,9 +21,9 @@ router.get(urls.events.activity.data.route, fetchAllActivityFeedEvents)
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
 router.get('/aventri/:aventriEventId/details', renderEventsView)
-router.get(urls.events.aventri.data.route, fetchAventriEvent)
+router.get(urls.events.aventri.detailsData.route, fetchAventriEvent)
 router.get('/aventri/:aventriEventId/attendees', renderEventsView)
-router.get(urls.events.aventriAttendees.data.route, fetchAventriAttendees)
+router.get(urls.events.aventri.attendeesData.route, fetchAventriAttendees)
 
 router.use(
   '/:eventId',

--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Route } from 'react-router-dom'
 import styled from 'styled-components'
 import { GREY_4, WHITE, BLUE, BLACK } from 'govuk-colours'
@@ -30,17 +31,35 @@ const StyledInactiveLink = styled('a')({
   },
 })
 
-export const LocalNav = ({ children }) => <nav>{children}</nav>
+export const LocalNav = ({ children, dataTest = 'local-nav' }) => (
+  <nav data-test={dataTest}>{children}</nav>
+)
 
-export const LocalNavLink = ({ children, href, ...rest }) => (
+export const LocalNavLink = ({
+  children,
+  href,
+  dataTest = 'local-nav-link',
+  ...rest
+}) => (
   <Route>
     {({ location: { pathname } }) => {
       const NavLink = pathname === href ? StyledActiveLink : StyledInactiveLink
       return (
-        <NavLink href={href} {...rest}>
+        <NavLink href={href} data-test={dataTest} {...rest}>
           {children}
         </NavLink>
       )
     }}
   </Route>
 )
+
+LocalNav.propTypes = {
+  dataTest: PropTypes.string,
+  children: PropTypes.node,
+}
+
+LocalNavLink.propTypes = {
+  dataTest: PropTypes.string,
+  href: PropTypes.string,
+  children: PropTypes.node,
+}

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -52,15 +52,15 @@ const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
               {() => (
                 <GridRow data-test="event-aventri-attendee">
                   <GridCol setWidth="one-quarter">
-                    <LocalNav data-test="event-aventri-nav">
+                    <LocalNav dataTest="event-aventri-nav">
                       <LocalNavLink
-                        data-test="event-aventri-details-link"
+                        dataTest="event-aventri-details-link"
                         href={urls.events.aventri.details(aventriEventId)}
                       >
                         Details
                       </LocalNavLink>
                       <LocalNavLink
-                        data-test="event-aventri-attendees-link"
+                        dataTest="event-aventri-attendees-link"
                         href={urls.events.aventriAttendees.index(
                           aventriEventId
                         )}

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -54,6 +54,12 @@ const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
                   <GridCol setWidth="one-quarter">
                     <LocalNav data-test="event-aventri-nav">
                       <LocalNavLink
+                        data-test="event-aventri-details-link"
+                        href={urls.events.aventri.details(aventriEventId)}
+                      >
+                        Details
+                      </LocalNavLink>
+                      <LocalNavLink
                         data-test="event-aventri-attendees-link"
                         href={urls.events.aventriAttendees.index(
                           aventriEventId

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -61,9 +61,7 @@ const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
                       </LocalNavLink>
                       <LocalNavLink
                         dataTest="event-aventri-attendees-link"
-                        href={urls.events.aventriAttendees.index(
-                          aventriEventId
-                        )}
+                        href={urls.events.aventri.attendees(aventriEventId)}
                       >
                         Attendees
                       </LocalNavLink>

--- a/src/client/modules/Events/EventAventriAttendees/tasks.js
+++ b/src/client/modules/Events/EventAventriAttendees/tasks.js
@@ -3,7 +3,7 @@ const urls = require('../../../../lib/urls')
 
 export const getEventAventriAttendees = (aventriEventId) => {
   return axios
-    .get(urls.events.aventriAttendees.data(aventriEventId))
+    .get(urls.events.aventri.attendeesData(aventriEventId))
     .then(({ data }) => data)
     .catch(() => {
       return Promise.reject('Unable to load Aventri Attendees.')

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -77,9 +77,7 @@ const EventAventriDetails = ({
                           </LocalNavLink>
                           <LocalNavLink
                             dataTest="event-aventri-attendees-link"
-                            href={urls.events.aventriAttendees.index(
-                              aventriEventId
-                            )}
+                            href={urls.events.aventri.attendees(aventriEventId)}
                           >
                             Attendees
                           </LocalNavLink>

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -68,15 +68,15 @@ const EventAventriDetails = ({
                   name && (
                     <GridRow data-test="eventAventriDetails">
                       <GridCol setWidth="one-quarter">
-                        <LocalNav data-test="event-aventri-details-nav">
+                        <LocalNav dataTest="event-aventri-nav">
                           <LocalNavLink
-                            data-test="event-aventri-details-link"
+                            dataTest="event-aventri-details-link"
                             href={urls.events.aventri.details(aventriEventId)}
                           >
                             Details
                           </LocalNavLink>
                           <LocalNavLink
-                            data-test="event-aventri-attendees-link"
+                            dataTest="event-aventri-attendees-link"
                             href={urls.events.aventriAttendees.index(
                               aventriEventId
                             )}

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -75,6 +75,14 @@ const EventAventriDetails = ({
                           >
                             Details
                           </LocalNavLink>
+                          <LocalNavLink
+                            data-test="event-aventri-attendees-link"
+                            href={urls.events.aventriAttendees.index(
+                              aventriEventId
+                            )}
+                          >
+                            Attendees
+                          </LocalNavLink>
                         </LocalNav>
                       </GridCol>
                       <GridCol setWidth="three-quarters">

--- a/src/client/modules/Events/EventAventriDetails/tasks.js
+++ b/src/client/modules/Events/EventAventriDetails/tasks.js
@@ -4,6 +4,6 @@ import { transformResponseToEventAventriDetails } from '../transformers'
 
 export const getEventAventriDetails = (aventriEventId) =>
   axios
-    .get(urls.events.aventri.data(aventriEventId))
+    .get(urls.events.aventri.detailsData(aventriEventId))
     .then(({ data }) => transformResponseToEventAventriDetails(data))
     .catch(() => Promise.reject('Unable to load aventri event details.'))

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -254,11 +254,9 @@ module.exports = {
     find: url('/events', '/:eventId/attendees/find-new'),
     aventri: {
       details: url('/events', '/aventri/:aventriEventId/details'),
-      data: url('/events', '/aventri/:aventriEventId/data'),
-    },
-    aventriAttendees: {
-      index: url('/events', '/aventri/:aventriEventId/attendees'),
-      data: url('/events', '/aventri/:aventriEventId/attendees/data'),
+      detailsData: url('/events', '/aventri/:aventriEventId/details/data'),
+      attendees: url('/events', '/aventri/:aventriEventId/attendees'),
+      attendeesData: url('/events', '/aventri/:aventriEventId/attendees/data'),
     },
   },
   search: {

--- a/test/functional/cypress/specs/events/aventri-attendees-spec.js
+++ b/test/functional/cypress/specs/events/aventri-attendees-spec.js
@@ -2,9 +2,13 @@ const {
   EVENT_ACTIVITY_FEATURE_FLAG,
 } = require('../../../../../src/apps/companies/apps/activity-feed/constants')
 const urls = require('../../../../../src/lib/urls')
-const { assertErrorDialog } = require('../../support/assertions')
+const {
+  assertErrorDialog,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
 
 describe('Aventri event attendees', () => {
+  const existingEventId = '1111'
   const errorId = '500'
   context('With the feature flag turned on', () => {
     before(() => {
@@ -12,7 +16,33 @@ describe('Aventri event attendees', () => {
     })
     context('With normal behaviour', () => {
       before(() => {
-        cy.visit(urls.events.aventriAttendees.index('1111'))
+        cy.visit(urls.events.aventriAttendees.index(existingEventId))
+      })
+
+      it('should display aventri event name in breadcrumb', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard.route,
+          Events: urls.events.index(),
+          'EITA Test Event 2022': null,
+        })
+      })
+
+      it('should display the side nav bar', () => {
+        cy.get('[data-test="event-aventri-nav"]').should('exist')
+        cy.get('[data-test="event-aventri-details-link"]')
+          .should('contain', 'Details')
+          .should(
+            'have.attr',
+            'href',
+            urls.events.aventri.details(existingEventId)
+          )
+        cy.get('[data-test="event-aventri-attendees-link"]')
+          .should('contain', 'Attendees')
+          .should(
+            'have.attr',
+            'href',
+            urls.events.aventriAttendees.index(existingEventId)
+          )
       })
 
       it('should display an attendee', () => {
@@ -47,7 +77,7 @@ describe('Aventri event attendees', () => {
 
   context('With the feature flag turned off', () => {
     before(() => {
-      cy.visit(urls.events.aventriAttendees.index('1111'))
+      cy.visit(urls.events.aventriAttendees.index(existingEventId))
     })
     it('should not display an aventri attendee', () => {
       cy.get('[data-test="aventri-attendee"]').should('not.exist')

--- a/test/functional/cypress/specs/events/aventri-attendees-spec.js
+++ b/test/functional/cypress/specs/events/aventri-attendees-spec.js
@@ -16,7 +16,7 @@ describe('Aventri event attendees', () => {
     })
     context('With normal behaviour', () => {
       before(() => {
-        cy.visit(urls.events.aventriAttendees.index(existingEventId))
+        cy.visit(urls.events.aventri.attendees(existingEventId))
       })
 
       it('should display aventri event name in breadcrumb', () => {
@@ -41,7 +41,7 @@ describe('Aventri event attendees', () => {
           .should(
             'have.attr',
             'href',
-            urls.events.aventriAttendees.index(existingEventId)
+            urls.events.aventri.attendees(existingEventId)
           )
       })
 
@@ -59,7 +59,7 @@ describe('Aventri event attendees', () => {
 
     context('With errors', () => {
       before(() => {
-        cy.visit(urls.events.aventriAttendees.index(errorId))
+        cy.visit(urls.events.aventri.attendees(errorId))
       })
 
       it('should render an error message', () => {
@@ -77,7 +77,7 @@ describe('Aventri event attendees', () => {
 
   context('With the feature flag turned off', () => {
     before(() => {
-      cy.visit(urls.events.aventriAttendees.index(existingEventId))
+      cy.visit(urls.events.aventri.attendees(existingEventId))
     })
     it('should not display an aventri attendee', () => {
       cy.get('[data-test="aventri-attendee"]').should('not.exist')

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -76,7 +76,9 @@ describe('Event Aventri Details', () => {
           })
         })
       })
+    })
 
+    context('with errors', () => {
       context('when the event is not found', () => {
         before(() => {
           cy.visit(urls.events.aventri.details(notFoundEventId))
@@ -93,7 +95,6 @@ describe('Event Aventri Details', () => {
           )
         })
       })
-
       context('when there is a network error', () => {
         before(() => {
           cy.visit(urls.events.aventri.details(errorEventId))
@@ -111,23 +112,21 @@ describe('Event Aventri Details', () => {
         })
       })
     })
+    after(() => {
+      cy.resetUser()
+    })
+  })
 
-    context(
-      'when viewing aventri details with the feature flag is disabled',
-      () => {
-        before(() => {
-          cy.setUserFeatures([])
-        })
+  context('when the feature flag is disabled', () => {
+    before(() => {
+      cy.visit(urls.events.aventri.details(existingEventId))
+    })
 
-        it('should not display aventri event name in breadcrumb', () => {
-          cy.visit(urls.events.aventri.details(existingEventId))
-
-          assertBreadcrumbs({
-            Home: urls.dashboard.route,
-            Events: urls.events.index(),
-          })
-        })
-      }
-    )
+    it('should not display aventri event name in breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard.route,
+        Events: urls.events.index(),
+      })
+    })
   })
 })

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -16,13 +16,10 @@ describe('Event Aventri Details', () => {
   context('when the feature flag is on', () => {
     before(() => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
+      cy.visit(urls.events.aventri.details(existingEventId))
     })
 
     context('when it is a valid event', () => {
-      before(() => {
-        cy.visit(urls.events.aventri.details(existingEventId))
-      })
-
       it('should display aventri event name in breadcrumb', () => {
         assertBreadcrumbs({
           Home: urls.dashboard.route,
@@ -54,62 +51,61 @@ describe('Event Aventri Details', () => {
           'contain',
           'EITA Test Event 2022'
         )
+      })
 
-        it('should display event details', () => {
+      it('should display event details', () => {
+        assertKeyValueTable('eventAventriDetails', {
+          'Type of event': 'dit:aventri:Event',
+          'Event date': '02 Mar 2021 to 04 May 2022',
+          'Event location type': 'Name of Location',
+          Address: '1 street avenueBrockleyLondonABC 123England',
+        })
+      })
+
+      context('when optional details are missing', () => {
+        it('should display "Not set"', () => {
+          cy.visit(urls.events.aventri.details('6666'))
           assertKeyValueTable('eventAventriDetails', {
             'Type of event': 'dit:aventri:Event',
-            'Event date': '02 Mar 2021 to 04 May 2022',
-            'Event location type': 'Name of Location',
-            Address: '1 street avenueBrockleyLondonABC 123England',
-          })
-        })
-
-        context('when optional details are missing', () => {
-          it('should display "Not set"', () => {
-            cy.visit(urls.events.aventri.details('6666'))
-            assertKeyValueTable('eventAventriDetails', {
-              'Type of event': 'dit:aventri:Event',
-              'Event date': '02 Mar 2021',
-              'Event location type': 'Not set',
-              Address: 'Not set',
-            })
+            'Event date': '02 Mar 2021',
+            'Event location type': 'Not set',
+            Address: 'Not set',
           })
         })
       })
     })
 
-    context('with errors', () => {
-      context('when the event is not found', () => {
-        before(() => {
-          cy.visit(urls.events.aventri.details(notFoundEventId))
-        })
-
-        it('should render an error message', () => {
-          assertBreadcrumbs({
-            Home: urls.dashboard.route,
-            Events: urls.events.index(),
-          })
-          assertErrorDialog(
-            'TASK_GET_EVENT_AVENTRI_DETAILS',
-            'Unable to load aventri event details.'
-          )
-        })
+    context('when the event is not found', () => {
+      before(() => {
+        cy.visit(urls.events.aventri.details(notFoundEventId))
       })
-      context('when there is a network error', () => {
-        before(() => {
-          cy.visit(urls.events.aventri.details(errorEventId))
-        })
 
-        it('should render an error message', () => {
-          assertBreadcrumbs({
-            Home: urls.dashboard.route,
-            Events: urls.events.index(),
-          })
-          assertErrorDialog(
-            'TASK_GET_EVENT_AVENTRI_DETAILS',
-            'Unable to load aventri event details.'
-          )
+      it('should render an error message', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard.route,
+          Events: urls.events.index(),
         })
+        assertErrorDialog(
+          'TASK_GET_EVENT_AVENTRI_DETAILS',
+          'Unable to load aventri event details.'
+        )
+      })
+    })
+
+    context('when there is a network error', () => {
+      before(() => {
+        cy.visit(urls.events.aventri.details(errorEventId))
+      })
+
+      it('should render an error message', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard.route,
+          Events: urls.events.index(),
+        })
+        assertErrorDialog(
+          'TASK_GET_EVENT_AVENTRI_DETAILS',
+          'Unable to load aventri event details.'
+        )
       })
     })
     after(() => {
@@ -117,16 +113,19 @@ describe('Event Aventri Details', () => {
     })
   })
 
-  context('when the feature flag is disabled', () => {
-    before(() => {
-      cy.visit(urls.events.aventri.details(existingEventId))
-    })
-
-    it('should not display aventri event name in breadcrumb', () => {
-      assertBreadcrumbs({
-        Home: urls.dashboard.route,
-        Events: urls.events.index(),
+  context(
+    'when viewing aventri details with the feature flag is disabled',
+    () => {
+      before(() => {
+        cy.visit(urls.events.aventri.details(existingEventId))
       })
-    })
-  })
+
+      it('should not display aventri event name in breadcrumb', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard.route,
+          Events: urls.events.index(),
+        })
+      })
+    }
+  )
 })

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -45,7 +45,7 @@ describe('Event Aventri Details', () => {
           .should(
             'have.attr',
             'href',
-            urls.events.aventriAttendees.index(existingEventId)
+            urls.events.aventri.attendees(existingEventId)
           )
       })
 

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -19,9 +19,11 @@ describe('Event Aventri Details', () => {
     })
 
     context('when it is a valid event', () => {
-      it('should display aventri event name in breadcrumb', () => {
+      before(() => {
         cy.visit(urls.events.aventri.details(existingEventId))
+      })
 
+      it('should display aventri event name in breadcrumb', () => {
         assertBreadcrumbs({
           Home: urls.dashboard.route,
           Events: urls.events.index(),
@@ -29,85 +31,103 @@ describe('Event Aventri Details', () => {
         })
       })
 
+      it('should display the side nav bar', () => {
+        cy.get('[data-test="event-aventri-nav"]').should('exist')
+        cy.get('[data-test="event-aventri-details-link"]')
+          .should('contain', 'Details')
+          .should(
+            'have.attr',
+            'href',
+            urls.events.aventri.details(existingEventId)
+          )
+        cy.get('[data-test="event-aventri-attendees-link"]')
+          .should('contain', 'Attendees')
+          .should(
+            'have.attr',
+            'href',
+            urls.events.aventriAttendees.index(existingEventId)
+          )
+      })
+
       it('should display the event name in the header', () => {
         cy.get('[data-test="heading"]').should(
           'contain',
           'EITA Test Event 2022'
         )
-      })
 
-      it('should display event details', () => {
-        assertKeyValueTable('eventAventriDetails', {
-          'Type of event': 'dit:aventri:Event',
-          'Event date': '02 Mar 2021 to 04 May 2022',
-          'Event location type': 'Name of Location',
-          Address: '1 street avenueBrockleyLondonABC 123England',
-        })
-      })
-
-      context('when optional details are missing', () => {
-        it('should display "Not set"', () => {
-          cy.visit(urls.events.aventri.details('6666'))
+        it('should display event details', () => {
           assertKeyValueTable('eventAventriDetails', {
             'Type of event': 'dit:aventri:Event',
-            'Event date': '02 Mar 2021',
-            'Event location type': 'Not set',
-            Address: 'Not set',
+            'Event date': '02 Mar 2021 to 04 May 2022',
+            'Event location type': 'Name of Location',
+            Address: '1 street avenueBrockleyLondonABC 123England',
+          })
+        })
+
+        context('when optional details are missing', () => {
+          it('should display "Not set"', () => {
+            cy.visit(urls.events.aventri.details('6666'))
+            assertKeyValueTable('eventAventriDetails', {
+              'Type of event': 'dit:aventri:Event',
+              'Event date': '02 Mar 2021',
+              'Event location type': 'Not set',
+              Address: 'Not set',
+            })
           })
         })
       })
-    })
 
-    context('when the event is not found', () => {
-      before(() => {
-        cy.visit(urls.events.aventri.details(notFoundEventId))
-      })
-
-      it('should render an error message', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard.route,
-          Events: urls.events.index(),
+      context('when the event is not found', () => {
+        before(() => {
+          cy.visit(urls.events.aventri.details(notFoundEventId))
         })
-        assertErrorDialog(
-          'TASK_GET_EVENT_AVENTRI_DETAILS',
-          'Unable to load aventri event details.'
-        )
-      })
-    })
 
-    context('when there is a network error', () => {
-      before(() => {
-        cy.visit(urls.events.aventri.details(errorEventId))
-      })
-
-      it('should render an error message', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard.route,
-          Events: urls.events.index(),
+        it('should render an error message', () => {
+          assertBreadcrumbs({
+            Home: urls.dashboard.route,
+            Events: urls.events.index(),
+          })
+          assertErrorDialog(
+            'TASK_GET_EVENT_AVENTRI_DETAILS',
+            'Unable to load aventri event details.'
+          )
         })
-        assertErrorDialog(
-          'TASK_GET_EVENT_AVENTRI_DETAILS',
-          'Unable to load aventri event details.'
-        )
+      })
+
+      context('when there is a network error', () => {
+        before(() => {
+          cy.visit(urls.events.aventri.details(errorEventId))
+        })
+
+        it('should render an error message', () => {
+          assertBreadcrumbs({
+            Home: urls.dashboard.route,
+            Events: urls.events.index(),
+          })
+          assertErrorDialog(
+            'TASK_GET_EVENT_AVENTRI_DETAILS',
+            'Unable to load aventri event details.'
+          )
+        })
       })
     })
+
+    context(
+      'when viewing aventri details with the feature flag is disabled',
+      () => {
+        before(() => {
+          cy.setUserFeatures([])
+        })
+
+        it('should not display aventri event name in breadcrumb', () => {
+          cy.visit(urls.events.aventri.details(existingEventId))
+
+          assertBreadcrumbs({
+            Home: urls.dashboard.route,
+            Events: urls.events.index(),
+          })
+        })
+      }
+    )
   })
-
-  context(
-    'when viewing aventri details with the feature flag is disabled',
-    () => {
-      before(() => {
-        cy.setUserFeatures([])
-      })
-
-      it('should not display aventri event name in breadcrumb', () => {
-        cy.visit(urls.events.aventri.details(existingEventId))
-
-        assertBreadcrumbs({
-          Home: urls.dashboard.route,
-          Events: urls.events.index(),
-        })
-      })
-    }
-  )
 })


### PR DESCRIPTION
## Description of change
Currently if you navigate to `/events/aventri/:aventriEventId/details` or `/events/aventri/:aventriEventId/attendees` you will only see one link in the left hand side navigation bar, Details or Attendees respectively. 

This PR adds in the missing nav link for both Aventri Details and Attendees pages so that both have nav bars that contain a link to Details and Attendees. 

## Test instructions
- In Django dev API, add the user feature flag user-event-activities to your adviser profile.
- Go to the new [Aventri events details page](http://localhost:3000/events/aventri/1111/details?featureTesting=user-event-activities) and the new [Aventri events attendees page](http://localhost:3000/events/aventri/1111/attendees?featureTesting=user-event-activities).
- The side navigation bar should have links to both the Details and the Attendees page, with the active page link highlighted in blue.
- You can repeat this with other Aventri test events by changing the event id to '2222' or '3333' in the url.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/70902973/177169315-78e6fa9d-5c10-49a6-9b87-e52c86a6810e.png)
![image](https://user-images.githubusercontent.com/70902973/177169340-d5f0b0e9-6889-40bc-9420-bded27d5b1ed.png)


### After
![image](https://user-images.githubusercontent.com/70902973/177169429-a635cf15-8a06-4345-a670-0294406e41a5.png)
![image](https://user-images.githubusercontent.com/70902973/177169485-89da5c19-99a0-49e5-94d7-7ea8ca2c322a.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
