### PR TITLE
Feature/DET-244 Remove incomplete registrations from Contacts activity feed and Aventri attendees page

### DIFF
--- a/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
@@ -13,6 +13,16 @@ const aventriAttendeeQuery = ({ eventId, sort, from }) => ({
             'object.attributedTo.id': `dit:aventri:Event:${eventId}`,
           },
         },
+        {
+          terms: {
+            'object.dit:registrationStatus': [
+              'Attended',
+              'Confirmed',
+              'Cancelled',
+              'Registered',
+            ],
+          },
+        },
       ],
     },
   },

--- a/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
@@ -52,6 +52,16 @@ const contactActivityQuery = (
                           },
                         },
                       },
+                      {
+                        terms: {
+                          'object.dit:registrationStatus': [
+                            'Attended',
+                            'Confirmed',
+                            'Cancelled',
+                            'Registered',
+                          ],
+                        },
+                      },
                     ],
                   },
                 },

--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -24,9 +24,7 @@ export const transformAventriAttendee = (attendee) => ({
   date: formatStartAndEndDate(attendee.startDate, attendee.endDate),
   eventName: attendee.eventName,
   registrationStatus:
-    AVENTRI_ATTENDEE_REG_STATUSES[
-      attendee.object['dit:aventri:registrationstatus']
-    ],
+    AVENTRI_ATTENDEE_REG_STATUSES[attendee.object['dit:registrationStatus']],
   contactUrl: attendee.datahubContactUrl,
 })
 

--- a/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
@@ -10,7 +10,7 @@ describe('transformAventriAttendee', () => {
     endDate: '2023-02-14T20:09:14',
     startDate: '2022-02-14T20:09:14',
     object: {
-      'dit:aventri:registrationstatus': registrationStatus,
+      'dit:registrationStatus': registrationStatus,
     },
   })
 

--- a/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
@@ -10,7 +10,7 @@ describe('AventriAttendee', () => {
       'dit:aventri:email': 'johndoe@outlook.com',
       'dit:firstName': 'Firstname1',
       'dit:lastName': 'Lastname1',
-      'dit:aventri:registrationstatus': 'Confirmed',
+      'dit:registrationStatus': 'Confirmed',
       'dit:emailAddress': 'johndoe@outlook.com',
       id: 'dit:aventri:Attendee:1111',
     },
@@ -68,7 +68,7 @@ describe('AventriAttendee', () => {
 
     context('when there is no registration status', () => {
       beforeEach(() => {
-        activity.object['dit:aventri:registrationstatus'] = undefined
+        activity.object['dit:registrationStatus'] = undefined
         mount(<Component activity={activity} />)
       })
 

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-sort-a-z.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-sort-a-z.json
@@ -43,6 +43,7 @@
             "dit:firstName": "Alex",
             "dit:lastName": "Alderman",
             "dit:companyName": "Alderman Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -82,6 +83,7 @@
             "dit:firstName": "Barry",
             "dit:lastName": "Bennett",
             "dit:companyName": "Bennett Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -121,6 +123,7 @@
             "dit:firstName": "Carrie",
             "dit:lastName": "Carson",
             "dit:companyName": "Carson Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -160,6 +163,7 @@
             "dit:firstName": "Diana",
             "dit:lastName": "Durrell",
             "dit:companyName": "Durrell Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-sort-z-a.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees-sort-z-a.json
@@ -43,6 +43,7 @@
             "dit:firstName": "Diana",
             "dit:lastName": "Durrell",
             "dit:companyName": "Durrell Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -82,6 +83,7 @@
             "dit:firstName": "Carrie",
             "dit:lastName": "Carson",
             "dit:companyName": "Carson Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -121,6 +123,7 @@
             "dit:firstName": "Barry",
             "dit:lastName": "Bennett",
             "dit:companyName": "Bennett Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -160,6 +163,7 @@
             "dit:firstName": "Alex",
             "dit:lastName": "Alderman",
             "dit:companyName": "Alderman Corp",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendees.json
@@ -42,6 +42,7 @@
             "dit:emailAddress": "elle.woods@example.com",
             "dit:firstName": "Elle",
             "dit:lastName": "Woods",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:1234",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -81,6 +82,7 @@
             "dit:emailAddress": "cinders@gmail.com",
             "dit:firstName": "Cindy",
             "dit:lastName": "Ella",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -119,6 +121,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Fiona",
             "dit:lastName": "Shrek",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -157,6 +160,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Ariel",
             "dit:lastName": "Ocean",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -195,6 +199,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Tiana",
             "dit:lastName": "Green",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -233,6 +238,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Belle",
             "dit:lastName": "Beastly",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -271,6 +277,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Snow",
             "dit:lastName": "White",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -309,6 +316,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Rapunzel",
             "dit:lastName": "Hair",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -347,6 +355,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Elsa",
             "dit:lastName": "Ice",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -385,6 +394,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Jasmine",
             "dit:lastName": "Tiger",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [
@@ -423,6 +433,7 @@
             "dit:emailAddress": "",
             "dit:firstName": "Fiona",
             "dit:lastName": "Shrek",
+            "dit:registrationStatus": "Confirmed",
             "id": "dit:aventri:Attendee:2222",
             "published": "1970-01-01T00:00:00",
             "type": [


### PR DESCRIPTION
## Description of change

We need to prevent incomplete registrations from displaying on the front end. These will display blank fields, which look like a fault and could remain incomplete indefinitely so we want to block them. There is a specific registration status for these, “incomplete” so we want to exclude attendees where registration status is Incomplete.

This will be done for the Contacts activity feed and the Aventri attendees page.

## For Contacts activity page:
## Test instructions

-Ensure you have the `user-contact-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit a contact activity page that had Aventri interactions: John Middlename Doe is a good example:
http://localhost:3000/contacts/236944dd-2e75-4bc1-999f-52ea19c6adf8/interactions?featureTesting=user-contact-activities


## Screenshots
### Before
![image](https://user-images.githubusercontent.com/83657534/185092913-7b72fe32-268f-48a2-ac73-d165d5b52b55.png)


### After
![image](https://user-images.githubusercontent.com/83657534/185097713-65e7d685-f703-4249-96bd-25eabdfcbfe7.png)


## For Aventri attendees page:
## Test instructions

-Ensure you have the `user-event-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit an Aventri event page e.g. 
http://localhost:3000/events/aventri/1111/attendees?featureTesting=user-event-activities http://localhost:3000/events/aventri/2222/attendees?featureTesting=user-event-activities http://localhost:3000/events/aventri/3333/attendees?featureTesting=user-event-activities 
-You should be able to see fewer numbers of attendees listed than on the master branch

## Screenshots
### Before
Previously, the Aventri attendees page would show all attendees (including those with an Incomplete registration status). Now these incomplete registrations will be removed. 
![image](https://user-images.githubusercontent.com/83657534/184893124-60564071-b71a-4198-b6b6-7440b6d32975.png)

### After
![image](https://user-images.githubusercontent.com/83657534/184892970-069723e2-faa4-4913-baba-bfc48d12b9c8.png)


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
