### PR TITLE
Temporarily disable attendees tab for Aventri events

### DIFF
--- a/src/client/modules/Events/EventAventriDetails/index.jsx
+++ b/src/client/modules/Events/EventAventriDetails/index.jsx
@@ -106,14 +106,6 @@ const EventAventriDetails = ({ name, eventDate, location, fullAddress }) => {
                             >
                               Details
                             </LocalNavLink>
-                            <LocalNavLink
-                              dataTest="event-aventri-attendees-link"
-                              href={urls.events.aventri.attendees(
-                                aventriEventId
-                              )}
-                            >
-                              Attendees
-                            </LocalNavLink>
                           </LocalNav>
                         </GridCol>
                         <GridCol setWidth="three-quarters">

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -42,13 +42,6 @@ describe('Event Aventri Details', () => {
             'href',
             urls.events.aventri.details(existingEventId)
           )
-        cy.get('[data-test="event-aventri-attendees-link"]')
-          .should('contain', 'Attendees')
-          .should(
-            'have.attr',
-            'href',
-            urls.events.aventri.attendees(existingEventId)
-          )
       })
 
       it('should display the event name in the header', () => {


### PR DESCRIPTION
## Description of change

So we can make a first release of Contacts & the related Events Details page we want to temporarily disable the Attendees tab on Aventri events. This means users won't see the incomplete Attendees tab for Aventri events and we can finish work on it.

There is already a ticket in the backlog to reinstate the attendees tab. 

## Test instructions

-Ensure you have the `user-event-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Visit an aventri event page e.g. http://localhost:3000/events/aventri/3333/details
-The attendees tab should be hidden

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/187709559-fa260340-7061-4d87-9c30-5798a10a66da.png)


### After

![image](https://user-images.githubusercontent.com/83657534/187709445-a33e3451-a674-4148-a08b-db4cf71323df.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
