### PR TITLE
[RR-506] Ensure address is only shown when country is selected

### DIFF
--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -258,7 +258,7 @@ const _ContactForm = ({
                           label="Email address"
                           name="email"
                           type="email"
-                          required="Enter an email"
+                          required="Enter an email address"
                           validate={validators.email}
                         />
                         <FieldInput

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -220,6 +220,32 @@ const FieldAddress = ({
     if (isUK) return 'Enter a postcode'
   }
 
+  let renderPostcode
+
+  const renderUKPostcode = (
+    <StyledFieldPostcode
+      type="search"
+      name="postcode"
+      label={postcodeLabel()}
+      required={postcodeErrorMessage()}
+      maxLength={10}
+      validate={postcodeValidator}
+    />
+  )
+
+  if (country_form_value !== UNITED_KINGDOM_ID) {
+    renderPostcode = (
+      <StyledFieldPostcode
+        type="text"
+        name="postcode"
+        label={postcodeLabel()}
+        required={postcodeErrorMessage()}
+        maxLength={null}
+        validate={postcodeValidator}
+      />
+    )
+  }
+
   return (
     <FieldWrapper {...{ label, legend, hint, name }} showBorder={true}>
       {isCountrySelectable ? (
@@ -242,14 +268,7 @@ const FieldAddress = ({
           {isUK && (
             <>
               <SyledRowDiv>
-                <StyledFieldPostcode
-                  type={'search'}
-                  name="postcode"
-                  label={postcodeLabel()}
-                  required={postcodeErrorMessage()}
-                  maxLength={10}
-                  validate={postcodeValidator}
-                />
+                {renderUKPostcode}
                 <StyledButtonWrapper>
                   <Button
                     onClick={onSearchClick}
@@ -311,16 +330,7 @@ const FieldAddress = ({
               </StatusMessage>
             )}
           </>
-          {!isUK && (
-            <StyledFieldPostcode
-              type={'text'}
-              name="postcode"
-              label={postcodeLabel()}
-              required={postcodeErrorMessage()}
-              maxLength={null}
-              validate={postcodeValidator}
-            />
-          )}
+          {!isUK && renderPostcode}
         </>
       )}
     </FieldWrapper>

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -40,6 +40,18 @@ const SyledDiv = styled('div')`
   padding-bottom: ${SPACING.SCALE_5};
 `
 
+const StyledButtonWrapper = styled('div')`
+  margin-bottom: -22px;
+  margin-left: 10px;
+`
+
+const SyledRowDiv = styled('div')`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+`
+
 const FieldAddress = ({
   label,
   legend,
@@ -145,7 +157,7 @@ const FieldAddress = ({
           label="State"
           options={usStates}
           required="Select a state"
-          emptyOption="-- Select state --"
+          emptyOption="Select"
         />
       )
     }
@@ -160,15 +172,15 @@ const FieldAddress = ({
           label="Province"
           options={canadaProvinces}
           required="Select a province"
-          emptyOption="-- Select province --"
+          emptyOption="Select"
         />
       )
     }
   }
 
   const postcodeLabel = () => {
-    if (isUS) return 'ZIP Code'
-    if (isCanada) return 'Postal Code'
+    if (isUS) return 'ZIP Code (optional)'
+    if (isCanada) return 'Postal Code (optional)'
     if (isUK) return 'Postcode'
     return 'Postcode (optional)'
   }
@@ -205,8 +217,6 @@ const FieldAddress = ({
   }
 
   const postcodeErrorMessage = () => {
-    if (isUS) return 'Enter a ZIP code'
-    if (isCanada) return 'Enter a postal code'
     if (isUK) return 'Enter a postcode'
   }
 
@@ -214,81 +224,105 @@ const FieldAddress = ({
     <FieldWrapper {...{ label, legend, hint, name }} showBorder={true}>
       {isCountrySelectable ? (
         <SyledDiv>
-          <FieldCountrySelect name="country" required="Select a country" />
+          <FieldCountrySelect
+            name="country"
+            required="Select a country"
+            onChange={() => {
+              setFieldValue('country_form_value', country_form_value)
+            }}
+          />
         </SyledDiv>
       ) : (
         <FieldUneditable name="country" label="Country">
           {country.name}
         </FieldUneditable>
       )}
-      {isUK && (
+      {country_form_value && (
         <>
-          <Button
-            onClick={onSearchClick}
-            buttonColour={GREY_3}
-            buttonTextColour={BLACK}
-            icon={<Search />}
-            id="postcode-search"
-          >
-            Find UK address
-          </Button>
-          {error && (
-            <StatusMessage>
-              Error occurred while searching for an address. Enter the address
-              manually.
-            </StatusMessage>
+          {isUK && (
+            <>
+              <SyledRowDiv>
+                <StyledFieldPostcode
+                  type={'search'}
+                  name="postcode"
+                  label={postcodeLabel()}
+                  required={postcodeErrorMessage()}
+                  maxLength={10}
+                  validate={postcodeValidator}
+                />
+                <StyledButtonWrapper>
+                  <Button
+                    onClick={onSearchClick}
+                    buttonColour={GREY_3}
+                    buttonTextColour={BLACK}
+                    icon={<Search />}
+                    id="postcode-search"
+                  >
+                    Find UK address
+                  </Button>
+                </StyledButtonWrapper>
+              </SyledRowDiv>
+              {error && (
+                <StatusMessage>
+                  Error occurred while searching for an address. Enter the
+                  address manually.
+                </StatusMessage>
+              )}
+              {addressList && addressList.length > 0 && (
+                <FormGroup>
+                  <Select label="Select an address" onChange={onAddressSelect}>
+                    {addressList.map(({ address1 }, index) => (
+                      // eslint-disable-next-line react/no-array-index-key
+                      <option key={index} value={index}>
+                        {address1}
+                      </option>
+                    ))}
+                  </Select>
+                </FormGroup>
+              )}
+            </>
           )}
-          {addressList && addressList.length > 0 && (
-            <FormGroup>
-              <Select label="Select an address" onChange={onAddressSelect}>
-                {addressList.map(({ address1 }, index) => (
-                  // eslint-disable-next-line react/no-array-index-key
-                  <option key={index} value={index}>
-                    {address1}
-                  </option>
-                ))}
-              </Select>
-            </FormGroup>
+          <FieldInput
+            type="text"
+            name="address1"
+            label="Address line 1"
+            required="Enter an address"
+          />
+          <FieldInput
+            type="text"
+            name="address2"
+            label="Address line 2 (optional)"
+          />
+          <FieldInput
+            type="text"
+            name="city"
+            label="Town or city"
+            required="Enter a town or city"
+          />
+          {!(isUS || isCanada) && (
+            <FieldInput type="text" name="county" label="County (optional)" />
+          )}
+          <>
+            {renderUsStateField()}
+            {renderCanadaProvinceField()}
+            {administrativeAreaSearchError && (
+              <StatusMessage>
+                Error occurred while retrieving Administrative Areas.
+              </StatusMessage>
+            )}
+          </>
+          {!isUK && (
+            <StyledFieldPostcode
+              type={'text'}
+              name="postcode"
+              label={postcodeLabel()}
+              required={postcodeErrorMessage()}
+              maxLength={null}
+              validate={postcodeValidator}
+            />
           )}
         </>
       )}
-      <FieldInput
-        type="text"
-        name="address1"
-        label="Address line 1"
-        required="Enter an address"
-      />
-      <FieldInput
-        type="text"
-        name="address2"
-        label="Address line 2 (optional)"
-      />
-      <FieldInput
-        type="text"
-        name="city"
-        label="Town or city"
-        required="Enter a town or city"
-      />
-      {!(isUS || isCanada) && (
-        <FieldInput type="text" name="county" label="County (optional)" />
-      )}
-      <>
-        {renderUsStateField()}
-        {renderCanadaProvinceField()}
-        {administrativeAreaSearchError && (
-          <StatusMessage>
-            Error occurred while retrieving Administrative Areas.
-          </StatusMessage>
-        )}
-      </>
-      <StyledFieldPostcode
-        type={isUK ? 'search' : 'text'}
-        name="postcode"
-        label={postcodeLabel()}
-        required={postcodeErrorMessage()}
-        maxLength={isUK ? 10 : null}
-        validate={postcodeValidator}
-      />
     </FieldWrapper>
   )
 }

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -45,7 +45,7 @@ const StyledButtonWrapper = styled('div')`
   margin-left: 10px;
 `
 
-const SyledRowDiv = styled('div')`
+const StyledRowDiv = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
@@ -220,32 +220,6 @@ const FieldAddress = ({
     if (isUK) return 'Enter a postcode'
   }
 
-  let renderPostcode
-
-  const renderUKPostcode = (
-    <StyledFieldPostcode
-      type="search"
-      name="postcode"
-      label={postcodeLabel()}
-      required={postcodeErrorMessage()}
-      maxLength={10}
-      validate={postcodeValidator}
-    />
-  )
-
-  if (country_form_value !== UNITED_KINGDOM_ID) {
-    renderPostcode = (
-      <StyledFieldPostcode
-        type="text"
-        name="postcode"
-        label={postcodeLabel()}
-        required={postcodeErrorMessage()}
-        maxLength={null}
-        validate={postcodeValidator}
-      />
-    )
-  }
-
   return (
     <FieldWrapper {...{ label, legend, hint, name }} showBorder={true}>
       {isCountrySelectable ? (
@@ -267,8 +241,15 @@ const FieldAddress = ({
         <>
           {isUK && (
             <>
-              <SyledRowDiv>
-                {renderUKPostcode}
+              <StyledRowDiv>
+                <StyledFieldPostcode
+                  type="search"
+                  name="postcode"
+                  label={postcodeLabel()}
+                  required={postcodeErrorMessage()}
+                  maxLength={10}
+                  validate={postcodeValidator}
+                />
                 <StyledButtonWrapper>
                   <Button
                     onClick={onSearchClick}
@@ -280,7 +261,7 @@ const FieldAddress = ({
                     Find UK address
                   </Button>
                 </StyledButtonWrapper>
-              </SyledRowDiv>
+              </StyledRowDiv>
               {error && (
                 <StatusMessage>
                   Error occurred while searching for an address. Enter the
@@ -330,7 +311,16 @@ const FieldAddress = ({
               </StatusMessage>
             )}
           </>
-          {!isUK && renderPostcode}
+          {!isUK && country_form_value !== UNITED_KINGDOM_ID && (
+            <StyledFieldPostcode
+              type="text"
+              name="postcode"
+              label={postcodeLabel()}
+              required={postcodeErrorMessage()}
+              maxLength={null}
+              validate={postcodeValidator}
+            />
+          )}
         </>
       )}
     </FieldWrapper>

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -237,7 +237,7 @@ const FieldAddress = ({
           {country.name}
         </FieldUneditable>
       )}
-      {country_form_value && (
+      {(country_form_value || !isCountrySelectable) && (
         <>
           {isUK && (
             <>

--- a/src/client/components/Form/elements/FieldAddress/index.jsx
+++ b/src/client/components/Form/elements/FieldAddress/index.jsx
@@ -179,8 +179,8 @@ const FieldAddress = ({
   }
 
   const postcodeLabel = () => {
-    if (isUS) return 'ZIP Code (optional)'
-    if (isCanada) return 'Postal Code (optional)'
+    if (isUS) return 'ZIP code (optional)'
+    if (isCanada) return 'Postal code (optional)'
     if (isUK) return 'Postcode'
     return 'Postcode (optional)'
   }
@@ -192,17 +192,17 @@ const FieldAddress = ({
 
   const usZipCodeValidator = (value) => {
     if (!value) {
-      return 'Enter a ZIP Code'
+      return 'Enter a ZIP code'
     } else if (value && !usZipCodeRegex.test(value)) {
-      return 'Enter a valid ZIP Code'
+      return 'Enter a valid ZIP code'
     }
   }
 
   const canadaPostalCodeValidator = (value) => {
     if (!value) {
-      return 'Enter a Postal Code'
+      return 'Enter a Postal code'
     } else if (value && !canadaPostalCodeRegex.test(value)) {
-      return 'Enter a valid Postal Code'
+      return 'Enter a valid Postal code'
     }
   }
 

--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Select from '@govuk-react/select'
-
 import { useField } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
 

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -48,6 +48,7 @@ describe('Contact', () => {
   })
 
   it('should display name of the person who made contact record changes', () => {
+    cy.get('#postcode').type('NE28 5JB')
     cy.getSubmitButtonByLabel('Save and return').click()
     cy.contains('Contact record updated')
 

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -48,7 +48,6 @@ describe('Contact', () => {
   })
 
   it('should display name of the person who made contact record changes', () => {
-    cy.get('#postcode').type('NE28 5JB')
     cy.getSubmitButtonByLabel('Save and return').click()
     cy.contains('Contact record updated')
 

--- a/test/end-to-end/cypress/support/user-actions/contacts.js
+++ b/test/end-to-end/cypress/support/user-actions/contacts.js
@@ -22,10 +22,10 @@ const createWithNewAddress = (data) => {
     'Is this contact’s work address the same as the company address?',
     'No'
   )
+  cy.contains('Country').parent().find('select').select(data.country)
   cy.contains('Address line 1').type(data.address1)
   cy.contains('Address line 2').type(data.address2)
   cy.contains('Town or city').type(data.city)
-  cy.contains('Country').parent().find('select').select(data.country)
   cy.getSubmitButtonByLabel('Add contact').click()
 }
 

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -651,11 +651,11 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.continueButton).click()
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid Postal Code'
+        'Enter a valid Postal code'
       )
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid ZIP Code'
+        'Enter a valid ZIP code'
       )
     })
 
@@ -779,7 +779,7 @@ describe('Add company form', () => {
         'A1A 1A1'
       )
       cy.get(selectors.companyAdd.continueButton).click()
-      cy.get(selectors.companyAdd.form).contains('Enter a valid ZIP Code')
+      cy.get(selectors.companyAdd.form).contains('Enter a valid ZIP code')
     })
 
     it('should not show an invalid ZIP code error when completed correctly', () => {
@@ -790,7 +790,7 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.continueButton).click()
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid ZIP Code'
+        'Enter a valid ZIP code'
       )
     })
   })
@@ -827,7 +827,7 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.form).contains('Enter an address')
       cy.get(selectors.companyAdd.form).contains('Enter a town or city')
       cy.get(selectors.companyAdd.form).contains('Select a province')
-      cy.get(selectors.companyAdd.form).contains('Enter a postal code')
+      cy.get(selectors.companyAdd.form).contains('Enter a Postal code')
     })
 
     it('should show an invalid postal code error', () => {
@@ -835,7 +835,7 @@ describe('Add company form', () => {
         '12345'
       )
       cy.get(selectors.companyAdd.continueButton).click()
-      cy.get(selectors.companyAdd.form).contains('Enter a valid Postal Code')
+      cy.get(selectors.companyAdd.form).contains('Enter a valid Postal code')
     })
 
     it('should not show an invalid postal code error when completed correctly', () => {
@@ -846,7 +846,7 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.continueButton).click()
       cy.get(selectors.companyAdd.form).should(
         'not.contain',
-        'Enter a valid Postal Code'
+        'Enter a valid Postal code'
       )
     })
   })

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -250,7 +250,7 @@ describe('Company edit', () => {
     })
 
     it('renders state selection errors correctly', () => {
-      cy.get(selectors.companyEdit.address.areaUS).select('-- Select state --')
+      cy.get(selectors.companyEdit.address.areaUS).select('Select')
       cy.contains('Submit').click()
       cy.get(selectors.companyEdit.form).contains('Select a state')
     })
@@ -259,7 +259,7 @@ describe('Company edit', () => {
       cy.get(selectors.companyEdit.address.postcode).clear()
       cy.get(selectors.companyEdit.address.postcode).type('ABC 123')
       cy.contains('Submit').click()
-      cy.get(selectors.companyEdit.form).contains('Enter a valid ZIP Code')
+      cy.get(selectors.companyEdit.form).contains('Enter a valid ZIP code')
     })
 
     it('does not render ZIP code errors if ZIP code is valid', () => {
@@ -268,7 +268,7 @@ describe('Company edit', () => {
       cy.contains('Submit').click()
       cy.get(selectors.companyEdit.form).should(
         'not.contain',
-        'Enter a valid ZIP Code'
+        'Enter a valid ZIP code'
       )
     })
   })
@@ -351,9 +351,7 @@ describe('Company edit', () => {
     })
 
     it('renders province selection errors correctly', () => {
-      cy.get(selectors.companyEdit.address.areaCanada).select(
-        '-- Select province --'
-      )
+      cy.get(selectors.companyEdit.address.areaCanada).select('Select')
       cy.contains('Submit').click()
       cy.get(selectors.companyEdit.form).contains('Select a province')
     })
@@ -362,7 +360,7 @@ describe('Company edit', () => {
       cy.get(selectors.companyEdit.address.postcode).clear()
       cy.get(selectors.companyEdit.address.postcode).type('ABC 123')
       cy.contains('Submit').click()
-      cy.get(selectors.companyEdit.form).contains('Enter a valid Postal Code')
+      cy.get(selectors.companyEdit.form).contains('Enter a valid Postal code')
     })
 
     it('does not render postal code errors if postal code is valid', () => {
@@ -371,7 +369,7 @@ describe('Company edit', () => {
       cy.contains('Submit').click()
       cy.get(selectors.companyEdit.form).should(
         'not.contain',
-        'Enter a valid Postal Code'
+        'Enter a valid Postal code'
       )
     })
   })

--- a/test/functional/cypress/specs/contacts/create-and-edit.jsx
+++ b/test/functional/cypress/specs/contacts/create-and-edit.jsx
@@ -77,7 +77,7 @@ describe('Create contact form', () => {
       'First name': 'Enter a first name',
       'Last name': 'Enter a last name',
       'Job title': 'Enter a job title',
-      'Email address': 'Enter an email',
+      'Email address': 'Enter an email address',
       'Is this contact’s work address the same as the company address?':
         "Select yes if the contact's work address is the same as the company address",
       'Is this person a primary contact?':
@@ -97,7 +97,19 @@ describe('Create contact form', () => {
       'First name': 'Enter a first name',
       'Last name': 'Enter a last name',
       'Job title': 'Enter a job title',
-      'Email address': 'Enter an email',
+      'Email address': 'Enter an email address',
+      'Is this person a primary contact?':
+        "Select yes if this person is the company's primary contact",
+    })
+
+    cy.contains('Country').parent().find('select').select('Brazil')
+    cy.clickSubmitButton('Add contact')
+
+    assertErrors({
+      'First name': 'Enter a first name',
+      'Last name': 'Enter a last name',
+      'Job title': 'Enter a job title',
+      'Email address': 'Enter an email address',
       'Is this person a primary contact?':
         "Select yes if this person is the company's primary contact",
       'Address line 1': 'Enter an address',

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -344,10 +344,13 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
   const isCanadianBased = value.country.name === 'Canada'
   const hasStateField = isUSBased || isCanadianBased
   const postcodeLabel = () => {
-    if (isUSBased) return 'ZIP Code'
-    if (isCanadianBased) return 'Postal Code'
+    if (isUSBased) return 'ZIP code (optional)'
+    if (isCanadianBased) return 'Postal code (optional)'
     if (isUKBased) return 'Postcode'
     return 'Postcode (optional)'
+  }
+  if (isUKBased) {
+    cy.contains('Find UK address').should('be.visible').and('match', 'button')
   }
   let addressElements = [
     {
@@ -362,11 +365,9 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
       assert: assertFieldUneditable,
     },
     isUKBased && {
-      assert: ({ element }) =>
-        cy
-          .wrap(element)
-          .should('contain', 'Find UK address')
-          .and('match', 'button'),
+      label: postcodeLabel(),
+      value: value.postcode,
+      assert: assertFieldInput,
     },
     {
       label: 'Address line 1',
@@ -394,7 +395,7 @@ const assertFieldAddress = ({ element, hint = null, value = {} }) => {
       value: value.area.name,
       assert: assertFieldSelect,
     },
-    {
+    !isUKBased && {
       label: postcodeLabel(),
       value: value.postcode,
       assert: assertFieldInput,

--- a/test/sandbox/fixtures/v3/contact/contact-by-id-uk.json
+++ b/test/sandbox/fixtures/v3/contact/contact-by-id-uk.json
@@ -28,7 +28,7 @@
   "address_country": {
     "id": "80756b9a-5d95-e211-a939-e4115bead28a"
   },
-  "address_postcode":null,
+  "address_postcode":"E14 8RJ",
   "telephone_alternative":null,
   "email_alternative":null,
   "notes":null,

--- a/test/sandbox/fixtures/v3/contact/contact-by-id-us.json
+++ b/test/sandbox/fixtures/v3/contact/contact-by-id-us.json
@@ -31,7 +31,7 @@
   "address_area": {
     "id": "fed8f33a-724e-423a-ae4a-af24446ed455"
   },
-  "address_postcode":null,
+  "address_postcode":"12345",
   "telephone_alternative":null,
   "email_alternative":null,
   "notes":null,


### PR DESCRIPTION
## Description of change

This PR handles the below:

- Address fields shouldn’t be displayed before a country is selected.
- When Canada is the country selected, Province drop down’s placeholder text should be in secondary text colour (GDS grey) and it should say Select only.
- When Canada is the country selected, Postal Code needs to be updated with Postal code (optional).
- When United States is the country selected, State drop down’s placeholder text should be in secondary text colour (GDS grey) and it should say Select only.
- When United States is the country selected, ZIP Code needs to be updated with ZIP code (optional) 
- When UK is the country selected, it should be rebuilt as shown in the prototype.

## Test instructions

All test suites should pass as usual.

## Screenshots
### Before

<img width="697" alt="Screenshot 2022-08-19 at 11 45 03" src="https://user-images.githubusercontent.com/105509190/185602386-d4827717-eaa0-4f17-9913-8d8b33f66749.png">


### After

<img width="856" alt="Screenshot 2022-08-19 at 11 44 16" src="https://user-images.githubusercontent.com/105509190/185602406-dc19abc2-0509-45ea-a188-df88cdeed0bd.png">
<img width="633" alt="Screenshot 2022-08-19 at 11 43 57" src="https://user-images.githubusercontent.com/105509190/185602413-65994cd3-291c-4ec2-afc1-251f020385b4.png">


## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [ ] Has the branch been rebased to master?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
