### PR TITLE
Feature/det 227 display event reference number

### DIFF
--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -11,6 +11,7 @@ import {
   LocalNav,
   LocalNavLink,
   NewWindowLink,
+  StatusMessage,
   SummaryTable,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
@@ -65,59 +66,76 @@ const EventAventriDetails = ({ name, eventDate, location, fullAddress }) => {
               {() => {
                 return (
                   name && (
-                    <GridRow data-test="eventAventriDetails">
-                      <GridCol setWidth="one-quarter">
-                        <LocalNav dataTest="event-aventri-nav">
-                          <LocalNavLink
-                            dataTest="event-aventri-details-link"
-                            href={urls.events.aventri.details(aventriEventId)}
-                          >
-                            Details
-                          </LocalNavLink>
-                          <LocalNavLink
-                            dataTest="event-aventri-attendees-link"
-                            href={urls.events.aventri.attendees(aventriEventId)}
-                          >
-                            Attendees
-                          </LocalNavLink>
-                        </LocalNav>
-                      </GridCol>
-                      <GridCol setWidth="three-quarters">
-                        <StyledSummaryTable>
-                          <SummaryTable.Row
-                            heading="Event date"
-                            children={eventDate}
-                          />
-                          <SummaryTable.Row
-                            heading="Event location type"
-                            children={isEmpty(location) ? 'Not set' : location}
-                          />
-                          <SummaryTable.Row
-                            heading="Address"
-                            children={
-                              isEmpty(fullAddress) ? 'Not set' : fullAddress
-                            }
-                          />
-                          <SummaryTable.Row
-                            heading="Aventri reference number"
-                            children={
-                              isEmpty(aventriEventId) ? (
-                                'No event reference'
-                              ) : (
-                                <>
-                                  <span>
-                                    {aventriEventId}&nbsp;
-                                    <NewWindowLink href={aventriEventLink}>
-                                      View in Aventri
-                                    </NewWindowLink>
-                                  </span>
-                                </>
-                              )
-                            }
-                          />
-                        </StyledSummaryTable>
-                      </GridCol>
-                    </GridRow>
+                    <>
+                      <StatusMessage>
+                        This event has been automatically synced from Aventri.
+                        <br />
+                        Event details, registrants and attendees can only be
+                        edited in Aventri. Changes can take up to 24 hours to
+                        sync.
+                        <br />
+                        <NewWindowLink href={aventriEventLink}>
+                          View in Aventri
+                        </NewWindowLink>
+                      </StatusMessage>
+                      <GridRow data-test="eventAventriDetails">
+                        <GridCol setWidth="one-quarter">
+                          <LocalNav dataTest="event-aventri-nav">
+                            <LocalNavLink
+                              dataTest="event-aventri-details-link"
+                              href={urls.events.aventri.details(aventriEventId)}
+                            >
+                              Details
+                            </LocalNavLink>
+                            <LocalNavLink
+                              dataTest="event-aventri-attendees-link"
+                              href={urls.events.aventri.attendees(
+                                aventriEventId
+                              )}
+                            >
+                              Attendees
+                            </LocalNavLink>
+                          </LocalNav>
+                        </GridCol>
+                        <GridCol setWidth="three-quarters">
+                          <StyledSummaryTable>
+                            <SummaryTable.Row
+                              heading="Event date"
+                              children={eventDate}
+                            />
+                            <SummaryTable.Row
+                              heading="Event location type"
+                              children={
+                                isEmpty(location) ? 'Not set' : location
+                              }
+                            />
+                            <SummaryTable.Row
+                              heading="Address"
+                              children={
+                                isEmpty(fullAddress) ? 'Not set' : fullAddress
+                              }
+                            />
+                            <SummaryTable.Row
+                              heading="Aventri reference number"
+                              children={
+                                isEmpty(aventriEventId) ? (
+                                  'No event reference'
+                                ) : (
+                                  <>
+                                    <span>
+                                      {aventriEventId}&nbsp;
+                                      <NewWindowLink href={aventriEventLink}>
+                                        View in Aventri
+                                      </NewWindowLink>
+                                    </span>
+                                  </>
+                                )
+                              }
+                            />
+                          </StyledSummaryTable>
+                        </GridCol>
+                      </GridRow>
+                    </>
                   )
                 )
               }}

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -10,6 +10,7 @@ import {
   DefaultLayout,
   LocalNav,
   LocalNavLink,
+  NewWindowLink,
   SummaryTable,
 } from '../../../components'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
@@ -22,13 +23,7 @@ const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
 })
 
-const EventAventriDetails = ({
-  name,
-  type,
-  eventDate,
-  location,
-  fullAddress,
-}) => {
+const EventAventriDetails = ({ name, eventDate, location, fullAddress }) => {
   const { aventriEventId } = useParams()
   const breadcrumbs = [
     {
@@ -43,6 +38,10 @@ const EventAventriDetails = ({
       text: name,
     },
   ]
+
+  const aventriEventLink =
+    'https://eu-admin.eventscloud.com/loggedin/eVent/index.php?eventid=' +
+    aventriEventId
 
   return (
     <DefaultLayout
@@ -86,10 +85,6 @@ const EventAventriDetails = ({
                       <GridCol setWidth="three-quarters">
                         <StyledSummaryTable>
                           <SummaryTable.Row
-                            heading="Type of event"
-                            children={type}
-                          />
-                          <SummaryTable.Row
                             heading="Event date"
                             children={eventDate}
                           />
@@ -101,6 +96,23 @@ const EventAventriDetails = ({
                             heading="Address"
                             children={
                               isEmpty(fullAddress) ? 'Not set' : fullAddress
+                            }
+                          />
+                          <SummaryTable.Row
+                            heading="Aventri reference number"
+                            children={
+                              isEmpty(aventriEventId) ? (
+                                'No event reference'
+                              ) : (
+                                <>
+                                  <span>
+                                    {aventriEventId}&nbsp;
+                                    <NewWindowLink href={aventriEventLink}>
+                                      View in Aventri
+                                    </NewWindowLink>
+                                  </span>
+                                </>
+                              )
                             }
                           />
                         </StyledSummaryTable>

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -20,6 +20,18 @@ import { GridCol, GridRow } from 'govuk-react'
 import styled from 'styled-components'
 import { isEmpty } from 'lodash'
 
+const StyledStatusMessage = styled(StatusMessage)`
+  div.statusHeader {
+    font-size: x-large;
+  }
+  div.statusContent {
+    font-size: medium;
+  }
+  div.statusLink {
+    font-size: 80%;
+  }
+`
+
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
 })
@@ -67,17 +79,24 @@ const EventAventriDetails = ({ name, eventDate, location, fullAddress }) => {
                 return (
                   name && (
                     <>
-                      <StatusMessage>
-                        This event has been automatically synced from Aventri.
-                        <br />
-                        Event details, registrants and attendees can only be
-                        edited in Aventri. Changes can take up to 24 hours to
-                        sync.
-                        <br />
-                        <NewWindowLink href={aventriEventLink}>
-                          View in Aventri
-                        </NewWindowLink>
-                      </StatusMessage>
+                      <StyledStatusMessage>
+                        <div class="statusHeader">
+                          {' '}
+                          This event has been automatically synced from Aventri.
+                        </div>
+
+                        <div class="statusContent">
+                          Event details, registrants and attendees can only be
+                          edited in Aventri. Changes can take up to 24 hours to
+                          sync.
+                        </div>
+
+                        <div class="statusLink">
+                          <NewWindowLink href={aventriEventLink}>
+                            View in Aventri
+                          </NewWindowLink>
+                        </div>
+                      </StyledStatusMessage>
                       <GridRow data-test="eventAventriDetails">
                         <GridCol setWidth="one-quarter">
                           <LocalNav dataTest="event-aventri-nav">

--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -137,18 +137,14 @@ const EventAventriDetails = ({ name, eventDate, location, fullAddress }) => {
                             <SummaryTable.Row
                               heading="Aventri reference number"
                               children={
-                                isEmpty(aventriEventId) ? (
-                                  'No event reference'
-                                ) : (
-                                  <>
-                                    <span>
-                                      {aventriEventId}&nbsp;
-                                      <NewWindowLink href={aventriEventLink}>
-                                        View in Aventri
-                                      </NewWindowLink>
-                                    </span>
-                                  </>
-                                )
+                                <>
+                                  <span>
+                                    {aventriEventId}&nbsp;
+                                    <NewWindowLink href={aventriEventLink}>
+                                      View in Aventri
+                                    </NewWindowLink>
+                                  </span>
+                                </>
                               }
                             />
                           </StyledSummaryTable>

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -13,6 +13,11 @@ describe('Event Aventri Details', () => {
   const notFoundEventId = '404'
   const errorEventId = '500'
 
+  const aventriLink =
+    'https://eu-admin.eventscloud.com/loggedin/eVent/index.php?eventid='
+  const aventriLinkText = 'View in Aventri'
+  const newTabText = 'opens in a new window or tab'
+
   context('when the feature flag is on', () => {
     before(() => {
       cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
@@ -55,21 +60,55 @@ describe('Event Aventri Details', () => {
 
       it('should display event details', () => {
         assertKeyValueTable('eventAventriDetails', {
-          'Type of event': 'dit:aventri:Event',
           'Event date': '02 Mar 2021 to 04 May 2022',
           'Event location type': 'Name of Location',
           Address: '1 street avenueBrockleyLondonABC 123England',
+        })
+        cy.get('[data-test="eventAventriDetails"]').within(() => {
+          cy.get('[data-test="newWindowLink"]')
+            .should('have.attr', 'aria-label', 'Opens in a new window or tab')
+            .should('have.attr', 'href', aventriLink + existingEventId)
+            .should('have.text', aventriLinkText)
+        })
+      })
+
+      it('should render the aventri status message and link', () => {
+        const aventriStatusHeader =
+          'This event has been automatically synced from Aventri.'
+        const aventriStatusContent =
+          'Event details, registrants and attendees can only be edited in Aventri. Changes can take up to 24 hours to sync.'
+
+        cy.get('[data-test="status-message"]').within(() => {
+          cy.get('[class="statusHeader"]').should(
+            'contain.text',
+            aventriStatusHeader
+          )
+          cy.get('[class="statusContent"]').should(
+            'contain.text',
+            aventriStatusContent
+          )
+          cy.get('[data-test="newWindowLink"]')
+            .should('have.attr', 'aria-label', 'Opens in a new window or tab')
+            .should('have.attr', 'href', aventriLink + existingEventId)
+            .should('have.text', aventriLinkText)
+          cy.contains(newTabText).should('be.visible')
         })
       })
 
       context('when optional details are missing', () => {
         it('should display "Not set"', () => {
-          cy.visit(urls.events.aventri.details('6666'))
+          const eventId = '6666'
+          cy.visit(urls.events.aventri.details(eventId))
           assertKeyValueTable('eventAventriDetails', {
-            'Type of event': 'dit:aventri:Event',
             'Event date': '02 Mar 2021',
             'Event location type': 'Not set',
             Address: 'Not set',
+          })
+          cy.get('[data-test="eventAventriDetails"]').within(() => {
+            cy.get('[data-test="newWindowLink"]')
+              .should('have.attr', 'aria-label', 'Opens in a new window or tab')
+              .should('have.attr', 'href', aventriLink + eventId)
+              .should('have.text', aventriLinkText)
           })
         })
       })


### PR DESCRIPTION
## Description of change

Adds Aventri Event Id to the Aventri Event Details Page 

## Test instructions

You will see a status message with the Aventri ID and link and the Aventri ID in the event details table 

## Screenshots
### Before

![Screenshot 2022-08-09 at 11 19 56](https://user-images.githubusercontent.com/72502389/183625104-369968db-1b2e-4f49-8249-d6db60c618d0.png)

### After


![Screenshot 2022-08-09 at 11 19 12](https://user-images.githubusercontent.com/72502389/183625074-9998ca26-6153-4151-ab1d-c6f0ea070b0d.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
