### PR TITLE
Bug/DET-264 Fix missing activities on Contact Interactions page

### DIFF
--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -26,22 +26,8 @@ export default class MaxemailCampaign extends React.PureComponent {
   static canRender(activity) {
     return (
       CardUtils.canRenderByTypes(activity, ACTIVITY_TYPE.MaxemailCampaign) &&
-      this.checkActivityHasContent(activity)
+      CardUtils.hasMaxemailContent(activity)
     )
-  }
-
-  static checkActivityHasContent = (activity) => {
-    const activityType = get(activity, 'object.type')
-    if (activityType == 'dit:maxemail:Campaign') {
-      return get(activity, 'object.contacts')?.length
-    }
-    if (
-      activityType.includes('dit:maxemail:Email') ||
-      activityType.includes('dit:maxemail:Email:Sent')
-    ) {
-      return get(activity, 'object.dit:emailAddress')?.length
-    }
-    return false
   }
 
   render() {

--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -26,8 +26,22 @@ export default class MaxemailCampaign extends React.PureComponent {
   static canRender(activity) {
     return (
       CardUtils.canRenderByTypes(activity, ACTIVITY_TYPE.MaxemailCampaign) &&
-      get(activity, 'object.contacts').length
+      this.checkActivityHasContent(activity)
     )
+  }
+
+  static checkActivityHasContent = (activity) => {
+    const activityType = get(activity, 'object.type')
+    if (activityType == 'dit:maxemail:Campaign') {
+      return get(activity, 'object.contacts')?.length
+    }
+    if (
+      activityType.includes('dit:maxemail:Email') ||
+      activityType.includes('dit:maxemail:Email:Sent')
+    ) {
+      return get(activity, 'object.dit:emailAddress')?.length
+    }
+    return false
   }
 
   render() {

--- a/src/client/components/ActivityFeed/activities/__test__/MaxemailCampaign.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/MaxemailCampaign.test.js
@@ -1,0 +1,61 @@
+import CardUtils from '../card/CardUtils'
+
+const maxemailCampaign = {
+  'dit:application': 'maxemail',
+  id: 'dit:maxemail:Campaign:1:Create',
+  object: {
+    contacts: [
+      {
+        id: '236f8b6c-afac-4fba-a8eb-5739aa14823a',
+        title: null,
+        first_name: 'Max',
+        last_name: 'Weight',
+      },
+    ],
+    type: 'dit:maxemail:Campaign',
+  },
+}
+
+const maxemailContact = {
+  'dit:application': 'maxemail',
+  id: 'dit:maxemail:Campaign:1:Create',
+  object: {
+    type: ['dit:maxemail:Email', 'dit:maxemail:Email:Sent'],
+  },
+  'dit:emailAddress': 'max.speed@example.com',
+}
+
+describe('Maxemail tests', () => {
+  describe('Maxemail campaigns content checker', () => {
+    it('should return 1 when there is 1 contact', () => {
+      const actual = CardUtils.hasMaxemailContent(maxemailCampaign)
+      expect(actual).to.equal(1)
+    })
+    it('should return 0 when there is 0 contacts', () => {
+      maxemailCampaign['object.contacts'] = []
+      const actual = CardUtils.hasMaxemailContent(maxemailCampaign)
+      expect(actual).to.equal(0)
+    })
+  })
+  describe('Maxemail contact checker', () => {
+    it('should return true when there is an email address', () => {
+      const actual = CardUtils.hasMaxemailContent(maxemailContact)
+      expect(actual && true).to.equal(true)
+    })
+    it('should return false when there is no email address', () => {
+      maxemailContact['object.type'] = 'dit:maxemail:Email:Sent'
+      const actual = CardUtils.hasMaxemailContent(maxemailContact)
+      expect(actual && true).to.equal(true)
+    })
+    it('should return false when there is no email address', () => {
+      maxemailContact['dit:emailAddress'] = ''
+      const actual = CardUtils.hasMaxemailContent(maxemailContact)
+      expect(actual && true).to.equal(0)
+    })
+    it('should return false when the type does not match', () => {
+      maxemailContact['object.type'] = 'dit:Interaction'
+      const actual = CardUtils.hasMaxemailContent(maxemailContact)
+      expect(actual && true).to.equal(false)
+    })
+  })
+})

--- a/src/client/components/ActivityFeed/activities/__test__/MaxemailCampaign.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/MaxemailCampaign.test.js
@@ -1,3 +1,4 @@
+import { ACTIVITY_TYPE } from '../../constants'
 import CardUtils from '../card/CardUtils'
 
 const maxemailCampaign = {
@@ -27,35 +28,43 @@ const maxemailContact = {
 
 describe('Maxemail tests', () => {
   describe('Maxemail campaigns content checker', () => {
-    it('should return 1 when there is 1 contact', () => {
+    const renderResult = CardUtils.canRenderByTypes(
+      maxemailCampaign,
+      ACTIVITY_TYPE.MaxemailCampaign
+    )
+    it('should return true when there is 1 contact', () => {
       const actual = CardUtils.hasMaxemailContent(maxemailCampaign)
-      expect(actual).to.equal(1)
+      expect(renderResult && actual).to.equal(true)
     })
-    it('should return 0 when there is 0 contacts', () => {
+    it('should return false when there is 0 contacts', () => {
       maxemailCampaign['object.contacts'] = []
       const actual = CardUtils.hasMaxemailContent(maxemailCampaign)
-      expect(actual).to.equal(0)
+      expect(renderResult && actual).to.equal(false)
     })
   })
-  describe('Maxemail contact checker', () => {
+  describe('Maxemail contacts content checker', () => {
+    const renderContactResult = CardUtils.canRenderByTypes(
+      maxemailContact,
+      ACTIVITY_TYPE.MaxemailCampaign
+    )
     it('should return true when there is an email address', () => {
       const actual = CardUtils.hasMaxemailContent(maxemailContact)
-      expect(actual && true).to.equal(true)
+      expect(renderContactResult && actual).to.equal(true)
     })
-    it('should return false when there is no email address', () => {
+    it('should return true when there is one match in type ', () => {
       maxemailContact['object.type'] = 'dit:maxemail:Email:Sent'
       const actual = CardUtils.hasMaxemailContent(maxemailContact)
-      expect(actual && true).to.equal(true)
+      expect(renderContactResult && actual).to.equal(true)
     })
     it('should return false when there is no email address', () => {
       maxemailContact['dit:emailAddress'] = ''
       const actual = CardUtils.hasMaxemailContent(maxemailContact)
-      expect(actual && true).to.equal(0)
+      expect(renderContactResult && actual).to.equal(false)
     })
     it('should return false when the type does not match', () => {
       maxemailContact['object.type'] = 'dit:Interaction'
       const actual = CardUtils.hasMaxemailContent(maxemailContact)
-      expect(actual && true).to.equal(false)
+      expect(renderContactResult && actual).to.equal(false)
     })
   })
 })

--- a/src/client/components/ActivityFeed/activities/card/CardDetailsList.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardDetailsList.jsx
@@ -18,7 +18,7 @@ const StyledListItem = styled(ListItem)`
 const CardDetailsList = ({ items, itemRenderer, itemPropName }) => {
   return (
     <StyledUnorderedList listStyleType="none">
-      {items.map((item, index) => (
+      {items?.map((item, index) => (
         <StyledListItem key={item.id}>
           {itemRenderer(item, index, itemPropName)}
         </StyledListItem>

--- a/src/client/components/ActivityFeed/activities/card/CardUtils.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardUtils.jsx
@@ -58,13 +58,13 @@ const canRenderByTypes = (activity, types) => {
 const hasMaxemailContent = (activity) => {
   const activityType = get(activity, 'object.type')
   if (activityType === 'dit:maxemail:Campaign') {
-    return get(activity, 'object.contacts')?.length
+    return get(activity, 'object.contacts')?.length > 0
   }
   if (
     activityType?.includes('dit:maxemail:Email') ||
     activityType?.includes('dit:maxemail:Email:Sent')
   ) {
-    return get(activity, 'dit:emailAddress')?.length
+    return get(activity, 'dit:emailAddress')?.length > 0
   }
   return false
 }

--- a/src/client/components/ActivityFeed/activities/card/CardUtils.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardUtils.jsx
@@ -55,6 +55,20 @@ const canRenderByTypes = (activity, types) => {
   return some(types, (type) => includes(activityTypes, type))
 }
 
+const hasMaxemailContent = (activity) => {
+  const activityType = get(activity, 'object.type')
+  if (activityType === 'dit:maxemail:Campaign') {
+    return get(activity, 'object.contacts')?.length
+  }
+  if (
+    activityType?.includes('dit:maxemail:Email') ||
+    activityType?.includes('dit:maxemail:Email:Sent')
+  ) {
+    return get(activity, 'dit:emailAddress')?.length
+  }
+  return false
+}
+
 const getAdviser = (activity) => {
   const adviser = {
     id: get(activity, 'actor.id'),
@@ -79,4 +93,5 @@ export default {
   getCompany,
   getAdviser,
   transform,
+  hasMaxemailContent,
 }

--- a/src/client/components/ActivityFeed/constants.js
+++ b/src/client/components/ActivityFeed/constants.js
@@ -59,7 +59,11 @@ export const ACTIVITY_TYPE = {
   Omis: ['dit:OMISOrder'],
   Referral: ['dit:CompanyReferral'],
   DirectoryFormsApi: ['dit:directoryFormsApi:Submission'],
-  MaxemailCampaign: ['dit:maxemail:Campaign'],
+  MaxemailCampaign: [
+    'dit:maxemail:Campaign',
+    'dit:maxemail:Email',
+    'dit:maxemail:Email:Sent',
+  ],
 }
 
 export const ACTIVITY_TYPE_FILTERS = {


### PR DESCRIPTION
## Description of change

The Maxemail activities are not being rendered on the Contacts interactions page so it looks like the activities number is incorrect and there are less than 10 activities on each page.  
This is an example, https://www.datahub.trade.gov.uk/contacts/8fc203e6-c4ad-43c0-a290-bbcef2c0aa3a/interactions?featureTesting=user-contact-activities&page=2

This PR fixes the issue so Maxemail activities are rendered as expected.

## Test instructions
-Ensure you have the `user-contact-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit a contact activity page that had Maxemail interactions: Max Speed is a good example:
http://localhost:3000/contacts/9136dd49-df67-4b2b-b241-6b64a662f1af/interactions?featureTesting=user-company-activities

You should see the Email Campaign showing up.

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/83657534/186429955-3d41cadb-d2a4-425d-bfb5-d01c47bc416a.png)


### After
![image](https://user-images.githubusercontent.com/83657534/186429132-d16e86d3-7858-4090-b030-6695c372068b.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
