### PR TITLE
Add event name filter to new events collection list

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -7,7 +7,7 @@ const {
   DATA_HUB_AND_EXTERNAL_ACTIVITY,
   EVENT_ACTIVITY_SORT_OPTIONS,
 } = require('../constants')
-const { filtersQueryBuilder } = require('../controllers')
+const { eventsColListQueryBuilder } = require('../controllers')
 const activityFeedEventsQuery = require('../es-queries/activity-feed-all-events-query')
 
 describe('Activity feed controllers', () => {
@@ -540,7 +540,7 @@ describe('Activity feed controllers', () => {
       }
 
       const actualQuery = activityFeedEventsQuery({
-        filtersQuery: filtersQueryBuilder(name),
+        fullQuery: eventsColListQueryBuilder(name),
         sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
       })
 

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -513,38 +513,70 @@ describe('Activity feed controllers', () => {
   })
   describe('#filtersQueryBuilder', () => {
     context('check dsl query when filtering on event name', () => {
-      const name = 'cool event'
-      const expectedEsQuery = {
-        query: {
-          bool: {
-            must: [
-              {
-                terms: {
-                  'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+      it('builds the right query when being filtered by event name', () => {
+        const name = 'cool event'
+        const expectedEsQuery = {
+          query: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+                  },
                 },
-              },
-              {
-                match: {
-                  'object.name': name,
+                {
+                  match: {
+                    'object.name': name,
+                  },
                 },
-              },
-            ],
+              ],
+            },
           },
-        },
-        sort: {
-          'object.updated': {
-            order: 'desc',
-            unmapped_type: 'date',
+          sort: {
+            'object.updated': {
+              order: 'desc',
+              unmapped_type: 'date',
+            },
           },
-        },
-      }
+        }
 
-      const actualQuery = activityFeedEventsQuery({
-        fullQuery: eventsColListQueryBuilder(name),
-        sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        const actualQuery = activityFeedEventsQuery({
+          fullQuery: eventsColListQueryBuilder(name),
+          sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+
+        expect(expectedEsQuery).to.deep.equal(actualQuery)
       })
 
-      expect(expectedEsQuery).to.deep.equal(actualQuery)
+      it('builds the right query when there is nothing entered into the event name filter', () => {
+        const name = undefined
+        const expectedEsQuery = {
+          query: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+                  },
+                },
+              ],
+            },
+          },
+          sort: {
+            'object.updated': {
+              order: 'desc',
+              unmapped_type: 'date',
+            },
+          },
+        }
+
+        const actualQuery = activityFeedEventsQuery({
+          fullQuery: eventsColListQueryBuilder(name),
+          sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+
+        expect(expectedEsQuery).to.deep.equal(actualQuery)
+      })
     })
   })
 })

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -75,6 +75,12 @@ const EVENT_ACTIVITY_SORT_OPTIONS = {
   },
 }
 
+const EVENT_ALL_ACTIVITY = {
+  terms: {
+    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+  },
+}
+
 const DATA_HUB_ACTIVITY = [
   'dit:Interaction', // Interaction
   'dit:ServiceDelivery', // Interaction
@@ -99,6 +105,7 @@ module.exports = {
   EVENT_ATTENDEES_SORT_OPTIONS,
   EVENT_ACTIVITY_FEATURE_FLAG,
   EVENT_ACTIVITY_SORT_OPTIONS,
+  EVENT_ALL_ACTIVITY,
   FILTER_KEYS,
   FILTER_ITEMS,
   DATA_HUB_ACTIVITY,

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -355,7 +355,7 @@ async function fetchAventriAttendees(req, res, next) {
   }
 }
 
-const filtersQueryBuilder = (name) => {
+const eventsColListQueryBuilder = (name) => {
   // return query if name is present, else return null
   const eventNameFilter = name
     ? {
@@ -383,7 +383,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
       allActivityFeedEventsQuery({
-        filtersQuery: filtersQueryBuilder(name),
+        fullQuery: eventsColListQueryBuilder(name),
         sort:
           EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
           EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
@@ -409,5 +409,5 @@ module.exports = {
   fetchAventriEvent,
   fetchAllActivityFeedEvents,
   fetchAventriAttendees,
-  filtersQueryBuilder,
+  eventsColListQueryBuilder,
 }

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -356,7 +356,6 @@ async function fetchAventriAttendees(req, res, next) {
 }
 
 const eventsColListQueryBuilder = (name) => {
-  // return query if name is present, else return null
   const eventNameFilter = name
     ? {
         match: {
@@ -367,10 +366,7 @@ const eventsColListQueryBuilder = (name) => {
 
   const filtersArray = [eventNameFilter]
 
-  // do not pass in filter if its value is null
-  const cleansedFiltersArray = filtersArray
-    .filter((filter) => filter != null)
-    .map((filter) => filter)
+  const cleansedFiltersArray = filtersArray.filter((filter) => filter != null)
 
   const queryBuilder = [EVENT_ALL_ACTIVITY, ...cleansedFiltersArray]
   return queryBuilder

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -356,7 +356,7 @@ async function fetchAventriAttendees(req, res, next) {
 
 async function fetchAllActivityFeedEvents(req, res, next) {
   try {
-    const { sortBy } = req.query
+    const { sortBy, name } = req.query
 
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
@@ -364,6 +364,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
         sort:
           EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
           EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        eventName: name,
       })
     )
 

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -355,35 +355,35 @@ async function fetchAventriAttendees(req, res, next) {
   }
 }
 
+const filtersQueryBuilder = (name) => {
+  // return query if name is present, else return null
+  const eventNameFilter = name
+    ? {
+        match: {
+          'object.name': name,
+        },
+      }
+    : null
+
+  const filtersArray = [eventNameFilter]
+
+  // do not pass in filter if its value is null
+  const cleansedFiltersArray = filtersArray
+    .filter((filter) => filter != null)
+    .map((filter) => filter)
+
+  const queryBuilder = [EVENT_ALL_ACTIVITY, ...cleansedFiltersArray]
+  return queryBuilder
+}
+
 async function fetchAllActivityFeedEvents(req, res, next) {
   try {
     const { sortBy, name } = req.query
 
-    // return query if name is present, else return null
-    const eventNameFilter = name
-      ? {
-          match: {
-            'object.name': name,
-          },
-        }
-      : null
-
-    const filtersQueryBuilder = () => {
-      const filtersArray = [eventNameFilter]
-
-      // do not pass in filter if its value is null
-      const cleansedFiltersArray = filtersArray
-        .filter((filter) => filter != null)
-        .map((filter) => filter)
-
-      const queryBuilder = [EVENT_ALL_ACTIVITY, ...cleansedFiltersArray]
-      return queryBuilder
-    }
-
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
       allActivityFeedEventsQuery({
-        filtersQuery: filtersQueryBuilder(),
+        filtersQuery: filtersQueryBuilder(name),
         sort:
           EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
           EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
@@ -409,4 +409,5 @@ module.exports = {
   fetchAventriEvent,
   fetchAllActivityFeedEvents,
   fetchAventriAttendees,
+  filtersQueryBuilder,
 }

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,10 +1,17 @@
-const activityFeedEventsQuery = ({ sort }) => ({
+const activityFeedEventsQuery = ({ sort, eventName }) => ({
   query: {
     bool: {
       must: [
         {
           terms: {
             'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+          },
+        },
+      ],
+      should: [
+        {
+          match: {
+            'object.name': eventName || '*',
           },
         },
       ],

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,7 +1,7 @@
-const activityFeedEventsQuery = ({ filtersQuery, sort }) => ({
+const activityFeedEventsQuery = ({ fullQuery, sort }) => ({
   query: {
     bool: {
-      must: filtersQuery,
+      must: fullQuery,
     },
   },
   sort,

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,20 +1,7 @@
-const activityFeedEventsQuery = ({ sort, eventName }) => ({
+const activityFeedEventsQuery = ({ filtersQuery, sort }) => ({
   query: {
     bool: {
-      must: [
-        {
-          terms: {
-            'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-          },
-        },
-      ],
-      should: [
-        {
-          match: {
-            'object.name': eventName || '*',
-          },
-        },
-      ],
+      must: filtersQuery,
     },
   },
   sort,

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -196,6 +196,16 @@ const EventsCollection = ({
                   },
                 ]}
               />
+              <CollectionFilters>
+                <Filters.Input
+                  id="EventsCollection.name"
+                  qsParam="name"
+                  name="name"
+                  label={LABELS.eventName}
+                  placeholder="Search event name"
+                  data-test="event-name-filter"
+                />
+              </CollectionFilters>
               <Task.Status
                 name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}
                 id={ID}

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { GridCol, GridRow } from 'govuk-react'
 import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 
 import {
@@ -196,16 +197,6 @@ const EventsCollection = ({
                   },
                 ]}
               />
-              <CollectionFilters>
-                <Filters.Input
-                  id="EventsCollection.name"
-                  qsParam="name"
-                  name="name"
-                  label={LABELS.eventName}
-                  placeholder="Search event name"
-                  data-test="event-name-filter"
-                />
-              </CollectionFilters>
               <Task.Status
                 name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}
                 id={ID}
@@ -216,15 +207,29 @@ const EventsCollection = ({
                 }}
               >
                 {() => (
-                  <ActivityList>
-                    {allActivityFeedEvents?.map((event, index) => {
-                      return (
-                        <li key={`event-${index}`}>
-                          <Activity activity={event} />
-                        </li>
-                      )
-                    })}
-                  </ActivityList>
+                  <GridRow>
+                    <CollectionFilters>
+                      <Filters.Input
+                        id="EventsCollection.name"
+                        qsParam="name"
+                        name="name"
+                        label={LABELS.eventName}
+                        placeholder="Search event name"
+                        data-test="event-name-filter"
+                      />
+                    </CollectionFilters>
+                    <GridCol>
+                      <ActivityList>
+                        {allActivityFeedEvents?.map((event, index) => {
+                          return (
+                            <li key={`event-${index}`}>
+                              <Activity activity={event} />
+                            </li>
+                          )
+                        })}
+                      </ActivityList>
+                    </GridCol>
+                  </GridRow>
                 )}
               </Task.Status>
             </>

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -49,9 +49,11 @@ const getEventsMetadata = () =>
     }))
     .catch(handleError)
 
-const getAllActivityFeedEvents = ({ sortby }) =>
+const getAllActivityFeedEvents = ({ sortby, name }) =>
   axios
-    .get(urls.events.activity.data(), { params: { sortBy: sortby } })
+    .get(urls.events.activity.data(), {
+      params: { sortBy: sortby, name: name },
+    })
     .then(({ data }) => data)
     .catch(() => Promise.reject('Unable to load events.'))
 

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -265,6 +265,27 @@ describe('Event Collection List Page - React', () => {
           cy.get('@aventriEvents').should('have.length', 0)
         })
       })
+      context('filtering by event name', () => {
+        const element = '[data-test="event-name-filter"]'
+        const eventName = 'Big Event'
+        const queryParamWithName = 'name=Big+Event'
+        const queryParamEmpty = 'name='
+
+        it('should not add anything to the query param whe the page is first loaded', () => {
+          cy.url().should('not.include', queryParamEmpty)
+        })
+
+        it('should add name from user input to query param', () => {
+          cy.get(element).type(`${eventName}{enter}`)
+          cy.url().should('include', queryParamWithName)
+        })
+
+        it('should not add anything to the query param if the name is backspaced', () => {
+          cy.get(element).type(`${eventName}{enter}`)
+          cy.get(element).type(`{selectAll}{backspace}{enter}`)
+          cy.url().should('not.include', queryParamWithName)
+        })
+      })
     })
 
     context(

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -265,27 +265,6 @@ describe('Event Collection List Page - React', () => {
           cy.get('@aventriEvents').should('have.length', 0)
         })
       })
-      context('filtering by event name', () => {
-        const element = '[data-test="event-name-filter"]'
-        const eventName = 'Big Event'
-        const queryParamWithName = 'name=Big+Event'
-        const queryParamEmpty = 'name='
-
-        it('should not add anything to the query param whe the page is first loaded', () => {
-          cy.url().should('not.include', queryParamEmpty)
-        })
-
-        it('should add name from user input to query param', () => {
-          cy.get(element).type(`${eventName}{enter}`)
-          cy.url().should('include', queryParamWithName)
-        })
-
-        it('should not add anything to the query param if the name is backspaced', () => {
-          cy.get(element).type(`${eventName}{enter}`)
-          cy.get(element).type(`{selectAll}{backspace}{enter}`)
-          cy.url().should('not.include', queryParamWithName)
-        })
-      })
     })
 
     context(

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -42,411 +42,425 @@ const eventTypeEndpoint = '/api-proxy/v4/metadata/event-type'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
 
 describe('events Collections Filter', () => {
-  const disabledEventType = eventTypeFaker({ disabled_on: '2020-01-01' })
-  const eventTypes = [disabledEventType, ...eventTypeListFaker(2)]
+  context('with the events activity stream feature flag disabled', () => {
+    const disabledEventType = eventTypeFaker({ disabled_on: '2020-01-01' })
+    const eventTypes = [disabledEventType, ...eventTypeListFaker(2)]
 
-  context('Default Params', () => {
-    it('should set the default params', () => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+    context('Default Params', () => {
+      it('should set the default params', () => {
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
 
-      cy.visit(urls.events.index())
+        cy.visit(urls.events.index())
 
-      // Second call to the api with default params
-      assertPayload('@apiRequest', minimumPayload)
-    })
-  })
-
-  context('Toggle groups', () => {
-    it('should show event details filters and hide them on toggle', () => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit('/events')
-      cy.wait('@apiRequest')
-      cy.get('[data-test="event-name-filter"]').should('be.visible')
-      cy.get('[data-test="toggle-section-button"]')
-        .contains('Event details')
-        .click()
-      cy.get('[data-test="event-name-filter"]').should('not.be.visible')
-    })
-  })
-
-  context('Event Name', () => {
-    const element = '[data-test="event-name-filter"]'
-    const eventNameQuery = 'Big Event'
-    const expectedPayload = {
-      offset: 0,
-      limit: 10,
-      sortby: 'modified_on:desc',
-      name: eventNameQuery,
-    }
-
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({ name: eventNameQuery })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      assertPayload('@apiRequest', expectedPayload)
-      cy.get(element).should('have.value', eventNameQuery)
-      assertChipExists({ label: eventNameQuery, position: 1 })
+        // Second call to the api with default params
+        assertPayload('@apiRequest', minimumPayload)
+      })
     })
 
-    it('should filter from user input and remove chips', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@apiRequest')
-
-      cy.get(element).type(`${eventNameQuery}{enter}`)
-      assertPayload('@apiRequest', expectedPayload)
-
-      assertQueryParams('name', eventNameQuery)
-      assertChipExists({ label: eventNameQuery, position: 1 })
-      removeChip(eventNameQuery)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-      assertFieldEmpty(element)
+    context('Toggle groups', () => {
+      it('should show event details filters and hide them on toggle', () => {
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit('/events')
+        cy.wait('@apiRequest')
+        cy.get('[data-test="event-name-filter"]').should('be.visible')
+        cy.get('[data-test="toggle-section-button"]')
+          .contains('Event details')
+          .click()
+        cy.get('[data-test="event-name-filter"]').should('not.be.visible')
+      })
     })
-  })
 
-  context('Country', () => {
-    const element = '[data-test="country-filter"]'
-    const brazilCountryId = 'b05f66a0-5d95-e211-a939-e4115bead28a'
-    const expectedPayload = {
-      offset: 0,
-      limit: 10,
-      sortby: 'modified_on:desc',
-      address_country: [brazilCountryId],
-    }
+    context('Event Name', () => {
+      const element = '[data-test="event-name-filter"]'
+      const eventNameQuery = 'Big Event'
+      const expectedPayload = {
+        offset: 0,
+        limit: 10,
+        sortby: 'modified_on:desc',
+        name: eventNameQuery,
+      }
 
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({ name: eventNameQuery })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        assertPayload('@apiRequest', expectedPayload)
+        cy.get(element).should('have.value', eventNameQuery)
+        assertChipExists({ label: eventNameQuery, position: 1 })
+      })
+
+      it('should filter from user input and remove chips', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@apiRequest')
+
+        cy.get(element).type(`${eventNameQuery}{enter}`)
+        assertPayload('@apiRequest', expectedPayload)
+
+        assertQueryParams('name', eventNameQuery)
+        assertChipExists({ label: eventNameQuery, position: 1 })
+        removeChip(eventNameQuery)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+        assertFieldEmpty(element)
+      })
+    })
+
+    context('Country', () => {
+      const element = '[data-test="country-filter"]'
+      const brazilCountryId = 'b05f66a0-5d95-e211-a939-e4115bead28a'
+      const expectedPayload = {
+        offset: 0,
+        limit: 10,
+        sortby: 'modified_on:desc',
         address_country: [brazilCountryId],
+      }
+
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({
+          address_country: [brazilCountryId],
+        })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        assertPayload('@apiRequest', expectedPayload)
+        cy.get(element).should('contain', 'Brazil')
+        assertChipExists({ label: 'Brazil', position: 1 })
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      assertPayload('@apiRequest', expectedPayload)
-      cy.get(element).should('contain', 'Brazil')
-      assertChipExists({ label: 'Brazil', position: 1 })
+
+      it('should filter from user input and remove chips', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@apiRequest')
+
+        cy.get('[data-test="toggle-section-button"]')
+          .contains('Event location details')
+          .click()
+
+        testTypeahead({
+          element,
+          label: 'Country',
+          placeholder: 'Search country',
+          input: 'braz',
+          expectedOption: 'Brazil',
+        })
+        assertPayload('@apiRequest', expectedPayload)
+        assertQueryParams('address_country', [brazilCountryId])
+        assertChipExists({ label: 'Brazil', position: 1 })
+        removeChip(brazilCountryId)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+        assertFieldEmpty(element)
+      })
     })
 
-    it('should filter from user input and remove chips', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@apiRequest')
-
-      cy.get('[data-test="toggle-section-button"]')
-        .contains('Event location details')
-        .click()
-
-      testTypeahead({
-        element,
-        label: 'Country',
-        placeholder: 'Search country',
-        input: 'braz',
-        expectedOption: 'Brazil',
-      })
-      assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('address_country', [brazilCountryId])
-      assertChipExists({ label: 'Brazil', position: 1 })
-      removeChip(brazilCountryId)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-      assertFieldEmpty(element)
-    })
-  })
-
-  context('UK Region', () => {
-    const element = '[data-test="uk-region-filter"]'
-    const ukRegion = ukRegionFaker()
-    const ukRegions = [
-      ukRegion,
-      ...ukRegionListFaker(5),
-      ...ukRegionListFaker(5, { disabled_on: '2000-01-01' }),
-    ]
-    const expectedPayload = {
-      offset: 0,
-      limit: 10,
-      sortby: 'modified_on:desc',
-      uk_region: [ukRegion.id],
-    }
-
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({
+    context('UK Region', () => {
+      const element = '[data-test="uk-region-filter"]'
+      const ukRegion = ukRegionFaker()
+      const ukRegions = [
+        ukRegion,
+        ...ukRegionListFaker(5),
+        ...ukRegionListFaker(5, { disabled_on: '2000-01-01' }),
+      ]
+      const expectedPayload = {
+        offset: 0,
+        limit: 10,
+        sortby: 'modified_on:desc',
         uk_region: [ukRegion.id],
-      })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
-        'ukRegionsApiRequest'
-      )
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@ukRegionsApiRequest')
-      assertPayload('@apiRequest', expectedPayload)
-      cy.get(element).should('contain', ukRegion.name)
-      assertChipExists({ label: ukRegion.name, position: 1 })
-    })
+      }
 
-    it('should filter from user input and remove chips', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
-        'ukRegionsApiRequest'
-      )
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@ukRegionsApiRequest')
-      cy.wait('@apiRequest')
-
-      cy.get('[data-test="toggle-section-button"]')
-        .contains('Event location details')
-        .click()
-      testTypeaheadOptionsLength({ element, length: ukRegions.length })
-      testTypeahead({
-        element,
-        label: 'UK region',
-        placeholder: 'Search UK region',
-        input: ukRegion.name,
-        expectedOption: ukRegion.name,
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({
+          uk_region: [ukRegion.id],
+        })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
+          'ukRegionsApiRequest'
+        )
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@ukRegionsApiRequest')
+        assertPayload('@apiRequest', expectedPayload)
+        cy.get(element).should('contain', ukRegion.name)
+        assertChipExists({ label: ukRegion.name, position: 1 })
       })
 
-      assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('uk_region', [ukRegion.id])
-      assertChipExists({ label: ukRegion.name, position: 1 })
-      removeChip(ukRegion.id)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-      assertFieldEmpty(element)
-    })
-  })
+      it('should filter from user input and remove chips', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
+          'ukRegionsApiRequest'
+        )
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@ukRegionsApiRequest')
+        cy.wait('@apiRequest')
 
-  context('Organiser', () => {
-    const element = '[data-test="organiser-filter"]'
-    const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
-    const adviserName = 'Puck Head'
-    const expectedPayload = {
-      offset: 0,
-      limit: 10,
-      sortby: 'modified_on:desc',
-      organiser: [adviserId],
-    }
+        cy.get('[data-test="toggle-section-button"]')
+          .contains('Event location details')
+          .click()
+        testTypeaheadOptionsLength({ element, length: ukRegions.length })
+        testTypeahead({
+          element,
+          label: 'UK region',
+          placeholder: 'Search UK region',
+          input: ukRegion.name,
+          expectedOption: ukRegion.name,
+        })
 
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({ organiser: [adviserId] })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      assertPayload('@apiRequest', expectedPayload)
-      cy.get(element).should('contain', adviserName)
-      assertChipExists({ label: adviserName, position: 1 })
-    })
-
-    it('should filter from user input and remove chips', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@apiRequest')
-
-      selectFirstAdvisersTypeaheadOption({ element, input: adviserName })
-      assertPayload('@apiRequest', expectedPayload)
-      assertQueryParams('organiser', [adviserId])
-      assertChipExists({
-        label: `Organiser: ${adviserName}`,
-        position: 1,
-      })
-      removeChip(adviserId)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-      assertFieldEmpty(element)
-    })
-  })
-
-  context('Event Type', () => {
-    const element = '[data-test="event-type-filter"] fieldset'
-    const eventType = randomChoice(eventTypes)
-
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({ event_type: [eventType.id] })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
-        'eventTypeApiRequest'
-      )
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@eventTypeApiRequest')
-      assertPayload('@apiRequest', {
-        ...minimumPayload,
-        event_type: [eventType.id],
-      })
-      assertCheckboxGroupOption({ element, value: eventType.id })
-      assertChipExists({ label: eventType.name, position: 1 })
-    })
-
-    it('should filter from user input and remove the chip', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
-        'eventTypeApiRequest'
-      )
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@eventTypeApiRequest')
-      cy.wait('@apiRequest')
-
-      cy.get(element).find('label').should('have.length', eventTypes.length)
-      clickCheckboxGroupOption({ element, value: eventType.id })
-      assertPayload('@apiRequest', {
-        ...minimumPayload,
-        event_type: [eventType.id],
-      })
-      assertQueryParams('event_type', [eventType.id])
-      assertChipExists({ label: eventType.name, position: 1 })
-
-      removeChip(eventType.id)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-      assertCheckboxGroupOption({
-        element,
-        value: eventType.id,
-        checked: false,
-      })
-    })
-  })
-
-  context('From / To Dates', () => {
-    const fromElement = '[data-test="start-date-after-filter"]'
-    const fromDate = '2020-01-01'
-    const formattedFromDate = '1 January 2020'
-    const toElement = '[data-test="start-date-before-filter"]'
-    const toDate = '2021-10-05'
-    const formattedToDate = '5 October 2021'
-    const expectedPayload = {
-      ...minimumPayload,
-      start_date_after: fromDate,
-      start_date_before: toDate,
-    }
-
-    it('should filter from the url', () => {
-      const queryString = buildQueryString({
-        start_date_after: fromDate,
-        start_date_before: toDate,
-      })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      assertPayload('@apiRequest', expectedPayload)
-      assertChipExists({ label: `From: ${formattedFromDate}`, position: 1 })
-      assertChipExists({ label: `To: ${formattedToDate}`, position: 2 })
-      assertDateInput({
-        element: fromElement,
-        label: 'From',
-        value: fromDate,
-      })
-      assertDateInput({
-        element: toElement,
-        label: 'To',
-        value: toDate,
+        assertPayload('@apiRequest', expectedPayload)
+        assertQueryParams('uk_region', [ukRegion.id])
+        assertChipExists({ label: ukRegion.name, position: 1 })
+        removeChip(ukRegion.id)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+        assertFieldEmpty(element)
       })
     })
 
-    it('should filter from user input and remove the chip', () => {
-      const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@apiRequest')
-
-      inputDateValue({
-        element: fromElement,
-        value: fromDate,
-      })
-      cy.wait('@apiRequest')
-      inputDateValue({
-        element: toElement,
-        value: toDate,
-      })
-      assertPayload('@apiRequest', expectedPayload)
-
-      assertQueryParams('start_date_after', fromDate)
-      assertQueryParams('start_date_before', toDate)
-      assertChipExists({ label: `From: ${formattedFromDate}`, position: 1 })
-      assertChipExists({ label: `To: ${formattedToDate}`, position: 2 })
-      assertDateInput({
-        element: fromElement,
-        label: 'From',
-        value: fromDate,
-      })
-      assertDateInput({
-        element: toElement,
-        label: 'To',
-        value: toDate,
-      })
-
-      removeChip(fromDate)
-      cy.wait('@apiRequest')
-      removeChip(toDate)
-      assertPayload('@apiRequest', minimumPayload)
-      assertChipsEmpty()
-
-      assertDateInput({
-        element: fromElement,
-        label: 'From',
-        value: '',
-      })
-      assertDateInput({
-        element: toElement,
-        label: 'To',
-        value: '',
-      })
-    })
-  })
-
-  context('Remove all filters', () => {
-    before(() => {
-      const ukCountryId = '80756b9a-5d95-e211-a939-e4115bead28a'
+    context('Organiser', () => {
+      const element = '[data-test="organiser-filter"]'
       const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
-      const fromDate = '2020-01-01'
-      const toDate = '2021-10-05'
-      const eventType = randomChoice(eventTypes)
-      const ukRegions = ukRegionListFaker(10)
-      const queryString = qs.stringify({
-        page: 1,
-        name: 'Big Event',
-        address_country: [ukCountryId],
-        uk_region: [ukRegions[0].id],
+      const adviserName = 'Puck Head'
+      const expectedPayload = {
+        offset: 0,
+        limit: 10,
+        sortby: 'modified_on:desc',
         organiser: [adviserId],
-        event_type: [eventType.id],
-        start_date_after: fromDate,
-        start_date_before: toDate,
+      }
+
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({ organiser: [adviserId] })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        assertPayload('@apiRequest', expectedPayload)
+        cy.get(element).should('contain', adviserName)
+        assertChipExists({ label: adviserName, position: 1 })
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
-        'eventTypeApiRequest'
-      )
-      cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
-        'ukRegionsApiRequest'
-      )
-      cy.visit(`/events?${queryString}`)
-      cy.wait('@eventTypeApiRequest')
-      cy.wait('@ukRegionsApiRequest')
-      cy.wait('@apiRequest')
+
+      it('should filter from user input and remove chips', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@apiRequest')
+
+        selectFirstAdvisersTypeaheadOption({ element, input: adviserName })
+        assertPayload('@apiRequest', expectedPayload)
+        assertQueryParams('organiser', [adviserId])
+        assertChipExists({
+          label: `Organiser: ${adviserName}`,
+          position: 1,
+        })
+        removeChip(adviserId)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+        assertFieldEmpty(element)
+      })
     })
 
-    it('should remove all filters and chips', () => {
-      cy.get('[data-test=clear-filters]').click()
-      cy.get('[data-test=filter-chips]').children().should('have.length', 0)
-      cy.get('[data-test="event-name-filter"]').should('have.value', '')
-      cy.get('[data-test="country-filter"]')
-        .find('[data-test="typeahead-chip"]')
-        .should('have.length', 0)
-      cy.get('[data-test="uk-region-filter"]')
-        .find('[data-test="typeahead-chip"]')
-        .should('have.length', 0)
-      cy.get('[data-test="organiser-filter"]')
-        .find('[data-test="typeahead-chip"]')
-        .should('have.length', 0)
-      assertDateInput({
-        element: '[data-test="start-date-after-filter"]',
-        label: 'From',
-        value: '',
+    context('Event Type', () => {
+      const element = '[data-test="event-type-filter"] fieldset'
+      const eventType = randomChoice(eventTypes)
+
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({ event_type: [eventType.id] })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
+          'eventTypeApiRequest'
+        )
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@eventTypeApiRequest')
+        assertPayload('@apiRequest', {
+          ...minimumPayload,
+          event_type: [eventType.id],
+        })
+        assertCheckboxGroupOption({ element, value: eventType.id })
+        assertChipExists({ label: eventType.name, position: 1 })
       })
-      assertDateInput({
-        element: '[data-test="start-date-before-filter"]',
-        label: 'To',
-        value: '',
+
+      it('should filter from user input and remove the chip', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
+          'eventTypeApiRequest'
+        )
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@eventTypeApiRequest')
+        cy.wait('@apiRequest')
+
+        cy.get(element).find('label').should('have.length', eventTypes.length)
+        clickCheckboxGroupOption({ element, value: eventType.id })
+        assertPayload('@apiRequest', {
+          ...minimumPayload,
+          event_type: [eventType.id],
+        })
+        assertQueryParams('event_type', [eventType.id])
+        assertChipExists({ label: eventType.name, position: 1 })
+
+        removeChip(eventType.id)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+        assertCheckboxGroupOption({
+          element,
+          value: eventType.id,
+          checked: false,
+        })
       })
-      assertCheckboxGroupNoneSelected('[data-test="event-type-filter"]')
+    })
+
+    context('From / To Dates', () => {
+      const fromElement = '[data-test="start-date-after-filter"]'
+      const fromDate = '2020-01-01'
+      const formattedFromDate = '1 January 2020'
+      const toElement = '[data-test="start-date-before-filter"]'
+      const toDate = '2021-10-05'
+      const formattedToDate = '5 October 2021'
+      const expectedPayload = {
+        ...minimumPayload,
+        start_date_after: fromDate,
+        start_date_before: toDate,
+      }
+
+      it('should filter from the url', () => {
+        const queryString = buildQueryString({
+          start_date_after: fromDate,
+          start_date_before: toDate,
+        })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        assertPayload('@apiRequest', expectedPayload)
+        assertChipExists({ label: `From: ${formattedFromDate}`, position: 1 })
+        assertChipExists({ label: `To: ${formattedToDate}`, position: 2 })
+        assertDateInput({
+          element: fromElement,
+          label: 'From',
+          value: fromDate,
+        })
+        assertDateInput({
+          element: toElement,
+          label: 'To',
+          value: toDate,
+        })
+      })
+
+      it('should filter from user input and remove the chip', () => {
+        const queryString = buildQueryString()
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@apiRequest')
+
+        inputDateValue({
+          element: fromElement,
+          value: fromDate,
+        })
+        cy.wait('@apiRequest')
+        inputDateValue({
+          element: toElement,
+          value: toDate,
+        })
+        assertPayload('@apiRequest', expectedPayload)
+
+        assertQueryParams('start_date_after', fromDate)
+        assertQueryParams('start_date_before', toDate)
+        assertChipExists({ label: `From: ${formattedFromDate}`, position: 1 })
+        assertChipExists({ label: `To: ${formattedToDate}`, position: 2 })
+        assertDateInput({
+          element: fromElement,
+          label: 'From',
+          value: fromDate,
+        })
+        assertDateInput({
+          element: toElement,
+          label: 'To',
+          value: toDate,
+        })
+
+        removeChip(fromDate)
+        cy.wait('@apiRequest')
+        removeChip(toDate)
+        assertPayload('@apiRequest', minimumPayload)
+        assertChipsEmpty()
+
+        assertDateInput({
+          element: fromElement,
+          label: 'From',
+          value: '',
+        })
+        assertDateInput({
+          element: toElement,
+          label: 'To',
+          value: '',
+        })
+      })
+    })
+
+    context('Remove all filters', () => {
+      before(() => {
+        const ukCountryId = '80756b9a-5d95-e211-a939-e4115bead28a'
+        const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
+        const fromDate = '2020-01-01'
+        const toDate = '2021-10-05'
+        const eventType = randomChoice(eventTypes)
+        const ukRegions = ukRegionListFaker(10)
+        const queryString = qs.stringify({
+          page: 1,
+          name: 'Big Event',
+          address_country: [ukCountryId],
+          uk_region: [ukRegions[0].id],
+          organiser: [adviserId],
+          event_type: [eventType.id],
+          start_date_after: fromDate,
+          start_date_before: toDate,
+        })
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.intercept('GET', eventTypeEndpoint, eventTypes).as(
+          'eventTypeApiRequest'
+        )
+        cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
+          'ukRegionsApiRequest'
+        )
+        cy.visit(`/events?${queryString}`)
+        cy.wait('@eventTypeApiRequest')
+        cy.wait('@ukRegionsApiRequest')
+        cy.wait('@apiRequest')
+      })
+
+      it('should remove all filters and chips', () => {
+        cy.get('[data-test=clear-filters]').click()
+        cy.get('[data-test=filter-chips]').children().should('have.length', 0)
+        cy.get('[data-test="event-name-filter"]').should('have.value', '')
+        cy.get('[data-test="country-filter"]')
+          .find('[data-test="typeahead-chip"]')
+          .should('have.length', 0)
+        cy.get('[data-test="uk-region-filter"]')
+          .find('[data-test="typeahead-chip"]')
+          .should('have.length', 0)
+        cy.get('[data-test="organiser-filter"]')
+          .find('[data-test="typeahead-chip"]')
+          .should('have.length', 0)
+        assertDateInput({
+          element: '[data-test="start-date-after-filter"]',
+          label: 'From',
+          value: '',
+        })
+        assertDateInput({
+          element: '[data-test="start-date-before-filter"]',
+          label: 'To',
+          value: '',
+        })
+        assertCheckboxGroupNoneSelected('[data-test="event-type-filter"]')
+      })
+    })
+  })
+  context('with the events activity stream feature flag enabled', () => {
+    before(() => {
+      cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
+    })
+    context('Event name', () => {
+      it('should filter from the url', () => {})
+      it('should filter from user input', () => {})
+    })
+    after(() => {
+      cy.resetUser()
     })
   })
 })

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -3,6 +3,8 @@ import qs from 'qs'
 
 import { randomChoice } from '../../fakers/utils'
 import { eventTypeFaker, eventTypeListFaker } from '../../fakers/event-types'
+import { events } from '../../../../../src/lib/urls'
+import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../../src/apps/companies/apps/activity-feed/constants'
 
 import {
   clickCheckboxGroupOption,
@@ -454,10 +456,28 @@ describe('events Collections Filter', () => {
   context('with the events activity stream feature flag enabled', () => {
     before(() => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
+      cy.visit(events.index())
     })
     context('Event name', () => {
-      it('should filter from the url', () => {})
-      it('should filter from user input', () => {})
+      const element = '[data-test="event-name-filter"]'
+      const eventName = 'Big Event'
+      const queryParamWithName = 'name=Big+Event'
+      const queryParamEmpty = 'name='
+
+      it('should not add anything to the query param when the page is first loaded', () => {
+        cy.url().should('not.include', queryParamEmpty)
+      })
+
+      it('should add name from user input to query param', () => {
+        cy.get(element).type(`${eventName}{enter}`)
+        cy.url().should('include', queryParamWithName)
+      })
+
+      it('should not add anything to the query param if the name is backspaced', () => {
+        cy.get(element).type(`${eventName}{enter}`)
+        cy.get(element).type(`{selectAll}{backspace}{enter}`)
+        cy.url().should('not.include', queryParamWithName)
+      })
     })
     after(() => {
       cy.resetUser()


### PR DESCRIPTION
## Description of change
This PR adds an Event Name filter to the new Events Collection page. 
It works by modifying the query that is sent to Activity Stream. 

## Test instructions
- In Django dev API, add the user feature flag user-event-activities to your adviser profile.
- Bring up this branch on your local dev frontend and navigate to http://localhost:3000/events
- You should see an Event name filter on the left hand side. 
- In the filter box type 'project zeus' and press enter. It should add project zeus to the query params in the url and it should only be displaying events called Project Zeus. 
- In the filter box backspace everything and press enter. All the events should reappear. 

## Screenshots
### Before
<img width="1028" alt="image" src="https://user-images.githubusercontent.com/70902973/181228101-834a8377-45e7-4c25-800b-97a4eb5e3baf.png">

### After
<img width="1033" alt="image" src="https://user-images.githubusercontent.com/70902973/181228005-3b43663f-8e49-4def-b89d-fd90d9d6b9f2.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
