### PR TITLE
Implements Aventri Event name with routed link

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import CardUtils from './card/CardUtils'
+import { Link as RouterLink } from 'react-router-dom'
+import Link from '@govuk-react/link'
 
 import { formatStartAndEndDate } from '../../../utils/date'
 import { ACTIVITY_TYPE } from '../constants'
@@ -8,15 +10,21 @@ import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 
+// Event index to extract id from Aventri Event string feed by activity-stream
+// e.g. dit:aventri:Event:1113:Create
+const EVENT_ID_INDEX = 3
 export default function AventriEvent({ activity: event }) {
   const eventObject = event.object
   const name = eventObject.name
+  const aventriEventId = eventObject.id.split(':')[EVENT_ID_INDEX]
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
 
   return (
     <ActivityCardWrapper dataTest="aventri-event">
       <ActivityCardSubject dataTest="aventri-event-name">
-        {name}
+        <Link as={RouterLink} to={`/events/aventri/${aventriEventId}/details`}>
+          {name}
+        </Link>
       </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -161,8 +161,8 @@ describe('Event Collection List Page - React', () => {
         cy.get('@firstDataHubEvent')
           .find('[data-test="data-hub-event-name"]')
           .should('exist')
-          .should('contain', 'Holiday to the Seaside')
-          .contains('a')
+          .contains('a', 'Holiday to the Seaside')
+          .should('be.visible')
           .should('have.attr', 'href', '/events/6666/details')
       })
 
@@ -170,8 +170,8 @@ describe('Event Collection List Page - React', () => {
         cy.get('@firstAventriEvent')
           .find('[data-test="aventri-event-name"]')
           .should('exist')
-          .should('contain', 'Aventri Test Event')
-          .contains('a')
+          .contains('a', 'Aventri Test Event')
+          .should('be.visible')
           .should('have.attr', 'href', '/events/aventri/1113/details')
       })
 

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -166,11 +166,13 @@ describe('Event Collection List Page - React', () => {
           .should('have.attr', 'href', '/events/6666/details')
       })
 
-      it('should display an aventri event name', () => {
+      it('should display an aventri event name with link', () => {
         cy.get('@firstAventriEvent')
           .find('[data-test="aventri-event-name"]')
           .should('exist')
           .should('contain', 'Aventri Test Event')
+          .contains('a')
+          .should('have.attr', 'href', '/events/aventri/1113/details')
       })
 
       it('should display a data hub event date', () => {


### PR DESCRIPTION
## Description of change
To provide a routed link from Aventri Event name into newly created Datahub Events collection list.

## Test instructions

- Activates events-user-feature-flag from dev-api Django Admin.
- Navigate DH-CRM Events page, then see the events collection list from activity-feed dit:avetri

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/28296624/179234444-8f4c8f9a-ef20-4c68-b265-fd8d6834a03a.png)

### After

![image](https://user-images.githubusercontent.com/28296624/179235386-b42eb0e3-e503-4287-8d06-c6a572f1775b.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
