### PR TITLE
Ensure Reminders are responsive across Mobile, Tablet and Desktop

### DIFF
--- a/src/client/modules/Reminders/CollectionHeader.jsx
+++ b/src/client/modules/Reminders/CollectionHeader.jsx
@@ -3,7 +3,12 @@ import { H2 } from '@govuk-react/heading'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
-import { FONT_SIZE, FONT_WEIGHTS, HEADING_SIZES } from '@govuk-react/constants'
+import {
+  FONT_SIZE,
+  FONT_WEIGHTS,
+  HEADING_SIZES,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
 
 import { CollectionHeaderRow } from '../../components'
 import { decimal } from '../../utils/number-utils'
@@ -26,7 +31,14 @@ const StyledCollectionHeaderRow = styled(CollectionHeaderRow)({
 })
 
 const SettingsLink = styled(Link)({
+  display: 'none',
   fontSize: FONT_SIZE.SIZE_19,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'block',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'block',
+  },
 })
 
 const CollectionHeader = ({ totalItems, settings = true }) => {

--- a/src/client/modules/Reminders/CollectionList.jsx
+++ b/src/client/modules/Reminders/CollectionList.jsx
@@ -3,7 +3,7 @@ import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
-import { GREY_2 } from 'govuk-colours'
+import { BLACK, GREY_2 } from 'govuk-colours'
 import { H3 } from '@govuk-react/heading'
 import { FONT_SIZE, HEADING_SIZES, SPACING } from '@govuk-react/constants'
 
@@ -49,7 +49,7 @@ const ItemHeader = styled(H3)({
 })
 
 const ItemContent = styled('div')({
-  color: DARK_GREY,
+  color: ({ colour }) => colour,
   marginBottom: SPACING.SCALE_3,
 })
 
@@ -70,7 +70,7 @@ const CollectionList = ({ results, onDeleteReminder, disableDelete }) => {
                 <ItemHeader data-test="item-header">
                   Reminder deleted
                 </ItemHeader>
-                <ItemContent data-test="item-content">
+                <ItemContent colour={DARK_GREY} data-test="item-content">
                   {event} for {project.name}
                 </ItemContent>
                 <ItemFooter data-test="item-footer"></ItemFooter>
@@ -81,7 +81,7 @@ const CollectionList = ({ results, onDeleteReminder, disableDelete }) => {
                   <ItemHeader data-test="item-header">
                     Received {formatMediumDate(created_on)}
                   </ItemHeader>
-                  <ItemContent data-test="item-content">
+                  <ItemContent colour={BLACK} data-test="item-content">
                     {event} for{' '}
                     <Link
                       href={`${urls.investments.projects.details(project.id)}`}
@@ -92,7 +92,15 @@ const CollectionList = ({ results, onDeleteReminder, disableDelete }) => {
                   <ItemFooter data-test="item-footer">
                     Project code {project.project_code}
                   </ItemFooter>
+                  {/* Display only on mobile */}
+                  <DeleteButton
+                    data-test="delete-button"
+                    onClick={() => onDeleteReminder(id)}
+                  >
+                    Delete reminder
+                  </DeleteButton>
                 </GridCol>
+                {/* When only on Desktop */}
                 {onDeleteReminder && (
                   <RightCol setWidth="one-quarter">
                     {!disableDelete && (

--- a/src/client/modules/Reminders/CollectionList.jsx
+++ b/src/client/modules/Reminders/CollectionList.jsx
@@ -5,16 +5,19 @@ import { Link } from 'govuk-react'
 import styled from 'styled-components'
 import { BLACK, GREY_2 } from 'govuk-colours'
 import { H3 } from '@govuk-react/heading'
-import { FONT_SIZE, HEADING_SIZES, SPACING } from '@govuk-react/constants'
+import {
+  SPACING,
+  FONT_SIZE,
+  HEADING_SIZES,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
 
 import { formatMediumDate } from '../../utils/date'
 import { DARK_GREY } from '../../utils/colors'
 import urls from '../../../lib/urls'
 
-const DeleteButton = styled('button')({
-  display: 'inline',
+const Button = styled('button')({
   padding: 0,
-  margin: `${SPACING.SCALE_3} 0`,
   background: 'transparent',
   border: 'none',
   fontSize: FONT_SIZE.SIZE_16,
@@ -24,8 +27,28 @@ const DeleteButton = styled('button')({
   textDecoration: 'underline',
 })
 
+const DeleteButton = styled(Button)({
+  display: ({ isMobile }) => (isMobile ? 'inline' : 'none'),
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.TABLET]: {
+    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
+    margin: `${SPACING.SCALE_3} 0`,
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
+    margin: `${SPACING.SCALE_3} 0`,
+  },
+})
+
 const RightCol = styled(GridCol)({
+  display: 'none',
   textAlign: 'right',
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'block',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'block',
+  },
 })
 
 const List = styled('ol')({
@@ -92,15 +115,18 @@ const CollectionList = ({ results, onDeleteReminder, disableDelete }) => {
                   <ItemFooter data-test="item-footer">
                     Project code {project.project_code}
                   </ItemFooter>
-                  {/* Display only on mobile */}
-                  <DeleteButton
-                    data-test="delete-button"
-                    onClick={() => onDeleteReminder(id)}
-                  >
-                    Delete reminder
-                  </DeleteButton>
+                  {/* Display on mobile only */}
+                  {onDeleteReminder && !disableDelete && (
+                    <DeleteButton
+                      isMobile={true}
+                      data-test="delete-button"
+                      onClick={() => onDeleteReminder(id)}
+                    >
+                      Delete reminder
+                    </DeleteButton>
+                  )}
                 </GridCol>
-                {/* When only on Desktop */}
+                {/* Display on Tablet and Desktop only */}
                 {onDeleteReminder && (
                   <RightCol setWidth="one-quarter">
                     {!disableDelete && (

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -45,7 +45,7 @@ const MenuContainer = styled('div')({
   width: '100%',
   [MEDIA_QUERIES.DESKTOP]: {
     width: 'calc(33% - 20px)',
-    padding: 10,
+    padding: SPACING.SCALE_2,
   },
 })
 
@@ -58,8 +58,8 @@ const ListContainer = styled('div')({
 
 const SettingsLink = styled(Link)({
   display: 'block',
-  marginTop: 30,
-  marginBottom: 15,
+  marginTop: SPACING.SCALE_5,
+  marginBottom: SPACING.SCALE_3,
   [MEDIA_QUERIES.TABLET]: {
     display: 'none',
   },

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { Link } from 'govuk-react'
+import { BLACK } from 'govuk-colours'
 import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
@@ -20,7 +21,7 @@ import {
 } from './state'
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
-import { DARK_GREY } from '../../utils/colors'
+
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
@@ -33,13 +34,6 @@ import {
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
-
-const StyledDiv = styled('div')({
-  fontSize: FONT_SIZE.SIZE_16,
-  color: DARK_GREY,
-  paddingTop: SPACING.SCALE_4,
-  paddingBottom: SPACING.SCALE_3,
-})
 
 const Container = styled('div')({
   [MEDIA_QUERIES.DESKTOP]: {
@@ -74,6 +68,12 @@ const SettingsLink = styled(Link)({
   },
 })
 
+const Summary = styled('p')({
+  color: BLACK,
+  paddingTop: SPACING.SCALE_2,
+  fontSize: FONT_SIZE.SIZE_19,
+})
+
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   const { results, count, nextPending } = estimatedLandDateReminders
   const location = useLocation()
@@ -104,9 +104,7 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
         <ListContainer>
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
-            <StyledDiv data-test="no-reminders">
-              You have no reminders.
-            </StyledDiv>
+            <Summary data-test="no-reminders">You have no reminders.</Summary>
           ) : (
             <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
           )}

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { SPACING, FONT_SIZE } from '@govuk-react/constants'
-import GridRow from '@govuk-react/grid-row'
-import GridCol from '@govuk-react/grid-col'
+import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
 
@@ -42,6 +40,27 @@ const StyledDiv = styled('div')({
   paddingBottom: SPACING.SCALE_3,
 })
 
+const Container = styled('div')({
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'flex',
+  },
+})
+
+const MenuContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: 'calc(33% - 20px)',
+    padding: 10,
+  },
+})
+
+const ListContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '67%',
+  },
+})
+
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   const { results, count, nextPending } = estimatedLandDateReminders
   const location = useLocation()
@@ -59,11 +78,11 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <GridRow>
-        <GridCol setWidth="one-third">
+      <Container>
+        <MenuContainer>
           <RemindersMenu />
-        </GridCol>
-        <GridCol>
+        </MenuContainer>
+        <ListContainer>
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
             <StyledDiv data-test="no-reminders">
@@ -123,8 +142,8 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
               </Task>
             )}
           </Task.Status>
-        </GridCol>
-      </GridRow>
+        </ListContainer>
+      </Container>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -101,79 +101,87 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <Container>
-        <MenuContainer>
-          <RemindersMenu />
-          <SettingsLink
-            data-test="reminders-settings-link"
-            href="/reminders/settings"
-          >
-            Reminders settings
-          </SettingsLink>
-        </MenuContainer>
-        <ListContainer>
-          <CollectionHeader totalItems={count} />
-          {results.length === 0 ? (
-            <Summary data-test="no-reminders">You have no reminders.</Summary>
-          ) : (
-            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
-          )}
-          <Task.Status
-            name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
-            id={ID}
-            startOnRender={{
-              payload: { page, sortby: qsParams.sortby },
-              onSuccessDispatch:
-                REMINDERS__ESTIMATED_LAND_DATE_REMINDERS_LOADED,
-            }}
-          >
-            {() => (
-              <Task>
-                {(getTask) => {
-                  const deleteTask = getTask(
-                    TASK_DELETE_ESTIMATED_LAND_DATE_REMINDER,
-                    ID
-                  )
-                  const getNextTask = getTask(
-                    TASK_GET_NEXT_ESTIMATED_LAND_DATE_REMINDER,
-                    ID
-                  )
-                  return (
-                    <>
-                      <Effect
-                        dependencyList={[nextPending]}
-                        effect={() =>
-                          nextPending &&
-                          getNextTask.start({
-                            payload: { page, sortby: qsParams.sortby },
-                            onSuccessDispatch:
-                              REMINDERS__ESTIMATED_LAND_DATE_REMINDER_GOT_NEXT,
-                          })
-                        }
-                      />
-                      <CollectionList
-                        results={results}
-                        disableDelete={nextPending}
-                        onDeleteReminder={(reminderId) => {
-                          deleteTask.start({
-                            payload: { id: reminderId },
-                            onSuccessDispatch:
-                              REMINDERS__ESTIMATED_LAND_DATE_REMINDER_DELETED,
-                          })
-                        }}
-                      />
-                      <RoutedPagination initialPage={page} items={count || 0} />
-                    </>
-                  )
-                }}
-              </Task>
+      <>
+        <Container>
+          <MenuContainer>
+            <RemindersMenu />
+            <SettingsLink
+              data-test="reminders-settings-link"
+              href="/reminders/settings"
+            >
+              Reminders settings
+            </SettingsLink>
+          </MenuContainer>
+          <ListContainer>
+            <CollectionHeader totalItems={count} />
+            {results.length === 0 ? (
+              <Summary data-test="no-reminders">You have no reminders.</Summary>
+            ) : (
+              <CollectionSort
+                sortOptions={sortOptions}
+                totalPages={totalPages}
+              />
             )}
-          </Task.Status>
-        </ListContainer>
-      </Container>
-      <HomeLink data-test="home-link" href={urls.dashboard()}>
-        Home
-      </HomeLink>
+            <Task.Status
+              name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
+              id={ID}
+              startOnRender={{
+                payload: { page, sortby: qsParams.sortby },
+                onSuccessDispatch:
+                  REMINDERS__ESTIMATED_LAND_DATE_REMINDERS_LOADED,
+              }}
+            >
+              {() => (
+                <Task>
+                  {(getTask) => {
+                    const deleteTask = getTask(
+                      TASK_DELETE_ESTIMATED_LAND_DATE_REMINDER,
+                      ID
+                    )
+                    const getNextTask = getTask(
+                      TASK_GET_NEXT_ESTIMATED_LAND_DATE_REMINDER,
+                      ID
+                    )
+                    return (
+                      <>
+                        <Effect
+                          dependencyList={[nextPending]}
+                          effect={() =>
+                            nextPending &&
+                            getNextTask.start({
+                              payload: { page, sortby: qsParams.sortby },
+                              onSuccessDispatch:
+                                REMINDERS__ESTIMATED_LAND_DATE_REMINDER_GOT_NEXT,
+                            })
+                          }
+                        />
+                        <CollectionList
+                          results={results}
+                          disableDelete={nextPending}
+                          onDeleteReminder={(reminderId) => {
+                            deleteTask.start({
+                              payload: { id: reminderId },
+                              onSuccessDispatch:
+                                REMINDERS__ESTIMATED_LAND_DATE_REMINDER_DELETED,
+                            })
+                          }}
+                        />
+                        <RoutedPagination
+                          initialPage={page}
+                          items={count || 0}
+                        />
+                      </>
+                    )
+                  }}
+                </Task>
+              )}
+            </Task.Status>
+          </ListContainer>
+        </Container>
+        <HomeLink data-test="home-link" href={urls.dashboard()}>
+          Home
+        </HomeLink>
+      </>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { Link } from 'govuk-react'
 import { BLACK } from 'govuk-colours'
-import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
 
@@ -22,66 +21,18 @@ import {
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
 
+import RemindersLayout from './RemindersLayout'
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
-import RemindersMenu from './RemindersMenu'
 import CollectionList from './CollectionList'
-import urls from '../../../lib/urls'
-import Heading from './Heading'
-import {
-  CollectionSort,
-  DefaultLayout,
-  RoutedPagination,
-} from '../../components'
 
-const Container = styled('div')({
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'flex',
-  },
-})
-
-const MenuContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: 'calc(33% - 20px)',
-    padding: SPACING.SCALE_2,
-  },
-})
-
-const ListContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '67%',
-  },
-})
-
-const SettingsLink = styled(Link)({
-  display: 'block',
-  marginTop: SPACING.SCALE_5,
-  marginBottom: SPACING.SCALE_3,
-  [MEDIA_QUERIES.TABLET]: {
-    display: 'none',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'none',
-  },
-})
+import { CollectionSort, RoutedPagination } from '../../components'
 
 const Summary = styled('p')({
   color: BLACK,
   paddingTop: SPACING.SCALE_2,
   fontSize: FONT_SIZE.SIZE_19,
-})
-
-const HomeLink = styled(Link)({
-  display: 'block',
-  marginTop: SPACING.SCALE_4,
-  marginBottom: SPACING.SCALE_4,
-  [MEDIA_QUERIES.DESKTOP]: {
-    marginLeft: 25,
-    marginBottom: 25,
-  },
 })
 
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
@@ -96,93 +47,64 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   )
 
   return (
-    <DefaultLayout
-      pageTitle={title}
-      heading={<Heading preHeading="Reminders for">{subject}</Heading>}
-      breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
-    >
-      <>
-        <Container>
-          <MenuContainer>
-            <RemindersMenu />
-            <SettingsLink
-              data-test="reminders-settings-link"
-              href="/reminders/settings"
-            >
-              Reminders settings
-            </SettingsLink>
-          </MenuContainer>
-          <ListContainer>
-            <CollectionHeader totalItems={count} />
-            {results.length === 0 ? (
-              <Summary data-test="no-reminders">You have no reminders.</Summary>
-            ) : (
-              <CollectionSort
-                sortOptions={sortOptions}
-                totalPages={totalPages}
-              />
-            )}
-            <Task.Status
-              name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
-              id={ID}
-              startOnRender={{
-                payload: { page, sortby: qsParams.sortby },
-                onSuccessDispatch:
-                  REMINDERS__ESTIMATED_LAND_DATE_REMINDERS_LOADED,
-              }}
-            >
-              {() => (
-                <Task>
-                  {(getTask) => {
-                    const deleteTask = getTask(
-                      TASK_DELETE_ESTIMATED_LAND_DATE_REMINDER,
-                      ID
-                    )
-                    const getNextTask = getTask(
-                      TASK_GET_NEXT_ESTIMATED_LAND_DATE_REMINDER,
-                      ID
-                    )
-                    return (
-                      <>
-                        <Effect
-                          dependencyList={[nextPending]}
-                          effect={() =>
-                            nextPending &&
-                            getNextTask.start({
-                              payload: { page, sortby: qsParams.sortby },
-                              onSuccessDispatch:
-                                REMINDERS__ESTIMATED_LAND_DATE_REMINDER_GOT_NEXT,
-                            })
-                          }
-                        />
-                        <CollectionList
-                          results={results}
-                          disableDelete={nextPending}
-                          onDeleteReminder={(reminderId) => {
-                            deleteTask.start({
-                              payload: { id: reminderId },
-                              onSuccessDispatch:
-                                REMINDERS__ESTIMATED_LAND_DATE_REMINDER_DELETED,
-                            })
-                          }}
-                        />
-                        <RoutedPagination
-                          initialPage={page}
-                          items={count || 0}
-                        />
-                      </>
-                    )
-                  }}
-                </Task>
-              )}
-            </Task.Status>
-          </ListContainer>
-        </Container>
-        <HomeLink data-test="home-link" href={urls.dashboard()}>
-          Home
-        </HomeLink>
-      </>
-    </DefaultLayout>
+    <RemindersLayout pageTitle={title} subject={subject}>
+      <CollectionHeader totalItems={count} />
+      {results.length === 0 ? (
+        <Summary data-test="no-reminders">You have no reminders.</Summary>
+      ) : (
+        <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+      )}
+      <Task.Status
+        name={TASK_GET_ESTIMATED_LAND_DATE_REMINDERS}
+        id={ID}
+        startOnRender={{
+          payload: { page, sortby: qsParams.sortby },
+          onSuccessDispatch: REMINDERS__ESTIMATED_LAND_DATE_REMINDERS_LOADED,
+        }}
+      >
+        {() => (
+          <Task>
+            {(getTask) => {
+              const deleteTask = getTask(
+                TASK_DELETE_ESTIMATED_LAND_DATE_REMINDER,
+                ID
+              )
+              const getNextTask = getTask(
+                TASK_GET_NEXT_ESTIMATED_LAND_DATE_REMINDER,
+                ID
+              )
+              return (
+                <>
+                  <Effect
+                    dependencyList={[nextPending]}
+                    effect={() =>
+                      nextPending &&
+                      getNextTask.start({
+                        payload: { page, sortby: qsParams.sortby },
+                        onSuccessDispatch:
+                          REMINDERS__ESTIMATED_LAND_DATE_REMINDER_GOT_NEXT,
+                      })
+                    }
+                  />
+                  <CollectionList
+                    results={results}
+                    disableDelete={nextPending}
+                    onDeleteReminder={(reminderId) => {
+                      deleteTask.start({
+                        payload: { id: reminderId },
+                        onSuccessDispatch:
+                          REMINDERS__ESTIMATED_LAND_DATE_REMINDER_DELETED,
+                      })
+                    }}
+                  />
+                  <RoutedPagination initialPage={page} items={count || 0} />
+                </>
+              )
+            }}
+          </Task>
+        )}
+      </Task.Status>
+    </RemindersLayout>
   )
 }
 

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { Link } from 'govuk-react'
 import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
@@ -61,6 +62,18 @@ const ListContainer = styled('div')({
   },
 })
 
+const SettingsLink = styled(Link)({
+  display: 'block',
+  marginTop: 30,
+  marginBottom: 15,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'none',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'none',
+  },
+})
+
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   const { results, count, nextPending } = estimatedLandDateReminders
   const location = useLocation()
@@ -81,6 +94,12 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
       <Container>
         <MenuContainer>
           <RemindersMenu />
+          <SettingsLink
+            data-test="reminders-settings-link"
+            href="/reminders/settings"
+          >
+            Reminders settings
+          </SettingsLink>
         </MenuContainer>
         <ListContainer>
           <CollectionHeader totalItems={count} />

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -74,6 +74,16 @@ const Summary = styled('p')({
   fontSize: FONT_SIZE.SIZE_19,
 })
 
+const HomeLink = styled(Link)({
+  display: 'block',
+  marginTop: SPACING.SCALE_4,
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.DESKTOP]: {
+    marginLeft: 25,
+    marginBottom: 25,
+  },
+})
+
 const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
   const { results, count, nextPending } = estimatedLandDateReminders
   const location = useLocation()
@@ -161,6 +171,9 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
           </Task.Status>
         </ListContainer>
       </Container>
+      <HomeLink data-test="home-link" href={urls.dashboard()}>
+        Home
+      </HomeLink>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
+++ b/src/client/modules/Reminders/EstimatedLandDateReminders.jsx
@@ -86,7 +86,7 @@ const EstimatedLandDateReminders = ({ estimatedLandDateReminders }) => {
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
             <StyledDiv data-test="no-reminders">
-              You have no reminders
+              You have no reminders.
             </StyledDiv>
           ) : (
             <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { Link } from 'govuk-react'
+import { BLACK } from 'govuk-colours'
 import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
@@ -20,7 +21,6 @@ import {
 } from './state'
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
-import { DARK_GREY } from '../../utils/colors'
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
@@ -33,13 +33,6 @@ import {
   DefaultLayout,
   RoutedPagination,
 } from '../../components'
-
-const StyledDiv = styled('div')({
-  fontSize: FONT_SIZE.SIZE_16,
-  color: DARK_GREY,
-  paddingTop: SPACING.SCALE_4,
-  paddingBottom: SPACING.SCALE_3,
-})
 
 const Container = styled('div')({
   [MEDIA_QUERIES.DESKTOP]: {
@@ -74,6 +67,12 @@ const SettingsLink = styled(Link)({
   },
 })
 
+const Summary = styled('p')({
+  color: BLACK,
+  paddingTop: SPACING.SCALE_2,
+  fontSize: FONT_SIZE.SIZE_19,
+})
+
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   const { results, count, nextPending } = noRecentInteractionReminders
   const location = useLocation()
@@ -104,9 +103,7 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
         <ListContainer>
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
-            <StyledDiv data-test="no-reminders">
-              You have no reminders.
-            </StyledDiv>
+            <Summary data-test="no-reminders">You have no reminders.</Summary>
           ) : (
             <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
           )}

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -73,6 +73,16 @@ const Summary = styled('p')({
   fontSize: FONT_SIZE.SIZE_19,
 })
 
+const HomeLink = styled(Link)({
+  display: 'block',
+  marginTop: SPACING.SCALE_4,
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.DESKTOP]: {
+    marginLeft: 25,
+    marginBottom: 25,
+  },
+})
+
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   const { results, count, nextPending } = noRecentInteractionReminders
   const location = useLocation()
@@ -163,6 +173,9 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
           </Task.Status>
         </ListContainer>
       </Container>
+      <HomeLink data-test="home-link" href={urls.dashboard()}>
+        Home
+      </HomeLink>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -100,82 +100,90 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <Container>
-        <MenuContainer>
-          <RemindersMenu />
-          <SettingsLink
-            data-test="reminders-settings-link"
-            href="/reminders/settings"
-          >
-            Reminders settings
-          </SettingsLink>
-        </MenuContainer>
-        <ListContainer>
-          <CollectionHeader totalItems={count} />
-          {results.length === 0 ? (
-            <Summary data-test="no-reminders">You have no reminders.</Summary>
-          ) : (
-            <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
-          )}
-          <Task.Status
-            name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
-            id={ID}
-            startOnRender={{
-              payload: { page, sortby: qsParams.sortby },
-              onSuccessDispatch:
-                REMINDERS__NO_RECENT_INTERACTION_REMINDERS_LOADED,
-            }}
-          >
-            {() => (
-              <Task>
-                {(getTask) => {
-                  const deleteTask = getTask(
-                    TASK_DELETE_NO_RECENT_INTERACTION_REMINDER,
-                    ID
-                  )
-                  const getNextTask = getTask(
-                    TASK_GET_NEXT_NO_RECENT_INTERACTION_REMINDER,
-                    ID
-                  )
-                  return (
-                    <>
-                      <Effect
-                        dependencyList={[nextPending]}
-                        effect={() =>
-                          nextPending &&
-                          getNextTask.start({
-                            payload: {
-                              page,
-                              sortby: qsParams.sortby,
-                            },
-                            onSuccessDispatch:
-                              REMINDERS__NO_RECENT_INTERACTION_REMINDER_GOT_NEXT,
-                          })
-                        }
-                      />
-                      <CollectionList
-                        results={results}
-                        disableDelete={deleteTask.status || nextPending}
-                        onDeleteReminder={(reminderId) => {
-                          deleteTask.start({
-                            payload: { id: reminderId },
-                            onSuccessDispatch:
-                              REMINDERS__NO_RECENT_INTERACTION_REMINDER_DELETED,
-                          })
-                        }}
-                      />
-                      <RoutedPagination initialPage={page} items={count || 0} />
-                    </>
-                  )
-                }}
-              </Task>
+      <>
+        <Container>
+          <MenuContainer>
+            <RemindersMenu />
+            <SettingsLink
+              data-test="reminders-settings-link"
+              href="/reminders/settings"
+            >
+              Reminders settings
+            </SettingsLink>
+          </MenuContainer>
+          <ListContainer>
+            <CollectionHeader totalItems={count} />
+            {results.length === 0 ? (
+              <Summary data-test="no-reminders">You have no reminders.</Summary>
+            ) : (
+              <CollectionSort
+                sortOptions={sortOptions}
+                totalPages={totalPages}
+              />
             )}
-          </Task.Status>
-        </ListContainer>
-      </Container>
-      <HomeLink data-test="home-link" href={urls.dashboard()}>
-        Home
-      </HomeLink>
+            <Task.Status
+              name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
+              id={ID}
+              startOnRender={{
+                payload: { page, sortby: qsParams.sortby },
+                onSuccessDispatch:
+                  REMINDERS__NO_RECENT_INTERACTION_REMINDERS_LOADED,
+              }}
+            >
+              {() => (
+                <Task>
+                  {(getTask) => {
+                    const deleteTask = getTask(
+                      TASK_DELETE_NO_RECENT_INTERACTION_REMINDER,
+                      ID
+                    )
+                    const getNextTask = getTask(
+                      TASK_GET_NEXT_NO_RECENT_INTERACTION_REMINDER,
+                      ID
+                    )
+                    return (
+                      <>
+                        <Effect
+                          dependencyList={[nextPending]}
+                          effect={() =>
+                            nextPending &&
+                            getNextTask.start({
+                              payload: {
+                                page,
+                                sortby: qsParams.sortby,
+                              },
+                              onSuccessDispatch:
+                                REMINDERS__NO_RECENT_INTERACTION_REMINDER_GOT_NEXT,
+                            })
+                          }
+                        />
+                        <CollectionList
+                          results={results}
+                          disableDelete={deleteTask.status || nextPending}
+                          onDeleteReminder={(reminderId) => {
+                            deleteTask.start({
+                              payload: { id: reminderId },
+                              onSuccessDispatch:
+                                REMINDERS__NO_RECENT_INTERACTION_REMINDER_DELETED,
+                            })
+                          }}
+                        />
+                        <RoutedPagination
+                          initialPage={page}
+                          items={count || 0}
+                        />
+                      </>
+                    )
+                  }}
+                </Task>
+              )}
+            </Task.Status>
+          </ListContainer>
+        </Container>
+        <HomeLink data-test="home-link" href={urls.dashboard()}>
+          Home
+        </HomeLink>
+      </>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -86,7 +86,7 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
             <StyledDiv data-test="no-reminders">
-              You have no reminders
+              You have no reminders.
             </StyledDiv>
           ) : (
             <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { SPACING, FONT_SIZE } from '@govuk-react/constants'
-import GridRow from '@govuk-react/grid-row'
-import GridCol from '@govuk-react/grid-col'
+import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
 
@@ -42,6 +40,27 @@ const StyledDiv = styled('div')({
   paddingBottom: SPACING.SCALE_3,
 })
 
+const Container = styled('div')({
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'flex',
+  },
+})
+
+const MenuContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: 'calc(33% - 20px)',
+    padding: 10,
+  },
+})
+
+const ListContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '67%',
+  },
+})
+
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   const { results, count, nextPending } = noRecentInteractionReminders
   const location = useLocation()
@@ -59,11 +78,11 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <GridRow>
-        <GridCol setWidth="one-third">
+      <Container>
+        <MenuContainer>
           <RemindersMenu />
-        </GridCol>
-        <GridCol>
+        </MenuContainer>
+        <ListContainer>
           <CollectionHeader totalItems={count} />
           {results.length === 0 ? (
             <StyledDiv data-test="no-reminders">
@@ -126,8 +145,8 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
               </Task>
             )}
           </Task.Status>
-        </GridCol>
-      </GridRow>
+        </ListContainer>
+      </Container>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -1,9 +1,8 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { Link } from 'govuk-react'
 import { BLACK } from 'govuk-colours'
-import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
 
@@ -21,66 +20,18 @@ import {
 } from './state'
 
 import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
+
+import RemindersLayout from './RemindersLayout'
 import CollectionHeader from './CollectionHeader'
 import Effect from '../../components/Effect'
 import Task from '../../components/Task'
-import RemindersMenu from './RemindersMenu'
 import CollectionList from './CollectionList'
-import urls from '../../../lib/urls'
-import Heading from './Heading'
-import {
-  CollectionSort,
-  DefaultLayout,
-  RoutedPagination,
-} from '../../components'
-
-const Container = styled('div')({
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'flex',
-  },
-})
-
-const MenuContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: 'calc(33% - 20px)',
-    padding: SPACING.SCALE_2,
-  },
-})
-
-const ListContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '67%',
-  },
-})
-
-const SettingsLink = styled(Link)({
-  display: 'block',
-  marginTop: SPACING.SCALE_5,
-  marginBottom: SPACING.SCALE_3,
-  [MEDIA_QUERIES.TABLET]: {
-    display: 'none',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'none',
-  },
-})
+import { CollectionSort, RoutedPagination } from '../../components'
 
 const Summary = styled('p')({
   color: BLACK,
   paddingTop: SPACING.SCALE_2,
   fontSize: FONT_SIZE.SIZE_19,
-})
-
-const HomeLink = styled(Link)({
-  display: 'block',
-  marginTop: SPACING.SCALE_4,
-  marginBottom: SPACING.SCALE_4,
-  [MEDIA_QUERIES.DESKTOP]: {
-    marginLeft: 25,
-    marginBottom: 25,
-  },
 })
 
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
@@ -95,96 +46,67 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   )
 
   return (
-    <DefaultLayout
-      pageTitle={title}
-      heading={<Heading preHeading="Reminders for">{subject}</Heading>}
-      breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
-    >
-      <>
-        <Container>
-          <MenuContainer>
-            <RemindersMenu />
-            <SettingsLink
-              data-test="reminders-settings-link"
-              href="/reminders/settings"
-            >
-              Reminders settings
-            </SettingsLink>
-          </MenuContainer>
-          <ListContainer>
-            <CollectionHeader totalItems={count} />
-            {results.length === 0 ? (
-              <Summary data-test="no-reminders">You have no reminders.</Summary>
-            ) : (
-              <CollectionSort
-                sortOptions={sortOptions}
-                totalPages={totalPages}
-              />
-            )}
-            <Task.Status
-              name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
-              id={ID}
-              startOnRender={{
-                payload: { page, sortby: qsParams.sortby },
-                onSuccessDispatch:
-                  REMINDERS__NO_RECENT_INTERACTION_REMINDERS_LOADED,
-              }}
-            >
-              {() => (
-                <Task>
-                  {(getTask) => {
-                    const deleteTask = getTask(
-                      TASK_DELETE_NO_RECENT_INTERACTION_REMINDER,
-                      ID
-                    )
-                    const getNextTask = getTask(
-                      TASK_GET_NEXT_NO_RECENT_INTERACTION_REMINDER,
-                      ID
-                    )
-                    return (
-                      <>
-                        <Effect
-                          dependencyList={[nextPending]}
-                          effect={() =>
-                            nextPending &&
-                            getNextTask.start({
-                              payload: {
-                                page,
-                                sortby: qsParams.sortby,
-                              },
-                              onSuccessDispatch:
-                                REMINDERS__NO_RECENT_INTERACTION_REMINDER_GOT_NEXT,
-                            })
-                          }
-                        />
-                        <CollectionList
-                          results={results}
-                          disableDelete={deleteTask.status || nextPending}
-                          onDeleteReminder={(reminderId) => {
-                            deleteTask.start({
-                              payload: { id: reminderId },
-                              onSuccessDispatch:
-                                REMINDERS__NO_RECENT_INTERACTION_REMINDER_DELETED,
-                            })
-                          }}
-                        />
-                        <RoutedPagination
-                          initialPage={page}
-                          items={count || 0}
-                        />
-                      </>
-                    )
-                  }}
-                </Task>
-              )}
-            </Task.Status>
-          </ListContainer>
-        </Container>
-        <HomeLink data-test="home-link" href={urls.dashboard()}>
-          Home
-        </HomeLink>
-      </>
-    </DefaultLayout>
+    <RemindersLayout pageTitle={title} subject={subject}>
+      <CollectionHeader totalItems={count} />
+      {results.length === 0 ? (
+        <Summary data-test="no-reminders">You have no reminders.</Summary>
+      ) : (
+        <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+      )}
+      <Task.Status
+        name={TASK_GET_NO_RECENT_INTERACTION_REMINDERS}
+        id={ID}
+        startOnRender={{
+          payload: { page, sortby: qsParams.sortby },
+          onSuccessDispatch: REMINDERS__NO_RECENT_INTERACTION_REMINDERS_LOADED,
+        }}
+      >
+        {() => (
+          <Task>
+            {(getTask) => {
+              const deleteTask = getTask(
+                TASK_DELETE_NO_RECENT_INTERACTION_REMINDER,
+                ID
+              )
+              const getNextTask = getTask(
+                TASK_GET_NEXT_NO_RECENT_INTERACTION_REMINDER,
+                ID
+              )
+              return (
+                <>
+                  <Effect
+                    dependencyList={[nextPending]}
+                    effect={() =>
+                      nextPending &&
+                      getNextTask.start({
+                        payload: {
+                          page,
+                          sortby: qsParams.sortby,
+                        },
+                        onSuccessDispatch:
+                          REMINDERS__NO_RECENT_INTERACTION_REMINDER_GOT_NEXT,
+                      })
+                    }
+                  />
+                  <CollectionList
+                    results={results}
+                    disableDelete={deleteTask.status || nextPending}
+                    onDeleteReminder={(reminderId) => {
+                      deleteTask.start({
+                        payload: { id: reminderId },
+                        onSuccessDispatch:
+                          REMINDERS__NO_RECENT_INTERACTION_REMINDER_DELETED,
+                      })
+                    }}
+                  />
+                  <RoutedPagination initialPage={page} items={count || 0} />
+                </>
+              )
+            }}
+          </Task>
+        )}
+      </Task.Status>
+    </RemindersLayout>
   )
 }
 

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { Link } from 'govuk-react'
 import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 import qs from 'qs'
@@ -61,6 +62,18 @@ const ListContainer = styled('div')({
   },
 })
 
+const SettingsLink = styled(Link)({
+  display: 'block',
+  marginTop: 30,
+  marginBottom: 15,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'none',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'none',
+  },
+})
+
 const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
   const { results, count, nextPending } = noRecentInteractionReminders
   const location = useLocation()
@@ -81,6 +94,12 @@ const NoRecentInteractionReminders = ({ noRecentInteractionReminders }) => {
       <Container>
         <MenuContainer>
           <RemindersMenu />
+          <SettingsLink
+            data-test="reminders-settings-link"
+            href="/reminders/settings"
+          >
+            Reminders settings
+          </SettingsLink>
         </MenuContainer>
         <ListContainer>
           <CollectionHeader totalItems={count} />

--- a/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
+++ b/src/client/modules/Reminders/NoRecentInteractionReminders.jsx
@@ -44,7 +44,7 @@ const MenuContainer = styled('div')({
   width: '100%',
   [MEDIA_QUERIES.DESKTOP]: {
     width: 'calc(33% - 20px)',
-    padding: 10,
+    padding: SPACING.SCALE_2,
   },
 })
 
@@ -57,8 +57,8 @@ const ListContainer = styled('div')({
 
 const SettingsLink = styled(Link)({
   display: 'block',
-  marginTop: 30,
-  marginBottom: 15,
+  marginTop: SPACING.SCALE_5,
+  marginBottom: SPACING.SCALE_3,
   [MEDIA_QUERIES.TABLET]: {
     display: 'none',
   },

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -119,7 +119,7 @@ const OutstandingPropositionReminders = ({
             data-test="pagination-summary"
           >
             {results.length === 0
-              ? 'You have no reminders'
+              ? 'You have no reminders.'
               : `Page ${page || 1} of ${totalPages}`}
           </PaginationSummary>
           <Task.Status

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -122,63 +122,67 @@ const OutstandingPropositionReminders = ({
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <Container>
-        <MenuContainer>
-          <RemindersMenu />
-        </MenuContainer>
-        <ListContainer>
-          <CollectionHeader settings={false} totalItems={count} />
-          {results.length === 0 ? (
-            <Summary data-test="no-reminders">You have no reminders.</Summary>
-          ) : (
-            <PaginationSummary data-test="pagination-summary">
-              {`Page ${page || 1} of ${totalPages}`}
-            </PaginationSummary>
-          )}
-          <Task.Status
-            name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
-            id={ID}
-            startOnRender={{
-              payload: { page, sortby: qsParams.sortby },
-              onSuccessDispatch: REMINDERS__OUTSTANDING_PROPOSITIONS_LOADED,
-            }}
-          >
-            {() => (
-              <>
-                <List data-test="reminders-list">
-                  {results.map(({ id, name, deadline, investment_project }) => (
-                    <ListItem key={id} data-test="reminders-list-item">
-                      <GridRow>
-                        <GridCol>
-                          <ListItemHeader data-test="item-header">
-                            Due {format(deadline, DATE_DAY_LONG_FORMAT)}
-                          </ListItemHeader>
-                          <ListItemContent data-test="item-content">
-                            <Link
-                              href={`${urls.investments.projects.propositions(
-                                investment_project.id
-                              )}`}
-                            >
-                              {name}
-                            </Link>
-                          </ListItemContent>
-                          <ListItemFooter data-test="item-footer">
-                            Project code {investment_project.project_code}
-                          </ListItemFooter>
-                        </GridCol>
-                      </GridRow>
-                    </ListItem>
-                  ))}
-                </List>
-                <RoutedPagination initialPage={page} items={count || 0} />
-              </>
+      <>
+        <Container>
+          <MenuContainer>
+            <RemindersMenu />
+          </MenuContainer>
+          <ListContainer>
+            <CollectionHeader settings={false} totalItems={count} />
+            {results.length === 0 ? (
+              <Summary data-test="no-reminders">You have no reminders.</Summary>
+            ) : (
+              <PaginationSummary data-test="pagination-summary">
+                {`Page ${page || 1} of ${totalPages}`}
+              </PaginationSummary>
             )}
-          </Task.Status>
-        </ListContainer>
-      </Container>
-      <HomeLink data-test="home-link" href={urls.dashboard()}>
-        Home
-      </HomeLink>
+            <Task.Status
+              name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
+              id={ID}
+              startOnRender={{
+                payload: { page, sortby: qsParams.sortby },
+                onSuccessDispatch: REMINDERS__OUTSTANDING_PROPOSITIONS_LOADED,
+              }}
+            >
+              {() => (
+                <>
+                  <List data-test="reminders-list">
+                    {results.map(
+                      ({ id, name, deadline, investment_project }) => (
+                        <ListItem key={id} data-test="reminders-list-item">
+                          <GridRow>
+                            <GridCol>
+                              <ListItemHeader data-test="item-header">
+                                Due {format(deadline, DATE_DAY_LONG_FORMAT)}
+                              </ListItemHeader>
+                              <ListItemContent data-test="item-content">
+                                <Link
+                                  href={`${urls.investments.projects.propositions(
+                                    investment_project.id
+                                  )}`}
+                                >
+                                  {name}
+                                </Link>
+                              </ListItemContent>
+                              <ListItemFooter data-test="item-footer">
+                                Project code {investment_project.project_code}
+                              </ListItemFooter>
+                            </GridCol>
+                          </GridRow>
+                        </ListItem>
+                      )
+                    )}
+                  </List>
+                  <RoutedPagination initialPage={page} items={count || 0} />
+                </>
+              )}
+            </Task.Status>
+          </ListContainer>
+        </Container>
+        <HomeLink data-test="home-link" href={urls.dashboard()}>
+          Home
+        </HomeLink>
+      </>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { SPACING, FONT_SIZE, HEADING_SIZES } from '@govuk-react/constants'
+import {
+  SPACING,
+  FONT_SIZE,
+  HEADING_SIZES,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
 import { Link } from 'govuk-react'
 import { GREY_2 } from 'govuk-colours'
 import GridRow from '@govuk-react/grid-row'
@@ -63,6 +68,27 @@ const PaginationSummary = styled('div')({
     hasReminders ? `solid 1px ${GREY_2}` : 'none',
 })
 
+const Container = styled('div')({
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'flex',
+  },
+})
+
+const MenuContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: 'calc(33% - 20px)',
+    padding: 10,
+  },
+})
+
+const ListContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '67%',
+  },
+})
+
 const OutstandingPropositionReminders = ({
   outstandingPropositionsReminders,
 }) => {
@@ -82,11 +108,11 @@ const OutstandingPropositionReminders = ({
       heading={<Heading preHeading="Reminders for">{subject}</Heading>}
       breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
     >
-      <GridRow>
-        <GridCol setWidth="one-third">
+      <Container>
+        <MenuContainer>
           <RemindersMenu />
-        </GridCol>
-        <GridCol>
+        </MenuContainer>
+        <ListContainer>
           <CollectionHeader settings={false} totalItems={count} />
           <PaginationSummary
             hasReminders={results.length > 0}
@@ -135,8 +161,8 @@ const OutstandingPropositionReminders = ({
               </>
             )}
           </Task.Status>
-        </GridCol>
-      </GridRow>
+        </ListContainer>
+      </Container>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -93,6 +93,16 @@ const ListContainer = styled('div')({
   },
 })
 
+const HomeLink = styled(Link)({
+  display: 'block',
+  marginTop: SPACING.SCALE_4,
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.DESKTOP]: {
+    marginLeft: 25,
+    marginBottom: 25,
+  },
+})
+
 const OutstandingPropositionReminders = ({
   outstandingPropositionsReminders,
 }) => {
@@ -166,6 +176,9 @@ const OutstandingPropositionReminders = ({
           </Task.Status>
         </ListContainer>
       </Container>
+      <HomeLink data-test="home-link" href={urls.dashboard()}>
+        Home
+      </HomeLink>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -8,7 +8,7 @@ import {
   MEDIA_QUERIES,
 } from '@govuk-react/constants'
 import { Link } from 'govuk-react'
-import { GREY_2 } from 'govuk-colours'
+import { BLACK, GREY_1, GREY_2 } from 'govuk-colours'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import styled from 'styled-components'
@@ -59,13 +59,17 @@ const ListItemFooter = styled('div')({
   marginBottom: SPACING.SCALE_4,
 })
 
-const PaginationSummary = styled('div')({
+const Summary = styled('p')({
+  color: BLACK,
+  paddingTop: SPACING.SCALE_2,
+  fontSize: FONT_SIZE.SIZE_19,
+})
+
+const PaginationSummary = styled(Summary)({
+  color: GREY_1,
   fontSize: FONT_SIZE.SIZE_16,
-  color: DARK_GREY,
-  paddingTop: SPACING.SCALE_4,
   paddingBottom: SPACING.SCALE_3,
-  borderBottom: ({ hasReminders }) =>
-    hasReminders ? `solid 1px ${GREY_2}` : 'none',
+  borderBottom: `solid 1px ${GREY_2}`,
 })
 
 const Container = styled('div')({
@@ -114,14 +118,13 @@ const OutstandingPropositionReminders = ({
         </MenuContainer>
         <ListContainer>
           <CollectionHeader settings={false} totalItems={count} />
-          <PaginationSummary
-            hasReminders={results.length > 0}
-            data-test="pagination-summary"
-          >
-            {results.length === 0
-              ? 'You have no reminders.'
-              : `Page ${page || 1} of ${totalPages}`}
-          </PaginationSummary>
+          {results.length === 0 ? (
+            <Summary data-test="no-reminders">You have no reminders.</Summary>
+          ) : (
+            <PaginationSummary data-test="pagination-summary">
+              {`Page ${page || 1} of ${totalPages}`}
+            </PaginationSummary>
+          )}
           <Task.Status
             name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
             id={ID}

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -1,12 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import {
-  SPACING,
-  FONT_SIZE,
-  HEADING_SIZES,
-  MEDIA_QUERIES,
-} from '@govuk-react/constants'
+import { SPACING, FONT_SIZE, HEADING_SIZES } from '@govuk-react/constants'
 import { Link } from 'govuk-react'
 import { BLACK, GREY_1, GREY_2 } from 'govuk-colours'
 import GridRow from '@govuk-react/grid-row'
@@ -22,12 +17,11 @@ import { format } from '../../utils/date'
 import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
 import { maxItemsToPaginate, itemsPerPage } from './constants'
 
-import { DefaultLayout, RoutedPagination } from '../../components'
+import { RoutedPagination } from '../../components'
 import CollectionHeader from './CollectionHeader'
-import RemindersMenu from './RemindersMenu'
+import RemindersLayout from './RemindersLayout'
 import Task from '../../components/Task'
 import urls from '../../../lib/urls'
-import Heading from './Heading'
 
 const List = styled('ol')({
   listStyleType: 'none',
@@ -72,37 +66,6 @@ const PaginationSummary = styled(Summary)({
   borderBottom: `solid 1px ${GREY_2}`,
 })
 
-const Container = styled('div')({
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'flex',
-  },
-})
-
-const MenuContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: 'calc(33% - 20px)',
-    padding: SPACING.SCALE_2,
-  },
-})
-
-const ListContainer = styled('div')({
-  width: '100%',
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '67%',
-  },
-})
-
-const HomeLink = styled(Link)({
-  display: 'block',
-  marginTop: SPACING.SCALE_4,
-  marginBottom: SPACING.SCALE_4,
-  [MEDIA_QUERIES.DESKTOP]: {
-    marginLeft: 25,
-    marginBottom: 25,
-  },
-})
-
 const OutstandingPropositionReminders = ({
   outstandingPropositionsReminders,
 }) => {
@@ -117,73 +80,59 @@ const OutstandingPropositionReminders = ({
   )
 
   return (
-    <DefaultLayout
+    <RemindersLayout
       pageTitle={title}
-      heading={<Heading preHeading="Reminders for">{subject}</Heading>}
-      breadcrumbs={[{ link: urls.dashboard(), text: 'Home' }, { text: title }]}
+      subject={subject}
+      hasSettingsLink={false}
     >
-      <>
-        <Container>
-          <MenuContainer>
-            <RemindersMenu />
-          </MenuContainer>
-          <ListContainer>
-            <CollectionHeader settings={false} totalItems={count} />
-            {results.length === 0 ? (
-              <Summary data-test="no-reminders">You have no reminders.</Summary>
-            ) : (
-              <PaginationSummary data-test="pagination-summary">
-                {`Page ${page || 1} of ${totalPages}`}
-              </PaginationSummary>
-            )}
-            <Task.Status
-              name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
-              id={ID}
-              startOnRender={{
-                payload: { page, sortby: qsParams.sortby },
-                onSuccessDispatch: REMINDERS__OUTSTANDING_PROPOSITIONS_LOADED,
-              }}
-            >
-              {() => (
-                <>
-                  <List data-test="reminders-list">
-                    {results.map(
-                      ({ id, name, deadline, investment_project }) => (
-                        <ListItem key={id} data-test="reminders-list-item">
-                          <GridRow>
-                            <GridCol>
-                              <ListItemHeader data-test="item-header">
-                                Due {format(deadline, DATE_DAY_LONG_FORMAT)}
-                              </ListItemHeader>
-                              <ListItemContent data-test="item-content">
-                                <Link
-                                  href={`${urls.investments.projects.propositions(
-                                    investment_project.id
-                                  )}`}
-                                >
-                                  {name}
-                                </Link>
-                              </ListItemContent>
-                              <ListItemFooter data-test="item-footer">
-                                Project code {investment_project.project_code}
-                              </ListItemFooter>
-                            </GridCol>
-                          </GridRow>
-                        </ListItem>
-                      )
-                    )}
-                  </List>
-                  <RoutedPagination initialPage={page} items={count || 0} />
-                </>
-              )}
-            </Task.Status>
-          </ListContainer>
-        </Container>
-        <HomeLink data-test="home-link" href={urls.dashboard()}>
-          Home
-        </HomeLink>
-      </>
-    </DefaultLayout>
+      <CollectionHeader settings={false} totalItems={count} />
+      {results.length === 0 ? (
+        <Summary data-test="no-reminders">You have no reminders.</Summary>
+      ) : (
+        <PaginationSummary data-test="pagination-summary">
+          {`Page ${page || 1} of ${totalPages}`}
+        </PaginationSummary>
+      )}
+      <Task.Status
+        name={TASK_GET_OUTSTANDING_PROPOSITIONS_REMINDERS}
+        id={ID}
+        startOnRender={{
+          payload: { page, sortby: qsParams.sortby },
+          onSuccessDispatch: REMINDERS__OUTSTANDING_PROPOSITIONS_LOADED,
+        }}
+      >
+        {() => (
+          <>
+            <List data-test="reminders-list">
+              {results.map(({ id, name, deadline, investment_project }) => (
+                <ListItem key={id} data-test="reminders-list-item">
+                  <GridRow>
+                    <GridCol>
+                      <ListItemHeader data-test="item-header">
+                        Due {format(deadline, DATE_DAY_LONG_FORMAT)}
+                      </ListItemHeader>
+                      <ListItemContent data-test="item-content">
+                        <Link
+                          href={`${urls.investments.projects.propositions(
+                            investment_project.id
+                          )}`}
+                        >
+                          {name}
+                        </Link>
+                      </ListItemContent>
+                      <ListItemFooter data-test="item-footer">
+                        Project code {investment_project.project_code}
+                      </ListItemFooter>
+                    </GridCol>
+                  </GridRow>
+                </ListItem>
+              ))}
+            </List>
+            <RoutedPagination initialPage={page} items={count || 0} />
+          </>
+        )}
+      </Task.Status>
+    </RemindersLayout>
   )
 }
 

--- a/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
+++ b/src/client/modules/Reminders/OutstandingPropositionReminders.jsx
@@ -82,7 +82,7 @@ const MenuContainer = styled('div')({
   width: '100%',
   [MEDIA_QUERIES.DESKTOP]: {
     width: 'calc(33% - 20px)',
-    padding: 10,
+    padding: SPACING.SCALE_2,
   },
 })
 

--- a/src/client/modules/Reminders/RemindersLayout.jsx
+++ b/src/client/modules/Reminders/RemindersLayout.jsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
+import styled from 'styled-components'
+import { Link } from 'govuk-react'
+
+import { DefaultLayout } from '../../components'
+import RemindersMenu from './RemindersMenu'
+import Heading from './Heading'
+
+import urls from '../../../lib/urls'
+
+const Container = styled('div')({
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'flex',
+  },
+})
+
+const MenuContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: 'calc(33% - 20px)',
+    padding: SPACING.SCALE_2,
+  },
+})
+
+const SettingsLink = styled(Link)({
+  display: 'block',
+  marginTop: SPACING.SCALE_5,
+  marginBottom: SPACING.SCALE_3,
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'none',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'none',
+  },
+})
+
+const ListContainer = styled('div')({
+  width: '100%',
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '67%',
+  },
+})
+
+const HomeLink = styled(Link)({
+  display: 'block',
+  marginTop: SPACING.SCALE_4,
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.DESKTOP]: {
+    marginLeft: 25,
+    marginBottom: 25,
+  },
+})
+
+const RemindersLayout = ({
+  pageTitle,
+  subject,
+  children,
+  hasSettingsLink = true,
+}) => (
+  <DefaultLayout
+    pageTitle={pageTitle}
+    heading={<Heading preHeading="Reminders for">{subject}</Heading>}
+    breadcrumbs={[
+      { link: urls.dashboard(), text: 'Home' },
+      { text: pageTitle },
+    ]}
+  >
+    <>
+      <Container>
+        <MenuContainer>
+          <RemindersMenu />
+          {hasSettingsLink && (
+            <SettingsLink
+              data-test="reminders-settings-link"
+              href="/reminders/settings"
+            >
+              Reminders settings
+            </SettingsLink>
+          )}
+        </MenuContainer>
+        <ListContainer>{children}</ListContainer>
+      </Container>
+      <HomeLink data-test="home-link" href={urls.dashboard()}>
+        Home
+      </HomeLink>
+    </>
+  </DefaultLayout>
+)
+
+export default RemindersLayout

--- a/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
@@ -265,7 +265,7 @@ describe('Estimated Land Date Reminders', () => {
       cy.get('[data-test="reminders-list-item"]').should('have.length', 10)
       cy.get('[data-test="reminders-list-item"]').eq(4).as('reminder')
 
-      cy.get('@reminder').find('[data-test="delete-button"]').click()
+      cy.get('@reminder').find('[data-test="delete-button"]').eq(1).click()
       cy.wait('@deleteReminder5ApiRequest')
       cy.get('[data-test="reminder-list-header"]').should(
         'contain',

--- a/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
@@ -177,7 +177,7 @@ describe('Estimated Land Date Reminders', () => {
     it('should include a message "You have no reminders"', () => {
       cy.get('[data-test="no-reminders"]').should(
         'contain',
-        'You have no reminders'
+        'You have no reminders.'
       )
     })
   })

--- a/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
@@ -178,7 +178,7 @@ describe('No Recent Interaction Reminders', () => {
     it('should include a message "You have no reminders"', () => {
       cy.get('[data-test="no-reminders"]').should(
         'contain',
-        'You have no reminders'
+        'You have no reminders.'
       )
     })
   })

--- a/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
@@ -266,7 +266,7 @@ describe('No Recent Interaction Reminders', () => {
       cy.get('[data-test="reminders-list-item"]').should('have.length', 10)
       cy.get('[data-test="reminders-list-item"]').eq(4).as('reminder')
 
-      cy.get('@reminder').find('[data-test="delete-button"]').click()
+      cy.get('@reminder').find('[data-test="delete-button"]').eq(1).click()
       cy.wait('@deleteReminder5ApiRequest')
       cy.get('[data-test="reminder-list-header"]').should(
         'contain',

--- a/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
+++ b/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
@@ -202,7 +202,7 @@ describe('Outstanding Proposition Reminders', () => {
     })
 
     it('should include a message "You have no reminders"', () => {
-      cy.get('[data-test="pagination-summary"]').should(
+      cy.get('[data-test="no-reminders"]').should(
         'contain',
         'You have no reminders.'
       )

--- a/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
+++ b/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
@@ -204,7 +204,7 @@ describe('Outstanding Proposition Reminders', () => {
     it('should include a message "You have no reminders"', () => {
       cy.get('[data-test="pagination-summary"]').should(
         'contain',
-        'You have no reminders'
+        'You have no reminders.'
       )
     })
   })


### PR DESCRIPTION
## Description of change

1.  Added a **Home** link to all three reminders pages (_outstanding propositions, no recent interaction, approaching estimated land date_)

2. Changed the main reminder message to black `#0b0c0c` on _approaching estimated and date_ and _no recent interaction reminder_ pages.

3. Added  a period to _You have no reminders_, and changed the font colour to `#0b0c0c` and size to 19px on all three reminders pages.

4. On mobile (320px -> 640px width) the _Reminders settings_ link has been moved above the number of reminders for both _approaching estimated land date_ and _no recent interaction reminder_ pages.

5. On mobile, the _Delete reminder_ link is now aligned to the left of the container on both _approaching estimated land date_ and _no recent interaction reminder_ pages.

6. On tablet (641px -> 768px) the reminders menu now remains on top of the reminders list across _approaching estimated land date_, _no recent interaction reminder_ and _outstanding propositions_. 

7. On tablet, the _Delete reminder_ link is now positioned in the top right-hand corner.

8. Refactor reminders (x3) to use a single layout for consistency and avoid duplication

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

## Test
Go to `/reminders` and open dev tools and play with the UI across the breakpoints (320px, 641px and 769px) to see how the UI responds.

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
