### PR TITLE
reorder contact form fields for a better UX

### DIFF
--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 import Link from '@govuk-react/link'
+import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import multiInstance from '../../utils/multiinstance'
 import { CONTACT_FORM__SUBMIT } from '../../actions'
@@ -31,6 +32,9 @@ import useAdministrativeAreaLookup from '../AdministrativeAreaSearch/useAdminist
 import useAdministrativeAreaSearch from '../AdministrativeAreaSearch/useAdministrativeAreaSearch'
 import urls from '../../../lib/urls'
 
+import styled from 'styled-components'
+import Label from '@govuk-react/label'
+
 const YES = 'Yes'
 const NO = 'No'
 
@@ -42,6 +46,11 @@ const stripHost = (u) => {
   const url = new URL(u)
   return url.pathname + url.search
 }
+
+const StyledLabel = styled(Label)`
+  padding-bottom: ${SPACING.SCALE_5};
+  font-weight: ${FONT_WEIGHTS.bold};
+`
 
 const _ContactForm = ({
   update,
@@ -247,14 +256,12 @@ const _ContactForm = ({
                           type="text"
                           required="Enter a job title"
                         />
-                        <FieldRadios
-                          legend="Is this person a primary contact?"
-                          name="primary"
-                          required="Select yes if this person is a primary contact"
-                          options={[
-                            { value: YES, label: YES },
-                            { value: NO, label: NO },
-                          ]}
+                        <FieldInput
+                          label="Email address"
+                          name="email"
+                          type="email"
+                          required="Enter an email"
+                          validate={validators.email}
                         />
                         <FieldInput
                           label="Telephone number (optional)"
@@ -265,12 +272,39 @@ const _ContactForm = ({
                             'Telephone number should consist of numbers'
                           }
                         />
-                        <FieldInput
-                          label="Email address"
-                          name="email"
-                          type="email"
-                          required="Enter an email"
-                          validate={validators.email}
+                        <FieldRadios
+                          legend="Is this contact’s work address the same as the company address?"
+                          name="addressSameAsCompany"
+                          required="Select yes if the contact's address is the same as the company address"
+                          options={[
+                            { value: YES, label: YES },
+                            {
+                              value: NO,
+                              label: NO,
+                              children: (
+                                <fieldset>
+                                  <StyledLabel>
+                                    What is the contact's work address?
+                                  </StyledLabel>
+                                  <FieldAddress
+                                    name="" // Required, but has no effect
+                                    apiEndpoint="/api/postcodelookup"
+                                    isCountrySelectable={true}
+                                    fontWeights={FONT_WEIGHTS.regular}
+                                  />
+                                </fieldset>
+                              ),
+                            },
+                          ]}
+                        />
+                        <FieldRadios
+                          legend="Is this person a primary contact?"
+                          name="primary"
+                          required="Select yes if this person is a primary contact"
+                          options={[
+                            { value: YES, label: YES },
+                            { value: NO, label: NO },
+                          ]}
                         />
                         <FieldCheckboxes
                           name="acceptsDitEmailMarketing"
@@ -284,28 +318,6 @@ const _ContactForm = ({
                                   YES
                                 ) &&
                                 'By checking this box, you confirm that the contact has opted in to email marketing.',
-                            },
-                          ]}
-                        />
-                        <FieldRadios
-                          legend="Is this contact’s work address the same as the company address?"
-                          name="addressSameAsCompany"
-                          required="Select yes if the contact's address is the same as the company address"
-                          options={[
-                            { value: YES, label: YES },
-                            {
-                              value: NO,
-                              label: NO,
-                              children: (
-                                <fieldset>
-                                  <legend>Contact address</legend>
-                                  <FieldAddress
-                                    name="" // Required, but has no effect
-                                    apiEndpoint="/api/postcodelookup"
-                                    isCountrySelectable={true}
-                                  />
-                                </fieldset>
-                              ),
                             },
                           ]}
                         />

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -8,6 +8,7 @@ import Button from '@govuk-react/button'
 import { MEDIA_QUERIES } from '@govuk-react/constants'
 import FormGroup from '@govuk-react/form-group'
 import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
 
 import { useFormContext } from '../../hooks'
 import useAddressSearch from '../../../AddressSearch/useAddressSearch'
@@ -33,6 +34,10 @@ const StyledFieldPostcode = styled(FieldInput)`
   ${MEDIA_QUERIES.TABLET} {
     max-width: 200px;
   }
+`
+
+const SyledDiv = styled('div')`
+  padding-bottom: ${SPACING.SCALE_5};
 `
 
 const FieldAddress = ({
@@ -207,14 +212,15 @@ const FieldAddress = ({
 
   return (
     <FieldWrapper {...{ label, legend, hint, name }} showBorder={true}>
-      <StyledFieldPostcode
-        type={isUK ? 'search' : 'text'}
-        name="postcode"
-        label={postcodeLabel()}
-        required={postcodeErrorMessage()}
-        maxLength={isUK ? 10 : null}
-        validate={postcodeValidator}
-      />
+      {isCountrySelectable ? (
+        <SyledDiv>
+          <FieldCountrySelect name="country" required="Select a country" />
+        </SyledDiv>
+      ) : (
+        <FieldUneditable name="country" label="Country">
+          {country.name}
+        </FieldUneditable>
+      )}
       {isUK && (
         <>
           <Button
@@ -275,13 +281,14 @@ const FieldAddress = ({
           </StatusMessage>
         )}
       </>
-      {isCountrySelectable ? (
-        <FieldCountrySelect name="country" required="Select a country" />
-      ) : (
-        <FieldUneditable name="country" label="Country">
-          {country.name}
-        </FieldUneditable>
-      )}
+      <StyledFieldPostcode
+        type={isUK ? 'search' : 'text'}
+        name="postcode"
+        label={postcodeLabel()}
+        required={postcodeErrorMessage()}
+        maxLength={isUK ? 10 : null}
+        validate={postcodeValidator}
+      />
     </FieldWrapper>
   )
 }

--- a/test/functional/cypress/specs/contacts/create-and-edit.jsx
+++ b/test/functional/cypress/specs/contacts/create-and-edit.jsx
@@ -86,11 +86,11 @@ describe('Create contact form', () => {
       'First name': 'Enter a first name',
       'Last name': 'Enter a last name',
       'Job title': 'Enter a job title',
-      'Is this person a primary contact?':
-        'Select yes if this person is a primary contact',
       'Email address': 'Enter an email',
       'Is this contact’s work address the same as the company address?':
         "Select yes if the contact's address is the same as the company address",
+      'Is this person a primary contact?':
+        'Select yes if this person is a primary contact',
     })
   })
 
@@ -106,9 +106,9 @@ describe('Create contact form', () => {
       'First name': 'Enter a first name',
       'Last name': 'Enter a last name',
       'Job title': 'Enter a job title',
+      'Email address': 'Enter an email',
       'Is this person a primary contact?':
         'Select yes if this person is a primary contact',
-      'Email address': 'Enter an email',
       'Address line 1': 'Enter an address line 1',
       'Town or city': 'Enter a town or city',
     })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -357,9 +357,9 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
       assert: ({ element }) => cy.wrap(element).should('have.text', hint),
     },
     {
-      label: postcodeLabel(),
-      value: value.postcode,
-      assert: assertFieldInput,
+      label: 'Country',
+      value: value.country.name,
+      assert: assertFieldUneditable,
     },
     isUKBased && {
       assert: ({ element }) =>
@@ -389,26 +389,18 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
         value: value.county,
         assert: assertFieldInput,
       },
-  ]
-
-  if (hasStateField) {
-    addressElements = [
-      ...addressElements,
-      {
-        label: isCanadianBased ? 'Province' : 'State',
-        value: value.area.name,
-        assert: assertFieldSelect,
-      },
-    ]
-  }
-  addressElements = [
-    ...addressElements,
+    hasStateField && {
+      label: isCanadianBased ? 'Province' : 'State',
+      value: value.area.name,
+      assert: assertFieldSelect,
+    },
     {
-      label: 'Country',
-      value: value.country.name,
-      assert: assertFieldUneditable,
+      label: postcodeLabel(),
+      value: value.postcode,
+      assert: assertFieldInput,
     },
   ].filter(isObject)
+
   cy.wrap(element)
     .as('field')
     .get('fieldset')


### PR DESCRIPTION
## Description of change

The intent of this PR is to reorder the contact form fields so the user can have a smoother user experience whilst adding a contact.

## Test instructions

Functional tests should work as usual.

## Screenshots
### Before

<img width="492" alt="Screenshot 2022-07-28 at 11 26 14" src="https://user-images.githubusercontent.com/105509190/181483915-8098eb57-98d2-43c8-b485-596b253fd376.png">

### After

<img width="859" alt="Screenshot 2022-07-28 at 11 23 38" src="https://user-images.githubusercontent.com/105509190/181483660-e4430a0d-7f8d-431a-93e1-98b10c935af9.png">

<img width="876" alt="Screenshot 2022-07-28 at 11 23 57" src="https://user-images.githubusercontent.com/105509190/181483675-107ab807-ea34-445e-a61f-d025c300dd38.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
