### PR TITLE
Fix validation error messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,12 +13,8 @@
         "@nivo/tooltip": "^0.79.0",
         "@redux-devtools/extension": "^3.2.2",
         "@reduxjs/toolkit": "^1.8.3",
-<<<<<<< HEAD
         "@sentry/browser": "^7.9.0",
-=======
-        "@sentry/browser": "^7.8.0",
         "@sentry/node": "^7.9.0",
->>>>>>> 072e0e7b8 (Install @sentry/node dependency)
         "autoprefixer": "^10.4.4",
         "axios": "^0.27.2",
         "basic-auth": "^2.0.1",

--- a/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
+++ b/src/client/modules/Reminders/Settings/NoRecentInteractionForm.jsx
@@ -111,13 +111,13 @@ const NoRecentInteractionForm = () => (
                               name={`reminder_days_${groupIndex}`}
                               data-test={`reminder_days_${groupIndex}`}
                               validate={(value) => {
-                                if (isEmpty(value)) {
-                                  return EMPTY_ERROR_MESSAGE
-                                } else if (isPositiveInteger(value)) {
+                                if (isPositiveInteger(value)) {
                                   const val = parseInt(value, 10)
                                   return val > 0 && val <= MAX_DAYS
                                     ? null
                                     : ERROR_MESSAGE
+                                } else if (isEmpty(value)) {
+                                  return EMPTY_ERROR_MESSAGE
                                 } else {
                                   return ERROR_MESSAGE
                                 }


### PR DESCRIPTION
## Description of change

1. Fixes an issue with the validation where entering the value '1' would incorrectly invalidate the form
2. Fixes our lock file, here is the [issue](https://raw.githubusercontent.com/uktrade/data-hub-frontend/master/package-lock.json).

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
