### PR TITLE
Sort Aventri Attendees

### DIFF
--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -39,6 +39,21 @@ const CONTACT_ACTIVITY_SORT_SELECT_OPTIONS = [
   { name: 'Oldest', value: 'oldest' },
 ]
 
+const EVENT_ATTENDEES_SORT_OPTIONS = {
+  'first_name:asc': {
+    'object.dit:firstName': {
+      order: 'asc',
+      unmapped_type: 'string',
+    },
+  },
+  'first_name:desc': {
+    'object.dit:firstName': {
+      order: 'desc',
+      unmapped_type: 'string',
+    },
+  },
+}
+
 const EVENT_ACTIVITY_SORT_OPTIONS = {
   'modified_on:asc': {
     'object.updated': {
@@ -81,6 +96,7 @@ const DATA_HUB_AND_EXTERNAL_ACTIVITY = [
 
 module.exports = {
   CONTACT_ACTIVITY_FEATURE_FLAG,
+  EVENT_ATTENDEES_SORT_OPTIONS,
   EVENT_ACTIVITY_FEATURE_FLAG,
   EVENT_ACTIVITY_SORT_OPTIONS,
   FILTER_KEYS,

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -6,6 +6,7 @@ const {
   DATA_HUB_AND_EXTERNAL_ACTIVITY,
   CONTACT_ACTIVITY_SORT_SEARCH_OPTIONS,
   EVENT_ACTIVITY_SORT_OPTIONS,
+  EVENT_ATTENDEES_SORT_OPTIONS,
 } = require('./constants')
 
 const { getGlobalUltimateHierarchy } = require('../../repos')
@@ -294,20 +295,23 @@ async function fetchAventriEvent(req, res, next) {
 }
 
 async function fetchAventriAttendees(req, res, next) {
-  const aventriEventId = req.params.aventriEventId
+  // istanbul ignore next: Covered by functional tests
   try {
+    const eventId = req.params.aventriEventId
+
+    const sort = EVENT_ATTENDEES_SORT_OPTIONS[req.query.sortBy]
+
     //get the attendees
     const aventriAttendeeResults = await fetchActivityFeed(
       req,
-      aventriAttendeeQuery(aventriEventId)
+      aventriAttendeeQuery({ eventId, sort })
     )
     // istanbul ignore next: Covered by functional tests
     let aventriAttendees = aventriAttendeeResults.hits.hits.map(
       (hit) => hit._source
     )
 
-    //get the event
-    const formattedAventriEventId = `dit:aventri:Event:${aventriEventId}:Create`
+    const formattedAventriEventId = `dit:aventri:Event:${eventId}:Create`
 
     const aventriEventResults = await fetchActivityFeed(
       req,

--- a/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
@@ -1,4 +1,4 @@
-const aventriAttendeeQuery = (eventId) => ({
+const aventriAttendeeQuery = ({ eventId, sort }) => ({
   query: {
     bool: {
       must: [
@@ -15,6 +15,7 @@ const aventriAttendeeQuery = (eventId) => ({
       ],
     },
   },
+  sort,
 })
 
 module.exports = { aventriAttendeeQuery }

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -3,7 +3,12 @@ import { connect } from 'react-redux'
 import { useParams } from 'react-router-dom'
 
 import urls from '../../../../lib/urls'
-import { DefaultLayout, LocalNav, LocalNavLink } from '../../../components'
+import {
+  CollectionSort,
+  DefaultLayout,
+  LocalNav,
+  LocalNavLink,
+} from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import { GridCol, GridRow } from 'govuk-react'
@@ -13,7 +18,11 @@ import { EVENTS__AVENTRI_ATTENDEES_LOADED } from '../../../actions'
 import Activity from '../../../components/ActivityFeed/Activity'
 import ActivityList from '../../../components/ActivityFeed/activities/card/ActivityList'
 
-const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
+const EventAventriAttendees = ({
+  aventriAttendees,
+  aventriEventData,
+  selectedSortBy,
+}) => {
   const { aventriEventId } = useParams()
   const eventName = aventriEventData?.object.name
   const breadcrumbs = [
@@ -45,7 +54,7 @@ const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
               id={ID}
               progressMessage="Loading Aventri attendees"
               startOnRender={{
-                payload: aventriEventId,
+                payload: { aventriEventId, selectedSortBy },
                 onSuccessDispatch: EVENTS__AVENTRI_ATTENDEES_LOADED,
               }}
             >
@@ -68,6 +77,18 @@ const EventAventriAttendees = ({ aventriAttendees, aventriEventData }) => {
                     </LocalNav>
                   </GridCol>
                   <GridCol setWidth="three-quarters">
+                    <CollectionSort
+                      sortOptions={[
+                        {
+                          name: 'First name:A-Z',
+                          value: 'first_name:asc',
+                        },
+                        {
+                          name: 'First name:Z-A',
+                          value: 'first_name:desc',
+                        },
+                      ]}
+                    />
                     <ActivityList>
                       {aventriAttendees?.map((attendee, index) => (
                         <li key={`aventri-attendee-${index}`}>

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -80,11 +80,11 @@ const EventAventriAttendees = ({
                     <CollectionSort
                       sortOptions={[
                         {
-                          name: 'First name:A-Z',
+                          name: 'First name: A-Z',
                           value: 'first_name:asc',
                         },
                         {
-                          name: 'First name:Z-A',
+                          name: 'First name: Z-A',
                           value: 'first_name:desc',
                         },
                       ]}

--- a/src/client/modules/Events/EventAventriAttendees/state.js
+++ b/src/client/modules/Events/EventAventriAttendees/state.js
@@ -1,10 +1,16 @@
+import qs from 'qs'
+
 export const TASK_GET_EVENT_AVENTRI_ATTENDEES =
   'TASK_GET_EVENT_AVENTRI_ATTENDEES'
 
 export const ID = 'eventAventriAttendees'
 
 export const state2props = ({ ...state }) => {
+  const selectedSortBy =
+    qs.parse(location.search.slice(1)).sortby || 'first_name:asc'
+
   return {
+    selectedSortBy,
     ...state[ID],
   }
 }

--- a/src/client/modules/Events/EventAventriAttendees/tasks.js
+++ b/src/client/modules/Events/EventAventriAttendees/tasks.js
@@ -1,9 +1,14 @@
 const { default: axios } = require('axios')
 const urls = require('../../../../lib/urls')
 
-export const getEventAventriAttendees = (aventriEventId) => {
+export const getEventAventriAttendees = ({
+  aventriEventId,
+  selectedSortBy,
+}) => {
   return axios
-    .get(urls.events.aventri.attendeesData(aventriEventId))
+    .get(urls.events.aventri.attendeesData(aventriEventId), {
+      params: { sortBy: selectedSortBy },
+    })
     .then(({ data }) => data)
     .catch(() => {
       return Promise.reject('Unable to load Aventri Attendees.')

--- a/test/functional/cypress/specs/events/aventri-attendees-spec.js
+++ b/test/functional/cypress/specs/events/aventri-attendees-spec.js
@@ -76,6 +76,41 @@ describe('Aventri event attendees', () => {
             .should('not.have.attr', 'href')
         })
       })
+
+      context('when sorting', () => {
+        beforeEach(() => {
+          cy.intercept(
+            'GET',
+            `${urls.events.aventri.attendeesData(
+              existingEventId
+            )}?sortBy=first_name:asc`
+          ).as('firstNameA-Z')
+          cy.intercept(
+            'GET',
+            `${urls.events.aventri.attendeesData(
+              existingEventId
+            )}?sortBy=first_name:desc`
+          ).as('firstNameZ-A')
+          cy.visit(urls.events.aventri.attendees(existingEventId))
+        })
+
+        it('should sort by "first name: A-Z" by default', () => {
+          cy.wait('@firstNameA-Z').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
+        it('sorts by "first name: Z-A" when selected', () => {
+          const element = '[data-test="sortby"] select'
+          cy.get(element).select('first_name:desc')
+          cy.wait('@firstNameZ-A').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+          cy.get('[data-test="aventri-attendee"]')
+            .eq(0)
+            .should('contain', 'Polly Parton')
+        })
+      })
     })
 
     context('With errors', () => {

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-new-order.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-new-order.json
@@ -1,0 +1,91 @@
+{
+  "took": 702,
+  "timed_out": false,
+  "_shards": {
+    "total": 286,
+    "successful": 286,
+    "skipped": 162,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 2,
+      "relation": "eq"
+    },
+    "max_score": 3.6005385,
+    "hits": [
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Nine to Five",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "polly@example.com",
+            "dit:aventri:firstname": "Polly",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Parton",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "polly@example.com",
+            "dit:firstName": "Polly",
+            "dit:lastName": "Parton",
+            "id": "dit:aventri:Attendee:1234",
+            "published": "2022-02-25T11:28:57",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-25T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:1111:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:1111:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "West End Corp",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "elle.woods@example.com",
+            "dit:aventri:firstname": "Elle",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Woods",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "elle.woods@example.com",
+            "dit:firstName": "Elle",
+            "dit:lastName": "Woods",
+            "id": "dit:aventri:Attendee:1234",
+            "published": "1970-01-01T00:00:00",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      }
+    ]
+  }
+}

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
@@ -1,128 +1,128 @@
 {
-    "took" : 702,
-    "timed_out" : false,
-    "_shards" : {
-      "total" : 286,
-      "successful" : 286,
-      "skipped" : 162,
-      "failed" : 0
+  "took": 702,
+  "timed_out": false,
+  "_shards": {
+    "total": 286,
+    "successful": 286,
+    "skipped": 162,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 2,
+      "relation": "eq"
     },
-    "hits" : {
-      "total" : {
-        "value" : 2,
-        "relation" : "eq"
-      },
-      "max_score" : 3.6005385,
-      "hits" : [
-        {
-          "_index" : "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
-          "_type" : "_doc",
-          "_id" : "dit:aventri:Event:1111:Attendee:1111:Create",
-          "_score" : 3.6005385,
-          "_source" : {
-            "dit:application" : "aventri",
-            "id" : "dit:aventri:Event:1111:Attendee:1111:Create",
-            "object" : {
-              "attributedTo" : {
-                "id" : "dit:aventri:Event:1111",
-                "type" : "dit:aventri:Event"
-              },
-              "dit:aventri:approvalstatus" : "",
-              "dit:aventri:category" : null,
-              "dit:aventri:companyname" : "West End Corp",
-              "dit:aventri:createdby" : "attendee",
-              "dit:aventri:email" : "elle.woods@gmail.com",
-              "dit:aventri:firstname" : "Elle",
-              "dit:aventri:language" : "eng",
-              "dit:aventri:lastmodified" : "2022-01-24T11:12:13",
-              "dit:aventri:lastname" : "Woods",
-              "dit:aventri:modifiedby" : "attendee",
-              "dit:aventri:registrationstatus" : "Confirmed",
-              "dit:aventri:virtual_event_attendance" : "Yes",
-              "dit:emailAddress" : "elle.woods@gmail.com",
-              "id" : "dit:aventri:Attendee:1234",
-              "published" : "1970-01-01T00:00:00",
-              "type" : [
-                "dit:aventri:Attendee"
-              ]
+    "max_score": 3.6005385,
+    "hits": [
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:1111:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:1111:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
             },
-            "published" : "2022-02-24T11:28:57",
-            "type" : "dit:aventri:Attendee",
-            "datahubContactUrl" : "/contacts/26f61090-df61-446c-b846-60c8bbca522f/details"
-          }
-        },
-        {
-          "_index" : "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
-          "_type" : "_doc",
-          "_id" : "dit:aventri:Event:1111:Attendee:2222:Create",
-          "_score" : 3.6005385,
-          "_source" : {
-            "dit:application" : "aventri",
-            "id" : "dit:aventri:Event:1111:Attendee:2222:Create",
-            "object" : {
-              "attributedTo" : {
-                "id" : "dit:aventri:Event:1111",
-                "type" : "dit:aventri:Event"
-              },
-              "dit:aventri:approvalstatus" : "",
-              "dit:aventri:category" : null,
-              "dit:aventri:companyname" : "Royal Palace",
-              "dit:aventri:createdby" : "attendee",
-              "dit:aventri:email" : "cinders@gmail.com",
-              "dit:aventri:firstname" : "Cindy",
-              "dit:aventri:language" : "eng",
-              "dit:aventri:lastmodified" : "2022-01-24T11:12:13",
-              "dit:aventri:lastname" : "Ella",
-              "dit:aventri:modifiedby" : "attendee",
-              "dit:aventri:registrationstatus" : "Confirmed",
-              "dit:aventri:virtual_event_attendance" : "Yes",
-              "dit:emailAddress" : "cinders@gmail.com",
-              "id" : "dit:aventri:Attendee:2222",
-              "published" : "1970-01-01T00:00:00",
-              "type" : [
-                "dit:aventri:Attendee"
-              ]
-            },
-            "published" : "2022-02-24T11:28:57",
-            "type" : "dit:aventri:Attendee"
-          }
-        },
-        {
-          "_index" : "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
-          "_type" : "_doc",
-          "_id" : "dit:aventri:Event:1111:Attendee:2222:Create",
-          "_score" : 3.6005385,
-          "_source" : {
-            "dit:application" : "aventri",
-            "id" : "dit:aventri:Event:1111:Attendee:2222:Create",
-            "object" : {
-              "attributedTo" : {
-                "id" : "dit:aventri:Event:1111",
-                "type" : "dit:aventri:Event"
-              },
-              "dit:aventri:approvalstatus" : "",
-              "dit:aventri:category" : null,
-              "dit:aventri:companyname" : "Ever Far Away",
-              "dit:aventri:createdby" : "attendee",
-              "dit:aventri:email" : "",
-              "dit:aventri:firstname" : "Fiona",
-              "dit:aventri:language" : "eng",
-              "dit:aventri:lastmodified" : "2022-01-24T11:12:13",
-              "dit:aventri:lastname" : "Shrek",
-              "dit:aventri:modifiedby" : "attendee",
-              "dit:aventri:registrationstatus" : "Confirmed",
-              "dit:aventri:virtual_event_attendance" : "Yes",
-              "dit:emailAddress" : "",
-              "id" : "dit:aventri:Attendee:2222",
-              "published" : "1970-01-01T00:00:00",
-              "type" : [
-                "dit:aventri:Attendee"
-              ]
-            },
-            "published" : "2022-02-24T11:28:57",
-            "type" : "dit:aventri:Attendee"
-          }
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "West End Corp",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "elle.woods@example.com",
+            "dit:aventri:firstname": "Elle",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Woods",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "elle.woods@example.com",
+            "dit:firstName": "Elle",
+            "dit:lastName": "Woods",
+            "id": "dit:aventri:Attendee:1234",
+            "published": "1970-01-01T00:00:00",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee",
+          "datahubContactUrl": "/contacts/26f61090-df61-446c-b846-60c8bbca522f/details"
         }
-      ]
-    }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Royal Palace",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "cinders@gmail.com",
+            "dit:aventri:firstname": "Cindy",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Ella",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "cinders@gmail.com",
+            "dit:firstName": "Cindy",
+            "dit:lastName": "Ella",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Fiona",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Shrek",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Fiona",
+            "dit:lastName": "Shrek",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": ["dit:aventri:Attendee"]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      }
+    ]
   }
+}

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -22,6 +22,7 @@ var dataHubEvents = require('../../../fixtures/v4/activity-feed/data-hub-events.
 var aventriEvents = require('../../../fixtures/v4/activity-feed/aventri-events.json')
 var aventriEventsNoDetails = require('../../../fixtures/v4/activity-feed/aventri-events-no-details.json')
 var aventriAttendees = require('../../../fixtures/v4/activity-feed/aventri-attendees.json')
+var aventriAttendeesNewOrder = require('../../../fixtures/v4/activity-feed/aventri-attendees-new-order.json')
 
 //All Activitiy feed events
 var allActivityFeedEvents = require('../../../fixtures/v4/activity-feed/all-activity-feed-events.json')
@@ -141,6 +142,11 @@ exports.activityFeed = function (req, res) {
     // network error
     if (aventriId === 'dit:aventri:Event:500') {
       return res.status(500).send('something went wrong')
+    }
+    //sort by first name desc
+    var firstNameOrder = req.body.sort['object.dit:firstName']?.order
+    if (firstNameOrder === 'desc') {
+      return res.json(aventriAttendeesNewOrder)
     }
     // happy path
     return res.json(aventriAttendees)


### PR DESCRIPTION
## Description of change

We would like to sort Aventri Attendees by first name A-Z and Z-A.

## Test instructions

With the `user-event-activities` feature flag on
on this page http://localhost:3000/events/aventri/1111/attendees?featureTesting=user-event-activities it should be possible to sort the attendees by first name.

## Screenshots
### Before
![Screenshot 2022-07-22 at 14 24 46](https://user-images.githubusercontent.com/16647486/180448639-aee00dea-5878-408f-9fc4-5dcb004204dc.png)

_Add a screenshot_

### After
![Screenshot 2022-07-22 at 14 25 50](https://user-images.githubusercontent.com/16647486/180448662-d4058610-34f3-4ea3-aeb4-2cc23f5a2935.png)

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
