### PR TITLE
Fix security warnings

### DIFF
--- a/src/apps/__test__/middleware.test.js
+++ b/src/apps/__test__/middleware.test.js
@@ -286,7 +286,7 @@ describe('Apps middleware', () => {
 
       expect(this.nextSpy).to.not.have.been.called
       expect(this.resMock.redirect).to.be.calledWith(
-        '/sub-app?filter=apple&sortby=sweetness'
+        '?filter=apple&sortby=sweetness'
       )
     })
 

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -79,7 +79,7 @@ function setLocalNav(items = [], appendBaseUrl = true) {
 function setDefaultQuery(query = {}) {
   return function handleDefaultRedirect(req, res, next) {
     if (isEmpty(req.query)) {
-      return res.redirect(`${req.originalUrl}?${queryString.stringify(query)}`)
+      return res.redirect(`?${queryString.stringify(query)}`)
     }
     next()
   }

--- a/src/apps/support/middleware.js
+++ b/src/apps/support/middleware.js
@@ -7,12 +7,18 @@ const { createZenDeskMessage, postToZenDesk } = require('./services')
 async function postFeedback(req, res, next) {
   const { title, feedback_type, email } = req.body
 
+  const validateEmail = () => {
+    if (email.length > 345 || !email.match(/.*@.*\..*/)) {
+      return 'A valid email address is required'
+    }
+  }
+
   const messages = pickBy({
     title: !title && 'Your feedback needs a title',
     feedback_type:
       !feedback_type &&
       'You need to choose between raising a problem and leaving feedback',
-    email: !email.match(/.*@.*\..*/) && 'A valid email address is required',
+    email: validateEmail(),
   })
 
   res.locals.formErrors = Object.assign({}, res.locals.formErrors, {

--- a/src/middleware/__test__/user-features.test.js
+++ b/src/middleware/__test__/user-features.test.js
@@ -1,0 +1,41 @@
+const userFeatures = require('../user-features')
+
+describe('user-features middleware', () => {
+  let req, res, next
+  const featureFlagName = 'mock-user-flag'
+  beforeEach(() => {
+    res = {
+      locals: {
+        userFeatures: [],
+      },
+      redirect: sinon.spy(),
+    }
+
+    req = {
+      method: 'GET',
+      query: {},
+    }
+
+    next = sinon.spy()
+  })
+
+  describe('when the flag is actives for the user', () => {
+    it('redirects to url with featuretesting param', () => {
+      res.locals.userFeatures = [featureFlagName]
+      userFeatures(featureFlagName)(req, res, next)
+      expect(res.redirect).to.have.been.calledWith(
+        `?featureTesting=${featureFlagName}`
+      )
+      expect(res.locals.isFeatureTesting).to.be.true
+    })
+  })
+
+  describe('when the flag is not active for the user', () => {
+    it('redirects to url with featuretesting param', () => {
+      userFeatures(featureFlagName)(req, res, next)
+      expect(res.redirect).to.not.have.been.called
+      expect(next).to.have.been.called
+      expect(res.locals.isFeatureTesting).to.be.false
+    })
+  })
+})

--- a/src/middleware/user-features.js
+++ b/src/middleware/user-features.js
@@ -33,11 +33,7 @@ module.exports = (feature) => async (req, res, next) => {
     !req.query.featureTesting &&
     req.method == HTTP_GET
   ) {
-    res.redirect(
-      `${req.originalUrl}${
-        isEmpty(req.query) ? '?' : '&'
-      }featureTesting=${feature}`
-    )
+    res.redirect(`${isEmpty(req.query) ? '?' : '&'}featureTesting=${feature}`)
   } else {
     next()
   }


### PR DESCRIPTION
## Description of change


Two commits for three different security warnings

**2. remove `originalURL` to stop possible tampering**
The use of possible user input to redirect was causing the CodeQL alert
[1][2] The redirect function doesn't actually need the original url as it
will just auto redirect to that anyway.

[1] https://codeql.github.com/codeql-query-help/javascript/js-server-side-unvalidated-url-redirection/
[2] https://github.com/uktrade/data-hub-frontend/security/code-scanning/2

**3. stop polynomial redo on email regex**
This regex would have been very slow if the user entered a huge amount
of text. One way to stop this is checking the length doesn't exceed the
max length of an email address.

_Document what the PR does and why the change is needed_

## Test instructions

Under the checks -> codeQL report for this PR, it should show three alerts fixed.  https://github.com/uktrade/data-hub-frontend/pull/4870/checks?check_run_id=8159587500

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
