### PR TITLE
Replace Raven with new Sentry SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
         "prop-types": "^15.8.1",
         "pure-uuid": "^1.6.2",
         "qs": "^6.11.0",
-        "raven": "^2.6.4",
         "react": "^17.0.2",
         "react-app-polyfill": "^3.0.0",
         "react-dom": "^17.0.2",
@@ -14455,6 +14454,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -15692,6 +15692,7 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -23254,7 +23255,8 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "node_modules/is-callable": {
       "version": "1.2.4",
@@ -25679,6 +25681,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
       "dependencies": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -30334,42 +30337,6 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "deprecated": "Please upgrade to @sentry/node. See the migration guide https://bit.ly/3ybOlo7",
-      "dependencies": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "bin": {
-        "raven": "bin/raven"
-      },
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
-    "node_modules/raven/node_modules/cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/raven/node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
       }
     },
     "node_modules/raw-body": {
@@ -35315,6 +35282,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
       "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -48761,7 +48729,8 @@
     "charenc": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "dev": true
     },
     "check-error": {
       "version": "1.0.2",
@@ -49749,7 +49718,8 @@
     "crypt": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.12.0",
@@ -55581,7 +55551,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.2.4",
@@ -57370,6 +57341,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
       "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
       "requires": {
         "charenc": "0.0.2",
         "crypt": "0.0.2",
@@ -60850,30 +60822,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
-    },
-    "raven": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
-      "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
-      "requires": {
-        "cookie": "0.3.1",
-        "md5": "^2.2.1",
-        "stack-trace": "0.0.10",
-        "timed-out": "4.0.1",
-        "uuid": "3.3.2"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw=="
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
     },
     "raw-body": {
       "version": "2.5.1",
@@ -64739,7 +64687,8 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA=="
+      "integrity": "sha512-G7r3AhovYtr5YKOWQkta8RKAPb+J9IsO4uVmzjl8AZwfhs8UcUwTiD6gcJYSgOtzyjvQKrKYn41syHbUWMkafA==",
+      "optional": true
     },
     "timers-browserify": {
       "version": "2.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,12 @@
         "@nivo/tooltip": "^0.79.0",
         "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.8.3",
+<<<<<<< HEAD
         "@sentry/browser": "^7.9.0",
+=======
+        "@sentry/browser": "^7.8.0",
+        "@sentry/node": "^7.9.0",
+>>>>>>> 072e0e7b8 (Install @sentry/node dependency)
         "autoprefixer": "^10.4.4",
         "axios": "^0.27.2",
         "basic-auth": "^2.0.1",
@@ -4314,6 +4319,71 @@
       "dependencies": {
         "@sentry/types": "7.9.0",
         "@sentry/utils": "7.9.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.9.0.tgz",
+      "integrity": "sha512-MeggSCLyhUhsX3gRRvDhTADKYshuWjTRO/dUv3Jw+2xToSDvSWXJXDkIg5mCdlyOhh9/G+5xdWY58CfomzPZgg==",
+      "dependencies": {
+        "@sentry/core": "7.9.0",
+        "@sentry/hub": "7.9.0",
+        "@sentry/types": "7.9.0",
+        "@sentry/utils": "7.9.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/core": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.9.0.tgz",
+      "integrity": "sha512-WVGd2hV7Clcpl7/GL8LsRr4Zk9o/7o4rZHfs1Qed5lMRNYcxiMwucC1CYILVpJqVfY+8vIRP9v9Ss9ta2VUikw==",
+      "dependencies": {
+        "@sentry/hub": "7.9.0",
+        "@sentry/types": "7.9.0",
+        "@sentry/utils": "7.9.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/hub": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.9.0.tgz",
+      "integrity": "sha512-KzPbGCB5mONgsXEzqHy6uOaOuqLnhmFmSpGg+M03J6UJnJaNM7nrNp80MhStmjLMq6whEYVE07DrMAn3+iaQdg==",
+      "dependencies": {
+        "@sentry/types": "7.9.0",
+        "@sentry/utils": "7.9.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/types": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.9.0.tgz",
+      "integrity": "sha512-VGnUgELVMpGJCYW1triO+5XSyaPjB2Zu6esUgbb8iJ5bi+OWtxklixXgwhdaTb0FDzmRL/T/pckmrIuBTLySHQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node/node_modules/@sentry/utils": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.9.0.tgz",
+      "integrity": "sha512-4f9TZvAVopgG7Lp1TcPSekSX1Ashk68Et4T8Y+60EVX5se19i0hpytbHWWwrXSrb3w0KpGANk0byoZkdaTgkYA==",
+      "dependencies": {
+        "@sentry/types": "7.9.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -25453,6 +25523,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -40669,6 +40744,58 @@
         "@sentry/types": "7.9.0",
         "@sentry/utils": "7.9.0",
         "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.9.0.tgz",
+      "integrity": "sha512-MeggSCLyhUhsX3gRRvDhTADKYshuWjTRO/dUv3Jw+2xToSDvSWXJXDkIg5mCdlyOhh9/G+5xdWY58CfomzPZgg==",
+      "requires": {
+        "@sentry/core": "7.9.0",
+        "@sentry/hub": "7.9.0",
+        "@sentry/types": "7.9.0",
+        "@sentry/utils": "7.9.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@sentry/core": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.9.0.tgz",
+          "integrity": "sha512-WVGd2hV7Clcpl7/GL8LsRr4Zk9o/7o4rZHfs1Qed5lMRNYcxiMwucC1CYILVpJqVfY+8vIRP9v9Ss9ta2VUikw==",
+          "requires": {
+            "@sentry/hub": "7.9.0",
+            "@sentry/types": "7.9.0",
+            "@sentry/utils": "7.9.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/hub": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-7.9.0.tgz",
+          "integrity": "sha512-KzPbGCB5mONgsXEzqHy6uOaOuqLnhmFmSpGg+M03J6UJnJaNM7nrNp80MhStmjLMq6whEYVE07DrMAn3+iaQdg==",
+          "requires": {
+            "@sentry/types": "7.9.0",
+            "@sentry/utils": "7.9.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@sentry/types": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.9.0.tgz",
+          "integrity": "sha512-VGnUgELVMpGJCYW1triO+5XSyaPjB2Zu6esUgbb8iJ5bi+OWtxklixXgwhdaTb0FDzmRL/T/pckmrIuBTLySHQ=="
+        },
+        "@sentry/utils": {
+          "version": "7.9.0",
+          "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.9.0.tgz",
+          "integrity": "sha512-4f9TZvAVopgG7Lp1TcPSekSX1Ashk68Et4T8Y+60EVX5se19i0hpytbHWWwrXSrb3w0KpGANk0byoZkdaTgkYA==",
+          "requires": {
+            "@sentry/types": "7.9.0",
+            "tslib": "^1.9.3"
+          }
+        }
       }
     },
     "@sentry/types": {
@@ -57122,6 +57249,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+    },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,6 @@
     "prop-types": "^15.8.1",
     "pure-uuid": "^1.6.2",
     "qs": "^6.11.0",
-    "raven": "^2.6.4",
     "react": "^17.0.2",
     "react-app-polyfill": "^3.0.0",
     "react-dom": "^17.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@redux-devtools/extension": "^3.2.2",
     "@reduxjs/toolkit": "^1.8.3",
     "@sentry/browser": "^7.9.0",
+    "@sentry/node": "^7.9.0",
     "autoprefixer": "^10.4.4",
     "axios": "^0.27.2",
     "basic-auth": "^2.0.1",

--- a/src/server.js
+++ b/src/server.js
@@ -62,7 +62,7 @@ Joi.assert(process.env, envSchema, {
 
 app.disable('x-powered-by')
 
-// Raven request handler must be the first middleware
+// Sentry request handler must be the first middleware
 reporter.setup(app)
 
 if (!config.ci) {
@@ -147,7 +147,7 @@ app.use(reactGlobalProps())
 app.use(fixSlashes())
 app.use(routers)
 
-// Raven error handler must come before other error middleware
+// Sentry error handler must come before other error middleware
 reporter.handleErrors(app)
 
 app.use(errors.notFound)


### PR DESCRIPTION
## Description of change

The `raven` SDK for Sentry has been deprecated and is not being fully maintained. This PR replaces it with the actively maintained `@sentry/node` package.

## Test instructions

Sentry integration should still work.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
