### PR TITLE
Refactor feature specs

### DIFF
--- a/test/component/cypress/specs/CompanyLists/Table.test.jsx
+++ b/test/component/cypress/specs/CompanyLists/Table.test.jsx
@@ -1,0 +1,158 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import Table from '../../../../../src/client/components/CompanyLists/Table'
+
+const allOptionalData = {
+  date: '2019-08-15',
+  ditParticipants: [
+    { name: 'Barry Oling', team: 'Isle of Wight Chamber of Commerce' },
+    { name: 'Bernard Harris-Patel', team: 'Isle of Wight Chamber of Commerce' },
+  ],
+  id: '375094ac-f79a-43e5-9c88-059a7caa17f0',
+  interactionId: '79d92719-7402-45b6-b3d7-eff559d6b282',
+  name: 'One List Corp',
+  subject:
+    'Here is a long interaction title some more text some more text some more text almost finished some more text nearly there more text finished',
+}
+
+const singleAdviser = {
+  date: '2019-08-18',
+  ditParticipants: [
+    { name: 'Barry Oling', team: 'Isle of Wight Chamber of Commerce' },
+  ],
+  id: 'a1138c1c-d449-4846-aa58-18fae7e1cb92',
+  interactionId: '79d92719-7402-45b6-b3d7-eff559d6b282',
+  name: 'BMW',
+  subject: 'Here is a long interaction title some more text some more text',
+}
+
+const singleAdviserWithNoData = {
+  date: '2019-08-18',
+  ditParticipants: [{ name: '', team: '' }],
+  id: 'a1138c1c-d449-4846-aa58-18fae7e1cb92',
+  interactionId: '79d92719-7402-45b6-b3d7-eff559d6b282',
+  name: 'BMW',
+  subject: 'Here is a long interaction title some more text some more text',
+}
+
+const noOptionalData = {
+  date: '',
+  ditParticipants: [],
+  id: '0fb3379c-341c-4da4-b825-bf8d47b26baa',
+  interactionId: '',
+  name: 'Lambda plc',
+  subject: 'Lorem ipsum dolor sit amet,',
+}
+
+const expectedRowData = [
+  //allOptionalData
+  [
+    {
+      text: 'One List Corp',
+      linksTo: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0',
+    },
+    {
+      text: '15 Aug 2019',
+    },
+    {
+      text: 'Here is a long interaction title some more text some more text some more text almost finished some more text nearly there...',
+      linksTo: '/interactions/79d92719-7402-45b6-b3d7-eff559d6b282',
+      shouldHaveEllipsis: true,
+    },
+    {
+      text: 'Multiple advisers',
+    },
+  ],
+  //noOptionalData:
+  [
+    {
+      text: 'Lambda plc',
+      linksTo: '/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa',
+    },
+    {
+      text: '-',
+    },
+    {
+      text: 'No interactions have been recorded',
+    },
+    {
+      text: 'Unknown adviser - Unknown team',
+    },
+  ],
+  //singleAdviser
+  [
+    {
+      text: 'BMW',
+      linksTo: '/companies/a1138c1c-d449-4846-aa58-18fae7e1cb92',
+    },
+    {
+      text: '18 Aug 2019',
+    },
+    {
+      text: 'Here is a long interaction title some more text some more text',
+      linksTo: '/interactions/79d92719-7402-45b6-b3d7-eff559d6b282',
+      shouldHaveEllipsis: false,
+    },
+    {
+      text: 'Barry Oling - Isle of Wight Chamber of Commerce',
+    },
+  ],
+  //singleAdviserWithNoData
+  [
+    {
+      text: 'BMW',
+      linksTo: '/companies/a1138c1c-d449-4846-aa58-18fae7e1cb92',
+    },
+    {
+      text: '18 Aug 2019',
+    },
+    {
+      text: 'Here is a long interaction title some more text some more text',
+      linksTo: '/interactions/79d92719-7402-45b6-b3d7-eff559d6b282',
+      shouldHaveEllipsis: false,
+    },
+    {
+      text: 'Unknown adviser - Unknown team',
+    },
+  ],
+]
+
+const describeTableCell = (cell, col, row) => {
+  cy.get('@tableRows')
+    .eq(row)
+    .find('td')
+    .eq(col)
+    .should(($elm) => {
+      const elText = $elm.text()
+      expect(elText).equal(cell.text)
+    })
+    .as('cell')
+
+  if (cell.linksTo === undefined) {
+    return
+  } else {
+    cy.get('@cell').find('a').should('have.attr', 'href', cell.linksTo)
+  }
+}
+
+describe('CompanyLists Table', () => {
+  const Component = ({ companies }) => <Table companies={companies} />
+
+  it('renders the rows', () => {
+    const rows = [
+      allOptionalData,
+      noOptionalData,
+      singleAdviser,
+      singleAdviserWithNoData,
+    ]
+    mount(<Component companies={rows} />)
+    cy.get('table tbody tr').as('tableRows')
+    cy.get('@tableRows').should('have.length', rows.length)
+
+    expectedRowData.forEach((cells, row) => {
+      cells.forEach((cell, col) => {
+        describeTableCell(cell, col, row)
+      })
+    })
+  })
+})

--- a/test/functional/cypress/specs/company-lists/list-spec.js
+++ b/test/functional/cypress/specs/company-lists/list-spec.js
@@ -5,17 +5,11 @@ const { assertAriaTablistTabSelected } = require('../../support/assertions')
 
 describe('My companies lists', () => {
   before(() => {
-    Cypress.Cookies.preserveOnce('datahub.sid')
     cy.visit('/')
   })
 
   it('my companies lists tab should be selected', () =>
     assertAriaTablistTabSelected('Dashboard', 'My companies lists'))
-
-  exports.describeSelectedList({
-    name: 'List A',
-    ...exports.expectedLists['List A'],
-  })
 
   Object.entries(exports.expectedLists).forEach(([name, expectedValues]) => {
     describe(`After selecting list "${name}"`, () => {

--- a/test/functional/cypress/specs/company-lists/view-spec-helper.js
+++ b/test/functional/cypress/specs/company-lists/view-spec-helper.js
@@ -9,14 +9,6 @@ const expectedRows = {
     {
       text: '14 Aug 2019',
     },
-    {
-      text: 'Here is a long interaction title some more text some more text some more text almost finished some more text nearly there more text finished',
-      linksTo: '/interactions/79d92719-7402-45b6-b3d7-eff559d6b282',
-      shouldHaveEllipsis: true,
-    },
-    {
-      text: 'Barry Oling - Isle of Wight Chamber of Commerce',
-    },
   ],
   oneList: [
     {
@@ -25,14 +17,6 @@ const expectedRows = {
     },
     {
       text: '15 Aug 2019',
-    },
-    {
-      text: 'Here is a long interaction title some more text some more text some more text almost finished some more text nearly there more text finished',
-      linksTo: '/interactions/79d92719-7402-45b6-b3d7-eff559d6b282',
-      shouldHaveEllipsis: true,
-    },
-    {
-      text: 'Multiple advisers',
     },
   ],
   lambda: [
@@ -43,14 +27,6 @@ const expectedRows = {
     {
       text: '21 Mar 2019',
     },
-    {
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      linksTo: '/interactions/86f92719-7402-45b6-b3d7-eff559d6b678',
-      shouldHaveEllipsis: true,
-    },
-    {
-      text: 'Unknown adviser - Unknown team',
-    },
   ],
   zebra: [
     {
@@ -59,14 +35,6 @@ const expectedRows = {
     },
     {
       text: '21 Feb 2019',
-    },
-    {
-      text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.',
-      linksTo: '/interactions/86f92719-7402-45b6-b3d7-eff559d6b678',
-      shouldHaveEllipsis: true,
-    },
-    {
-      text: 'Unknown adviser - Heart of the South West LEP',
     },
   ],
   potatoes: [
@@ -77,41 +45,22 @@ const expectedRows = {
     {
       text: '-',
     },
-    {
-      text: 'No interactions have been recorded',
-    },
-    {
-      text: 'Bernard Harris-Patel - Unknown team',
-    },
   ],
 }
 
-const describeTableCell = ({ row, col, text, linksTo, shouldHaveEllipsis }) =>
+const describeTableCell = ({ row, col, text, linksTo }) =>
   describe(`Cell in column ${col}, row ${row}`, () => {
     it('Should have the expected text and behavior', () => {
-      cy.get('table')
-        .find('tbody tr')
+      cy.get('table tbody tr')
         .eq(row)
         .find('td')
         .eq(col)
-        .should(($elm) => {
-          // TODO: Once the CSS version of truncating long text is in place remove this test.
-          const elText = $elm.text()
-          if (shouldHaveEllipsis) {
-            const [nonTruncated] = elText.split('...')
-            expect(text.startsWith(nonTruncated)).equal(true)
-            expect(elText.endsWith('...')).equal(true)
-          } else {
-            expect(elText).equal(text)
-          }
-        })
         .as('cell')
+        .contains(text)
 
-      if (linksTo === undefined) {
-        return
+      if (linksTo !== undefined) {
+        cy.get('@cell').find('a').should('have.attr', 'href', linksTo)
       }
-
-      cy.get('@cell').find('a').should('have.attr', 'href', linksTo)
     })
   })
 
@@ -122,13 +71,11 @@ const describeTable = (rows) => {
 
     describe('Cells', () => {
       rows.forEach((cells, row) =>
-        cells.forEach((cell, col) =>
-          describeTableCell({
-            ...cell,
-            row,
-            col,
-          })
-        )
+        describeTableCell({
+          ...cells[0],
+          row,
+          col: 0,
+        })
       )
     })
   })
@@ -241,13 +188,9 @@ exports.describeSelectedList = ({
             cy.contains('Search this list').should('not.exist')
             cy.contains('Sort by').should('not.exist')
           })
-          describeTable(rows)
         })
         break
       default:
-        describeTable(rows)
-        describeSortList(rows)
-
         searches &&
           Object.entries(searches).forEach(([query, rows]) => {
             describe(`When the search query is "${query}"`, () => {

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -78,24 +78,20 @@ const inputFilterTestCases = ({ filterName, selector, cases }) =>
   )
 
 describe('Investor profiles filters', () => {
+  it('returns 10 cases when no options selected', () => {
+    cy.visit(urls.investments.profiles.index())
+
+    cy.contains('10 profiles')
+    cy.get('h3').should('have.length', 10)
+  })
+
   typeaheadFilterTestCases({
     filterName: 'Country of company origin',
     selector: 'country-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Afghanistan'],
         expectedNumberOfResults: 3,
-      },
-      {
-        options: ['Zimbabwe'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Slovakia'],
-        expectedNumberOfResults: 0,
       },
     ],
   })
@@ -105,15 +101,8 @@ describe('Investor profiles filters', () => {
     selector: 'asset-class-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Biofuel'],
         expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Nuclear'],
-        expectedNumberOfResults: 3,
       },
       {
         options: ['Biofuel', 'Nuclear'],
@@ -127,14 +116,7 @@ describe('Investor profiles filters', () => {
     selector: 'investor-type-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Fund of funds'],
-        expectedNumberOfResults: 1,
-      },
-      {
-        options: ['Family office'],
         expectedNumberOfResults: 1,
       },
       {
@@ -149,15 +131,8 @@ describe('Investor profiles filters', () => {
     selector: 'required-checks-conducted-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Cleared'],
         expectedNumberOfResults: 1,
-      },
-      {
-        options: ['Issues identified'],
-        expectedNumberOfResults: 2,
       },
       {
         options: ['Cleared', 'Issues identified'],
@@ -174,14 +149,6 @@ describe('Investor profiles filters', () => {
         text: 'foo',
         expectedNumberOfResults: 2,
       },
-      {
-        text: 'bar',
-        expectedNumberOfResults: 1,
-      },
-      {
-        text: 'bing',
-        expectedNumberOfResults: 0,
-      },
     ],
   })
 
@@ -192,18 +159,6 @@ describe('Investor profiles filters', () => {
       {
         text: '1000',
         expectedNumberOfResults: 3,
-      },
-      {
-        text: '1001',
-        expectedNumberOfResults: 2,
-      },
-      {
-        text: '2001',
-        expectedNumberOfResults: 1,
-      },
-      {
-        text: '3001',
-        expectedNumberOfResults: 0,
       },
     ],
   })
@@ -216,18 +171,6 @@ describe('Investor profiles filters', () => {
         text: '999',
         expectedNumberOfResults: 0,
       },
-      {
-        text: '1000',
-        expectedNumberOfResults: 1,
-      },
-      {
-        text: '2000',
-        expectedNumberOfResults: 2,
-      },
-      {
-        text: '3000',
-        expectedNumberOfResults: 3,
-      },
     ],
   })
 
@@ -238,18 +181,6 @@ describe('Investor profiles filters', () => {
       {
         text: '1000',
         expectedNumberOfResults: 3,
-      },
-      {
-        text: '1001',
-        expectedNumberOfResults: 2,
-      },
-      {
-        text: '2001',
-        expectedNumberOfResults: 1,
-      },
-      {
-        text: '3001',
-        expectedNumberOfResults: 0,
       },
     ],
   })
@@ -262,18 +193,6 @@ describe('Investor profiles filters', () => {
         text: '999',
         expectedNumberOfResults: 0,
       },
-      {
-        text: '1000',
-        expectedNumberOfResults: 1,
-      },
-      {
-        text: '2000',
-        expectedNumberOfResults: 2,
-      },
-      {
-        text: '3000',
-        expectedNumberOfResults: 3,
-      },
     ],
   })
 
@@ -282,15 +201,8 @@ describe('Investor profiles filters', () => {
     selector: 'deal-ticket-size-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Up to £49 million'],
         expectedNumberOfResults: 2,
-      },
-      {
-        options: ['£50-99 million'],
-        expectedNumberOfResults: 4,
       },
       {
         options: ['Up to £49 million', '£50-99 million'],
@@ -304,14 +216,7 @@ describe('Investor profiles filters', () => {
     selector: 'types-of-investment-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Direct Investment in Project Equity'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Venture capital funds'],
         expectedNumberOfResults: 2,
       },
       {
@@ -329,14 +234,7 @@ describe('Investor profiles filters', () => {
     selector: 'minimum-return-rate-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['5-10%'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['10-15%'],
         expectedNumberOfResults: 2,
       },
       {
@@ -351,14 +249,7 @@ describe('Investor profiles filters', () => {
     selector: 'time-horizon-tenor-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Up to 5 years'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['15 years +'],
         expectedNumberOfResults: 2,
       },
       {
@@ -373,14 +264,7 @@ describe('Investor profiles filters', () => {
     selector: 'restrictions-conditions-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Require board seat'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Inflation adjustment'],
         expectedNumberOfResults: 2,
       },
       {
@@ -395,14 +279,7 @@ describe('Investor profiles filters', () => {
     selector: 'construction-risk-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Greenfield (construction risk)'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Brownfield (some construction risk)'],
         expectedNumberOfResults: 2,
       },
       {
@@ -420,14 +297,7 @@ describe('Investor profiles filters', () => {
     selector: 'minimum-equity-percentage-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['1-19%'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['50% +'],
         expectedNumberOfResults: 2,
       },
       {
@@ -442,14 +312,7 @@ describe('Investor profiles filters', () => {
     selector: 'desired-deal-role-filter',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Lead manager / deal structure'],
-        expectedNumberOfResults: 2,
-      },
-      {
-        options: ['Co-lead manager'],
         expectedNumberOfResults: 2,
       },
       {
@@ -464,19 +327,12 @@ describe('Investor profiles filters', () => {
     selector: 'uk-regions-of-interest',
     cases: [
       {
-        expectedNumberOfResults: 10,
-      },
-      {
         options: ['Benzonia'],
         expectedNumberOfResults: 2,
       },
       {
         options: ['Benzonia', 'Jersey'],
         expectedNumberOfResults: 3,
-      },
-      {
-        options: ['Jersey'],
-        expectedNumberOfResults: 2,
       },
     ],
   })

--- a/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-spec.js
@@ -154,27 +154,6 @@ function assertAcrossTabs(callback) {
 }
 
 describe('My pipeline app', () => {
-  context('when query string is used by analytic team', () => {
-    before(() => {
-      cy.visit(
-        `${urls.pipeline.index()}?
-        some_source=averylongquery&othersource=anotherlongquery`
-      )
-    })
-
-    it('should render the sub tab nav', () => {
-      cy.get('[data-test="pipelineSubTabNav"]').within(() => {
-        cy.contains('To do').should('have.attr', 'aria-selected', 'true')
-        cy.contains('In progress')
-        cy.contains('Done')
-      })
-    })
-
-    it('should render the item counter', () => {
-      cy.contains('4 projects')
-    })
-  })
-
   context('When viewing the to do status', () => {
     before(() => {
       cy.visit(urls.pipeline.index())


### PR DESCRIPTION
## Description of change

We're doing some investigation into some of the older feature specs to see if they could be refactored. 

`company-lists/list-spec` is one of our longest tests, sometimes [taking 3.5 minutes to run](https://dashboard.cypress.io/projects/w97se2/runs/30408/specs)
This PR has moved some of the logic of checking the Table renders correctly into a component test. This has the benefit of running in parallel, and means we don't need to check every cell of the table for every change we make in the functional test. 

`interactions/profiles-filter-spec` is also [long at runs of 2.36](https://dashboard.cypress.io/projects/w97se2/runs/30408/specs) 
This PR removes some of the repetitive cases in the test - as far as I can tell they didn't seem to add any value to the tests in terms of logic or contract testing. - e.g. once we have tested that a country name is sent to the backend and shown in chips etc., we know it's successfully covered the Task logic, which just sends the query to the API. That logic won't change if we test with another country, if I understand correctly.  [the code coverage hasn't decreased by removing them](https://codecov.io/github/uktrade/data-hub-frontend/commit/1a2d84f7a3d6405465a69cb67030b9fb35125b6a). Please let me know if I'm missing something!

The refactoring seems to have knocked off respectively ~3 minutes and ~1 minute for the individual specs, and just over a minute off the overall test running 🥳 

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
