### PR TITLE
Sort Events from Activity Stream (updated, name)

### DIFF
--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -39,6 +39,11 @@ const CONTACT_ACTIVITY_SORT_SELECT_OPTIONS = [
   { name: 'Oldest', value: 'oldest' },
 ]
 
+const EVENT_ACTIVITY_SORT_OPTIONS = {
+  'modified_on:asc': 'asc',
+  'modified_on:desc': 'desc',
+}
+
 const DATA_HUB_ACTIVITY = [
   'dit:Interaction', // Interaction
   'dit:ServiceDelivery', // Interaction
@@ -61,6 +66,7 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
 module.exports = {
   CONTACT_ACTIVITY_FEATURE_FLAG,
   EVENT_ACTIVITY_FEATURE_FLAG,
+  EVENT_ACTIVITY_SORT_OPTIONS,
   FILTER_KEYS,
   FILTER_ITEMS,
   DATA_HUB_ACTIVITY,

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -40,8 +40,24 @@ const CONTACT_ACTIVITY_SORT_SELECT_OPTIONS = [
 ]
 
 const EVENT_ACTIVITY_SORT_OPTIONS = {
-  'modified_on:asc': 'asc',
-  'modified_on:desc': 'desc',
+  'modified_on:asc': {
+    'object.updated': {
+      order: 'asc',
+      unmapped_type: 'date',
+    },
+  },
+  'modified_on:desc': {
+    'object.updated': {
+      order: 'desc',
+      unmapped_type: 'date',
+    },
+  },
+  'name:asc': {
+    'object.name.raw': {
+      order: 'asc',
+      unmapped_type: 'string',
+    },
+  },
 }
 
 const DATA_HUB_ACTIVITY = [

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -5,6 +5,7 @@ const {
   EXTERNAL_ACTIVITY,
   DATA_HUB_AND_EXTERNAL_ACTIVITY,
   CONTACT_ACTIVITY_SORT_SEARCH_OPTIONS,
+  EVENT_ACTIVITY_SORT_OPTIONS,
 } = require('./constants')
 
 const { getGlobalUltimateHierarchy } = require('../../repos')
@@ -325,9 +326,15 @@ async function fetchAventriAttendees(req, res, next) {
 
 async function fetchAllActivityFeedEvents(req, res, next) {
   try {
+    const { sortBy } = req.query
+
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
-      allActivityFeedEventsQuery()
+      allActivityFeedEventsQuery({
+        sort:
+          EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+          EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+      })
     )
 
     const allActivityFeedEvents = allActivityFeedEventsResults.hits.hits.map(

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,4 +1,4 @@
-const activityFeedEventsQuery = ({ order }) => ({
+const activityFeedEventsQuery = ({ sort }) => ({
   query: {
     bool: {
       must: [
@@ -10,12 +10,7 @@ const activityFeedEventsQuery = ({ order }) => ({
       ],
     },
   },
-  sort: {
-    'object.updated': {
-      order,
-      unmapped_type: 'date',
-    },
-  },
+  sort,
 })
 
 module.exports = activityFeedEventsQuery

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,4 +1,4 @@
-const activityFeedEventsQuery = () => ({
+const activityFeedEventsQuery = ({ order }) => ({
   query: {
     bool: {
       must: [
@@ -8,6 +8,12 @@ const activityFeedEventsQuery = () => ({
           },
         },
       ],
+    },
+  },
+  sort: {
+    'object.updated': {
+      order,
+      unmapped_type: 'date',
     },
   },
 })

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -14,6 +14,7 @@ import {
   Filters,
   FilterToggleSection,
   DefaultLayout,
+  CollectionSort,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
@@ -177,26 +178,41 @@ const EventsCollection = ({
               </CollectionFilters>
             </FilteredCollectionList>
           ) : (
-            <Task.Status
-              name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}
-              id={ID}
-              progressMessage="Loading events"
-              startOnRender={{
-                onSuccessDispatch: EVENTS__ALL_ACTIVITY_FEED_EVENTS_LOADED,
-              }}
-            >
-              {() => (
-                <ActivityList>
-                  {allActivityFeedEvents?.map((event, index) => {
-                    return (
-                      <li key={`event-${index}`}>
-                        <Activity activity={event} />
-                      </li>
-                    )
-                  })}
-                </ActivityList>
-              )}
-            </Task.Status>
+            <>
+              <CollectionSort
+                sortOptions={[
+                  {
+                    name: 'Recently updated',
+                    value: 'modified_on:desc',
+                  },
+                  {
+                    name: 'Least recently updated',
+                    value: 'modified_on:asc',
+                  },
+                ]}
+              />
+              <Task.Status
+                name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}
+                id={ID}
+                progressMessage="Loading events"
+                startOnRender={{
+                  payload: payload,
+                  onSuccessDispatch: EVENTS__ALL_ACTIVITY_FEED_EVENTS_LOADED,
+                }}
+              >
+                {() => (
+                  <ActivityList>
+                    {allActivityFeedEvents?.map((event, index) => {
+                      return (
+                        <li key={`event-${index}`}>
+                          <Activity activity={event} />
+                        </li>
+                      )
+                    })}
+                  </ActivityList>
+                )}
+              </Task.Status>
+            </>
           )
         }
       </CheckUserFeatureFlag>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -180,6 +180,7 @@ const EventsCollection = ({
           ) : (
             <>
               <CollectionSort
+                //TODO these can be replaces by SORT_OPTIONS when they eventually match
                 sortOptions={[
                   {
                     name: 'Recently updated',
@@ -188,6 +189,10 @@ const EventsCollection = ({
                   {
                     name: 'Least recently updated',
                     value: 'modified_on:asc',
+                  },
+                  {
+                    name: 'Event name A-Z',
+                    value: 'name:asc',
                   },
                 ]}
               />

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -49,9 +49,9 @@ const getEventsMetadata = () =>
     }))
     .catch(handleError)
 
-const getAllActivityFeedEvents = () =>
+const getAllActivityFeedEvents = ({ sortby }) =>
   axios
-    .get(urls.events.activity.data())
+    .get(urls.events.activity.data(), { params: { sortBy: sortby } })
     .then(({ data }) => data)
     .catch(() => Promise.reject('Unable to load events.'))
 

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -233,6 +233,9 @@ describe('Event Collection List Page - React', () => {
             'GET',
             `${events.activity.data()}?sortBy=modified_on:asc`
           ).as('leastRecentlyUpdatedRequest')
+          cy.intercept('GET', `${events.activity.data()}?sortBy=name:asc`).as(
+            'nameRequest'
+          )
           cy.visit(events.index())
         })
 
@@ -248,9 +251,16 @@ describe('Event Collection List Page - React', () => {
           cy.wait('@leastRecentlyUpdatedRequest').then((request) => {
             expect(request.response.statusCode).to.eql(200)
           })
-          cy.get('[data-test="aventri-event-name"]').contains(
-            'EITA Test Event 2022'
-          )
+          cy.get('@dataHubEvents').should('have.length', 0)
+        })
+
+        it('sorts by "name" when selected', () => {
+          const element = '[data-test="sortby"] select'
+          cy.get(element).select('name:asc')
+          cy.wait('@nameRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+          cy.get('@aventriEvents').should('have.length', 0)
         })
       })
     })

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -222,13 +222,48 @@ describe('Event Collection List Page - React', () => {
             .should('contain', 'Not set')
         })
       })
+
+      context('when sorting', () => {
+        beforeEach(() => {
+          cy.intercept(
+            'GET',
+            `${events.activity.data()}?sortBy=modified_on:desc`
+          ).as('recentlyUpdatedRequest')
+          cy.intercept(
+            'GET',
+            `${events.activity.data()}?sortBy=modified_on:asc`
+          ).as('leastRecentlyUpdatedRequest')
+          cy.visit(events.index())
+        })
+
+        it('sorts by recently updated by default', () => {
+          cy.wait('@recentlyUpdatedRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
+        it('sorts by "least recently updated" when selected', () => {
+          const element = '[data-test="sortby"] select'
+          cy.get(element).select('modified_on:asc')
+          cy.wait('@leastRecentlyUpdatedRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+          cy.get('[data-test="aventri-event-name"]').contains(
+            'EITA Test Event 2022'
+          )
+        })
+      })
     })
 
     context(
       'viewing the events collection page when there is an error loading events',
       () => {
         before(() => {
-          cy.intercept('GET', urls.events.activity.data(), { statusCode: 500 })
+          cy.intercept(
+            'GET',
+            `${events.activity.data()}?sortBy=modified_on:desc`,
+            { statusCode: 500 }
+          )
           cy.visit(urls.events.index())
         })
 

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -85,7 +85,15 @@ exports.activityFeed = function (req, res) {
     'dit:aventri:Event'
 
   if (isAllActivityStreamEvents) {
-    return res.json(allActivityFeedEvents)
+    // if the sort by is recently updated (modified_on:desc)
+    if (req.body.sort['object.updated']?.order === 'desc') {
+      return res.json(allActivityFeedEvents)
+    }
+
+    //if the story by is LEAST recently updated (modified_on:asc)
+    if (req.body.sort['object.updated']?.order === 'asc') {
+      return res.json(aventriEvents)
+    }
   }
 
   var isAventriEventQuery =

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -85,14 +85,20 @@ exports.activityFeed = function (req, res) {
     'dit:aventri:Event'
 
   if (isAllActivityStreamEvents) {
+    const { sort } = req.body
     // if the sort by is recently updated (modified_on:desc)
-    if (req.body.sort['object.updated']?.order === 'desc') {
+    if (sort['object.updated']?.order === 'desc') {
       return res.json(allActivityFeedEvents)
     }
 
     //if the story by is LEAST recently updated (modified_on:asc)
-    if (req.body.sort['object.updated']?.order === 'asc') {
+    if (sort['object.updated']?.order === 'asc') {
       return res.json(aventriEvents)
+    }
+
+    //if sorting by name
+    if (sort['object.name.raw']) {
+      return res.json(dataHubEvents)
     }
   }
 


### PR DESCRIPTION
## Description of change

We would like to sort the events returned from the Activity Stream by recently/least recently updated and name A-Z.
notes:
* We're reusing the `CollectionSort` component which includes the page count - that will be implemented in a future story
* I've left a 'TODO' in there for the sort Options - we're working towards parity with the existing Events collection sort, so a future story will look at adding the 'start date' sorting is currently missing, and we can just re-use the existing sort options. 

## Test instructions

On the Events collection page with the `user-event-activities` user feature flag on,
There should be a sort by selector which sorts by name or recently updated (we don't show the updated field on the card for the Event at the moment, but you can check that it's the right order on Activity Stream's kibana dashboard.)

## Screenshots
### Before
![Screenshot 2022-07-15 at 09 30 36](https://user-images.githubusercontent.com/16647486/179185311-4a7f2367-0b5f-4aa8-8027-982f6f511518.png)

### After

![Screenshot 2022-07-15 at 09 30 17](https://user-images.githubusercontent.com/16647486/179185323-3a6cd67b-07d4-4cc8-8596-ec05a5d3b875.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
