### PR TITLE
Remove deprecated MI site from GLOBAL_NAV_ITEMS

### DIFF
--- a/src/apps/global-nav-items.js
+++ b/src/apps/global-nav-items.js
@@ -2,7 +2,6 @@ const fs = require('fs')
 const path = require('path')
 const { compact, sortBy, concat, includes } = require('lodash')
 
-const config = require('../config')
 const urls = require('../lib/urls')
 
 const subApps = fs.readdirSync(__dirname)
@@ -26,19 +25,11 @@ const SORTED_APP_GLOBAL_NAV_ITEMS = sortBy(
   APP_GLOBAL_NAV_ITEMS,
   (globalNavItem) => globalNavItem.order
 )
-const GLOBAL_NAV_ITEMS = concat(
-  SORTED_APP_GLOBAL_NAV_ITEMS,
-  {
-    path: config.performanceDashboardsUrl,
-    label: 'MI dashboards',
-    key: 'datahub-mi',
-  },
-  {
-    path: urls.external.findExporters(),
-    label: 'Find exporters',
-    key: 'find-exporters',
-  }
-)
+const GLOBAL_NAV_ITEMS = concat(SORTED_APP_GLOBAL_NAV_ITEMS, {
+  path: urls.external.findExporters(),
+  label: 'Find exporters',
+  key: 'find-exporters',
+})
 
 /**
  * Required for querying access to apps


### PR DESCRIPTION
## Description of change

The old performance dashboards site has been switched off this morning. This was the only remaining mention of it in the frontend so I'm removing it.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
