### PR TITLE
Add flaky e2e test back

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/investment-team-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/investment-team-spec.js
@@ -65,6 +65,7 @@ describe('Investment team', () => {
         selectFirstAdvisersTypeaheadOption({
           element: '[data-test="field-adviser_0"]',
           input: 'Jenny',
+          mockAdviserResponse: false,
         })
         cy.get('[data-test="field-role_0"]').find('input').type('Test role')
       },

--- a/test/end-to-end/cypress/specs/DIT/referrals-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/referrals-spec.js
@@ -40,10 +40,6 @@ describe('Referrals', () => {
     })
   })
   context('when viewing a referral', () => {
-    it('should display in the companies activity feed', () => {
-      // TODO - currently we cannot view the activity feed, once this is fixed we should add this test
-    })
-
     it('should display the new referral on the homepage', () => {
       cy.get(companyLocalHeader.flashMessageList).find('a').eq(0).click()
       cy.get(selectors.tabbedNav().item(2)).click()

--- a/test/end-to-end/cypress/specs/DIT/referrals-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/referrals-spec.js
@@ -8,7 +8,7 @@ const {
 const formSelectors = selectors.interactionForm
 const companyLocalHeader = selectors.companyLocalHeader()
 
-xdescribe('Referrals', () => {
+describe('Referrals', () => {
   const company = fixtures.company.create.lambda()
   const contact = fixtures.contact.create(company.pk)
 

--- a/test/end-to-end/cypress/specs/DIT/referrals-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/referrals-spec.js
@@ -22,6 +22,7 @@ describe('Referrals', () => {
       selectFirstAdvisersTypeaheadOption({
         element: selectors.sendReferral.adviserField,
         input: 'dennis',
+        mockAdviserResponse: false,
       })
       cy.get(selectors.sendReferral.subjectField)
         .click()
@@ -48,7 +49,7 @@ describe('Referrals', () => {
       cy.get(selectors.tabbedNav().item(2)).click()
       cy.selectDhTablistTab('Dashboard', 'My referrals').within(() => {
         cy.get('select').select('Sent referrals')
-        cy.contains('h1', 'sent referral')
+        cy.contains('h3', '1 sent referral')
           .parent()
           .parent()
           .find('ol li')


### PR DESCRIPTION
## Description of change

Fix flaky e2e test

## Test instructions

The test should always pass

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
