### PR TITLE
Update validation error messages for no recent interaction

### DIFF
--- a/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
+++ b/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
@@ -35,11 +35,11 @@ const StyledFieldInput = styled(FieldInput)({
   width: 50,
 })
 
-const MAX_DAYS = 32767 // Set on the API endpoint (DB constraint)
+const MAX_DAYS = 365
 const POSITIVE_INT_REGEX = /^[0-9]+$/
-const EMPTY_ERR_MSG = 'Enter when you want to get reminders for your projects'
-const MIN_ERR_MSG = 'Enter a whole number that’s 1 or higher, like 25'
-const MAX_ERR_MSG = `Enter a whole number that’s less than or equal to ${MAX_DAYS}`
+const ERROR_MESSAGE = 'Enter a whole number that’s between 1 and 365, like 25'
+const EMPTY_ERROR_MESSAGE =
+  'Enter when you want to get reminders for your projects'
 
 const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
 
@@ -111,17 +111,15 @@ const NoRecentInteractionForm = () => (
                               name={`reminder_days_${groupIndex}`}
                               data-test={`reminder_days_${groupIndex}`}
                               validate={(value) => {
-                                if (isPositiveInteger(value)) {
+                                if (isEmpty(value)) {
+                                  return EMPTY_ERROR_MESSAGE
+                                } else if (isPositiveInteger(value)) {
                                   const val = parseInt(value, 10)
-                                  return val === 0
-                                    ? MIN_ERR_MSG
-                                    : val > MAX_DAYS
-                                    ? MAX_ERR_MSG
-                                    : null
+                                  return val > 0 && val <= MAX_DAYS
+                                    ? null
+                                    : ERROR_MESSAGE
                                 } else {
-                                  return isEmpty(value)
-                                    ? EMPTY_ERR_MSG
-                                    : MIN_ERR_MSG
+                                  return ERROR_MESSAGE
                                 }
                               }}
                             />

--- a/test/functional/cypress/specs/reminders/settings/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/no-recent-interaction-spec.js
@@ -311,6 +311,17 @@ describe('Edit no recent interaction', () => {
     })
   })
 
+  const assertErrorMessage = (value) => {
+    cy.get('[data-test="reminders-yes"]').check()
+    cy.get('[data-test="reminder_days_0"]').clear()
+    cy.get('[data-test="reminder_days_0"]').type(value)
+    cy.get('[data-test="submit-button"]').click()
+    cy.get('[data-test="summary-form-errors"] ul > li').should(
+      'contain',
+      'Enter a whole number that’s between 1 and 365, like 25'
+    )
+  }
+
   context('Form validation', () => {
     const indices = [0, 1, 2, 3, 4]
     before(() => {
@@ -358,58 +369,23 @@ describe('Edit no recent interaction', () => {
     })
 
     it('should display an error when the value is negative', () => {
-      cy.get('[data-test="reminders-yes"]').check()
-      cy.get('[data-test="reminder_days_0"]').clear()
-      cy.get('[data-test="reminder_days_0"]').type('-1')
-      cy.get('[data-test="submit-button"]').click()
-      cy.get('[data-test="summary-form-errors"] ul > li').should(
-        'contain',
-        'Enter a whole number that’s 1 or higher, like 25'
-      )
+      assertErrorMessage('-1')
     })
 
     it('should display an error on any non-numerical value', () => {
-      cy.get('[data-test="reminders-yes"]').check()
-      cy.get('[data-test="reminder_days_0"]').clear()
-      cy.get('[data-test="reminder_days_0"]').type('t')
-      cy.get('[data-test="submit-button"]').click()
-      cy.get('[data-test="summary-form-errors"] ul > li').should(
-        'contain',
-        'Enter a whole number that’s 1 or higher, like 25'
-      )
+      assertErrorMessage('t')
     })
 
-    it('should display an error on a floating point values', () => {
-      cy.get('[data-test="reminders-yes"]').check()
-      cy.get('[data-test="reminder_days_0"]').clear()
-      cy.get('[data-test="reminder_days_0"]').type('1.5')
-      cy.get('[data-test="submit-button"]').click()
-      cy.get('[data-test="summary-form-errors"] ul > li').should(
-        'contain',
-        'Enter a whole number that’s 1 or higher, like 25'
-      )
+    it('should display an error on a floating point value', () => {
+      assertErrorMessage('1.5')
     })
 
     it('should display an error when the value is zero', () => {
-      cy.get('[data-test="reminders-yes"]').check()
-      cy.get('[data-test="reminder_days_0"]').clear()
-      cy.get('[data-test="reminder_days_0"]').type('0')
-      cy.get('[data-test="submit-button"]').click()
-      cy.get('[data-test="summary-form-errors"] ul > li').should(
-        'contain',
-        'Enter a whole number that’s 1 or higher, like 25'
-      )
+      assertErrorMessage('0')
     })
 
     it('should display an error when the value has breached the limit', () => {
-      cy.get('[data-test="reminders-yes"]').check()
-      cy.get('[data-test="reminder_days_0"]').clear()
-      cy.get('[data-test="reminder_days_0"]').type('32768')
-      cy.get('[data-test="submit-button"]').click()
-      cy.get('[data-test="summary-form-errors"] ul > li').should(
-        'contain',
-        'Enter a whole number that’s less than or equal to 32767'
-      )
+      assertErrorMessage('366')
     })
   })
 
@@ -428,7 +404,7 @@ describe('Edit no recent interaction', () => {
 
     it('should render a "Settings updated" banner', () => {
       cy.get('[data-test="reminders-yes"]').check()
-      cy.get(`[data-test="reminder_days_0"]`).type(5)
+      cy.get(`[data-test="reminder_days_0"]`).type(1)
       cy.get('[data-test="add-another"]').click()
       cy.get(`[data-test="reminder_days_1"]`).type(10)
       cy.get('[data-test="add-another"]').click()
@@ -436,10 +412,10 @@ describe('Edit no recent interaction', () => {
       cy.get('[data-test="add-another"]').click()
       cy.get(`[data-test="reminder_days_3"]`).type(20)
       cy.get('[data-test="add-another"]').click()
-      cy.get(`[data-test="reminder_days_4"]`).type(25)
+      cy.get(`[data-test="reminder_days_4"]`).type(365)
       cy.get(`[data-test="submit-button"]`).click()
       assertPayload('@saveNri', {
-        reminder_days: ['5', '10', '15', '20', '25'],
+        reminder_days: ['1', '10', '15', '20', '365'],
         email_reminders_enabled: true,
       })
       cy.get('[data-test="flash"]').should('have.text', 'Settings updated')


### PR DESCRIPTION
## Description of change
Provide better validation error messages around the no recent interaction settings form. Specifically, a user is only allowed to enter values between 1 and 365.

## Test instructions
Go to `/reminders/settings/no-recent-interaction` and choose **Yes** to the question "Do you want to get reminders for projects with no recent interaction?" then select "Add another" and generally play with the input field by adding negative numbers, zero, 365 (the max number of days) and any old gobbledygook.

## Screenshots
<img width="899" alt="Screenshot 2022-08-08 at 13 17 07" src="https://user-images.githubusercontent.com/964268/183415947-2cd7043a-8056-4d65-aedb-19cadead3e58.png">

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
