### PR TITLE
Improve form validation by providing better error messages to the user

### DIFF
--- a/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
+++ b/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
@@ -32,6 +32,14 @@ const StyledFieldInput = styled(FieldInput)({
   width: 50,
 })
 
+const MAX_DAYS = 32767 // Set on the API endpoint (DB constraint)
+const POSITIVE_INT_REGEX = /^[0-9]+$/
+const EMPTY_ERR_MSG = 'Enter when you want to get reminders for your projects'
+const MIN_ERR_MSG = 'Enter a whole number that’s 1 or higher, like 25'
+const MAX_ERR_MSG = `Enter a whole number that’s less than or equal to ${MAX_DAYS}`
+
+const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
+
 const NoRecentInteractionForm = () => (
   <DefaultLayout
     heading={
@@ -94,15 +102,24 @@ const NoRecentInteractionForm = () => (
                         >
                           {({ groupIndex }) => (
                             <StyledFieldInput
-                              type="number"
+                              type="text"
                               text="days with no interaction"
                               name={`reminder_days_${groupIndex}`}
                               data-test={`reminder_days_${groupIndex}`}
-                              validate={(value) =>
-                                value
-                                  ? null
-                                  : 'Enter when you want to get reminders for your projects'
-                              }
+                              validate={(value) => {
+                                if (isPositiveInteger(value)) {
+                                  const val = parseInt(value, 10)
+                                  return val === 0
+                                    ? MIN_ERR_MSG
+                                    : val > MAX_DAYS
+                                    ? MAX_ERR_MSG
+                                    : null
+                                } else {
+                                  return isEmpty(value)
+                                    ? EMPTY_ERR_MSG
+                                    : MIN_ERR_MSG
+                                }
+                              }}
                             />
                           )}
                         </FieldAddAnother>

--- a/test/functional/cypress/specs/reminders/settings/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/no-recent-interaction-spec.js
@@ -356,6 +356,61 @@ describe('Edit no recent interaction', () => {
         )
       })
     })
+
+    it('should display an error when the value is negative', () => {
+      cy.get('[data-test="reminders-yes"]').check()
+      cy.get('[data-test="reminder_days_0"]').clear()
+      cy.get('[data-test="reminder_days_0"]').type('-1')
+      cy.get('[data-test="submit-button"]').click()
+      cy.get('[data-test="summary-form-errors"] ul > li').should(
+        'contain',
+        'Enter a whole number that’s 1 or higher, like 25'
+      )
+    })
+
+    it('should display an error on any non-numerical value', () => {
+      cy.get('[data-test="reminders-yes"]').check()
+      cy.get('[data-test="reminder_days_0"]').clear()
+      cy.get('[data-test="reminder_days_0"]').type('t')
+      cy.get('[data-test="submit-button"]').click()
+      cy.get('[data-test="summary-form-errors"] ul > li').should(
+        'contain',
+        'Enter a whole number that’s 1 or higher, like 25'
+      )
+    })
+
+    it('should display an error on a floating point values', () => {
+      cy.get('[data-test="reminders-yes"]').check()
+      cy.get('[data-test="reminder_days_0"]').clear()
+      cy.get('[data-test="reminder_days_0"]').type('1.5')
+      cy.get('[data-test="submit-button"]').click()
+      cy.get('[data-test="summary-form-errors"] ul > li').should(
+        'contain',
+        'Enter a whole number that’s 1 or higher, like 25'
+      )
+    })
+
+    it('should display an error when the value is zero', () => {
+      cy.get('[data-test="reminders-yes"]').check()
+      cy.get('[data-test="reminder_days_0"]').clear()
+      cy.get('[data-test="reminder_days_0"]').type('0')
+      cy.get('[data-test="submit-button"]').click()
+      cy.get('[data-test="summary-form-errors"] ul > li').should(
+        'contain',
+        'Enter a whole number that’s 1 or higher, like 25'
+      )
+    })
+
+    it('should display an error when the value has breached the limit', () => {
+      cy.get('[data-test="reminders-yes"]').check()
+      cy.get('[data-test="reminder_days_0"]').clear()
+      cy.get('[data-test="reminder_days_0"]').type('32768')
+      cy.get('[data-test="submit-button"]').click()
+      cy.get('[data-test="summary-form-errors"] ul > li').should(
+        'contain',
+        'Enter a whole number that’s less than or equal to 32767'
+      )
+    })
   })
 
   context('Form submission', () => {


### PR DESCRIPTION
## Description of change

This PR improves the **Settings for projects with no recent interaction** form validation by providing specific error messages allowing users to correct themselves.

## Test instructions
Go to `/reminders/settings/no-recent-interaction` and answer **Yes** to **Do you want to get reminders for projects with no recent interaction?** then add some days and save.

## Screen
<img width="987" alt="Screenshot 2022-07-22 at 14 42 52" src="https://user-images.githubusercontent.com/964268/180452236-f9a64989-b583-4406-b024-bee0f53a4023.png">
shot

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
