### PR TITLE
Feature/DET-259 Add logic for kind label for Contacts Activity Feed

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -40,7 +40,14 @@ export default function AventriAttendee({ activity: attendee }) {
 
   return eventName ? (
     <ActivityCardWrapper dataTest="aventri-activity">
-      <ActivityCardLabels service="event" kind="aventri service delivery" />
+      <ActivityCardLabels
+        service="event"
+        kind={
+          registrationStatus === 'Attended'
+            ? 'aventri service delivery'
+            : 'interaction'
+        }
+      />
       <ActivityCardSubject>
         {eventName}
         {registrationStatus && (

--- a/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
@@ -51,12 +51,11 @@ describe('AventriAttendee', () => {
       })
     })
 
-    it('should display the Kind label', () => {
+    it('should display the Interaction Kind label when registration status is not Attended', () => {
       cy.get('[data-test="aventri-activity"]').within(() => {
-        cy.get('[data-test="activity-kind-label"]').contains(
-          'aventri service delivery',
-          { matchCase: false }
-        )
+        cy.get('[data-test="activity-kind-label"]').contains('interaction', {
+          matchCase: false,
+        })
       })
     })
 
@@ -64,6 +63,24 @@ describe('AventriAttendee', () => {
       cy.get('[data-test="aventri-activity"]').contains(
         'test event name: Registered'
       )
+    })
+
+    context('when the registration status is Attended', () => {
+      beforeEach(() => {
+        activity.object['dit:registrationStatus'] = 'Attended'
+        mount(<Component activity={activity} />)
+      })
+
+      it('should display the Aventri Service Delivery label when registration status is Attended', () => {
+        cy.get('[data-test="aventri-activity"]').within(() => {
+          cy.get('[data-test="activity-kind-label"]').contains(
+            'aventri service delivery',
+            {
+              matchCase: false,
+            }
+          )
+        })
+      })
     })
 
     context('when there is no registration status', () => {


### PR DESCRIPTION
## Description of change

Currently, all event registration status (e.g. Registration) are being tagged with `Aventri Service Delivery`, when this should only apply to records of “Attended” as this is when DIT have actually delivered a service to a customer.

Therefore all other statuses should display `Interaction`.

This PR adds in this logic.

## Test instructions
-Ensure you have the `user-contact-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit a contact activity page that had Aventri interactions: John Middlename Doe is a good example:
http://localhost:3000/contacts/236944dd-2e75-4bc1-999f-52ea19c6adf8/interactions?featureTesting=user-contact-activities

The kind label should be `Interaction` if the status is not Attended.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/186138333-02b858f5-1353-4231-ae07-2eb15e4e262a.png)


### After

![image](https://user-images.githubusercontent.com/83657534/186138211-182b07ce-3805-4dd6-a055-1ec531271115.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
