### PR TITLE
Reminders UX refinements

### DIFF
--- a/src/client/modules/Reminders/CollectionList.jsx
+++ b/src/client/modules/Reminders/CollectionList.jsx
@@ -3,7 +3,7 @@ import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
-import { GREY_1, GREY_2 } from 'govuk-colours'
+import { GREY_2 } from 'govuk-colours'
 import { H3 } from '@govuk-react/heading'
 import { FONT_SIZE, HEADING_SIZES, SPACING } from '@govuk-react/constants'
 
@@ -19,7 +19,7 @@ const DeleteButton = styled('button')({
   border: 'none',
   fontSize: FONT_SIZE.SIZE_16,
   fontFamily: 'inherit',
-  color: GREY_1,
+  color: DARK_GREY,
   cursor: 'pointer',
   textDecoration: 'underline',
 })
@@ -49,6 +49,7 @@ const ItemHeader = styled(H3)({
 })
 
 const ItemContent = styled('div')({
+  color: DARK_GREY,
   marginBottom: SPACING.SCALE_3,
 })
 

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
+import styled from 'styled-components'
 import qs from 'qs'
 
 import {
@@ -19,6 +21,7 @@ import {
 } from './state'
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
+import { DARK_GREY } from '../../utils/colors'
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
@@ -31,6 +34,13 @@ import {
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
+
+const StyledDiv = styled('div')({
+  fontSize: FONT_SIZE.SIZE_16,
+  color: DARK_GREY,
+  paddingTop: SPACING.SCALE_4,
+  paddingBottom: SPACING.SCALE_3,
+})
 
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   const { results, count, nextPending } = estimatedLandDateReminders
@@ -55,7 +65,13 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
         </GridCol>
         <GridCol>
           <CollectionHeader totalItems={count} />
-          <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+          {results.length === 0 ? (
+            <StyledDiv data-test="no-reminders">
+              You have no reminders
+            </StyledDiv>
+          ) : (
+            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+          )}
           <Task.Status
             name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
             id={ID}

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
+import styled from 'styled-components'
 import qs from 'qs'
 
 import {
@@ -19,6 +21,7 @@ import {
 } from './state'
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
+import { DARK_GREY } from '../../utils/colors'
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
@@ -31,6 +34,13 @@ import {
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
+
+const StyledDiv = styled('div')({
+  fontSize: FONT_SIZE.SIZE_16,
+  color: DARK_GREY,
+  paddingTop: SPACING.SCALE_4,
+  paddingBottom: SPACING.SCALE_3,
+})
 
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   const { results, count, nextPending } = noRecentInteractionReminders
@@ -55,7 +65,13 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
         </GridCol>
         <GridCol>
           <CollectionHeader totalItems={count} />
-          <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+          {results.length === 0 ? (
+            <StyledDiv data-test="no-reminders">
+              You have no reminders
+            </StyledDiv>
+          ) : (
+            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+          )}
           <Task.Status
             name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
             id={ID}

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -3,7 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { SPACING, FONT_SIZE, HEADING_SIZES } from '@govuk-react/constants'
 import { Link } from 'govuk-react'
-import { GREY_1, GREY_2 } from 'govuk-colours'
+import { GREY_2 } from 'govuk-colours'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import styled from 'styled-components'
@@ -56,10 +56,11 @@ const ListItemFooter = styled('div')({
 
 const PaginationSummary = styled('div')({
   fontSize: FONT_SIZE.SIZE_16,
-  color: GREY_1,
-  paddingTop: 19,
+  color: DARK_GREY,
+  paddingTop: SPACING.SCALE_4,
   paddingBottom: SPACING.SCALE_3,
-  borderBottom: `solid 1px ${GREY_2}`,
+  borderBottom: ({ hasReminders }) =>
+    hasReminders ? `solid 1px ${GREY_2}` : 'none',
 })
 
 const OutstandingPropositionReminders = ({
@@ -87,8 +88,13 @@ const OutstandingPropositionReminders = ({
         </GridCol>
         <GridCol>
           <CollectionHeader settings={false} totalItems={count} />
-          <PaginationSummary data-test="pagination-summary">
-            Page {page || 1} of {totalPages}
+          <PaginationSummary
+            hasReminders={results.length > 0}
+            data-test="pagination-summary"
+          >
+            {results.length === 0
+              ? 'You have no reminders'
+              : `Page ${page || 1} of ${totalPages}`}
           </PaginationSummary>
           <Task.Status
             name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
@@ -101,7 +107,7 @@ const OutstandingPropositionReminders = ({
             {() => (
               <>
                 <List data-test="reminders-list">
-                  {results.map(({ id, deadline, investment_project }) => (
+                  {results.map(({ id, name, deadline, investment_project }) => (
                     <ListItem key={id} data-test="reminders-list-item">
                       <GridRow>
                         <GridCol>
@@ -114,7 +120,7 @@ const OutstandingPropositionReminders = ({
                                 investment_project.id
                               )}`}
                             >
-                              {investment_project.name}
+                              {name}
                             </Link>
                           </ListItemContent>
                           <ListItemFooter data-test="item-footer">

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -48,24 +48,24 @@ const RemindersSettings = () => {
   const openESL = get(qsParams, 'estimated_land_date', false)
   const openNRI = get(qsParams, 'no_recent_interaction', false)
   return (
-    <Resource
-      name={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
-      id={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
+    <DefaultLayout
+      heading="Reminders and email notifications settings"
+      pageTitle="Reminders"
+      breadcrumbs={[
+        {
+          link: urls.dashboard(),
+          text: 'Home',
+        },
+        {
+          text: 'Reminders and email notifications settings',
+        },
+      ]}
     >
-      {({ estimatedLandDate, noRecentInteraction }) => (
-        <DefaultLayout
-          heading="Reminders and email notifications settings"
-          pageTitle="Reminders"
-          breadcrumbs={[
-            {
-              link: urls.dashboard(),
-              text: 'Home',
-            },
-            {
-              text: 'Reminders and email notifications settings',
-            },
-          ]}
-        >
+      <Resource
+        name={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
+        id={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
+      >
+        {({ estimatedLandDate, noRecentInteraction }) => (
           <ToggleSectionContainer>
             <RemindersToggleSection
               label="Approaching estimated land date settings"
@@ -128,9 +128,9 @@ const RemindersSettings = () => {
               Home
             </StyledHomeLink>
           </ToggleSectionContainer>
-        </DefaultLayout>
-      )}
-    </Resource>
+        )}
+      </Resource>
+    </DefaultLayout>
   )
 }
 

--- a/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
@@ -153,6 +153,35 @@ describe('Estimated Land Date Reminders', () => {
     })
   })
 
+  context('No reminders', () => {
+    before(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          pathname: remindersEndpoint,
+          query: { limit: '10', offset: '0', sortby: '-created_on' },
+        },
+        {
+          body: {
+            count: 0,
+            results: [],
+            next: null,
+            previous: null,
+          },
+        }
+      ).as('remindersApiRequest')
+      cy.visit(urls.reminders.estimatedLandDate())
+      cy.wait('@remindersApiRequest')
+    })
+
+    it('should include a message "You have no reminders"', () => {
+      cy.get('[data-test="no-reminders"]').should(
+        'contain',
+        'You have no reminders'
+      )
+    })
+  })
+
   context('Pagination', () => {
     beforeEach(() => {
       interceptApiCalls()

--- a/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
@@ -154,6 +154,35 @@ describe('No Recent Interaction Reminders', () => {
     })
   })
 
+  context('No reminders', () => {
+    before(() => {
+      cy.intercept(
+        {
+          method: 'GET',
+          pathname: remindersEndpoint,
+          query: { limit: '10', offset: '0', sortby: '-created_on' },
+        },
+        {
+          body: {
+            count: 0,
+            results: [],
+            next: null,
+            previous: null,
+          },
+        }
+      ).as('remindersApiRequest')
+      cy.visit(urls.reminders.noRecentInteraction())
+      cy.wait('@remindersApiRequest')
+    })
+
+    it('should include a message "You have no reminders"', () => {
+      cy.get('[data-test="no-reminders"]').should(
+        'contain',
+        'You have no reminders'
+      )
+    })
+  })
+
   context('Pagination', () => {
     beforeEach(() => {
       interceptApiCalls()

--- a/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
+++ b/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
@@ -150,7 +150,7 @@ describe('Outstanding Proposition Reminders', () => {
         .should('contain', 'Due Tue, 25 Jan 2022')
       cy.get('@reminder')
         .find('[data-test="item-content"]')
-        .should('contain', `${propositions[0].investment_project.name}`)
+        .should('contain', `${propositions[0].name}`)
         .find('a')
         .should(
           'have.attr',
@@ -159,13 +159,53 @@ describe('Outstanding Proposition Reminders', () => {
             propositions[0].investment_project.id
           )
         )
-        .should('contain', propositions[0].investment_project.name)
+        .should('contain', propositions[0].name)
       cy.get('@reminder')
         .find('[data-test="item-footer"]')
         .should(
           'contain',
           `Project code ${propositions[0].investment_project.project_code}`
         )
+    })
+  })
+
+  context('No reminders', () => {
+    before(() => {
+      cy.intercept(
+        { method: 'GET', pathname: whoAmIEndpoint },
+        { body: user }
+      ).as('whoAmIApiRequest')
+      cy.intercept(
+        {
+          method: 'GET',
+          pathname: propositionsEndpoint,
+          query: {
+            adviser_id: user.id,
+            status: 'ongoing',
+            sortby: 'deadline',
+            offset: '0',
+            limit: '10',
+          },
+        },
+        {
+          body: {
+            count: 0,
+            results: [],
+            next: null,
+            previous: null,
+          },
+        }
+      ).as('noPropositionsAPIRequest')
+      cy.visit(urls.reminders.outstandingPropositions())
+      cy.wait('@whoAmIApiRequest')
+      cy.wait('@noPropositionsAPIRequest')
+    })
+
+    it('should include a message "You have no reminders"', () => {
+      cy.get('[data-test="pagination-summary"]').should(
+        'contain',
+        'You have no reminders'
+      )
     })
   })
 


### PR DESCRIPTION
## Description of change

UX refinements around reminders:
* Approaching estimated land dates
* Projects for no recent interactions
* Outstanding propositions

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
