### PR TITLE
Explore flaky tests with quick solutions

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -159,7 +159,9 @@ Cypress.Commands.add(
   'removeAllTypeaheadValues',
   { prevSubject: 'element' },
   (subject) => {
-    cy.wrap(subject).find('[data-test="typeahead-chip"]').each((el) => cy.wrap(el).click())
+    cy.wrap(subject)
+      .find('[data-test="typeahead-chip"]')
+      .each((el) => cy.wrap(el).click())
     return cy.wrap(subject)
   }
 )

--- a/test/functional/cypress/specs/events/edit-spec.js
+++ b/test/functional/cypress/specs/events/edit-spec.js
@@ -17,6 +17,7 @@ import urls from '../../../../../src/lib/urls'
 describe('Event edit', () => {
   beforeEach(() => {
     cy.intercept('PATCH', '/api-proxy/v4/event/*').as('eventHttpRequest')
+    cy.intercept('GET', '/api-proxy/v4/event/*').as('getEventHttpRequest')
     cy.visit('/events/8253a4d2-0a61-4928-80cb-ebd70cce9971/edit')
   })
 
@@ -34,6 +35,7 @@ describe('Event edit', () => {
 
   context('when loading in a valid event form', () => {
     it('should render expected form fields with original values ', () => {
+      cy.wait('@getEventHttpRequest')
       assertEventFormFields({
         hasRelatedTradeAgreement: 'No',
         eventName: 'One-day exhibition',

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -195,6 +195,7 @@ describe('Interactions Collections Filter', () => {
       selectFirstAdvisersTypeaheadOption({
         element: advisersFilter,
         input: adviser.name,
+        mockAdviserResponse: false,
       })
       cy.wait('@adviserListApiRequest')
       cy.wait('@adviserApiRequest')

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -181,6 +181,7 @@ describe('Investments Collections Filter', () => {
       selectFirstAdvisersTypeaheadOption({
         element: advisersFilter,
         input: myAdviser.name,
+        mockAdviserResponse: false,
       })
       cy.wait('@adviserListApiRequest')
       cy.wait('@adviserApiRequest')

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -23,6 +23,10 @@ export const selectFirstAdvisersTypeaheadOption = ({
     ).as('adviserResults')
     cy.get('input').clear().type(input)
     cy.wait('@adviserResults')
+    cy.get('[data-test="typeahead-menu-option"]').contains(input, {
+      matchCase: false,
+      timeout: 120000,
+    })
     cy.get('input').type('{downarrow}{enter}{esc}')
   })
 

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -1,14 +1,26 @@
+const adviserResult = require('../../../sandbox/fixtures/autocomplete-adviser-list.json')
+
 /**
  * Enter `input` into an advisers typeahead `element` and select the first result
  *
  * This waits for the adviser api request to complete before selecting the
- * first option.
+ * first option, but has a mocked intercepted adviser response to circumvent
+ * network latency.
  */
-export const selectFirstAdvisersTypeaheadOption = ({ element, input }) =>
+export const selectFirstAdvisersTypeaheadOption = ({
+  element,
+  input,
+  mockAdviserResponse = true,
+}) =>
   cy.get(element).within(() => {
-    cy.intercept(`/api-proxy/adviser/?*${input.replace(' ', '+')}*`).as(
-      'adviserResults'
-    )
+    cy.intercept(
+      `/api-proxy/adviser/?*${input.replace(' ', '+')}*`,
+      mockAdviserResponse
+        ? {
+            body: adviserResult,
+          }
+        : undefined
+    ).as('adviserResults')
     cy.get('input').clear().type(input)
     cy.wait('@adviserResults')
     cy.get('input').type('{downarrow}{enter}{esc}')


### PR DESCRIPTION
## Description of change

Fix for two flaky tests:

1. `events/filter-spec` - the command to select the first typeahead option was being triggered before the option had rendered, due to the data being throttled/network latency. This is resolved by intercepting the network request and directly returning mock data, rather than making a 'real' request to the sandbox. We aren't losing any test value here because it's still mocking the same logic as before, just without network latency. 
2.  `events/edit-spec` - this test was flakey as it would sometimes check form values before the form had been populated by an API request, the solution is to wait for that request to complete which seems to give it time to populate the form. 

## Test instructions

No flakey tests being logged for this **fix/flakey-event-filter-spec** branch

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
