### PR TITLE
Add event link to contact activity page

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -19,10 +19,19 @@ export const AVENTRI_ATTENDEE_REG_STATUSES = {
   Incomplete: 'Incomplete',
 }
 
+export const extractAventriId = (attendee) => {
+  // Event index to extract id from Aventri Event string feed by activity-stream
+  // e.g. dit:aventri:Event:1113:Create
+  const EVENT_ID_INDEX = 3
+  const aventriEventId =
+    attendee.object.attributedTo.id.split(':')[EVENT_ID_INDEX]
+  return aventriEventId
+}
 export const transformAventriAttendee = (attendee) => ({
   attendeeName: `${attendee.object['dit:firstName']} ${attendee.object['dit:lastName']}`,
   date: formatStartAndEndDate(attendee.startDate, attendee.endDate),
   eventName: attendee.eventName,
+  eventId: extractAventriId(attendee),
   registrationStatus:
     AVENTRI_ATTENDEE_REG_STATUSES[attendee.object['dit:registrationStatus']],
   contactUrl: attendee.datahubContactUrl,
@@ -35,8 +44,14 @@ const StyledSpan = styled('span')`
 `
 
 export default function AventriAttendee({ activity: attendee }) {
-  const { attendeeName, eventName, date, registrationStatus, contactUrl } =
-    transformAventriAttendee(attendee)
+  const {
+    attendeeName,
+    eventName,
+    eventId,
+    date,
+    registrationStatus,
+    contactUrl,
+  } = transformAventriAttendee(attendee)
 
   return eventName ? (
     <ActivityCardWrapper dataTest="aventri-activity">
@@ -49,7 +64,8 @@ export default function AventriAttendee({ activity: attendee }) {
         }
       />
       <ActivityCardSubject>
-        {eventName}
+        <Link href={`/events/aventri/${eventId}/details`}>{eventName}</Link>
+
         {registrationStatus && (
           <StyledSpan>
             : <span>{registrationStatus}</span>

--- a/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
@@ -11,6 +11,9 @@ describe('transformAventriAttendee', () => {
     startDate: '2022-02-14T20:09:14',
     object: {
       'dit:registrationStatus': registrationStatus,
+      attributedTo: {
+        id: 'dit:aventri:Attendee:1111',
+      },
     },
   })
 

--- a/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/AventriAttendee.test.js
@@ -61,4 +61,10 @@ describe('transformAventriAttendee', () => {
       dateStub.calledWith(activity().startDate, activity().endDate)
     })
   })
+
+  describe('aventri id', () => {
+    it('should extract and return the id number', () => {
+      expect(transformAventriAttendee(activity()).eventId).to.eq('1111')
+    })
+  })
 })

--- a/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
@@ -13,6 +13,9 @@ describe('AventriAttendee', () => {
       'dit:registrationStatus': 'Confirmed',
       'dit:emailAddress': 'johndoe@outlook.com',
       id: 'dit:aventri:Attendee:1111',
+      attributedTo: {
+        id: 'dit:aventri:Attendee:1111',
+      },
     },
     startDate: '2022-02-24T11:28:57',
     endDate: '2023-01-01T11:28:57',

--- a/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/AventriAttendee.test.jsx
@@ -2,6 +2,8 @@ import { mount } from '@cypress/react'
 import React from 'react'
 import AventriAttendee from '../../../../../src/client/components/ActivityFeed/activities/AventriAttendee'
 
+const urls = require('../../../../../src/lib/urls')
+
 describe('AventriAttendee', () => {
   const Component = (props) => <AventriAttendee {...props} />
   const activity = {
@@ -40,9 +42,12 @@ describe('AventriAttendee', () => {
       mount(<Component activity={activity} />)
     })
 
-    it('should display event date from Aventri', () => {
-      cy.get('[data-test="aventri-activity"]').contains(
-        'Event date: 24 Feb 2022 to 01 Jan 2023'
+    it('should have a link to the event page', () => {
+      const eventId = '1111'
+      cy.get('[data-test="activity-card-subject"] > a').should(
+        'have.attr',
+        'href',
+        urls.events.aventri.details(eventId)
       )
     })
 


### PR DESCRIPTION
## Description of change

This PR adds a hyperlink to the `event/details` page on the event name on the contact activity feed.

## Test instructions

-Ensure you have the `user-contact-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit a contact activity page that had Aventri interactions: John Middlename Doe is a good example:
http://localhost:3000/contacts/236944dd-2e75-4bc1-999f-52ea19c6adf8/interactions?featureTesting=user-contact-activities
-You should see the event name hyperlinked and when you click on it, you should be taken to the event details page

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/187656774-150b63a5-247c-4adb-ab3c-4d25c03932e2.png)


### After
![image](https://user-images.githubusercontent.com/83657534/187656491-c71e28c6-ca70-4d2c-aa69-987f8229b310.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
