### PR TITLE
Paginate events collection list and header count result

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -514,8 +514,12 @@ describe('Activity feed controllers', () => {
   describe('#filtersQueryBuilder', () => {
     context('check dsl query when filtering on event name', () => {
       it('builds the right query when being filtered by event name', () => {
+        const page = 1
+        const size = 10
         const name = 'cool event'
         const expectedEsQuery = {
+          page,
+          size,
           query: {
             bool: {
               must: [
@@ -542,6 +546,8 @@ describe('Activity feed controllers', () => {
 
         const actualQuery = activityFeedEventsQuery({
           fullQuery: eventsColListQueryBuilder(name),
+          page,
+          size,
           sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
         })
 
@@ -549,8 +555,12 @@ describe('Activity feed controllers', () => {
       })
 
       it('builds the right query when there is nothing entered into the event name filter', () => {
+        const page = 1
+        const size = 10
         const name = undefined
         const expectedEsQuery = {
+          page,
+          size,
           query: {
             bool: {
               must: [
@@ -571,6 +581,8 @@ describe('Activity feed controllers', () => {
         }
 
         const actualQuery = activityFeedEventsQuery({
+          page,
+          size,
           fullQuery: eventsColListQueryBuilder(name),
           sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
         })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -374,12 +374,16 @@ const eventsColListQueryBuilder = (name) => {
 
 async function fetchAllActivityFeedEvents(req, res, next) {
   try {
-    const { sortBy, name } = req.query
+    const { sortBy, page, name } = req.query
+
+    const from = (page - 1) * ACTIVITIES_PER_PAGE
 
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
       allActivityFeedEventsQuery({
         fullQuery: eventsColListQueryBuilder(name),
+        from,
+        ACTIVITIES_PER_PAGE,
         sort:
           EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
           EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -386,12 +386,14 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       })
     )
 
+    const total = allActivityFeedEventsResults.hits.total.value
     const allActivityFeedEvents = allActivityFeedEventsResults.hits.hits.map(
       (hit) => hit._source
     )
 
     res.json({
       allActivityFeedEvents,
+      total,
     })
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,4 +1,6 @@
-const activityFeedEventsQuery = ({ fullQuery, sort }) => ({
+const activityFeedEventsQuery = ({ fullQuery, page, size, sort }) => ({
+  page,
+  size,
   query: {
     bool: {
       must: fullQuery,

--- a/src/client/modules/Events/CollectionList/constants.js
+++ b/src/client/modules/Events/CollectionList/constants.js
@@ -30,3 +30,18 @@ export const SORT_OPTIONS = [
     value: 'start_date:desc',
   },
 ]
+
+export const COLLECTION_LIST_SORT_SELECT_OPTIONS = [
+  {
+    name: 'Recently updated',
+    value: 'modified_on:desc',
+  },
+  {
+    name: 'Least recently updated',
+    value: 'modified_on:asc',
+  },
+  {
+    name: 'Event name A-Z',
+    value: 'name:asc',
+  },
+]

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -17,6 +17,7 @@ import {
   DefaultLayout,
   CollectionSort,
   CollectionHeader,
+  RoutedPagination,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
@@ -49,6 +50,7 @@ const EventsCollection = ({
   selectedFilters,
   allActivityFeedEvents,
   total,
+  page = 1,
   itemsPerPage = 10,
   maxItemsToPaginate = 10000,
   ...props
@@ -235,6 +237,7 @@ const EventsCollection = ({
           )
         }
       </CheckUserFeatureFlag>
+      <RoutedPagination initialPage={page} items={total} />
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -16,6 +16,7 @@ import {
   FilterToggleSection,
   DefaultLayout,
   CollectionSort,
+  CollectionHeader,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
@@ -26,7 +27,7 @@ import {
   ToggleHeadingPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
-import { LABELS } from './constants'
+import { LABELS, COLLECTION_LIST_SORT_SELECT_OPTIONS } from './constants'
 
 import Task from '../../../components/Task'
 
@@ -47,8 +48,14 @@ const EventsCollection = ({
   optionMetadata,
   selectedFilters,
   allActivityFeedEvents,
+  total,
+  itemsPerPage = 10,
+  maxItemsToPaginate = 10000,
   ...props
 }) => {
+  const totalPages = Math.ceil(
+    Math.min(total, maxItemsToPaginate) / itemsPerPage
+  )
   const collectionListTask = {
     name: TASK_GET_EVENTS_LIST,
     id: ID,
@@ -180,22 +187,14 @@ const EventsCollection = ({
             </FilteredCollectionList>
           ) : (
             <>
+              <CollectionHeader
+                totalItems={total}
+                collectionName="events"
+                data-test="collection-header"
+              />
               <CollectionSort
-                //TODO these can be replaces by SORT_OPTIONS when they eventually match
-                sortOptions={[
-                  {
-                    name: 'Recently updated',
-                    value: 'modified_on:desc',
-                  },
-                  {
-                    name: 'Least recently updated',
-                    value: 'modified_on:asc',
-                  },
-                  {
-                    name: 'Event name A-Z',
-                    value: 'name:asc',
-                  },
-                ]}
+                sortOptions={COLLECTION_LIST_SORT_SELECT_OPTIONS}
+                totalPages={totalPages}
               />
               <Task.Status
                 name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -50,7 +50,7 @@ const EventsCollection = ({
   selectedFilters,
   allActivityFeedEvents,
   total,
-  page = 1,
+  page,
   itemsPerPage = 10,
   maxItemsToPaginate = 10000,
   ...props

--- a/src/client/modules/Events/CollectionList/state.js
+++ b/src/client/modules/Events/CollectionList/state.js
@@ -38,6 +38,7 @@ export const state2props = ({ router, ...state }) => {
   return {
     ...state[ID],
     payload: { ...queryParams },
+    page: queryParams.page,
     optionMetadata: {
       sortOptions: SORT_OPTIONS,
       ...metadata,

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -49,10 +49,10 @@ const getEventsMetadata = () =>
     }))
     .catch(handleError)
 
-const getAllActivityFeedEvents = ({ sortby, name }) =>
+const getAllActivityFeedEvents = ({ sortby, page, name }) =>
   axios
     .get(urls.events.activity.data(), {
-      params: { sortBy: sortby, name: name },
+      params: { sortBy: sortby, page, name },
     })
     .then(({ data }) => data)
     .catch(() => Promise.reject('Unable to load events.'))

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -153,6 +153,17 @@ describe('Event Collection List Page - React', () => {
         cy.get('@aventriEvents').eq(0).as('firstAventriEvent')
       })
 
+      it('should display the events result count header', () => {
+        cy.get('[data-test="collection-header"]').should(
+          'have.text',
+          '82 events'
+        )
+      })
+
+      it('should display the expected number of pages', () => {
+        cy.get('[data-test=pagination-summary]').contains('Page 1 of 9')
+      })
+
       it('should not display the data hub API collection list', () => {
         cy.get('[data-test="collection-list"]').should('not.exist')
       })

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -240,15 +240,16 @@ describe('Event Collection List Page - React', () => {
         beforeEach(() => {
           cy.intercept(
             'GET',
-            `${events.activity.data()}?sortBy=modified_on:desc`
+            `${events.activity.data()}?sortBy=modified_on:desc&page=1`
           ).as('recentlyUpdatedRequest')
           cy.intercept(
             'GET',
-            `${events.activity.data()}?sortBy=modified_on:asc`
+            `${events.activity.data()}?sortBy=modified_on:asc&page=1`
           ).as('leastRecentlyUpdatedRequest')
-          cy.intercept('GET', `${events.activity.data()}?sortBy=name:asc`).as(
-            'nameRequest'
-          )
+          cy.intercept(
+            'GET',
+            `${events.activity.data()}?sortBy=name:asc&page=1`
+          ).as('nameRequest')
           cy.visit(events.index())
         })
 
@@ -294,7 +295,7 @@ describe('Event Collection List Page - React', () => {
         before(() => {
           cy.intercept(
             'GET',
-            `${events.activity.data()}?sortBy=modified_on:desc`,
+            `${events.activity.data()}?sortBy=modified_on:desc&page=1`,
             { statusCode: 500 }
           )
           cy.visit(urls.events.index())

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -276,6 +276,16 @@ describe('Event Collection List Page - React', () => {
           cy.get('@aventriEvents').should('have.length', 0)
         })
       })
+
+      context('when there are more than 10 events', () => {
+        it('should be possible to page through', () => {
+          cy.get('[data-page-number="2"]').click()
+          cy.get('[data-test=pagination-summary]').contains('Page 2 of 9')
+          cy.get('@firstDataHubEvent')
+            .find('[data-test="data-hub-event-name"]')
+            .should('exist')
+        })
+      })
     })
 
     context(

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -26,9 +26,6 @@ var aventriAttendeesNewOrder = require('../../../fixtures/v4/activity-feed/avent
 
 //All Activitiy feed events
 var allActivityFeedEvents = require('../../../fixtures/v4/activity-feed/all-activity-feed-events.json')
-const {
-  ACTIVITIES_PER_PAGE,
-} = require('../../../../../src/apps/contacts/constants')
 
 const DATA_HUB_ACTIVITY = [
   'dit:Interaction',
@@ -46,6 +43,8 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
 ]
 
 const ALL_ACTIVITY_STREAM_EVENTS = ['dit:aventri:Event', 'dit:dataHub:Event']
+
+const ALL_ACTIVITIES_PER_PAGE = 10
 
 const VENUS_LTD = 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611'
 
@@ -100,7 +99,7 @@ exports.activityFeed = function (req, res) {
     const { sort, from } = req.body
 
     //if page 2
-    if (from == ACTIVITIES_PER_PAGE) {
+    if (from == ALL_ACTIVITIES_PER_PAGE) {
       return res.json(allActivityFeedEvents)
     }
 

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -26,6 +26,9 @@ var aventriAttendeesNewOrder = require('../../../fixtures/v4/activity-feed/avent
 
 //All Activitiy feed events
 var allActivityFeedEvents = require('../../../fixtures/v4/activity-feed/all-activity-feed-events.json')
+const {
+  ACTIVITIES_PER_PAGE,
+} = require('../../../../../src/apps/contacts/constants')
 
 const DATA_HUB_ACTIVITY = [
   'dit:Interaction',
@@ -41,6 +44,8 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
   ...DATA_HUB_ACTIVITY,
   ...EXTERNAL_ACTIVITY,
 ]
+
+const ALL_ACTIVITY_STREAM_EVENTS = ['dit:aventri:Event', 'dit:dataHub:Event']
 
 const VENUS_LTD = 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611'
 
@@ -81,12 +86,24 @@ exports.activityFeed = function (req, res) {
     }
   }
 
-  var isAllActivityStreamEvents =
-    get(req.body, "query.bool.must[0].terms['object.type'][0]") ===
-    'dit:aventri:Event'
+  var allActivityStreamEventTypes = get(
+    req.body,
+    "query.bool.must[0].terms['object.type']"
+  )
+
+  var isAllActivityStreamEvents = isEqual(
+    allActivityStreamEventTypes,
+    ALL_ACTIVITY_STREAM_EVENTS
+  )
 
   if (isAllActivityStreamEvents) {
-    const { sort } = req.body
+    const { sort, from } = req.body
+
+    //if page 2
+    if (from == ACTIVITIES_PER_PAGE) {
+      return res.json(allActivityFeedEvents)
+    }
+
     // if the sort by is recently updated (modified_on:desc)
     if (sort['object.updated']?.order === 'desc') {
       return res.json(allActivityFeedEvents)


### PR DESCRIPTION
## Description of change

To provide a new Events collection list header, page indicator and pagination of the page.

## Test instructions

- Activates events-user-feature-flag from dev-api Django Admin.
- Navigate DH-CRM Events page, then see the events collection list
- Events collection list header, page indicator and pagination is functional

## Screenshots
### Before

![image](https://user-images.githubusercontent.com/28296624/180270040-393c0443-73f7-451e-a725-b04037c5ca50.png)

### After

![image](https://user-images.githubusercontent.com/28296624/180269838-5199af0f-a77d-4a41-a216-b53f8bdc120b.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
