### PR TITLE
Add three new component tests

### DIFF
--- a/test/component/cypress/specs/ButtonLink.test.jsx
+++ b/test/component/cypress/specs/ButtonLink.test.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import ButtonLink from '../../../../src/client/components/ButtonLink'
+
+describe('ButtonLink', () => {
+  const Component = (props) => <ButtonLink data-test="button-link" {...props} />
+
+  const linkText = 'Example ButtonLink'
+
+  context('When the inline prop is not set', () => {
+    beforeEach(() => {
+      mount(
+        <div>
+          <Component>{linkText}</Component>
+        </div>
+      )
+    })
+
+    it('should render the expected text', () => {
+      cy.get('[data-test="button-link"]')
+        .should('exist')
+        .should('contain', linkText)
+    })
+
+    it('should render with the default styles', () => {
+      cy.get('[data-test="button-link"]')
+        .should('have.css', 'color', 'rgb(29, 112, 184)')
+        .should(
+          'have.css',
+          'text-decoration',
+          'underline solid rgb(29, 112, 184)'
+        )
+    })
+  })
+
+  context('When the inline prop is set', () => {
+    beforeEach(() => {
+      mount(
+        <div data-test="button-link-container">
+          Some text <Component inline={true}>{linkText}</Component>
+        </div>
+      )
+    })
+
+    it('should render the expected text', () => {
+      cy.get('[data-test="button-link-container"]')
+        .should('exist')
+        .should('contain', 'Some text')
+
+      cy.get('[data-test="button-link"]')
+        .should('exist')
+        .should('contain', linkText)
+    })
+
+    it('should render with the default styles', () => {
+      cy.get('[data-test="button-link"]')
+        .should('have.css', 'color', 'rgb(29, 112, 184)')
+        .should(
+          'have.css',
+          'text-decoration',
+          'underline solid rgb(29, 112, 184)'
+        )
+    })
+
+    it('should render with the inline margins', () => {
+      cy.get('[data-test="button-link"]')
+        .should('have.css', 'padding', '0px')
+        .should('have.css', 'margin', '0px 0px 0px 5px')
+        .should('have.css', 'border', '0px none rgb(29, 112, 184)')
+    })
+  })
+})

--- a/test/component/cypress/specs/StatusMessage.test.jsx
+++ b/test/component/cypress/specs/StatusMessage.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import StatusMessage from '../../../../src/client/components/StatusMessage'
+
+const Component = (props) => <StatusMessage {...props} />
+
+describe('StatusMessage', () => {
+  context('When the colour prop is not set', () => {
+    assertStatusMessage('rgb(29, 112, 184)')
+  })
+
+  context('When the colour prop is set', () => {
+    assertStatusMessage('rgb(255, 0, 0)')
+  })
+})
+
+function assertStatusMessage(colour) {
+  beforeEach(() => {
+    mount(<Component colour={colour}>Status Message</Component>)
+  })
+
+  it('should render the text', () => {
+    cy.get('[data-test=status-message]')
+      .should('exist')
+      .should('have.text', 'Status Message')
+  })
+
+  it('should render with the default styling', () => {
+    cy.get('[data-test=status-message]')
+      .should('have.css', 'padding', '15px')
+      .should('have.css', 'margin-bottom', '20px')
+      .should('have.css', 'font-weight', '700')
+      .should('have.css', 'line-height', '24px')
+  })
+
+  it('should render with the expected colours', () => {
+    cy.get('[data-test=status-message]')
+      .should('have.css', 'color', colour)
+      .should('have.css', 'border-color', colour)
+  })
+}

--- a/test/component/cypress/specs/Tag.test.jsx
+++ b/test/component/cypress/specs/Tag.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import Tag from '../../../../src/client/components/Tag'
+
+const Component = (props) => <Tag {...props} data-test="tag" />
+
+describe('Tag', () => {
+  context('When the colour prop is not set', () => {
+    beforeEach(() => {
+      mount(<Component>Test</Component>)
+    })
+
+    it('should render the text', () => {
+      cy.get('[data-test=tag]').should('exist').should('have.text', 'Test')
+    })
+
+    it('should render with the default colours', () => {
+      cy.get('[data-test=tag]')
+        .should('have.css', 'color', 'rgb(255, 255, 255)')
+        .should('have.css', 'background-color', 'rgb(29, 112, 184)')
+    })
+  })
+
+  context('When the colour prop is set', () => {
+    assertTagColours('grey', 'rgb(69, 74, 77)', 'rgb(239, 240, 241)')
+    assertTagColours('green', 'rgb(0, 90, 48)', 'rgb(204, 226, 216)')
+    assertTagColours('turquoise', 'rgb(16, 64, 60)', 'rgb(191, 227, 224)')
+    assertTagColours('blue', 'rgb(20, 78, 129)', 'rgb(210, 226, 241)')
+    assertTagColours('purple', 'rgb(61, 35, 117)', 'rgb(219, 213, 233)')
+    assertTagColours('pink', 'rgb(128, 34, 77)', 'rgb(247, 215, 230)')
+    assertTagColours('red', 'rgb(148, 37, 20)', 'rgb(246, 215, 210)')
+    assertTagColours('orange', 'rgb(110, 54, 25)', 'rgb(252, 214, 195)')
+    assertTagColours('yellow', 'rgb(89, 77, 0)', 'rgb(255, 247, 191)')
+  })
+})
+
+function assertTagColours(
+  colour,
+  expectedTextColour,
+  expectedBackgroundColour
+) {
+  context(`When the colour is set to ${colour}`, () => {
+    beforeEach(() => {
+      mount(<Component colour={colour}>Test</Component>)
+    })
+
+    it('should render the text', () => {
+      cy.get('[data-test=tag]').should('exist').should('have.text', 'Test')
+    })
+
+    it('should render with the correct colours', () => {
+      cy.get('[data-test=tag]')
+        .should('have.css', 'color', expectedTextColour)
+        .should('have.css', 'background-color', expectedBackgroundColour)
+    })
+  })
+}


### PR DESCRIPTION
## Description of change

Adding component tests for three components. Two of the new tests are rewrites of the old ones from the component library (the `Tag` one is original).

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
