### PR TITLE
Add start date sort by options for new events col page

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -633,7 +633,7 @@ describe('Activity feed controllers', () => {
       before(async () => {
         middlewareParameters = buildMiddlewareParameters({
           requestQuery: {
-            sortBy: 'modified_on:desc',
+            sortBy: 'name:asc',
             name: 'project zeus',
             earliestStartDate: '2020-11-01',
             latestStartDate: '2020-11-10',
@@ -683,9 +683,9 @@ describe('Activity feed controllers', () => {
             },
           },
           sort: {
-            'object.updated': {
-              order: 'desc',
-              unmapped_type: 'date',
+            'object.name.raw': {
+              order: 'asc',
+              unmapped_type: 'string',
             },
           },
         }

--- a/src/apps/companies/apps/activity-feed/__test__/query.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/query.test.js
@@ -1,0 +1,156 @@
+const { EVENT_ACTIVITY_SORT_OPTIONS } = require('../constants')
+const activityFeedEventsQuery = require('../es-queries/activity-feed-all-events-query')
+
+describe('#activityFeedEventsQuery', () => {
+  const allDataHubAndAventriEventsQuery = [
+    {
+      terms: {
+        'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+      },
+    },
+  ]
+
+  context('sorts by recently updated', () => {
+    const expectedEsQuery = (order) => ({
+      from: 0,
+      size: 10,
+      query: {
+        bool: {
+          must: [
+            {
+              terms: {
+                'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+              },
+            },
+          ],
+        },
+      },
+      sort: {
+        'object.updated': {
+          order: order,
+          unmapped_type: 'date',
+        },
+      },
+    })
+
+    it('should return the right query when default sort is used', () => {
+      const sortBy = undefined
+      expect(expectedEsQuery('desc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+
+    it('should return the right query when "recently updated" filter is selected', () => {
+      const sortBy = 'modified_on:asc'
+      expect(expectedEsQuery('asc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+
+    it('should return the right query when "least recently updated" filter is selected', () => {
+      const sortBy = 'modified_on:desc'
+      expect(expectedEsQuery('desc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+  })
+
+  context('sorts by name', () => {
+    const expectedEsQuery = (order) => ({
+      from: 0,
+      size: 10,
+      query: {
+        bool: {
+          must: [
+            {
+              terms: {
+                'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+              },
+            },
+          ],
+        },
+      },
+      sort: {
+        'object.name.raw': {
+          order: order,
+          unmapped_type: 'string',
+        },
+      },
+    })
+
+    it('should return the right query when "name" ', () => {
+      const sortBy = 'name:asc'
+      expect(expectedEsQuery('asc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+  })
+
+  context('sorts by start date', () => {
+    const expectedEsQuery = (order) => ({
+      from: 0,
+      size: 10,
+      query: {
+        bool: {
+          must: [
+            {
+              terms: {
+                'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+              },
+            },
+          ],
+        },
+      },
+      sort: {
+        'object.startTime': {
+          order: order,
+          unmapped_type: 'date',
+        },
+      },
+    })
+
+    it('should return the right query when "earliest start date" filter is selected', () => {
+      const sortBy = 'start_date:asc'
+      expect(expectedEsQuery('asc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+
+    it('should return the right query when "latest start date" filter is selected', () => {
+      const sortBy = 'start_date:desc'
+      expect(expectedEsQuery('desc')).to.deep.equal(
+        activityFeedEventsQuery({
+          fullQuery: allDataHubAndAventriEventsQuery,
+          sort:
+            EVENT_ACTIVITY_SORT_OPTIONS[sortBy] ||
+            EVENT_ACTIVITY_SORT_OPTIONS['modified_on:desc'],
+        })
+      )
+    })
+  })
+})

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -73,6 +73,18 @@ const EVENT_ACTIVITY_SORT_OPTIONS = {
       unmapped_type: 'string',
     },
   },
+  'start_date:asc': {
+    'object.startTime': {
+      order: 'asc',
+      unmapped_type: 'date',
+    },
+  },
+  'start_date:desc': {
+    'object.startTime': {
+      order: 'desc',
+      unmapped_type: 'date',
+    },
+  },
 }
 
 const EVENT_ALL_ACTIVITY = {

--- a/src/client/modules/Events/CollectionList/constants.js
+++ b/src/client/modules/Events/CollectionList/constants.js
@@ -44,4 +44,12 @@ export const COLLECTION_LIST_SORT_SELECT_OPTIONS = [
     name: 'Event name A-Z',
     value: 'name:asc',
   },
+  {
+    name: 'Earliest start date',
+    value: 'start_date:asc',
+  },
+  {
+    name: 'Latest start date',
+    value: 'start_date:desc',
+  },
 ]

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -236,48 +236,6 @@ describe('Event Collection List Page - React', () => {
         })
       })
 
-      context('when sorting', () => {
-        beforeEach(() => {
-          cy.intercept(
-            'GET',
-            `${events.activity.data()}?sortBy=modified_on:desc&page=1`
-          ).as('recentlyUpdatedRequest')
-          cy.intercept(
-            'GET',
-            `${events.activity.data()}?sortBy=modified_on:asc&page=1`
-          ).as('leastRecentlyUpdatedRequest')
-          cy.intercept(
-            'GET',
-            `${events.activity.data()}?sortBy=name:asc&page=1`
-          ).as('nameRequest')
-          cy.visit(events.index())
-        })
-
-        it('sorts by recently updated by default', () => {
-          cy.wait('@recentlyUpdatedRequest').then((request) => {
-            expect(request.response.statusCode).to.eql(200)
-          })
-        })
-
-        it('sorts by "least recently updated" when selected', () => {
-          const element = '[data-test="sortby"] select'
-          cy.get(element).select('modified_on:asc')
-          cy.wait('@leastRecentlyUpdatedRequest').then((request) => {
-            expect(request.response.statusCode).to.eql(200)
-          })
-          cy.get('@dataHubEvents').should('have.length', 0)
-        })
-
-        it('sorts by "name" when selected', () => {
-          const element = '[data-test="sortby"] select'
-          cy.get(element).select('name:asc')
-          cy.wait('@nameRequest').then((request) => {
-            expect(request.response.statusCode).to.eql(200)
-          })
-          cy.get('@aventriEvents').should('have.length', 0)
-        })
-      })
-
       context('when there are more than 10 events', () => {
         it('should be possible to page through', () => {
           cy.get('[data-page-number="2"]').click()

--- a/test/functional/cypress/specs/events/sort-spec.js
+++ b/test/functional/cypress/specs/events/sort-spec.js
@@ -1,78 +1,166 @@
 import { events } from '../../../../../src/lib/urls'
+import { EVENT_ACTIVITY_FEATURE_FLAG } from '../../../../../src/apps/companies/apps/activity-feed/constants'
 
 const searchEndpoint = '/api-proxy/v3/search/event'
 
 describe('Event Collections Sort', () => {
-  context('Default sort', () => {
-    before(() => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(events.index())
+  context('When the activity stream feature flag is off', () => {
+    context('Default sort', () => {
+      before(() => {
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(events.index())
+      })
+
+      it('should apply the default sort', () => {
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('modified_on:desc')
+        })
+      })
+
+      it('should have all sort options', () => {
+        cy.get('[data-test="sortby"] option').then((options) => {
+          const sortOptions = [...options].map((o) => [o.value, o.text])
+          expect(sortOptions).to.deep.eq([
+            ['name:asc', 'Event name A-Z'],
+            ['modified_on:desc', 'Recently updated'],
+            ['modified_on:asc', 'Least recently updated'],
+            ['start_date:asc', 'Earliest start date'],
+            ['start_date:desc', 'Latest start date'],
+          ])
+        })
+      })
     })
 
-    it('should apply the default sort', () => {
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('modified_on:desc')
+    context('User sort', () => {
+      const element = '[data-test="sortby"] select'
+
+      beforeEach(() => {
+        cy.intercept('POST', searchEndpoint).as('apiRequest')
+        cy.visit(`${events.index()}?page=1`)
+        cy.wait('@apiRequest')
       })
+
+      it('should sort by "Event name A-Z" when changed back to default', () => {
+        cy.get(element).select('modified_on:desc')
+        cy.wait('@apiRequest')
+        cy.get(element).select('name:asc')
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('name:asc')
+        })
+      })
+
+      it('should sort by "Recently updated"', () => {
+        cy.get(element).select('modified_on:desc')
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('modified_on:desc')
+        })
+      })
+
+      it('should sort by "Least recently updated"', () => {
+        cy.get(element).select('modified_on:asc')
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('modified_on:asc')
+        })
+      })
+
+      it('should sort by "Earliest start date"', () => {
+        cy.get(element).select('start_date:asc')
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('start_date:asc')
+        })
+      })
+
+      it('should sort by "Latest start date"', () => {
+        cy.get(element).select('start_date:desc')
+        cy.wait('@apiRequest').then(({ request }) => {
+          expect(request.body.sortby).to.equal('start_date:desc')
+        })
+      })
+    })
+  })
+
+  context('When the activity stream feature flag is on', () => {
+    before(() => {
+      cy.setUserFeatures([EVENT_ACTIVITY_FEATURE_FLAG])
+    })
+
+    beforeEach(() => {
+      cy.intercept(
+        'GET',
+        `${events.activity.data()}?sortBy=modified_on:desc&page=1`
+      ).as('recentlyUpdatedRequest')
+      cy.intercept(
+        'GET',
+        `${events.activity.data()}?sortBy=modified_on:asc&page=1`
+      ).as('leastRecentlyUpdatedRequest')
+      cy.intercept(
+        'GET',
+        `${events.activity.data()}?sortBy=name:asc&page=1`
+      ).as('nameRequest')
+      cy.intercept(
+        'GET',
+        `${events.activity.data()}?sortBy=start_date:asc&page=1`
+      ).as('earliestStartDateRequest')
+      cy.intercept(
+        'GET',
+        `${events.activity.data()}?sortBy=start_date:desc&page=1`
+      ).as('latestStartDateRequest')
+      cy.visit(events.index())
     })
 
     it('should have all sort options', () => {
       cy.get('[data-test="sortby"] option').then((options) => {
         const sortOptions = [...options].map((o) => [o.value, o.text])
         expect(sortOptions).to.deep.eq([
-          ['name:asc', 'Event name A-Z'],
           ['modified_on:desc', 'Recently updated'],
           ['modified_on:asc', 'Least recently updated'],
+          ['name:asc', 'Event name A-Z'],
           ['start_date:asc', 'Earliest start date'],
           ['start_date:desc', 'Latest start date'],
         ])
       })
     })
-  })
 
-  context('User sort', () => {
-    const element = '[data-test="sortby"] select'
-
-    beforeEach(() => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.visit(`${events.index()}?page=1`)
-      cy.wait('@apiRequest')
-    })
-
-    it('should sort by "Event name A-Z" when changed back to default', () => {
-      cy.get(element).select('modified_on:desc')
-      cy.wait('@apiRequest')
-      cy.get(element).select('name:asc')
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('name:asc')
+    it('sorts by recently updated by default', () => {
+      cy.wait('@recentlyUpdatedRequest').then((request) => {
+        expect(request.response.statusCode).to.eql(200)
       })
     })
 
-    it('should sort by "Recently updated"', () => {
-      cy.get(element).select('modified_on:desc')
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('modified_on:desc')
-      })
-    })
-
-    it('should sort by "Least recently updated"', () => {
+    it('sorts by "least recently updated" when selected', () => {
+      const element = '[data-test="sortby"] select'
       cy.get(element).select('modified_on:asc')
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('modified_on:asc')
+      cy.wait('@leastRecentlyUpdatedRequest').then((request) => {
+        expect(request.response.statusCode).to.eql(200)
       })
     })
 
-    it('should sort by "Earliest start date"', () => {
+    it('sorts by "name" when selected', () => {
+      const element = '[data-test="sortby"] select'
+      cy.get(element).select('name:asc')
+      cy.wait('@nameRequest').then((request) => {
+        expect(request.response.statusCode).to.eql(200)
+      })
+    })
+
+    it('sorts by "earliest start date" when selected', () => {
+      const element = '[data-test="sortby"] select'
       cy.get(element).select('start_date:asc')
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('start_date:asc')
+      cy.wait('@earliestStartDateRequest').then((request) => {
+        expect(request.response.statusCode).to.eql(200)
       })
     })
 
-    it('should sort by "Latest start date"', () => {
+    it('sorts by "latest start date" when selected', () => {
+      const element = '[data-test="sortby"] select'
       cy.get(element).select('start_date:desc')
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('start_date:desc')
+      cy.wait('@latestStartDateRequest').then((request) => {
+        expect(request.response.statusCode).to.eql(200)
       })
+    })
+
+    after(() => {
+      cy.resetUser()
     })
   })
 })


### PR DESCRIPTION
## Description of change

Add "Earliest Start Date" & "Latest Start Date" to the sort by options on the Events Collection list. 

## Test instructions

- In Django dev API, add the user feature flag `user-event-activities` to your adviser profile.
- Bring up this branch on your local dev frontend and navigate to http://localhost:3000/events
- You should see 'Earliest start date' and 'Latest start date' in the sort by dropdown.
- The sort should work if you click on either of these new options and should also add to query string in the url.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/70902973/184179181-cdbaa77f-2cd7-41ba-bf39-bd1065e5b18c.png)

### After

![image](https://user-images.githubusercontent.com/70902973/184179023-bb8be3d1-f52f-49f7-86b3-5e9f1d10c9f3.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
