### PR TITLE
Add pagination to Aventri attendees page

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -299,13 +299,15 @@ async function fetchAventriAttendees(req, res, next) {
   // istanbul ignore next: Covered by functional tests
   try {
     const eventId = req.params.aventriEventId
+    const { page } = req.query
 
     const sort = EVENT_ATTENDEES_SORT_OPTIONS[req.query.sortBy]
+    const from = (page - 1) * ACTIVITIES_PER_PAGE
 
     //get the attendees
     const aventriAttendeeResults = await fetchActivityFeed(
       req,
-      aventriAttendeeQuery({ eventId, sort })
+      aventriAttendeeQuery({ eventId, sort, from })
     )
 
     const totalAttendees = aventriAttendeeResults.hits.total.value

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -307,6 +307,9 @@ async function fetchAventriAttendees(req, res, next) {
       req,
       aventriAttendeeQuery({ eventId, sort })
     )
+
+    const totalAttendees = aventriAttendeeResults.hits.total.value
+
     // istanbul ignore next: Covered by functional tests
     let aventriAttendees = aventriAttendeeResults.hits.hits.map(
       (hit) => hit._source
@@ -347,6 +350,7 @@ async function fetchAventriAttendees(req, res, next) {
     )
 
     res.json({
+      totalAttendees,
       aventriEventData,
       aventriAttendees,
     })

--- a/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
@@ -1,4 +1,5 @@
-const aventriAttendeeQuery = ({ eventId, sort }) => ({
+const aventriAttendeeQuery = ({ eventId, sort, from }) => ({
+  from,
   query: {
     bool: {
       must: [

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -23,9 +23,8 @@ import ActivityList from '../../../components/ActivityFeed/activities/card/Activ
 const EventAventriAttendees = ({
   aventriAttendees,
   aventriEventData,
-  selectedSortBy,
-  selectedPage,
-  page,
+  payload,
+  page = parseInt(page || 1, 10),
   totalAttendees,
   itemsPerPage = 10,
   maxItemsToPaginate = 10000,
@@ -64,7 +63,7 @@ const EventAventriAttendees = ({
               id={ID}
               progressMessage="Loading Aventri attendees"
               startOnRender={{
-                payload: { aventriEventId, selectedSortBy, selectedPage },
+                payload: { aventriEventId, ...payload },
                 onSuccessDispatch: EVENTS__AVENTRI_ATTENDEES_LOADED,
               }}
             >
@@ -121,10 +120,7 @@ const EventAventriAttendees = ({
           )
         }
       </CheckUserFeatureFlag>
-      <RoutedPagination
-        initialPage={page}
-        items={totalAttendees}
-      ></RoutedPagination>
+      <RoutedPagination initialPage={page} items={totalAttendees} />
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -9,6 +9,7 @@ import {
   DefaultLayout,
   LocalNav,
   LocalNavLink,
+  RoutedPagination,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
@@ -23,6 +24,8 @@ const EventAventriAttendees = ({
   aventriAttendees,
   aventriEventData,
   selectedSortBy,
+  selectedPage,
+  page,
   totalAttendees,
   itemsPerPage = 10,
   maxItemsToPaginate = 10000,
@@ -61,7 +64,7 @@ const EventAventriAttendees = ({
               id={ID}
               progressMessage="Loading Aventri attendees"
               startOnRender={{
-                payload: { aventriEventId, selectedSortBy },
+                payload: { aventriEventId, selectedSortBy, selectedPage },
                 onSuccessDispatch: EVENTS__AVENTRI_ATTENDEES_LOADED,
               }}
             >
@@ -83,39 +86,45 @@ const EventAventriAttendees = ({
                       </LocalNavLink>
                     </LocalNav>
                   </GridCol>
-                  <GridCol setWidth="three-quarters">
-                    <CollectionHeader
-                      totalItems={totalAttendees}
-                      collectionName="attendee"
-                      data-test="attendee-collection-header"
-                    />
-                    <CollectionSort
-                      sortOptions={[
-                        {
-                          name: 'First name: A-Z',
-                          value: 'first_name:asc',
-                        },
-                        {
-                          name: 'First name: Z-A',
-                          value: 'first_name:desc',
-                        },
-                      ]}
-                      totalPages={totalPages}
-                    />
-                    <ActivityList>
-                      {aventriAttendees?.map((attendee, index) => (
-                        <li key={`aventri-attendee-${index}`}>
-                          <Activity activity={attendee}></Activity>
-                        </li>
-                      ))}
-                    </ActivityList>
-                  </GridCol>
+                  {aventriAttendees && (
+                    <GridCol setWidth="three-quarters">
+                      <CollectionHeader
+                        totalItems={totalAttendees}
+                        collectionName="attendee"
+                        data-test="attendee-collection-header"
+                      />
+                      <CollectionSort
+                        sortOptions={[
+                          {
+                            name: 'First name: A-Z',
+                            value: 'first_name:asc',
+                          },
+                          {
+                            name: 'First name: Z-A',
+                            value: 'first_name:desc',
+                          },
+                        ]}
+                        totalPages={totalPages}
+                      />
+                      <ActivityList>
+                        {aventriAttendees?.map((attendee, index) => (
+                          <li key={`aventri-attendee-${index}`}>
+                            <Activity activity={attendee}></Activity>
+                          </li>
+                        ))}
+                      </ActivityList>
+                    </GridCol>
+                  )}
                 </GridRow>
               )}
             </Task.Status>
           )
         }
       </CheckUserFeatureFlag>
+      <RoutedPagination
+        initialPage={page}
+        items={totalAttendees}
+      ></RoutedPagination>
     </DefaultLayout>
   )
 }

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { useParams } from 'react-router-dom'
+import { Route, useParams } from 'react-router-dom'
+import { isEmpty } from 'lodash'
+import qs from 'qs'
 
 import urls from '../../../../lib/urls'
 import {
@@ -23,6 +25,10 @@ import ActivityList from '../../../components/ActivityFeed/activities/card/Activ
 const EventAventriAttendees = ({
   aventriAttendees,
   aventriEventData,
+  defaultQueryParams = {
+    page: 1,
+    sortby: 'first_name:asc',
+  },
   payload,
   page = parseInt(page || 1, 10),
   totalAttendees,
@@ -49,79 +55,100 @@ const EventAventriAttendees = ({
   )
 
   return (
-    <DefaultLayout
-      heading={eventName}
-      pageTitle="Events Attendees"
-      breadcrumbs={breadcrumbs}
-      useReactRouter={true}
-    >
-      <CheckUserFeatureFlag userFeatureFlagName={EVENT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          isFeatureFlagEnabled && (
-            <Task.Status
-              name={TASK_GET_EVENT_AVENTRI_ATTENDEES}
-              id={ID}
-              progressMessage="Loading Aventri attendees"
-              startOnRender={{
-                payload: { aventriEventId, ...payload },
-                onSuccessDispatch: EVENTS__AVENTRI_ATTENDEES_LOADED,
-              }}
-            >
-              {() => (
-                <GridRow data-test="event-aventri-attendee">
-                  <GridCol setWidth="one-quarter">
-                    <LocalNav dataTest="event-aventri-nav">
-                      <LocalNavLink
-                        dataTest="event-aventri-details-link"
-                        href={urls.events.aventri.details(aventriEventId)}
-                      >
-                        Details
-                      </LocalNavLink>
-                      <LocalNavLink
-                        dataTest="event-aventri-attendees-link"
-                        href={urls.events.aventri.attendees(aventriEventId)}
-                      >
-                        Attendees
-                      </LocalNavLink>
-                    </LocalNav>
-                  </GridCol>
-                  {aventriAttendees && (
-                    <GridCol setWidth="three-quarters">
-                      <CollectionHeader
-                        totalItems={totalAttendees}
-                        collectionName="attendee"
-                        data-test="attendee-collection-header"
-                      />
-                      <CollectionSort
-                        sortOptions={[
-                          {
-                            name: 'First name: A-Z',
-                            value: 'first_name:asc',
-                          },
-                          {
-                            name: 'First name: Z-A',
-                            value: 'first_name:desc',
-                          },
-                        ]}
-                        totalPages={totalPages}
-                      />
-                      <ActivityList>
-                        {aventriAttendees?.map((attendee, index) => (
-                          <li key={`aventri-attendee-${index}`}>
-                            <Activity activity={attendee}></Activity>
-                          </li>
-                        ))}
-                      </ActivityList>
-                    </GridCol>
-                  )}
-                </GridRow>
-              )}
-            </Task.Status>
-          )
+    <Route>
+      {({ history, location }) => {
+        const qsParams = qs.parse(location.search.slice(1))
+
+        const page = parseInt(qsParams.page, 10)
+        if (isEmpty(qsParams)) {
+          history.push({
+            search: qs.stringify({
+              ...defaultQueryParams,
+            }),
+          })
         }
-      </CheckUserFeatureFlag>
-      <RoutedPagination initialPage={page} items={totalAttendees} />
-    </DefaultLayout>
+
+        return (
+          <DefaultLayout
+            heading={eventName}
+            pageTitle="Events Attendees"
+            breadcrumbs={breadcrumbs}
+            useReactRouter={true}
+          >
+            <CheckUserFeatureFlag
+              userFeatureFlagName={EVENT_ACTIVITY_FEATURE_FLAG}
+            >
+              {(isFeatureFlagEnabled) =>
+                isFeatureFlagEnabled && (
+                  <Task.Status
+                    name={TASK_GET_EVENT_AVENTRI_ATTENDEES}
+                    id={ID}
+                    progressMessage="Loading Aventri attendees"
+                    startOnRender={{
+                      payload: { aventriEventId, ...payload },
+                      onSuccessDispatch: EVENTS__AVENTRI_ATTENDEES_LOADED,
+                    }}
+                  >
+                    {() => (
+                      <GridRow data-test="event-aventri-attendee">
+                        <GridCol setWidth="one-quarter">
+                          <LocalNav dataTest="event-aventri-nav">
+                            <LocalNavLink
+                              dataTest="event-aventri-details-link"
+                              href={urls.events.aventri.details(aventriEventId)}
+                            >
+                              Details
+                            </LocalNavLink>
+                            <LocalNavLink
+                              dataTest="event-aventri-attendees-link"
+                              href={urls.events.aventri.attendees(
+                                aventriEventId
+                              )}
+                            >
+                              Attendees
+                            </LocalNavLink>
+                          </LocalNav>
+                        </GridCol>
+                        {aventriAttendees && (
+                          <GridCol setWidth="three-quarters">
+                            <CollectionHeader
+                              totalItems={totalAttendees}
+                              collectionName="attendee"
+                              data-test="attendee-collection-header"
+                            />
+                            <CollectionSort
+                              sortOptions={[
+                                {
+                                  name: 'First name: A-Z',
+                                  value: 'first_name:asc',
+                                },
+                                {
+                                  name: 'First name: Z-A',
+                                  value: 'first_name:desc',
+                                },
+                              ]}
+                              totalPages={totalPages}
+                            />
+                            <ActivityList>
+                              {aventriAttendees?.map((attendee, index) => (
+                                <li key={`aventri-attendee-${index}`}>
+                                  <Activity activity={attendee}></Activity>
+                                </li>
+                              ))}
+                            </ActivityList>
+                          </GridCol>
+                        )}
+                      </GridRow>
+                    )}
+                  </Task.Status>
+                )
+              }
+            </CheckUserFeatureFlag>
+            <RoutedPagination initialPage={page} items={totalAttendees} />
+          </DefaultLayout>
+        )
+      }}
+    </Route>
   )
 }
 

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -5,6 +5,7 @@ import { useParams } from 'react-router-dom'
 import urls from '../../../../lib/urls'
 import {
   CollectionSort,
+  CollectionHeader,
   DefaultLayout,
   LocalNav,
   LocalNavLink,
@@ -22,6 +23,7 @@ const EventAventriAttendees = ({
   aventriAttendees,
   aventriEventData,
   selectedSortBy,
+  totalAttendees,
 }) => {
   const { aventriEventId } = useParams()
   const eventName = aventriEventData?.object.name
@@ -77,6 +79,11 @@ const EventAventriAttendees = ({
                     </LocalNav>
                   </GridCol>
                   <GridCol setWidth="three-quarters">
+                    <CollectionHeader
+                      totalItems={totalAttendees}
+                      collectionName="attendee"
+                      data-test="attendee-collection-header"
+                    />
                     <CollectionSort
                       sortOptions={[
                         {

--- a/src/client/modules/Events/EventAventriAttendees/index.jsx
+++ b/src/client/modules/Events/EventAventriAttendees/index.jsx
@@ -24,6 +24,8 @@ const EventAventriAttendees = ({
   aventriEventData,
   selectedSortBy,
   totalAttendees,
+  itemsPerPage = 10,
+  maxItemsToPaginate = 10000,
 }) => {
   const { aventriEventId } = useParams()
   const eventName = aventriEventData?.object.name
@@ -40,6 +42,9 @@ const EventAventriAttendees = ({
       text: eventName,
     },
   ]
+  const totalPages = Math.ceil(
+    Math.min(totalAttendees, maxItemsToPaginate) / itemsPerPage
+  )
 
   return (
     <DefaultLayout
@@ -95,6 +100,7 @@ const EventAventriAttendees = ({
                           value: 'first_name:desc',
                         },
                       ]}
+                      totalPages={totalPages}
                     />
                     <ActivityList>
                       {aventriAttendees?.map((attendee, index) => (

--- a/src/client/modules/Events/EventAventriAttendees/state.js
+++ b/src/client/modules/Events/EventAventriAttendees/state.js
@@ -1,3 +1,4 @@
+import { omitBy, isEmpty } from 'lodash'
 import qs from 'qs'
 
 export const TASK_GET_EVENT_AVENTRI_ATTENDEES =
@@ -5,15 +6,24 @@ export const TASK_GET_EVENT_AVENTRI_ATTENDEES =
 
 export const ID = 'eventAventriAttendees'
 
-export const state2props = ({ ...state }) => {
+const parseQueryString = (queryString) => {
+  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
+  return {
+    ...queryParams,
+    page: parseInt(queryParams.page || 1, 10),
+  }
+}
+
+export const state2props = ({ router, ...state }) => {
+  const queryString = router.location.search.slice(1)
+  const queryParams = parseQueryString(queryString)
+
   const selectedSortBy =
     qs.parse(location.search.slice(1)).sortby || 'first_name:asc'
 
-  const selectedPage = qs.parse(location.search.slice(1)).page || '1'
-
   return {
-    selectedSortBy,
-    selectedPage,
+    payload: { ...queryParams, selectedSortBy },
+    page: queryParams.page,
     ...state[ID],
   }
 }

--- a/src/client/modules/Events/EventAventriAttendees/state.js
+++ b/src/client/modules/Events/EventAventriAttendees/state.js
@@ -9,8 +9,11 @@ export const state2props = ({ ...state }) => {
   const selectedSortBy =
     qs.parse(location.search.slice(1)).sortby || 'first_name:asc'
 
+  const selectedPage = qs.parse(location.search.slice(1)).page || '1'
+
   return {
     selectedSortBy,
+    selectedPage,
     ...state[ID],
   }
 }

--- a/src/client/modules/Events/EventAventriAttendees/tasks.js
+++ b/src/client/modules/Events/EventAventriAttendees/tasks.js
@@ -4,11 +4,11 @@ const urls = require('../../../../lib/urls')
 export const getEventAventriAttendees = ({
   aventriEventId,
   selectedSortBy,
-  selectedPage,
+  page,
 }) => {
   return axios
     .get(urls.events.aventri.attendeesData(aventriEventId), {
-      params: { sortBy: selectedSortBy, page: selectedPage },
+      params: { sortBy: selectedSortBy, page },
     })
     .then(({ data }) => data)
     .catch(() => {

--- a/src/client/modules/Events/EventAventriAttendees/tasks.js
+++ b/src/client/modules/Events/EventAventriAttendees/tasks.js
@@ -4,10 +4,11 @@ const urls = require('../../../../lib/urls')
 export const getEventAventriAttendees = ({
   aventriEventId,
   selectedSortBy,
+  selectedPage,
 }) => {
   return axios
     .get(urls.events.aventri.attendeesData(aventriEventId), {
-      params: { sortBy: selectedSortBy },
+      params: { sortBy: selectedSortBy, page: selectedPage },
     })
     .then(({ data }) => data)
     .catch(() => {

--- a/test/functional/cypress/specs/events/aventri-attendees-spec.js
+++ b/test/functional/cypress/specs/events/aventri-attendees-spec.js
@@ -28,6 +28,17 @@ describe('Aventri event attendees', () => {
         })
       })
 
+      it('should display the attendees result count header', () => {
+        cy.get('[data-test="attendee-collection-header"]').should(
+          'have.text',
+          '32 attendees'
+        )
+      })
+
+      it('should display the expected number of pages', () => {
+        cy.get('[data-test=pagination-summary]').contains('Page 1 of 4')
+      })
+
       it('should display the side nav bar', () => {
         cy.get('[data-test="event-aventri-nav"]').should('exist')
         cy.get('[data-test="event-aventri-details-link"]')
@@ -83,13 +94,13 @@ describe('Aventri event attendees', () => {
             'GET',
             `${urls.events.aventri.attendeesData(
               existingEventId
-            )}?sortBy=first_name:asc`
+            )}?sortBy=first_name:asc&page=1`
           ).as('firstNameA-Z')
           cy.intercept(
             'GET',
             `${urls.events.aventri.attendeesData(
               existingEventId
-            )}?sortBy=first_name:desc`
+            )}?sortBy=first_name:desc&page=1`
           ).as('firstNameZ-A')
           cy.visit(urls.events.aventri.attendees(existingEventId))
         })
@@ -109,6 +120,29 @@ describe('Aventri event attendees', () => {
           cy.get('[data-test="aventri-attendee"]')
             .eq(0)
             .should('contain', 'Polly Parton')
+        })
+      })
+
+      context('when there are more than 10 attendees', () => {
+        beforeEach(() => {
+          cy.intercept(
+            'GET',
+            `${urls.events.aventri.attendeesData(
+              existingEventId
+            )}?sortBy=first_name:asc&page=1`
+          ).as('firstNameA-Z')
+          cy.intercept(
+            'GET',
+            `${urls.events.aventri.attendeesData(
+              existingEventId
+            )}?sortBy=first_name:desc&page=1`
+          ).as('firstNameZ-A')
+          cy.visit(urls.events.aventri.attendees(existingEventId))
+        })
+        it('should be possible to page through', () => {
+          cy.get('[data-page-number="2"]').click()
+          cy.get('[data-test=pagination-summary]').contains('Page 2 of 4')
+          cy.get('[data-test="aventri-attendee"]').should('exist')
         })
       })
     })

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
@@ -9,7 +9,7 @@
   },
   "hits": {
     "total": {
-      "value": 2,
+      "value": 32,
       "relation": "eq"
     },
     "max_score": 3.6005385,
@@ -44,7 +44,9 @@
             "dit:lastName": "Woods",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
-            "type": ["dit:aventri:Attendee"]
+            "type": [
+              "dit:aventri:Attendee"
+            ]
           },
           "published": "2022-02-24T11:28:57",
           "type": "dit:aventri:Attendee",
@@ -81,7 +83,9 @@
             "dit:lastName": "Ella",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
-            "type": ["dit:aventri:Attendee"]
+            "type": [
+              "dit:aventri:Attendee"
+            ]
           },
           "published": "2022-02-24T11:28:57",
           "type": "dit:aventri:Attendee"
@@ -117,7 +121,313 @@
             "dit:lastName": "Shrek",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
-            "type": ["dit:aventri:Attendee"]
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Ariel",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Ocean",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Ariel",
+            "dit:lastName": "Ocean",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Tiana",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Green",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Tiana",
+            "dit:lastName": "Green",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Belle",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Beastly",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Belle",
+            "dit:lastName": "Beastly",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Snow",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "White",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Snow",
+            "dit:lastName": "White",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Rapunzel",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Hair",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Rapunzel",
+            "dit:lastName": "Hair",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Elsa",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Ice",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Elsa",
+            "dit:lastName": "Ice",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Jasmine",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Tiger",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Jasmine",
+            "dit:lastName": "Tiger",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
+          },
+          "published": "2022-02-24T11:28:57",
+          "type": "dit:aventri:Attendee"
+        }
+      },
+      {
+        "_index": "activities__feed_id_dummy-data-feed__date_2022-06-28__timestamp_1656410763__batch_id_ltepro51__",
+        "_type": "_doc",
+        "_id": "dit:aventri:Event:1111:Attendee:2222:Create",
+        "_score": 3.6005385,
+        "_source": {
+          "dit:application": "aventri",
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1111",
+              "type": "dit:aventri:Event"
+            },
+            "dit:aventri:approvalstatus": "",
+            "dit:aventri:category": null,
+            "dit:aventri:companyname": "Ever Far Away",
+            "dit:aventri:createdby": "attendee",
+            "dit:aventri:email": "",
+            "dit:aventri:firstname": "Fiona",
+            "dit:aventri:language": "eng",
+            "dit:aventri:lastmodified": "2022-01-24T11:12:13",
+            "dit:aventri:lastname": "Shrek",
+            "dit:aventri:modifiedby": "attendee",
+            "dit:aventri:registrationstatus": "Confirmed",
+            "dit:aventri:virtual_event_attendance": "Yes",
+            "dit:emailAddress": "",
+            "dit:firstName": "Fiona",
+            "dit:lastName": "Shrek",
+            "id": "dit:aventri:Attendee:2222",
+            "published": "1970-01-01T00:00:00",
+            "type": [
+              "dit:aventri:Attendee"
+            ]
           },
           "published": "2022-02-24T11:28:57",
           "type": "dit:aventri:Attendee"


### PR DESCRIPTION
## Description of change

This ticket adds pagination to the Aventri event attendees pages. We have replicated the behaviour on Data hub events attendees pages.

## Test instructions

- Ensure you have `user-event-activities` feature flag on. You can do this is dev django admin.
- Get this branch up locally 
- Visit this Aventri event page (as it's the only one with 10 or more attendees): http://localhost:3000/events/aventri/3333/attendees?featureTesting=user-event-activities

You should see:
- Number of attendees 
- Page X of Y
- URL with sort by and page as parameters
- Pagination on the bottom

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/83657534/182413536-8e73ae62-0fb3-44f4-a962-8ced6b9cab06.png)

### After
![image](https://user-images.githubusercontent.com/83657534/182414133-874f06dd-1220-483e-9337-5c01aa8df212.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
