### PR TITLE
Track users going from DH to DW by leveraging GA UTMs

### DIFF
--- a/src/client/components/DataHubHeader/LogoBar.jsx
+++ b/src/client/components/DataHubHeader/LogoBar.jsx
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom'
 import VisuallyHidden from '@govuk-react/visually-hidden'
 import styled from 'styled-components'
 import { BLACK, WHITE, YELLOW } from 'govuk-colours'
+import qs from 'qs'
 import {
   SPACING,
   FONT_SIZE,
@@ -13,6 +14,15 @@ import {
 // Colours not defined in 'govuk-colours' which we need for consistency
 // with Find Exporters and Market Access.
 import { DARK_BLUE_LEGACY } from '../../utils/colors'
+
+const SWITCH_TO_DATA_WORKSPACE = 'Switch to Data Workspace'
+
+const googleAnalyticsUTM = qs.stringify({
+  utm_source: 'Data Hub',
+  utm_medium: 'referral',
+  utm_campaign: 'dataflow',
+  utm_content: SWITCH_TO_DATA_WORKSPACE,
+})
 
 const StyledLogoContainer = styled.div({
   maxWidth: 960,
@@ -114,8 +124,10 @@ const LogoBar = ({ showVerticalNav }) => (
       aria-label="Header links"
     >
       <NavigationListItem>
-        <NavigationLink href="https://data.trade.gov.uk">
-          Switch to Data Workspace
+        <NavigationLink
+          href={`https://data.trade.gov.uk?${googleAnalyticsUTM}`}
+        >
+          {SWITCH_TO_DATA_WORKSPACE}
         </NavigationLink>
       </NavigationListItem>
     </NavigationList>

--- a/src/templates/_components/header.njk
+++ b/src/templates/_components/header.njk
@@ -7,6 +7,7 @@
 	{%- set marketAcessDomain = ( params.domains.marketAccess or 'https://market-access.trade.gov.uk/' ) %}
 	{%- set dataWorkspaceDomain = (params.domains.dataWorkspaceDomain or 'https://data.trade.gov.uk' ) %}
 
+  {%- set googleAnalyticsUTMParams = '?utm_source=Data%20Hub&utm_medium=referral&utm_campaign=dataflow&utm_content=Switch%20to%20Data%20Workspace' %}
 	{%- set datahubCrmKey = 'datahub-crm' %}
 	{%- set hasCrmPermission = false %}
 	{%- for permitted in permittedApps %}
@@ -81,7 +82,7 @@
 	{%- set headerLinks = [
 	{
 		text: 'Switch to Data Workspace',
-		href: dataWorkspaceDomain
+		href: ( dataWorkspaceDomain + googleAnalyticsUTMParams )
 	}
 ] -%}
 


### PR DESCRIPTION
## Description of change

When a user selects 'Switch to Data Workspace' on Data Hub we want to track that via Google Analytics (GA). We can easily achieve that by adding Urchin Traffic Monitors (UTMs) to the end of the Data Workspace domain name.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
