### PR TITLE
Upgrade cypress image diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -122,7 +122,7 @@
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
         "cypress": "^9.7.0",
-        "cypress-image-diff-js": "1.16.4",
+        "cypress-image-diff-js": "1.21.1",
         "eslint": "^8.22.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-import": "^2.26.0",
@@ -16195,15 +16195,15 @@
       }
     },
     "node_modules/cypress-image-diff-js": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.16.4.tgz",
-      "integrity": "sha512-e03MFOIlDiogSBYfGE/OUs8OyoVgG+xWuH1pNQGNwP7ET3rd7HRxqwxrNIp2jMsPkqzsIDCDYkfps/TEnXJaww==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.21.1.tgz",
+      "integrity": "sha512-WQkLjvj/H9lXym5ShvvAYMn8gdpGqKVfGzdMPCLqx9H1q6qPAw+l7g60tjhQ+zchHjAAZ6D/JuVUhddgJj992Q==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "arg": "^4.1.1",
         "colors": "^1.4.0",
-        "cypress": "^9.5.1",
+        "cypress": "^9.6.1",
         "cypress-recurse": "^1.13.1",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.7",
@@ -50409,15 +50409,15 @@
       "requires": {}
     },
     "cypress-image-diff-js": {
-      "version": "1.16.4",
-      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.16.4.tgz",
-      "integrity": "sha512-e03MFOIlDiogSBYfGE/OUs8OyoVgG+xWuH1pNQGNwP7ET3rd7HRxqwxrNIp2jMsPkqzsIDCDYkfps/TEnXJaww==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/cypress-image-diff-js/-/cypress-image-diff-js-1.21.1.tgz",
+      "integrity": "sha512-WQkLjvj/H9lXym5ShvvAYMn8gdpGqKVfGzdMPCLqx9H1q6qPAw+l7g60tjhQ+zchHjAAZ6D/JuVUhddgJj992Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "arg": "^4.1.1",
         "colors": "^1.4.0",
-        "cypress": "^9.5.1",
+        "cypress": "^9.6.1",
         "cypress-recurse": "^1.13.1",
         "fs-extra": "^9.0.1",
         "handlebars": "^4.7.7",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
     "cypress": "^9.7.0",
-    "cypress-image-diff-js": "1.16.4",
+    "cypress-image-diff-js": "1.21.1",
     "eslint": "^8.22.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
## Description of change

The intent of this PR is to upgrade cypress image diff which provides several new features:

- improved reporting
- retry mechanism
- enhanced performance
- preserve old screenshots

and more...

## Test instructions

All visual components should work as usual.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
