### PR TITLE
Bug/DET-260 Add 'Add Interaction' Button regardless of feature flag

### DIFF
--- a/src/client/components/ContactLocalHeader/index.jsx
+++ b/src/client/components/ContactLocalHeader/index.jsx
@@ -63,11 +63,7 @@ const buildBreadcrumbs = (currentTab, id, name) => {
   return initalBreadcrumbs.concat(dynamicBreadcrumbs)
 }
 
-const ContactLocalHeader = ({
-  contact,
-  isContactActivitiesFeatureOn,
-  writeFlashMessage,
-}) => {
+const ContactLocalHeader = ({ contact, writeFlashMessage }) => {
   return (
     <>
       <LocalHeader
@@ -95,7 +91,7 @@ const ContactLocalHeader = ({
               )}
             </StyledLocalHeaderHeading>
           </GridCol>
-          {isContactActivitiesFeatureOn && !contact.archived && (
+          {!contact.archived && (
             <GridCol setWidth="one-quarter">
               <Button
                 data-test="add-interaction-button"
@@ -125,7 +121,6 @@ const ContactLocalHeader = ({
 
 ContactLocalHeader.propTypes = {
   contactId: PropTypes.string.isRequired,
-  isContactActivitiesFeatureOn: PropTypes.bool.isRequired,
   writeFlashMessage: PropTypes.func,
 }
 

--- a/test/component/cypress/specs/ContactLocalHeader.test.jsx
+++ b/test/component/cypress/specs/ContactLocalHeader.test.jsx
@@ -46,8 +46,11 @@ describe('ContactLocalHeader', () => {
       cy.get('[data-test=archive-panel]').should('not.exist')
     })
 
-    it('should not render the Add Interaction button', () => {
-      cy.get('[data-test=add-interaction-button]').should('not.exist')
+    it('should render the Add Interaction button', () => {
+      cy.get('[data-test=add-interaction-button]')
+        .should('exist')
+        .should('have.text', 'Add interaction')
+        .should('have.attr', 'href', addInteractionUrl)
     })
   })
 
@@ -74,8 +77,11 @@ describe('ContactLocalHeader', () => {
         .should('not.contain', 'Primary')
     })
 
-    it('should not render the Add Interaction button', () => {
-      cy.get('[data-test=add-interaction-button]').should('not.exist')
+    it('should render the Add Interaction button', () => {
+      cy.get('[data-test=add-interaction-button]')
+        .should('exist')
+        .should('have.text', 'Add interaction')
+        .should('have.attr', 'href', addInteractionUrl)
     })
 
     it('should not render the archive panel', () => {


### PR DESCRIPTION
## Description of change

There was a bug where the 'Add Interaction' button wasn't showing on a Contacts' Interactions page when the feature flag was on. It also wasn't showing at all on the Details, Interactions, Audit history and Documents pages when the feature flag was off. We are also changing some logic so now the Add Interaction Button shows regardless of whether the person is a primary contact or not.

## Test instructions
Visit a Contact page e.g. 
http://localhost:3000/contacts/750d6496-1518-4c59-99ff-f9310cf29640

-Ensure your `user-contact-activities` feature flag is on
-Click through all the tabs (Details, Interactions, Audit history and Documents) and you should see the 'Add Interaction' button on every tab
-Turn your `user-contact-activities` feature flag off
-Click through all the tabs (Details, Interactions, Audit history and Documents) and you should still see the 'Add Interaction' button on every tab

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/83657534/185414496-a25fb20c-af4e-4a6f-9eeb-1179eab072ea.png)


### After
![image](https://user-images.githubusercontent.com/83657534/185413777-83a1073f-2f0b-45ad-873b-46b77e6fc93e.png)

## Checklist

[//]: # "When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/master/docs/Code%20review%20guidelines.md"

- [x] Has the branch been rebased to master?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
