### PR TITLE
Add greys from the GDS modern palette to our own colour palette

### DIFF
--- a/src/client/components/DataHubHeader/LogoBar.jsx
+++ b/src/client/components/DataHubHeader/LogoBar.jsx
@@ -12,7 +12,7 @@ import {
 
 // Colours not defined in 'govuk-colours' which we need for consistency
 // with Find Exporters and Market Access.
-import { DARK_BLUE } from '../../utils/colors'
+import { DARK_BLUE_LEGACY } from '../../utils/colors'
 
 const StyledLogoContainer = styled.div({
   maxWidth: 960,
@@ -56,7 +56,7 @@ const StyledTag = styled.strong({
   outline: '2px solid transparent',
   outlineOffset: '-2px',
   color: WHITE,
-  backgroundColor: DARK_BLUE,
+  backgroundColor: DARK_BLUE_LEGACY,
   letterSpacing: 1,
   textDecoration: 'none',
   textTransform: 'uppercase',

--- a/src/client/components/DataHubHeader/NavBar.jsx
+++ b/src/client/components/DataHubHeader/NavBar.jsx
@@ -13,7 +13,7 @@ import ProtectedLink from '../ProtectedLink'
 
 // Colours not defined in 'govuk-colours' which we need for consistency
 // with Find Exporters and Market Access.
-import { LIGHT_GREY, DARK_BLUE } from '../../utils/colors'
+import { GREY_3_LEGACY, DARK_BLUE_LEGACY } from '../../utils/colors'
 
 import links from './links'
 
@@ -24,7 +24,7 @@ const StyledNavContainer = styled.div({
 })
 
 const StyledNav = styled.nav({
-  backgroundColor: LIGHT_GREY,
+  backgroundColor: GREY_3_LEGACY,
   fontWeight: FONT_WEIGHTS.bold,
 })
 
@@ -59,7 +59,7 @@ const styledLinkActive = {
   right: 0,
   bottom: 0,
   borderBottom: `${BORDER_WIDTH} solid`,
-  borderColor: DARK_BLUE,
+  borderColor: DARK_BLUE_LEGACY,
 }
 
 const styledLink = {
@@ -73,7 +73,7 @@ const styledLink = {
     lineHeight: '23px',
     color: BLACK,
     '&.active': {
-      color: DARK_BLUE,
+      color: DARK_BLUE_LEGACY,
     },
     [MEDIA_QUERIES.TABLET]: {
       display: 'inline-block',

--- a/src/client/components/InvestmentProjectLocalHeader/timeline-theme.js
+++ b/src/client/components/InvestmentProjectLocalHeader/timeline-theme.js
@@ -1,6 +1,6 @@
 import { GREY_4 } from 'govuk-colours'
 import { SPACING } from '@govuk-react/constants'
-import { LIGHT_GREY } from '../../utils/colors'
+import { GREY_3_LEGACY } from '../../utils/colors'
 
 export default {
   container: {
@@ -15,14 +15,14 @@ export default {
       top: '2px',
       width: SPACING.SCALE_2,
       height: SPACING.SCALE_2,
-      border: `2px solid ${LIGHT_GREY}`,
+      border: `2px solid ${GREY_3_LEGACY}`,
     },
     span: {
       display: 'inline',
     },
     mqLargeScreen: {
       padding: `${SPACING.SCALE_4} 0 ${SPACING.SCALE_4} 0`,
-      borderTop: `2px solid ${LIGHT_GREY}`,
+      borderTop: `2px solid ${GREY_3_LEGACY}`,
       before: {
         top: '-8px',
         left: '-10px',

--- a/src/client/components/MyInvestmentProjects/InvestmentNextSteps.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentNextSteps.jsx
@@ -6,7 +6,8 @@ import { UnorderedList, ListItem } from 'govuk-react'
 
 import { investments } from '../../../lib/urls'
 import { INCOMPLETE_FIELDS } from './constants'
-import { rgba, FOCUS_COLOUR } from '../../utils/colors'
+import { rgba } from '../../utils/colors'
+import { FOCUS_COLOUR } from 'govuk-colours'
 
 const StyledDiv = styled('div')`
   height: 100%;

--- a/src/client/components/Timeline/index.jsx
+++ b/src/client/components/Timeline/index.jsx
@@ -5,7 +5,7 @@ import { WHITE, GREY_3 } from 'govuk-colours'
 import { MEDIA_QUERIES, SPACING, FONT_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 
-import { DARK_BLUE } from '../../utils/colors'
+import { DARK_BLUE_LEGACY } from '../../utils/colors'
 
 const TimelineContainer = styled('div')({
   backgroundColor: ({ theme }) =>
@@ -31,7 +31,7 @@ const StyledOl = styled('ol')({
 })
 
 const StyledLi = styled('li')({
-  borderLeft: `2px solid ${DARK_BLUE}`,
+  borderLeft: `2px solid ${DARK_BLUE_LEGACY}`,
   padding: `0 0 ${SPACING.SCALE_4} 0`,
   position: 'relative',
   '&:last-child': {
@@ -49,14 +49,14 @@ const StyledLi = styled('li')({
     width: ({ theme }) => get(theme, 'li.before.width', SPACING.SCALE_4),
     height: ({ theme }) => get(theme, 'li.before.height', SPACING.SCALE_4),
     backgroundColor: ({ isStageComplete }) =>
-      isStageComplete ? `${DARK_BLUE}` : `${WHITE}`,
+      isStageComplete ? `${DARK_BLUE_LEGACY}` : `${WHITE}`,
     border: ({ theme, isStageComplete }) => {
       const border = get(theme, 'li.before.border')
       return border
         ? isStageComplete
-          ? `2px solid ${DARK_BLUE}`
+          ? `2px solid ${DARK_BLUE_LEGACY}`
           : border
-        : `2px solid ${DARK_BLUE}`
+        : `2px solid ${DARK_BLUE_LEGACY}`
     },
   },
   span: {
@@ -71,9 +71,9 @@ const StyledLi = styled('li')({
     borderTop: ({ theme, isLinkActive }) => {
       const borderTop = get(theme, 'li.mqLargeScreen.borderTop')
       if (borderTop) {
-        return isLinkActive ? `2px solid ${DARK_BLUE}` : borderTop
+        return isLinkActive ? `2px solid ${DARK_BLUE_LEGACY}` : borderTop
       }
-      return `3px solid ${DARK_BLUE}`
+      return `3px solid ${DARK_BLUE_LEGACY}`
     },
     borderLeft: 'none',
     '&:last-child': {

--- a/src/client/utils/colors.js
+++ b/src/client/utils/colors.js
@@ -19,23 +19,27 @@ export const hexToRgb = (colorHex) => {
  */
 export const rgba = (colorHex, alpha) => `rgba(${hexToRgb(colorHex)},${alpha})`
 
-// The following colours are not included in either:
-// - https://github.com/penx/govuk-colours or
-// - https://github.com/govuk-react/govuk-react (which references govuk-colours)
-// Instead, the colours below have been taken from:
-// - https://github.com/alphagov/govuk-frontend (referenced by GOV.UK Design System)
+// Currently we import our colours from here: https://github.com/penx/govuk-colours/blob/master/src/index.js
+// GOV.UK Design System colours are here: https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/settings/_colours-palette.scss
+// Unfortunately, 'govuk-colours' has not been updated for a while and we need the following grey colours from the GDS modern palette
+export const DARK_GREY = '#505a5f'
+export const MID_GREY = '#b1b4b6'
+export const LIGHT_GREY = '#f3f2f1' // This is GREY_3 from 'govuk-colours'
 
-// Taken from the legacy palette, we're unable to choose a colour
-// from the modern palette as it's either too light or too dark
-// for the Data Hub header nav element which sits in between a
-// darker and lighter shade of grey forming a natural gradient.
-export const LIGHT_GREY = '#dee0e2'
+// -----------------------------------
+// Taken from the GDS legacy palette
+// -----------------------------------
+// We're unable to choose a colour from the GDS modern palette as
+// it's either too light or too dark for the Data Hub header nav
+// element which sits in between a darker and lighter shade of grey
+// forming a natural gradient.
+export const GREY_3_LEGACY = '#dee0e2'
 
+// -----------------------------------
+// Taken from the GDS legacy palette
+// -----------------------------------
+// We're unable to choose a colour from the GDS modern palette.
 // We require this specific blue for the navigation hover/selection.
 // This blue has to match the colour of both 'Find Exporters' and 'Market Access'.
 // It is also used for the investment project timeline.
-export const DARK_BLUE = '#005ea5'
-
-export const DARK_GREY = '#505a5f'
-export const MID_GREY = '#b1b4b6'
-export const FOCUS_COLOUR = '#ffdd00'
+export const DARK_BLUE_LEGACY = '#005ea5'


### PR DESCRIPTION
## Description of change

Because [govuk-colors](https://github.com/penx/govuk-colours/blob/master/src/index.js) hasn't been updated in a while and we want certain greys from the [GOV.UK Design System](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/settings/_colours-palette.scss#L47-L49) modern palette we will need to add them to our own colour palette.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
