### PR TITLE
Refactor script regex

### DIFF
--- a/src/lib/request.js
+++ b/src/lib/request.js
@@ -18,7 +18,7 @@ const stripScripts = (key, value) => {
 }
 
 const stripScript = (text) => {
-  const SCRIPT_REGEX = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi
+  const SCRIPT_REGEX = /<script\b[^>]*>[\s\S]*?<\/script\b[^>]*>/gi
   while (SCRIPT_REGEX.test(text)) {
     logger.warn('Found script tag in response')
     text = text.replace(SCRIPT_REGEX, '')


### PR DESCRIPTION
## Description of change

CodeQL was throwing a warning that this regex doesn't capture all script
tags[1] This new regex should capture code like:
`<script>alert(1)</script foo="bar">`

[1] https://codeql.github.com/codeql-query-help/javascript/js-bad-tag-filter/

[Looks like it fixed the alert!](https://github.com/uktrade/data-hub-frontend/pull/4869/checks?check_run_id=8154530944)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
