### PR TITLE
Add 'add event' button to Events Collection Page

### DIFF
--- a/src/client/components/ActivityFeedFilteredCollectionList/index.jsx
+++ b/src/client/components/ActivityFeedFilteredCollectionList/index.jsx
@@ -25,6 +25,7 @@ const ActivityFeedFilteredCollectionList = ({
   maxItemsToPaginate = 10000,
   defaultQueryParams,
   allActivityFeedEvents,
+  addItemURL,
 }) => {
   const totalPages = Math.ceil(
     Math.min(total, maxItemsToPaginate) / itemsPerPage
@@ -50,8 +51,9 @@ const ActivityFeedFilteredCollectionList = ({
                 {
                   <CollectionHeader
                     totalItems={total}
-                    collectionName="events"
+                    collectionName="event"
                     data-test="activity-feed-collection-header"
+                    addItemUrl={addItemURL}
                   />
                 }
                 {sortOptions && (

--- a/src/client/components/CollectionList/CollectionHeader.jsx
+++ b/src/client/components/CollectionList/CollectionHeader.jsx
@@ -41,6 +41,7 @@ function CollectionHeader({
       href={addItemUrl}
       buttonColour={GREY_3}
       buttonTextColour={BLACK}
+      data-test="add-collection-item-button"
     >
       Add {collectionName}
     </Button>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -193,6 +193,7 @@ const EventsCollection = ({
               taskProps={activityFeedEventTask}
               allActivityFeedEvents={allActivityFeedEvents}
               total={total}
+              addItemURL={'/events/create'}
             >
               <CollectionFilters>
                 <Filters.Input

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -154,10 +154,16 @@ describe('Event Collection List Page - React', () => {
       })
 
       it('should display the events result count header', () => {
-        cy.get('[data-test="activity-feed-collection-header"]').should(
-          'have.text',
+        cy.get('[data-test="activity-feed-collection-header"]').contains(
           '82 events'
         )
+      })
+
+      it('should have a link to add event', () => {
+        cy.get('[data-test="add-collection-item-button"]')
+          .should('exist')
+          .should('contain', 'Add event')
+          .should('have.attr', 'href', '/events/create')
       })
 
       it('should display the expected number of pages', () => {


### PR DESCRIPTION
## Description of change

The “Add Event” button is being re-introduced to the Events page so users are able to easily add an event. 

## Test instructions
-Ensure you have the `user-event-activities` feature flag on. You can do this in dev Django admin.
-Get this branch up locally
-Navigate to http://localhost:3000/events?featureTesting=user-event-activities
-You should see a button to add an event and this will direct you to the `http://localhost:3000/events/create` page 

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/187895932-d75e82da-056f-4a7e-831c-49c4c2fa88b2.png)

### After

![image](https://user-images.githubusercontent.com/83657534/187895788-5479d7c4-1efc-4d17-acca-c8b52f1296c8.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
