### PR TITLE
Fix event search broken links

### DIFF
--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -24,7 +24,7 @@ function transformEventToListItem({
   const item = {
     id,
     type: 'event',
-    urlSuffix: '/details',
+    url: `/events/${id}/details`,
     name,
     subTitle: {
       type: 'datetime',

--- a/src/apps/events/transformers.js
+++ b/src/apps/events/transformers.js
@@ -24,6 +24,7 @@ function transformEventToListItem({
   const item = {
     id,
     type: 'event',
+    urlSuffix: '/details',
     name,
     subTitle: {
       type: 'datetime',

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -9,7 +9,6 @@
  # @param {string} [props.id] - entity id, used to create a link to the entity if provided
  # @param {string} [props.url] - entity URL, defaults to props.urlPrefix + props.id
  # @param {string} [props.urlPrefix] - base URL for linking to an entity, by default it will pluralise props.type
- # @param {string} [props.urlSuffix] - will allow any url details to be added on the end of the url
  # @param {string|object} [props.subTitle] - sub-title below the main link/title
  # @param {array}  [props.metaBadges{}] - an array of metadata item objects
  # @param {array}  [props.metaItems{}] - an array of metadata item objects
@@ -21,8 +20,7 @@
 {% macro Entity (props) %}
   {% if props.name and props.type %}
     {% set urlPrefix = props.urlPrefix or props.type | pluralise + '/' %}
-    {% set urlSuffix = props.urlSuffix %}
-    {% set url = props.url | default('/' + urlPrefix + props.id + urlSuffix) %}
+    {% set url = props.url | default('/' + urlPrefix + props.id) %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
     {% set highlightedName = props.name | highlight(props.highlightTerm) %}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -9,6 +9,7 @@
  # @param {string} [props.id] - entity id, used to create a link to the entity if provided
  # @param {string} [props.url] - entity URL, defaults to props.urlPrefix + props.id
  # @param {string} [props.urlPrefix] - base URL for linking to an entity, by default it will pluralise props.type
+ # @param {string} [props.urlSuffix] - will allow any url details to be added on the end of the url
  # @param {string|object} [props.subTitle] - sub-title below the main link/title
  # @param {array}  [props.metaBadges{}] - an array of metadata item objects
  # @param {array}  [props.metaItems{}] - an array of metadata item objects
@@ -20,7 +21,8 @@
 {% macro Entity (props) %}
   {% if props.name and props.type %}
     {% set urlPrefix = props.urlPrefix or props.type | pluralise + '/' %}
-    {% set url = props.url | default('/' + urlPrefix + props.id) %}
+    {% set urlSuffix = props.urlSuffix %}
+    {% set url = props.url | default('/' + urlPrefix + props.id + urlSuffix) %}
     {% set metaBadges = props.meta | filter(['type', 'badge']) %}
     {% set metaItems = props.meta | reject(['type', 'badge']) %}
     {% set highlightedName = props.name | highlight(props.highlightTerm) %}


### PR DESCRIPTION
## Description of change

Before, when clicking on the event link generated from the search, nothing happened.

## Test instructions

Should be able to click on it and see the details.

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
