### PR TITLE
Add start date filters to new events collection page

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -545,7 +545,7 @@ describe('Activity feed controllers', () => {
         }
 
         const actualQuery = activityFeedEventsQuery({
-          fullQuery: eventsColListQueryBuilder(name),
+          fullQuery: eventsColListQueryBuilder({ name: name }),
           from,
           size,
           sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
@@ -583,7 +583,7 @@ describe('Activity feed controllers', () => {
         const actualQuery = activityFeedEventsQuery({
           from,
           size,
-          fullQuery: eventsColListQueryBuilder(name),
+          fullQuery: eventsColListQueryBuilder({ name: name }),
           sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
         })
 
@@ -641,7 +641,10 @@ describe('Activity feed controllers', () => {
           const endDate = undefined
 
           const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder(startDate, endDate),
+            fullQuery: eventsColListQueryBuilder({
+              startDate: startDate,
+              endDate: endDate,
+            }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
@@ -653,11 +656,14 @@ describe('Activity feed controllers', () => {
           const endDate = '2022-12-12T08:39:06'
 
           const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder(startDate, endDate),
+            fullQuery: eventsColListQueryBuilder({
+              startDate: startDate,
+              endDate: endDate,
+            }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
-          expect(expectedEsQuery).to.deep.equal(actualQuery)
+          expect(expectedEsQuery(startDate, endDate)).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the start and end date is selected', () => {
@@ -665,7 +671,10 @@ describe('Activity feed controllers', () => {
           const endDate = '2022-12-12T08:39:06'
 
           const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder(startDate, endDate),
+            fullQuery: eventsColListQueryBuilder({
+              startDate: startDate,
+              endDate: endDate,
+            }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
@@ -727,7 +736,11 @@ describe('Activity feed controllers', () => {
       }
 
       const actualQuery = activityFeedEventsQuery({
-        fullQuery: eventsColListQueryBuilder(name, startDate, endDate),
+        fullQuery: eventsColListQueryBuilder({
+          name: name,
+          startDate: startDate,
+          endDate: endDate,
+        }),
         sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
       })
 

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -1,20 +1,21 @@
 const activityFeedEsFixtures = require('../../../../../../test/unit/data/activity-feed/activity-feed-from-es.json')
+const allActivityFeedEvents = require('../../../../../../test/sandbox/fixtures/v4/activity-feed/all-activity-feed-events.json')
 const buildMiddlewareParameters = require('../../../../../../test/unit/helpers/middleware-parameters-builder')
 const companyMock = require('../../../../../../test/unit/data/company.json')
 const {
   DATA_HUB_ACTIVITY,
   EXTERNAL_ACTIVITY,
   DATA_HUB_AND_EXTERNAL_ACTIVITY,
-  EVENT_ACTIVITY_SORT_OPTIONS,
 } = require('../constants')
 const { eventsColListQueryBuilder } = require('../controllers')
-const activityFeedEventsQuery = require('../es-queries/activity-feed-all-events-query')
 
 describe('Activity feed controllers', () => {
   let fetchActivityFeedStub,
+    fetchAllActivityFeedEventsStub,
     getGlobalUltimateHierarchyStub,
     controllers,
     middlewareParameters
+
   describe('#fetchActivityFeedHandler', () => {
     before(() => {
       fetchActivityFeedStub = sinon.stub().resolves(activityFeedEsFixtures)
@@ -511,6 +512,7 @@ describe('Activity feed controllers', () => {
       })
     })
   })
+
   describe('#eventsColListQueryBuilder', () => {
     context('check query builder when filtering on event name', () => {
       it('builds the right query when being filtered by event name', () => {
@@ -611,59 +613,112 @@ describe('Activity feed controllers', () => {
       }
     )
   })
-  describe('#allActivityFeedEventsQuery', () => {
-    context('check full dsl query when all filters are active', () => {
-      const name = 'Big Event'
-      const from = 0
-      const size = 10
-      const earliestStartDate = '2022-11-01T08:39:06'
-      const latestStartDate = '2022-12-12T08:39:06'
 
-      const expectedEsQuery = {
-        from,
-        size,
-        query: {
-          bool: {
-            must: [
-              {
-                terms: {
-                  'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-                },
-              },
-              {
-                match: {
-                  'object.name': name,
-                },
-              },
-              {
-                range: {
-                  'object.startTime': {
-                    gte: earliestStartDate,
-                    lte: latestStartDate,
-                  },
-                },
-              },
-            ],
+  describe('#fetchAllActivityFeedEvents', () => {
+    before(() => {
+      fetchAllActivityFeedEventsStub = sinon
+        .stub()
+        .resolves(allActivityFeedEvents)
+      controllers = proxyquire(
+        '../../src/apps/companies/apps/activity-feed/controllers',
+        {
+          './repos': {
+            fetchActivityFeed: fetchAllActivityFeedEventsStub,
           },
-        },
-        sort: {
-          'object.updated': {
-            order: 'desc',
-            unmapped_type: 'date',
-          },
-        },
-      }
+        }
+      )
+    })
 
-      const actualQuery = activityFeedEventsQuery({
-        fullQuery: eventsColListQueryBuilder({
-          name: name,
-          earliestStartDate: earliestStartDate,
-          latestStartDate: latestStartDate,
-        }),
-        sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+    context('when filtering for the events collection page', () => {
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {
+            sortBy: 'modified_on:desc',
+            name: 'project zeus',
+            earliestStartDate: '2020-11-01',
+            latestStartDate: '2020-11-10',
+            page: 1,
+          },
+        })
+
+        await controllers.fetchAllActivityFeedEvents(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
       })
 
-      expect(expectedEsQuery).to.deep.equal(actualQuery)
+      it('should call fetchAllActivityFeedEvents with the right params', async () => {
+        const name = 'project zeus'
+        const from = 0
+        const size = 10
+        const earliestStartDate = '2020-11-01'
+        const latestStartDate = '2020-11-10'
+
+        const expectedEsQuery = {
+          from,
+          size,
+          query: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+                  },
+                },
+                {
+                  match: {
+                    'object.name': name,
+                  },
+                },
+                {
+                  range: {
+                    'object.startTime': {
+                      gte: earliestStartDate,
+                      lte: latestStartDate,
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          sort: {
+            'object.updated': {
+              order: 'desc',
+              unmapped_type: 'date',
+            },
+          },
+        }
+
+        expect(fetchAllActivityFeedEventsStub).to.be.calledWith(
+          middlewareParameters.reqMock,
+          expectedEsQuery
+        )
+      })
+    })
+
+    context('when the endpoint returns error', () => {
+      const error = {
+        status: 500,
+      }
+
+      before(async () => {
+        fetchAllActivityFeedEventsStub.rejects(error)
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {},
+        })
+
+        await controllers.fetchAllActivityFeedEvents(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should call next with an error', async () => {
+        expect(middlewareParameters.resMock.json).to.not.have.been.called
+        expect(middlewareParameters.nextSpy).to.have.been.calledWith(error)
+      })
     })
   })
 })

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -511,186 +511,108 @@ describe('Activity feed controllers', () => {
       })
     })
   })
-  describe('#filtersQueryBuilder', () => {
-    context('check dsl query when filtering on event name', () => {
+  describe('#eventsColListQueryBuilder', () => {
+    context('check query builder when filtering on event name', () => {
       it('builds the right query when being filtered by event name', () => {
-        const from = 0
-        const size = 10
         const name = 'cool event'
-        const expectedEsQuery = {
-          from,
-          size,
-          query: {
-            bool: {
-              must: [
-                {
-                  terms: {
-                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-                  },
-                },
-                {
-                  match: {
-                    'object.name': name,
-                  },
-                },
-              ],
+        const expectedQuery = [
+          {
+            terms: {
+              'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
             },
           },
-          sort: {
-            'object.updated': {
-              order: 'desc',
-              unmapped_type: 'date',
+          {
+            match: {
+              'object.name': name,
             },
           },
-        }
-
-        const actualQuery = activityFeedEventsQuery({
-          from,
-          size,
-          fullQuery: eventsColListQueryBuilder({
-            name: name,
-          }),
-          sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        ]
+        const actualQuery = eventsColListQueryBuilder({
+          name: name,
         })
 
-        expect(expectedEsQuery).to.deep.equal(actualQuery)
+        expect(expectedQuery).to.deep.equal(actualQuery)
       })
 
       it('builds the right query when there is nothing entered into the event name filter', () => {
-        const from = 0
-        const size = 10
         const name = undefined
-        const expectedEsQuery = {
-          from,
-          size,
-          query: {
-            bool: {
-              must: [
-                {
-                  terms: {
-                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-                  },
-                },
-              ],
+        const expectedQuery = [
+          {
+            terms: {
+              'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
             },
           },
-          sort: {
-            'object.updated': {
-              order: 'desc',
-              unmapped_type: 'date',
-            },
-          },
-        }
-
-        const actualQuery = activityFeedEventsQuery({
-          from,
-          size,
-          fullQuery: eventsColListQueryBuilder({ name: name }),
-          sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        ]
+        const actualQuery = eventsColListQueryBuilder({
+          name: name,
         })
 
-        expect(expectedEsQuery).to.deep.equal(actualQuery)
+        expect(expectedQuery).to.deep.equal(actualQuery)
       })
     })
 
     context(
-      'check dsl query when filtering on event start and end date',
+      'check query builder when filtering on event start and end date',
       () => {
-        const expectedEsQuery = (
-          from,
-          size,
-          earliestStartDate,
-          latestStartDate
-        ) => ({
-          from,
-          size,
-          query: {
-            bool: {
-              must: [
-                {
-                  terms: {
-                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-                  },
-                },
-                {
-                  range: {
-                    'object.startTime': {
-                      gte: earliestStartDate,
-                      lte: latestStartDate,
-                    },
-                  },
-                },
-              ],
+        const expectedQuery = (earliestStartDate, latestStartDate) => [
+          {
+            terms: {
+              'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
             },
           },
-          sort: {
-            'object.updated': {
-              order: 'desc',
-              unmapped_type: 'date',
+          {
+            range: {
+              'object.startTime': {
+                gte: earliestStartDate,
+                lte: latestStartDate,
+              },
             },
           },
-        })
+        ]
 
         it('builds the right query when start date selected', () => {
           const earliestStartDate = '2022-11-01T08:39:06'
           const latestStartDate = undefined
-          const from = 0
-          const size = 10
-
-          const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder({
-              earliestStartDate: earliestStartDate,
-              latestStartDate: latestStartDate,
-            }),
-            sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+          const actualQuery = eventsColListQueryBuilder({
+            earliestStartDate: earliestStartDate,
+            latestStartDate: latestStartDate,
           })
 
           expect(
-            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
+            expectedQuery(earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the end date is selected', () => {
           const earliestStartDate = undefined
           const latestStartDate = '2022-12-12T08:39:06'
-          const from = 0
-          const size = 10
-
-          const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder({
-              earliestStartDate: earliestStartDate,
-              latestStartDate: latestStartDate,
-            }),
-            sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+          const actualQuery = eventsColListQueryBuilder({
+            earliestStartDate: earliestStartDate,
+            latestStartDate: latestStartDate,
           })
 
           expect(
-            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
+            expectedQuery(earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the start and end date is selected', () => {
           const earliestStartDate = '2022-11-01'
           const latestStartDate = '2022-12-12T08:39:06'
-          const from = 0
-          const size = 10
-
-          const actualQuery = activityFeedEventsQuery({
-            fullQuery: eventsColListQueryBuilder({
-              earliestStartDate: earliestStartDate,
-              latestStartDate: latestStartDate,
-            }),
-            sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+          const actualQuery = eventsColListQueryBuilder({
+            earliestStartDate: earliestStartDate,
+            latestStartDate: latestStartDate,
           })
 
           expect(
-            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
+            expectedQuery(earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
       }
     )
-
-    context('check dsl query when all filters are active', () => {
+  })
+  describe('#allActivityFeedEventsQuery', () => {
+    context('check full dsl query when all filters are active', () => {
       const name = 'Big Event'
       const from = 0
       const size = 10

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -594,7 +594,7 @@ describe('Activity feed controllers', () => {
     context(
       'check dsl query when filtering on event start and end date',
       () => {
-        const expectedEsQuery = (startDate, endDate) => ({
+        const expectedEsQuery = (earliestStartDate, latestStartDate) => ({
           query: {
             bool: {
               must: [
@@ -604,25 +604,11 @@ describe('Activity feed controllers', () => {
                   },
                 },
                 {
-                  bool: {
-                    should: [
-                      {
-                        range: {
-                          'object.startTime': {
-                            gte: startDate,
-                            lte: endDate,
-                          },
-                        },
-                      },
-                      {
-                        range: {
-                          'object.endTime': {
-                            gte: startDate,
-                            lte: endDate,
-                          },
-                        },
-                      },
-                    ],
+                  range: {
+                    'object.startTime': {
+                      gte: earliestStartDate,
+                      lte: latestStartDate,
+                    },
                   },
                 },
               ],
@@ -637,56 +623,62 @@ describe('Activity feed controllers', () => {
         })
 
         it('builds the right query when start date selected', () => {
-          const startDate = '2022-11-01T08:39:06'
-          const endDate = undefined
+          const earliestStartDate = '2022-11-01T08:39:06'
+          const latestStartDate = undefined
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
-              startDate: startDate,
-              endDate: endDate,
+              earliestStartDate: earliestStartDate,
+              latestStartDate: latestStartDate,
             }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
-          expect(expectedEsQuery(startDate, endDate)).to.deep.equal(actualQuery)
+          expect(
+            expectedEsQuery(earliestStartDate, latestStartDate)
+          ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the end date is selected', () => {
-          const startDate = undefined
-          const endDate = '2022-12-12T08:39:06'
+          const earliestStartDate = undefined
+          const latestStartDate = '2022-12-12T08:39:06'
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
-              startDate: startDate,
-              endDate: endDate,
+              earliestStartDate: earliestStartDate,
+              latestStartDate: latestStartDate,
             }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
-          expect(expectedEsQuery(startDate, endDate)).to.deep.equal(actualQuery)
+          expect(
+            expectedEsQuery(earliestStartDate, latestStartDate)
+          ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the start and end date is selected', () => {
-          const startDate = '2022-11-01T08:39:06'
-          const endDate = '2022-12-12T08:39:06'
+          const earliestStartDate = '2022-11-01'
+          const latestStartDate = '2022-12-12T08:39:06'
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
-              startDate: startDate,
-              endDate: endDate,
+              earliestStartDate: earliestStartDate,
+              latestStartDate: latestStartDate,
             }),
             sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
           })
 
-          expect(expectedEsQuery(startDate, endDate)).to.deep.equal(actualQuery)
+          expect(
+            expectedEsQuery(earliestStartDate, latestStartDate)
+          ).to.deep.equal(actualQuery)
         })
       }
     )
 
     context('check dsl query when all filters are active', () => {
       const name = 'Big Event'
-      const startDate = '2022-11-01T08:39:06'
-      const endDate = '2022-12-12T08:39:06'
+      const earliestStartDate = '2022-11-01T08:39:06'
+      const latestStartDate = '2022-12-12T08:39:06'
 
       const expectedEsQuery = {
         query: {
@@ -703,25 +695,11 @@ describe('Activity feed controllers', () => {
                 },
               },
               {
-                bool: {
-                  should: [
-                    {
-                      range: {
-                        'object.startTime': {
-                          gte: startDate,
-                          lte: endDate,
-                        },
-                      },
-                    },
-                    {
-                      range: {
-                        'object.endTime': {
-                          gte: startDate,
-                          lte: endDate,
-                        },
-                      },
-                    },
-                  ],
+                range: {
+                  'object.startTime': {
+                    gte: earliestStartDate,
+                    lte: latestStartDate,
+                  },
                 },
               },
             ],
@@ -738,8 +716,8 @@ describe('Activity feed controllers', () => {
       const actualQuery = activityFeedEventsQuery({
         fullQuery: eventsColListQueryBuilder({
           name: name,
-          startDate: startDate,
-          endDate: endDate,
+          earliestStartDate: earliestStartDate,
+          latestStartDate: latestStartDate,
         }),
         sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
       })

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -514,7 +514,7 @@ describe('Activity feed controllers', () => {
   describe('#filtersQueryBuilder', () => {
     context('check dsl query when filtering on event name', () => {
       it('builds the right query when being filtered by event name', () => {
-        const from = 1
+        const from = 0
         const size = 10
         const name = 'cool event'
         const expectedEsQuery = {
@@ -545,9 +545,11 @@ describe('Activity feed controllers', () => {
         }
 
         const actualQuery = activityFeedEventsQuery({
-          fullQuery: eventsColListQueryBuilder({ name: name }),
           from,
           size,
+          fullQuery: eventsColListQueryBuilder({
+            name: name,
+          }),
           sort: EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
         })
 
@@ -555,7 +557,7 @@ describe('Activity feed controllers', () => {
       })
 
       it('builds the right query when there is nothing entered into the event name filter', () => {
-        const from = 1
+        const from = 0
         const size = 10
         const name = undefined
         const expectedEsQuery = {
@@ -594,7 +596,14 @@ describe('Activity feed controllers', () => {
     context(
       'check dsl query when filtering on event start and end date',
       () => {
-        const expectedEsQuery = (earliestStartDate, latestStartDate) => ({
+        const expectedEsQuery = (
+          from,
+          size,
+          earliestStartDate,
+          latestStartDate
+        ) => ({
+          from,
+          size,
           query: {
             bool: {
               must: [
@@ -625,6 +634,8 @@ describe('Activity feed controllers', () => {
         it('builds the right query when start date selected', () => {
           const earliestStartDate = '2022-11-01T08:39:06'
           const latestStartDate = undefined
+          const from = 0
+          const size = 10
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
@@ -635,13 +646,15 @@ describe('Activity feed controllers', () => {
           })
 
           expect(
-            expectedEsQuery(earliestStartDate, latestStartDate)
+            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the end date is selected', () => {
           const earliestStartDate = undefined
           const latestStartDate = '2022-12-12T08:39:06'
+          const from = 0
+          const size = 10
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
@@ -652,13 +665,15 @@ describe('Activity feed controllers', () => {
           })
 
           expect(
-            expectedEsQuery(earliestStartDate, latestStartDate)
+            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
 
         it('builds the right query when the start and end date is selected', () => {
           const earliestStartDate = '2022-11-01'
           const latestStartDate = '2022-12-12T08:39:06'
+          const from = 0
+          const size = 10
 
           const actualQuery = activityFeedEventsQuery({
             fullQuery: eventsColListQueryBuilder({
@@ -669,7 +684,7 @@ describe('Activity feed controllers', () => {
           })
 
           expect(
-            expectedEsQuery(earliestStartDate, latestStartDate)
+            expectedEsQuery(from, size, earliestStartDate, latestStartDate)
           ).to.deep.equal(actualQuery)
         })
       }
@@ -677,10 +692,14 @@ describe('Activity feed controllers', () => {
 
     context('check dsl query when all filters are active', () => {
       const name = 'Big Event'
+      const from = 0
+      const size = 10
       const earliestStartDate = '2022-11-01T08:39:06'
       const latestStartDate = '2022-12-12T08:39:06'
 
       const expectedEsQuery = {
+        from,
+        size,
         query: {
           bool: {
             must: [

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -530,7 +530,7 @@ describe('Activity feed controllers', () => {
           },
         ]
         const actualQuery = eventsColListQueryBuilder({
-          name: name,
+          name,
         })
 
         expect(expectedQuery).to.deep.equal(actualQuery)
@@ -546,7 +546,7 @@ describe('Activity feed controllers', () => {
           },
         ]
         const actualQuery = eventsColListQueryBuilder({
-          name: name,
+          name,
         })
 
         expect(expectedQuery).to.deep.equal(actualQuery)
@@ -576,8 +576,8 @@ describe('Activity feed controllers', () => {
           const earliestStartDate = '2022-11-01T08:39:06'
           const latestStartDate = undefined
           const actualQuery = eventsColListQueryBuilder({
-            earliestStartDate: earliestStartDate,
-            latestStartDate: latestStartDate,
+            earliestStartDate,
+            latestStartDate,
           })
 
           expect(
@@ -589,8 +589,8 @@ describe('Activity feed controllers', () => {
           const earliestStartDate = undefined
           const latestStartDate = '2022-12-12T08:39:06'
           const actualQuery = eventsColListQueryBuilder({
-            earliestStartDate: earliestStartDate,
-            latestStartDate: latestStartDate,
+            earliestStartDate,
+            latestStartDate,
           })
 
           expect(
@@ -602,8 +602,8 @@ describe('Activity feed controllers', () => {
           const earliestStartDate = '2022-11-01'
           const latestStartDate = '2022-12-12T08:39:06'
           const actualQuery = eventsColListQueryBuilder({
-            earliestStartDate: earliestStartDate,
-            latestStartDate: latestStartDate,
+            earliestStartDate,
+            latestStartDate,
           })
 
           expect(

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -409,7 +409,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
           latestStartDate: latestStartDate,
         }),
         from,
-        ACTIVITIES_PER_PAGE,
+        size: ACTIVITIES_PER_PAGE,
         sort:
           EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
           EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -404,9 +404,9 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       req,
       allActivityFeedEventsQuery({
         fullQuery: eventsColListQueryBuilder({
-          name: name,
-          earliestStartDate: earliestStartDate,
-          latestStartDate: latestStartDate,
+          name,
+          earliestStartDate,
+          latestStartDate,
         }),
         from,
         size: ACTIVITIES_PER_PAGE,

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -361,7 +361,7 @@ async function fetchAventriAttendees(req, res, next) {
   }
 }
 
-const eventsColListQueryBuilder = (name) => {
+const eventsColListQueryBuilder = ({ name }) => {
   const eventNameFilter = name
     ? {
         match: {
@@ -387,7 +387,9 @@ async function fetchAllActivityFeedEvents(req, res, next) {
     const allActivityFeedEventsResults = await fetchActivityFeed(
       req,
       allActivityFeedEventsQuery({
-        fullQuery: eventsColListQueryBuilder(name),
+        fullQuery: eventsColListQueryBuilder({
+          name: name,
+        }),
         from,
         ACTIVITIES_PER_PAGE,
         sort:

--- a/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/activity-feed-all-events-query.js
@@ -1,4 +1,4 @@
-const activityFeedEventsQuery = ({ fullQuery, from, size, sort }) => ({
+const activityFeedEventsQuery = ({ fullQuery, from = 0, size = 10, sort }) => ({
   from,
   size,
   query: {

--- a/src/client/components/ActivityFeedFilteredCollectionList/index.jsx
+++ b/src/client/components/ActivityFeedFilteredCollectionList/index.jsx
@@ -16,7 +16,7 @@ import CollectionHeader from '../CollectionList/CollectionHeader'
 import ActivityList from '../ActivityFeed/activities/card/ActivityList'
 import Activity from '../ActivityFeed/Activity'
 
-const EventsFilteredCollectionList = ({
+const ActivityFeedFilteredCollectionList = ({
   itemsPerPage = 10,
   sortOptions = null,
   taskProps,
@@ -43,7 +43,7 @@ const EventsFilteredCollectionList = ({
           })
         }
         return (
-          <GridRow data-test="new-collection-list">
+          <GridRow data-test="activity-feed-collection-list">
             {children}
             <GridCol>
               <article>
@@ -51,7 +51,7 @@ const EventsFilteredCollectionList = ({
                   <CollectionHeader
                     totalItems={total}
                     collectionName="events"
-                    data-test="new-collection-header"
+                    data-test="activity-feed-collection-header"
                   />
                 }
                 {sortOptions && (
@@ -83,7 +83,7 @@ const EventsFilteredCollectionList = ({
   )
 }
 
-EventsFilteredCollectionList.propTypes = {
+ActivityFeedFilteredCollectionList.propTypes = {
   taskProps: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.string,
@@ -109,6 +109,7 @@ EventsFilteredCollectionList.propTypes = {
       value: PropTypes.string,
     })
   ),
+  allActivityFeedEvents: PropTypes.array,
 }
 
-export default EventsFilteredCollectionList
+export default ActivityFeedFilteredCollectionList

--- a/src/client/components/DateField/index.jsx
+++ b/src/client/components/DateField/index.jsx
@@ -31,6 +31,7 @@ const DateField = ({
         key={name}
         name={name}
         value={value}
+        max="9999-12-31"
         aria-label={label}
         type={type}
         onChange={(e) => {

--- a/src/client/components/DateField/index.jsx
+++ b/src/client/components/DateField/index.jsx
@@ -28,6 +28,7 @@ const DateField = ({
     <FieldWrapper {...{ name, label, legend, hint }} {...props}>
       <Input
         id={`field-${name}-1`}
+        data-test={`field-${name}`}
         key={name}
         name={name}
         value={value}

--- a/src/client/components/NewFilteredCollectionList/index.jsx
+++ b/src/client/components/NewFilteredCollectionList/index.jsx
@@ -1,0 +1,114 @@
+/* eslint-disable react/no-array-index-key */
+// this is because there isn't necessarily a unique id to use as the key
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Route } from 'react-router-dom'
+import { GridRow, GridCol } from 'govuk-react'
+import { isEmpty } from 'lodash'
+import qs from 'qs'
+
+import Task from '../Task'
+import CollectionSort from '../CollectionList/CollectionSort'
+
+import RoutedPagination from '../Pagination/RoutedPagination'
+import CollectionHeader from '../CollectionList/CollectionHeader'
+import ActivityList from '../ActivityFeed/activities/card/ActivityList'
+import Activity from '../ActivityFeed/Activity'
+
+const NewFilteredCollectionList = ({
+  itemsPerPage = 10,
+  sortOptions = null,
+  taskProps,
+  total = 0,
+  children,
+  maxItemsToPaginate = 10000,
+  defaultQueryParams,
+  allActivityFeedEvents,
+}) => {
+  const totalPages = Math.ceil(
+    Math.min(total, maxItemsToPaginate) / itemsPerPage
+  )
+
+  return (
+    <Route>
+      {({ history, location }) => {
+        const qsParams = qs.parse(location.search.slice(1))
+        const initialPage = parseInt(qsParams.page, 10)
+        if (defaultQueryParams && isEmpty(qsParams)) {
+          history.push({
+            search: qs.stringify({
+              ...defaultQueryParams,
+            }),
+          })
+        }
+        return (
+          <GridRow data-test="collection-list">
+            {children}
+            <GridCol>
+              <article>
+                {
+                  <CollectionHeader
+                    totalItems={total}
+                    collectionName="events"
+                    data-test="collection-header"
+                  />
+                }
+                {sortOptions && (
+                  <CollectionSort
+                    sortOptions={sortOptions}
+                    totalPages={totalPages}
+                  />
+                )}
+                <Task.Status {...taskProps}>
+                  {() => (
+                    <ActivityList>
+                      {allActivityFeedEvents?.map((event, index) => {
+                        return (
+                          <li key={`event-${index}`}>
+                            <Activity activity={event} />
+                          </li>
+                        )
+                      })}
+                    </ActivityList>
+                  )}
+                </Task.Status>
+                <RoutedPagination initialPage={initialPage} items={total} />
+              </article>
+            </GridCol>
+          </GridRow>
+        )
+      }}
+    </Route>
+  )
+}
+
+NewFilteredCollectionList.propTypes = {
+  taskProps: PropTypes.shape({
+    name: PropTypes.string,
+    id: PropTypes.string,
+    progressMessage: PropTypes.string,
+    renderProgress: PropTypes.func,
+    startOnRender: PropTypes.shape({
+      payload: PropTypes.shape({
+        page: PropTypes.number,
+        filters: PropTypes.object,
+        search: PropTypes.string,
+      }).isRequired,
+      onSuccessDispatch: PropTypes.string,
+    }).isRequired,
+  }),
+  children: PropTypes.node,
+  maxItemsToPaginate: PropTypes.number,
+  defaultQueryParams: PropTypes.object,
+  total: PropTypes.number,
+  itemsPerPage: PropTypes.number,
+  sortOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    })
+  ),
+}
+
+export default NewFilteredCollectionList

--- a/src/client/components/NewFilteredCollectionList/index.jsx
+++ b/src/client/components/NewFilteredCollectionList/index.jsx
@@ -43,7 +43,7 @@ const NewFilteredCollectionList = ({
           })
         }
         return (
-          <GridRow data-test="collection-list">
+          <GridRow data-test="new-collection-list">
             {children}
             <GridCol>
               <article>
@@ -51,7 +51,7 @@ const NewFilteredCollectionList = ({
                   <CollectionHeader
                     totalItems={total}
                     collectionName="events"
-                    data-test="collection-header"
+                    data-test="new-collection-header"
                   />
                 }
                 {sortOptions && (

--- a/src/client/components/NewFilteredCollectionList/index.jsx
+++ b/src/client/components/NewFilteredCollectionList/index.jsx
@@ -16,7 +16,7 @@ import CollectionHeader from '../CollectionList/CollectionHeader'
 import ActivityList from '../ActivityFeed/activities/card/ActivityList'
 import Activity from '../ActivityFeed/Activity'
 
-const NewFilteredCollectionList = ({
+const EventsFilteredCollectionList = ({
   itemsPerPage = 10,
   sortOptions = null,
   taskProps,
@@ -83,7 +83,7 @@ const NewFilteredCollectionList = ({
   )
 }
 
-NewFilteredCollectionList.propTypes = {
+EventsFilteredCollectionList.propTypes = {
   taskProps: PropTypes.shape({
     name: PropTypes.string,
     id: PropTypes.string,
@@ -111,4 +111,4 @@ NewFilteredCollectionList.propTypes = {
   ),
 }
 
-export default NewFilteredCollectionList
+export default EventsFilteredCollectionList

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -218,6 +218,18 @@ const EventsCollection = ({
                         placeholder="Search event name"
                         data-test="event-name-filter"
                       />
+                      <Filters.Date
+                        label="Earliest start date"
+                        name="earliest_start_date"
+                        qsParamName="earliest_start_date"
+                        data-test="earliest-start-date-filter"
+                      />
+                      <Filters.Date
+                        label="Latest start date"
+                        name="latest_start_date"
+                        qsParamName="latest_start_date"
+                        data-test="latest-start-date-filter"
+                      />
                     </CollectionFilters>
                     <GridCol>
                       <ActivityList>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -35,7 +35,7 @@ import {
   state2props,
 } from './state'
 
-import NewFilteredCollectionList from '../../../components/NewFilteredCollectionList'
+import EventsFilteredCollectionList from '../../../components/NewFilteredCollectionList'
 
 const EventsCollection = ({
   payload,
@@ -186,7 +186,7 @@ const EventsCollection = ({
               </CollectionFilters>
             </FilteredCollectionList>
           ) : (
-            <NewFilteredCollectionList
+            <EventsFilteredCollectionList
               {...props}
               collectionName="event"
               sortOptions={COLLECTION_LIST_SORT_SELECT_OPTIONS}
@@ -216,7 +216,7 @@ const EventsCollection = ({
                   data-test="latest-start-date-filter"
                 />
               </CollectionFilters>
-            </NewFilteredCollectionList>
+            </EventsFilteredCollectionList>
           )
         }
       </CheckUserFeatureFlag>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { GridCol, GridRow } from 'govuk-react'
 import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 
 import {
@@ -15,9 +14,6 @@ import {
   Filters,
   FilterToggleSection,
   DefaultLayout,
-  CollectionSort,
-  CollectionHeader,
-  RoutedPagination,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 
@@ -30,8 +26,6 @@ import {
 
 import { LABELS, COLLECTION_LIST_SORT_SELECT_OPTIONS } from './constants'
 
-import Task from '../../../components/Task'
-
 import {
   ID,
   TASK_GET_EVENTS_LIST,
@@ -41,8 +35,7 @@ import {
   state2props,
 } from './state'
 
-import Activity from '../../../components/ActivityFeed/Activity'
-import ActivityList from '../../../components/ActivityFeed/activities/card/ActivityList'
+import NewFilteredCollectionList from '../../../components/NewFilteredCollectionList'
 
 const EventsCollection = ({
   payload,
@@ -51,13 +44,8 @@ const EventsCollection = ({
   allActivityFeedEvents,
   total,
   page,
-  itemsPerPage = 10,
-  maxItemsToPaginate = 10000,
   ...props
 }) => {
-  const totalPages = Math.ceil(
-    Math.min(total, maxItemsToPaginate) / itemsPerPage
-  )
   const collectionListTask = {
     name: TASK_GET_EVENTS_LIST,
     id: ID,
@@ -92,6 +80,16 @@ const EventsCollection = ({
     startOnRender: {
       payload: payload.organiser,
       onSuccessDispatch: EVENTS__SELECTED_ORGANISER,
+    },
+  }
+
+  const activityFeedEventTask = {
+    name: TASK_GET_ALL_ACTIVITY_FEED_EVENTS,
+    id: ID,
+    progressMessage: 'Loading events',
+    startOnRender: {
+      payload: payload,
+      onSuccessDispatch: EVENTS__ALL_ACTIVITY_FEED_EVENTS_LOADED,
     },
   }
 
@@ -188,68 +186,40 @@ const EventsCollection = ({
               </CollectionFilters>
             </FilteredCollectionList>
           ) : (
-            <>
-              <CollectionHeader
-                totalItems={total}
-                collectionName="events"
-                data-test="collection-header"
-              />
-              <CollectionSort
-                sortOptions={COLLECTION_LIST_SORT_SELECT_OPTIONS}
-                totalPages={totalPages}
-              />
-              <Task.Status
-                name={TASK_GET_ALL_ACTIVITY_FEED_EVENTS}
-                id={ID}
-                progressMessage="Loading events"
-                startOnRender={{
-                  payload: payload,
-                  onSuccessDispatch: EVENTS__ALL_ACTIVITY_FEED_EVENTS_LOADED,
-                }}
-              >
-                {() => (
-                  <GridRow>
-                    <CollectionFilters>
-                      <Filters.Input
-                        id="EventsCollection.name"
-                        qsParam="name"
-                        name="name"
-                        label={LABELS.eventName}
-                        placeholder="Search event name"
-                        data-test="event-name-filter"
-                      />
-                      <Filters.Date
-                        label="Earliest start date"
-                        name="earliest_start_date"
-                        qsParamName="earliest_start_date"
-                        data-test="earliest-start-date-filter"
-                      />
-                      <Filters.Date
-                        label="Latest start date"
-                        name="latest_start_date"
-                        qsParamName="latest_start_date"
-                        data-test="latest-start-date-filter"
-                      />
-                    </CollectionFilters>
-                    <GridCol>
-                      <ActivityList>
-                        {allActivityFeedEvents?.map((event, index) => {
-                          return (
-                            <li key={`event-${index}`}>
-                              <Activity activity={event} />
-                            </li>
-                          )
-                        })}
-                      </ActivityList>
-                    </GridCol>
-                  </GridRow>
-                )}
-              </Task.Status>
-            </>
+            <NewFilteredCollectionList
+              {...props}
+              collectionName="event"
+              sortOptions={COLLECTION_LIST_SORT_SELECT_OPTIONS}
+              taskProps={activityFeedEventTask}
+              allActivityFeedEvents={allActivityFeedEvents}
+              total={total}
+            >
+              <CollectionFilters>
+                <Filters.Input
+                  id="EventsCollection.name"
+                  qsParam="name"
+                  name="name"
+                  label={LABELS.eventName}
+                  placeholder="Search event name"
+                  data-test="event-name-filter"
+                />
+                <Filters.Date
+                  label="Earliest start date"
+                  name="earliest_start_date"
+                  qsParamName="earliest_start_date"
+                  data-test="earliest-start-date-filter"
+                />
+                <Filters.Date
+                  label="Latest start date"
+                  name="latest_start_date"
+                  qsParamName="latest_start_date"
+                  data-test="latest-start-date-filter"
+                />
+              </CollectionFilters>
+            </NewFilteredCollectionList>
           )
         }
       </CheckUserFeatureFlag>
-      <RoutedPagination initialPage={page} items={total} />
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -35,7 +35,7 @@ import {
   state2props,
 } from './state'
 
-import EventsFilteredCollectionList from '../../../components/NewFilteredCollectionList'
+import ActivityFeedFilteredCollectionList from '../../../components/ActivityFeedFilteredCollectionList'
 
 const EventsCollection = ({
   payload,
@@ -186,7 +186,7 @@ const EventsCollection = ({
               </CollectionFilters>
             </FilteredCollectionList>
           ) : (
-            <EventsFilteredCollectionList
+            <ActivityFeedFilteredCollectionList
               {...props}
               collectionName="event"
               sortOptions={COLLECTION_LIST_SORT_SELECT_OPTIONS}
@@ -216,7 +216,7 @@ const EventsCollection = ({
                   data-test="latest-start-date-filter"
                 />
               </CollectionFilters>
-            </EventsFilteredCollectionList>
+            </ActivityFeedFilteredCollectionList>
           )
         }
       </CheckUserFeatureFlag>

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -54,7 +54,7 @@ const getAllActivityFeedEvents = ({
   name,
   earliest_start_date,
   latest_start_date,
-  page
+  page,
 }) =>
   axios
     .get(urls.events.activity.data(), {
@@ -63,7 +63,7 @@ const getAllActivityFeedEvents = ({
         name: name,
         earliestStartDate: earliest_start_date,
         latestStartDate: latest_start_date,
-        page: page
+        page: page,
       },
     })
     .then(({ data }) => data)

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -49,10 +49,22 @@ const getEventsMetadata = () =>
     }))
     .catch(handleError)
 
-const getAllActivityFeedEvents = ({ sortby, page, name }) =>
+const getAllActivityFeedEvents = ({
+  sortby,
+  name,
+  earliest_start_date,
+  latest_start_date,
+  page
+}) =>
   axios
     .get(urls.events.activity.data(), {
-      params: { sortBy: sortby, page, name },
+      params: {
+        sortBy: sortby,
+        name: name,
+        earliestStartDate: earliest_start_date,
+        latestStartDate: latest_start_date,
+        page: page
+      },
     })
     .then(({ data }) => data)
     .catch(() => Promise.reject('Unable to load events.'))

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -154,7 +154,7 @@ describe('Event Collection List Page - React', () => {
       })
 
       it('should display the events result count header', () => {
-        cy.get('[data-test="collection-header"]').should(
+        cy.get('[data-test="new-collection-header"]').should(
           'have.text',
           '82 events'
         )

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -154,7 +154,7 @@ describe('Event Collection List Page - React', () => {
       })
 
       it('should display the events result count header', () => {
-        cy.get('[data-test="new-collection-header"]').should(
+        cy.get('[data-test="activity-feed-collection-header"]').should(
           'have.text',
           '82 events'
         )

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -465,6 +465,20 @@ describe('events Collections Filter', () => {
       const queryParamWithName = 'name=Big+Event'
 
       context('should filter from user input', () => {
+        before(() => {
+          cy.intercept(
+            'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&name=Big+Event&page=1`
+          ).as('nameRequest')
+        })
+
+        it('should pass the name to the controller', () => {
+          cy.get(element).type(`${eventName}{enter}`)
+          cy.wait('@nameRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
         it('should add name from user input to query param', () => {
           cy.get(element).type(`${eventName}{enter}`)
           cy.url().should('include', queryParamWithName)
@@ -484,6 +498,10 @@ describe('events Collections Filter', () => {
           cy.get(element).should('have.value', eventName)
         })
       })
+
+      after(() => {
+        cy.get(element).clear()
+      })
     })
 
     context('Start date', () => {
@@ -495,25 +513,45 @@ describe('events Collections Filter', () => {
       const queryParamWithLatestStartDate = 'latest_start_date=2020-11-10'
 
       context('should filter from user input', () => {
+        before(() => {
+          cy.intercept(
+            'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&earliestStartDate=2020-11-01&latestStartDate=2020-11-10&page=1`
+          ).as('dateRequest')
+        })
+        beforeEach(() => {
+          cy.get(earliestStartElement).clear()
+          cy.get(latestStartElement).clear()
+        })
+
+        it('should pass the date to the controller', () => {
+          cy.get(earliestStartElement).type(earliestStartDate)
+          cy.get(latestStartElement).type(latestStartDate)
+          cy.wait('@dateRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
         it('should add earliest start date to query param', () => {
           cy.get(earliestStartElement).type(earliestStartDate)
           cy.url().should('include', queryParamWithEarliestStartDate)
+          cy.url().should('not.include', queryParamWithLatestStartDate)
         })
 
-        it('should add earliest start and latest start date to query param', () => {
+        it('should add latest start date to query param', () => {
+          cy.get(latestStartElement).type(latestStartDate)
+          cy.url().should('not.include', queryParamWithEarliestStartDate)
+          cy.url().should('include', queryParamWithLatestStartDate)
+        })
+
+        it('should add earliest start date and latest start date to query param', () => {
+          cy.get(earliestStartElement).type(earliestStartDate)
           cy.get(latestStartElement).type(latestStartDate)
           cy.url().should('include', queryParamWithEarliestStartDate)
           cy.url().should('include', queryParamWithLatestStartDate)
         })
 
-        it('should add latest start date to query param', () => {
-          cy.get(earliestStartElement).clear()
-          cy.url().should('not.include', queryParamWithEarliestStartDate)
-          cy.url().should('include', queryParamWithLatestStartDate)
-        })
-
         it('should remove query params if date is cleared', () => {
-          cy.get(latestStartElement).clear()
           cy.url().should('not.include', queryParamWithEarliestStartDate)
           cy.url().should('not.include', queryParamWithLatestStartDate)
         })
@@ -527,6 +565,10 @@ describe('events Collections Filter', () => {
           cy.get(earliestStartElement).should('have.value', earliestStartDate)
           cy.get(latestStartElement).should('have.value', latestStartDate)
         })
+      })
+      after(() => {
+        cy.get(earliestStartElement).clear()
+        cy.get(latestStartElement).clear()
       })
     })
     after(() => {

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -458,25 +458,75 @@ describe('events Collections Filter', () => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
       cy.visit(events.index())
     })
+
     context('Event name', () => {
       const element = '[data-test="event-name-filter"]'
       const eventName = 'Big Event'
       const queryParamWithName = 'name=Big+Event'
-      const queryParamEmpty = 'name='
 
-      it('should not add anything to the query param when the page is first loaded', () => {
-        cy.url().should('not.include', queryParamEmpty)
+      context('should filter from user input', () => {
+        it('should add name from user input to query param', () => {
+          cy.get(element).type(`${eventName}{enter}`)
+          cy.url().should('include', queryParamWithName)
+        })
+
+        it('should not add anything to the query param if the name is backspaced', () => {
+          cy.get(element).type(`{selectAll}{backspace}{enter}`)
+          cy.url().should('not.include', queryParamWithName)
+        })
       })
 
-      it('should add name from user input to query param', () => {
-        cy.get(element).type(`${eventName}{enter}`)
-        cy.url().should('include', queryParamWithName)
+      context('should filter from url', () => {
+        it('should add name from url to filter', () => {
+          cy.visit(
+            `/events?page=1&sortby=modified_on%3Adesc&featureTesting=user-event-activities&${queryParamWithName}`
+          )
+          cy.get(element).should('have.value', eventName)
+        })
+      })
+    })
+
+    context('Start date', () => {
+      const earliestStartElement = '#field-earliest_start_date-1'
+      const latestStartElement = '#field-latest_start_date-1'
+      const earliestStartDate = '2020-11-01'
+      const latestStartDate = '2020-11-10'
+      const queryParamWithEarliestStartDate = 'earliest_start_date=2020-11-01'
+      const queryParamWithLatestStartDate = 'latest_start_date=2020-11-10'
+
+      context('should filter from user input', () => {
+        it('should add earliest start date to query param', () => {
+          cy.get(earliestStartElement).type(earliestStartDate)
+          cy.url().should('include', queryParamWithEarliestStartDate)
+        })
+
+        it('should add earliest start and latest start date to query param', () => {
+          cy.get(latestStartElement).type(latestStartDate)
+          cy.url().should('include', queryParamWithEarliestStartDate)
+          cy.url().should('include', queryParamWithLatestStartDate)
+        })
+
+        it('should add latest start date to query param', () => {
+          cy.get(earliestStartElement).clear()
+          cy.url().should('not.include', queryParamWithEarliestStartDate)
+          cy.url().should('include', queryParamWithLatestStartDate)
+        })
+
+        it('should remove query params if date is cleared', () => {
+          cy.get(latestStartElement).clear()
+          cy.url().should('not.include', queryParamWithEarliestStartDate)
+          cy.url().should('not.include', queryParamWithLatestStartDate)
+        })
       })
 
-      it('should not add anything to the query param if the name is backspaced', () => {
-        cy.get(element).type(`${eventName}{enter}`)
-        cy.get(element).type(`{selectAll}{backspace}{enter}`)
-        cy.url().should('not.include', queryParamWithName)
+      context('should filter from url', () => {
+        it('should add the earliest and latest start date to the url', () => {
+          cy.visit(
+            `/events?page=1&sortby=modified_on%3Adesc&featureTesting=user-event-activities&${queryParamWithEarliestStartDate}&${queryParamWithLatestStartDate}`
+          )
+          cy.get(earliestStartElement).should('have.value', earliestStartDate)
+          cy.get(latestStartElement).should('have.value', latestStartDate)
+        })
       })
     })
     after(() => {

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -505,8 +505,9 @@ describe('events Collections Filter', () => {
     })
 
     context('Start date', () => {
-      const earliestStartElement = '#field-earliest_start_date-1'
-      const latestStartElement = '#field-latest_start_date-1'
+      const earliestStartElement = '[data-test="field-earliest_start_date"]'
+      const latestStartElement = '[data-test="field-latest_start_date"]'
+
       const earliestStartDate = '2020-11-01'
       const latestStartDate = '2020-11-10'
       const queryParamWithEarliestStartDate = 'earliest_start_date=2020-11-01'


### PR DESCRIPTION
## Description of change
This PR adds in 'Earliest start date' and 'Latest start date' filters to the new events collection page via modification to the Activity Stream OpenSearch query. 

The page has also been refactored so that the header and filters match the layout in the existing events collection list. 

## Test instructions
- In Django dev API, add the user feature flag user-event-activities to your adviser profile.
- Bring up this branch on your local dev frontend and navigate to http://localhost:3000/events
- You should see an 'Earliest start date' filter and a 'Latest start date' filter on the left hand side.
- It should work if you add dates in either/both these filters and should also add to query string in the url. 

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/70902973/182385275-7c0c7bfe-69ea-4863-84d3-590b30bdcdf8.png)

### After
![image](https://user-images.githubusercontent.com/70902973/182385380-1b45e8ce-70e3-4a3a-af98-575561a58404.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
