### PR TITLE
Feature/det 171 contact record link

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -10,7 +10,7 @@ const {
 
 const { getGlobalUltimateHierarchy } = require('../../repos')
 const urls = require('../../../../lib/urls')
-const { fetchActivityFeed, fetchAventriAttendeeIDs } = require('./repos')
+const { fetchActivityFeed, fetchMatchingDataHubContact } = require('./repos')
 const config = require('../../../../config')
 
 const {
@@ -301,7 +301,7 @@ async function fetchAventriAttendees(req, res, next) {
       req,
       aventriAttendeeQuery(aventriEventId)
     )
-
+    // istanbul ignore next: Covered by functional tests
     let aventriAttendees = aventriAttendeeResults.hits.hits.map(
       (hit) => hit._source
     )
@@ -316,19 +316,28 @@ async function fetchAventriAttendees(req, res, next) {
 
     const aventriEventData = aventriEventResults.hits.hits[0]._source
 
-    // add the datahub ID to aventri attendees
-
+    // add the datahub ID to aventri attendees object
+    // istanbul ignore next: Covered by functional tests
+    const addDataHubUrlToAttendee = async (attendee) => {
+      const attendeeEmail = attendee.object['dit:aventri:email']
+      let attendeeContactUrl = null
+      if (attendeeEmail) {
+        const dataHubContactResults = await fetchMatchingDataHubContact(
+          req,
+          attendeeEmail
+        )
+        const dataHubContactId = dataHubContactResults?.results[0]?.id
+        attendeeContactUrl = dataHubContactId
+          ? `/contacts/${dataHubContactId}/details`
+          : null
+      }
+      attendee.datahubContactUrl = attendeeContactUrl
+      return attendee
+    }
+    // istanbul ignore next: Covered by functional tests
     aventriAttendees = await Promise.all(
       aventriAttendees.map(async (attendee) => {
-        const aventriIDsResult = await fetchAventriAttendeeIDs(req, attendee)
-        const attendeeIDValue = aventriIDsResult.count
-          ? aventriIDsResult.results[0].id
-          : null
-        const attendeeContactURL = attendeeIDValue
-          ? `/contacts/${attendeeIDValue}/details`
-          : attendeeIDValue
-        attendee.attendeeContactURL = attendeeContactURL
-        return attendee
+        return await addDataHubUrlToAttendee(attendee)
       })
     )
 

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -324,7 +324,10 @@ async function fetchAventriAttendees(req, res, next) {
         const attendeeIDValue = aventriIDsResult.count
           ? aventriIDsResult.results[0].id
           : null
-        attendee.dataHubID = attendeeIDValue
+        const attendeeContactURL = attendeeIDValue
+          ? `/contacts/${attendeeIDValue}/details`
+          : attendeeIDValue
+        attendee.attendeeContactURL = attendeeContactURL
         return attendee
       })
     )

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -8,6 +8,15 @@ function fetchActivityFeed(req, body) {
   })
 }
 
+function fetchAventriAttendeeIDs(req, aventriAttendee) {
+  const attendeeEmail = aventriAttendee.object['dit:aventri:email']
+  return authorisedRequest(req, {
+    method: 'GET',
+    url: `${config.apiRoot}/v3/contact?email=${attendeeEmail}`,
+  })
+}
+
 module.exports = {
   fetchActivityFeed,
+  fetchAventriAttendeeIDs,
 }

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -8,8 +8,9 @@ function fetchActivityFeed(req, body) {
   })
 }
 
-function fetchAventriAttendeeIDs(req, aventriAttendee) {
-  const attendeeEmail = aventriAttendee.object['dit:aventri:email']
+// istanbul ignore next: Covered by functional tests
+function fetchMatchingDataHubContact(req, attendeeEmail) {
+  // istanbul ignore next: Covered by functional tests
   return authorisedRequest(req, {
     method: 'GET',
     url: `${config.apiRoot}/v3/contact?email=${attendeeEmail}`,
@@ -18,5 +19,5 @@ function fetchAventriAttendeeIDs(req, aventriAttendee) {
 
 module.exports = {
   fetchActivityFeed,
-  fetchAventriAttendeeIDs,
+  fetchMatchingDataHubContact,
 }

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { Link as RouterLink } from 'react-router-dom'
+import Link from '@govuk-react/link'
 import CardUtils from './card/CardUtils'
 import { ACTIVITY_TYPE } from '../constants'
 import { GREY_1 } from 'govuk-colours'
@@ -26,6 +28,7 @@ export const transformAventriAttendee = (attendee) => ({
     AVENTRI_ATTENDEE_REG_STATUSES[
       attendee.object['dit:aventri:registrationstatus']
     ],
+  attendeeContactURL: attendee.attendeeContactURL,
 })
 
 const StyledSpan = styled('span')`
@@ -35,8 +38,13 @@ const StyledSpan = styled('span')`
 `
 
 export default function AventriAttendee({ activity: attendee }) {
-  const { attendeeName, eventName, date, registrationStatus } =
-    transformAventriAttendee(attendee)
+  const {
+    attendeeName,
+    eventName,
+    date,
+    registrationStatus,
+    attendeeContactURL,
+  } = transformAventriAttendee(attendee)
 
   return eventName ? (
     <ActivityCardWrapper dataTest="aventri-activity">
@@ -56,7 +64,13 @@ export default function AventriAttendee({ activity: attendee }) {
   ) : (
     <ActivityCardWrapper dataTest="aventri-attendee">
       <ActivityCardSubject dataTest="aventri-attendee-name">
-        {attendeeName}
+        {attendeeContactURL ? (
+          <Link as={RouterLink} to={attendeeContactURL}>
+            {attendeeName}
+          </Link>
+        ) : (
+          attendeeName
+        )}
       </ActivityCardSubject>
     </ActivityCardWrapper>
   )

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link as RouterLink } from 'react-router-dom'
 import Link from '@govuk-react/link'
 import CardUtils from './card/CardUtils'
 import { ACTIVITY_TYPE } from '../constants'
@@ -28,7 +27,7 @@ export const transformAventriAttendee = (attendee) => ({
     AVENTRI_ATTENDEE_REG_STATUSES[
       attendee.object['dit:aventri:registrationstatus']
     ],
-  attendeeContactURL: attendee.attendeeContactURL,
+  contactUrl: attendee.datahubContactUrl,
 })
 
 const StyledSpan = styled('span')`
@@ -38,13 +37,8 @@ const StyledSpan = styled('span')`
 `
 
 export default function AventriAttendee({ activity: attendee }) {
-  const {
-    attendeeName,
-    eventName,
-    date,
-    registrationStatus,
-    attendeeContactURL,
-  } = transformAventriAttendee(attendee)
+  const { attendeeName, eventName, date, registrationStatus, contactUrl } =
+    transformAventriAttendee(attendee)
 
   return eventName ? (
     <ActivityCardWrapper dataTest="aventri-activity">
@@ -64,10 +58,8 @@ export default function AventriAttendee({ activity: attendee }) {
   ) : (
     <ActivityCardWrapper dataTest="aventri-attendee">
       <ActivityCardSubject dataTest="aventri-attendee-name">
-        {attendeeContactURL ? (
-          <Link as={RouterLink} to={attendeeContactURL}>
-            {attendeeName}
-          </Link>
+        {contactUrl ? (
+          <Link href={contactUrl}>{attendeeName}</Link>
         ) : (
           attendeeName
         )}

--- a/test/functional/cypress/specs/events/aventri-attendees-spec.js
+++ b/test/functional/cypress/specs/events/aventri-attendees-spec.js
@@ -10,6 +10,7 @@ const {
 describe('Aventri event attendees', () => {
   const existingEventId = '1111'
   const errorId = '500'
+  const dataHubContactId = '26f61090-df61-446c-b846-60c8bbca522f'
   context('With the feature flag turned on', () => {
     before(() => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
@@ -47,6 +48,33 @@ describe('Aventri event attendees', () => {
 
       it('should display an attendee', () => {
         cy.get('[data-test="aventri-attendee"]').should('exist')
+      })
+
+      context('when you click on the contact name', () => {
+        beforeEach(() => {
+          cy.visit(urls.events.aventri.attendees(existingEventId))
+        })
+        it("should navigate to the contact's detail page if they exist in Data Hub", () => {
+          cy.get('[data-test="aventri-attendee-name"] > a')
+            .eq(0)
+            .should(
+              'have.attr',
+              'href',
+              urls.contacts.details(dataHubContactId)
+            )
+        })
+
+        it("should not navigate anywhere if the contact doesn't exist in Data Hub", () => {
+          cy.get('[data-test="aventri-attendee-name"]')
+            .eq(1)
+            .should('not.have.attr', 'href')
+        })
+
+        it('should not navigate anywhere if the attendee email address field is an empty string', () => {
+          cy.get('[data-test="aventri-attendee-name"]')
+            .eq(2)
+            .should('not.have.attr', 'href')
+        })
       })
     })
 

--- a/test/sandbox/fixtures/v3/contact/contact-aventri.json
+++ b/test/sandbox/fixtures/v3/contact/contact-aventri.json
@@ -1,0 +1,48 @@
+{
+    "count":1,
+    "next":null,
+    "previous":null,
+    "results":[
+        {
+            "id":"26f61090-df61-446c-b846-60c8bbca522f",
+            "title":null,
+            "first_name":"Elle",
+            "last_name":"Woods",
+            "name":"Elle Woods",
+            "job_title":"Harvard Lawyer",
+            "company":{
+            "name":"West End Corp",
+            "id":"c158c18f-8227-4784-bc7d-8800d4907209"
+            },
+            "adviser":{
+            "name":"DIT Staff",
+            "first_name":"DIT",
+            "last_name":"Staff",
+            "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+            },
+            "primary":true,
+            "telephone_countrycode":"",
+            "telephone_number":"",
+            "full_telephone_number":"07489563848",
+            "email":"elle.woods@gmail.com",
+            "address_same_as_company":true,
+            "address_1":null,
+            "address_2":null,
+            "address_town":null,
+            "address_county":null,
+            "address_country":null,
+            "address_postcode":null,
+            "telephone_alternative":null,
+            "email_alternative":null,
+            "notes":null,
+            "accepts_dit_email_marketing":false,
+            "archived":false,
+            "archived_documents_url_path":"",
+            "archived_on":null,
+            "archived_reason":null,
+            "archived_by":null,
+            "created_on":"2019-02-04T15:59:14.267412Z",
+            "modified_on":"2019-02-05T13:17:23.112153Z"
+        }
+    ]
+}

--- a/test/sandbox/fixtures/v3/contact/no-contact.json
+++ b/test/sandbox/fixtures/v3/contact/no-contact.json
@@ -1,0 +1,6 @@
+{
+    "count": 0,
+    "next":null,
+    "previous":null,
+    "results":[]
+}

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
@@ -49,6 +49,42 @@
             "published" : "2022-02-24T11:28:57",
             "type" : "dit:aventri:Attendee"
           }
+        },
+        {
+          "_index" : "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+          "_type" : "_doc",
+          "_id" : "dit:aventri:Event:1111:Attendee:2222:Create",
+          "_score" : 3.6005385,
+          "_source" : {
+            "dit:application" : "aventri",
+            "id" : "dit:aventri:Event:1111:Attendee:2222:Create",
+            "object" : {
+              "attributedTo" : {
+                "id" : "dit:aventri:Event:1111",
+                "type" : "dit:aventri:Event"
+              },
+              "dit:aventri:approvalstatus" : "",
+              "dit:aventri:category" : null,
+              "dit:aventri:companyname" : "Royal Palace",
+              "dit:aventri:createdby" : "attendee",
+              "dit:aventri:email" : "cinders@gmail.com",
+              "dit:aventri:firstname" : "Cindy",
+              "dit:aventri:language" : "eng",
+              "dit:aventri:lastmodified" : "2022-01-24T11:12:13",
+              "dit:aventri:lastname" : "Ella",
+              "dit:aventri:modifiedby" : "attendee",
+              "dit:aventri:registrationstatus" : "Confirmed",
+              "dit:aventri:virtual_event_attendance" : "Yes",
+              "dit:emailAddress" : "cinders@gmail.com",
+              "id" : "dit:aventri:Attendee:2222",
+              "published" : "1970-01-01T00:00:00",
+              "type" : [
+                "dit:aventri:Attendee"
+              ]
+            },
+            "published" : "2022-02-24T11:28:57",
+            "type" : "dit:aventri:Attendee"
+          }
         }
       ]
     }

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
@@ -47,7 +47,8 @@
               ]
             },
             "published" : "2022-02-24T11:28:57",
-            "type" : "dit:aventri:Attendee"
+            "type" : "dit:aventri:Attendee",
+            "datahubContactUrl" : "/contacts/26f61090-df61-446c-b846-60c8bbca522f/details"
           }
         },
         {
@@ -76,6 +77,42 @@
               "dit:aventri:registrationstatus" : "Confirmed",
               "dit:aventri:virtual_event_attendance" : "Yes",
               "dit:emailAddress" : "cinders@gmail.com",
+              "id" : "dit:aventri:Attendee:2222",
+              "published" : "1970-01-01T00:00:00",
+              "type" : [
+                "dit:aventri:Attendee"
+              ]
+            },
+            "published" : "2022-02-24T11:28:57",
+            "type" : "dit:aventri:Attendee"
+          }
+        },
+        {
+          "_index" : "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+          "_type" : "_doc",
+          "_id" : "dit:aventri:Event:1111:Attendee:2222:Create",
+          "_score" : 3.6005385,
+          "_source" : {
+            "dit:application" : "aventri",
+            "id" : "dit:aventri:Event:1111:Attendee:2222:Create",
+            "object" : {
+              "attributedTo" : {
+                "id" : "dit:aventri:Event:1111",
+                "type" : "dit:aventri:Event"
+              },
+              "dit:aventri:approvalstatus" : "",
+              "dit:aventri:category" : null,
+              "dit:aventri:companyname" : "Ever Far Away",
+              "dit:aventri:createdby" : "attendee",
+              "dit:aventri:email" : "",
+              "dit:aventri:firstname" : "Fiona",
+              "dit:aventri:language" : "eng",
+              "dit:aventri:lastmodified" : "2022-01-24T11:12:13",
+              "dit:aventri:lastname" : "Shrek",
+              "dit:aventri:modifiedby" : "attendee",
+              "dit:aventri:registrationstatus" : "Confirmed",
+              "dit:aventri:virtual_event_attendance" : "Yes",
+              "dit:emailAddress" : "",
               "id" : "dit:aventri:Attendee:2222",
               "published" : "1970-01-01T00:00:00",
               "type" : [

--- a/test/sandbox/routes/v3/contact/contact.js
+++ b/test/sandbox/routes/v3/contact/contact.js
@@ -23,11 +23,14 @@ const validateContactForm = function (formData) {
     .map((fieldName) => [fieldName, ['This field may not be null.']])
 }
 
-const matchingAventriDataHubEmail =
-  aventriContact?.hits?.hits[0]?._source.object['dit:emailAddress']
+const AventriEmailWithDataHubMatch =
+  aventriContact.hits?.hits[0]?._source.object['dit:emailAddress']
 
-const notMatchingAventriDataHubEmail =
-  aventriContact?.hits?.hits[1]?._source.object['dit:emailAddress']
+const AventriEmailWithoutDataHubMatch =
+  aventriContact.hits?.hits[1]?._source.object['dit:emailAddress']
+
+const EmptyStringAventriEmail =
+  aventriContact.hits?.hits[2]?._source.object['dit:emailAddress']
 
 exports.contact = function (req, res) {
   // This is here to allow creation of new contacts. The email must contain "new"
@@ -41,10 +44,13 @@ exports.contact = function (req, res) {
     )
     return res.json(contactsForReferral)
   }
-  if (req.query.email === matchingAventriDataHubEmail) {
+  if (req.query.email === AventriEmailWithDataHubMatch) {
     return res.json(ditContactforAventri)
   }
-  if (req.query.email === notMatchingAventriDataHubEmail) {
+  if (
+    req.query.email === AventriEmailWithoutDataHubMatch ||
+    req.query.email === EmptyStringAventriEmail
+  ) {
     return res.json(noContact)
   } else {
     res.json(contact)

--- a/test/sandbox/routes/v3/contact/contact.js
+++ b/test/sandbox/routes/v3/contact/contact.js
@@ -8,6 +8,9 @@ const incompleteUKContact = require('../../../fixtures/v3/contact/contact-incomp
 const contactWithCompanyAddress = require('../../../fixtures/v3/contact/contact-with-company-address.json')
 const contactWithUSAddress = require('../../../fixtures/v3/contact/contact-with-us-address.json')
 const archivedContact = require('../../../fixtures/v3/contact/contact-archived.json')
+const aventriContact = require('../../../fixtures/v4/activity-feed/aventri-attendees.json')
+const ditContactforAventri = require('../../../fixtures/v3/contact/contact-aventri.json')
+const noContact = require('../../../fixtures/v3/contact/no-contact.json')
 
 const lambdaPlc = require('../../../fixtures/v4/company/company-lambda-plc.json')
 const contactCreate = require('../../../fixtures/v3/contact/contact-create.json')
@@ -20,6 +23,12 @@ const validateContactForm = function (formData) {
     .map((fieldName) => [fieldName, ['This field may not be null.']])
 }
 
+const matchingAventriDataHubEmail =
+  aventriContact?.hits?.hits[0]?._source.object['dit:emailAddress']
+
+const notMatchingAventriDataHubEmail =
+  aventriContact?.hits?.hits[1]?._source.object['dit:emailAddress']
+
 exports.contact = function (req, res) {
   // This is here to allow creation of new contacts. The email must contain "new"
   if (req.query.email?.includes('new')) {
@@ -31,6 +40,12 @@ exports.contact = function (req, res) {
       'BEWARE: Lambda PLC uses contacts-for-referral.json rather than contact.json'
     )
     return res.json(contactsForReferral)
+  }
+  if (req.query.email === matchingAventriDataHubEmail) {
+    return res.json(ditContactforAventri)
+  }
+  if (req.query.email === notMatchingAventriDataHubEmail) {
+    return res.json(noContact)
   } else {
     res.json(contact)
   }


### PR DESCRIPTION
## Description of change
This PR adds a hyperlink to the Attendee name. When clicked, this links the user back to the Data hub contact record for that attendee.
If the Attendee does not exist as a Data Hub contact, the attendee name will be displayed without a hyperlink

_Document what the PR does and why the change is needed_
The current behaviour within the Event Attendees page is that the Attendee name becomes a hyperlink back to the contact record. We will need to replicate this for Aventri for data that comes from Activity Stream.

For this ticket, we are going to match the Aventri Attendee to the DH Contact record, using the email address captured in Aventri. We decided as a team to use the first data hub contact that matches as the MVP 

## Test instructions
Ensure you have `user-event-activities` feature flag on.
Visit an Aventri event page e.g. 
http://localhost:3000/events/aventri/1111/attendees?featureTesting=user-event-activities
or 
http://localhost:3000/events/aventri/2222/attendees?featureTesting=user-event-activities

You should see hyperlinked attendee names for those that are linked to a Data Hub contact

## Screenshots
### Before
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/83657534/179728249-3dd595d0-677d-4eea-9f2a-ce70fc970877.png">

### After
<img width="680" alt="image" src="https://user-images.githubusercontent.com/83657534/179728448-c582f85c-7133-4dc6-9148-449b320317e8.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
