### PR TITLE
Anonymise specific collection list filter values before sending to analytics

### DIFF
--- a/src/apps/investments/client/profiles/LargeCapitalProfileCollection.jsx
+++ b/src/apps/investments/client/profiles/LargeCapitalProfileCollection.jsx
@@ -12,6 +12,7 @@ import {
 import { listSkeletonPlaceholder } from '../../../../client/components/SkeletonPlaceholder'
 import { TASK_GET_PROFILES_LIST, ID } from './state'
 import { INVESTMENTS__PROFILES_LOADED } from '../../../../client/actions'
+import { sanitizeFilter } from '../../../../client/filters'
 
 const QS_PARAMS = {
   countryOfOrigin: 'country_of_origin',
@@ -124,6 +125,25 @@ const LargeCapitalProfileCollection = ({
           results={results}
           isComplete={isComplete}
           collectionName="profile"
+          sanitizeFiltersForAnalytics={({
+            investorCompanyName,
+            investableCapitalMin,
+            investableCapitalMax,
+            globalAssetsUnderManagementMin,
+            globalAssetsUnderManagementMax,
+          }) => ({
+            ...sanitizeFilter(investorCompanyName, 'Company name'),
+            ...sanitizeFilter(investableCapitalMin, 'Investable capital min'),
+            ...sanitizeFilter(investableCapitalMax, 'Investable capital max'),
+            ...sanitizeFilter(
+              globalAssetsUnderManagementMin,
+              'Global assets under management min'
+            ),
+            ...sanitizeFilter(
+              globalAssetsUnderManagementMax,
+              'Global assets under management max'
+            ),
+          })}
           taskProps={{
             name: TASK_GET_PROFILES_LIST,
             id: ID,

--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -28,6 +28,8 @@ import {
   INVESTMENTS__SET_PROJECTS_METADATA,
 } from '../../../../client/actions'
 
+import { sanitizeFilter } from '../../../../client/filters'
+
 const ProjectsCollection = ({
   payload,
   currentAdviserId,
@@ -92,6 +94,10 @@ const ProjectsCollection = ({
       baseDownloadLink="/investments/projects/export"
       entityName="project"
       addItemUrl="/investments/projects/create"
+      sanitizeFiltersForAnalytics={({ advisers, countries }) => ({
+        ...sanitizeFilter(advisers),
+        ...sanitizeFilter(countries),
+      })}
       defaultQueryParams={{
         page: 1,
         sortby: 'created_on:desc',

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -30,6 +30,13 @@ const filtersToAnalytics = (filters) =>
       ])
   )
 
+const getSelectedFilters = (filters) =>
+  Object.fromEntries(
+    Object.entries(filters).filter(
+      ([, value]) => value && value.options && value.options.length
+    )
+  )
+
 const FilteredCollectionList = ({
   results = [],
   summary = null,
@@ -49,6 +56,7 @@ const FilteredCollectionList = ({
   addItemUrl,
   defaultQueryParams,
   titleRenderer = null,
+  sanitizeFiltersForAnalytics = null,
   useReactRouter = false,
 }) => {
   const totalPages = Math.ceil(
@@ -113,7 +121,13 @@ const FilteredCollectionList = ({
                                 onClick={() => {
                                   pushAnalytics({
                                     event: 'filterResultClick',
-                                    extra: filtersToAnalytics(selectedFilters),
+                                    extra: {
+                                      ...filtersToAnalytics(selectedFilters),
+                                      ...(sanitizeFiltersForAnalytics &&
+                                        sanitizeFiltersForAnalytics(
+                                          getSelectedFilters(selectedFilters)
+                                        )),
+                                    },
                                   })
                                 }}
                               />
@@ -167,6 +181,7 @@ FilteredCollectionList.propTypes = {
   summary: PropTypes.object,
   defaultQueryParams: PropTypes.object,
   titleRenderer: PropTypes.func,
+  sanitizeFiltersForAnalytics: PropTypes.func,
   width: PropTypes.string,
 }
 

--- a/src/client/filters.js
+++ b/src/client/filters.js
@@ -37,3 +37,12 @@ export const buildDatesFilter = ({
         },
       ]
     : []
+
+export const sanitizeFilter = (filter, categoryLabel) =>
+  filter
+    ? {
+        [filter.queryParam]: filter.options.map(
+          (option) => option.categoryLabel || categoryLabel
+        ),
+      }
+    : {}

--- a/src/client/modules/Companies/CollectionList/index.jsx
+++ b/src/client/modules/Companies/CollectionList/index.jsx
@@ -32,6 +32,8 @@ import {
   state2props,
 } from './state'
 
+import { sanitizeFilter } from '../../../../client/filters'
+
 const CompaniesCollection = ({
   payload,
   currentAdviserId,
@@ -91,6 +93,15 @@ const CompaniesCollection = ({
         entityName="company"
         entityNamePlural="companies"
         addItemUrl="/companies/create"
+        sanitizeFiltersForAnalytics={({
+          name,
+          ukPostcode,
+          leadItaOrGlobalAccountManagers,
+        }) => ({
+          ...sanitizeFilter(name),
+          ...sanitizeFilter(ukPostcode),
+          ...sanitizeFilter(leadItaOrGlobalAccountManagers),
+        })}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           <FilterToggleSection

--- a/src/client/modules/Contacts/CollectionList/index.jsx
+++ b/src/client/modules/Contacts/CollectionList/index.jsx
@@ -26,6 +26,8 @@ import {
   TASK_GET_CONTACTS_METADATA,
 } from './state'
 
+import { sanitizeFilter } from '../../../../client/filters'
+
 const ContactsCollection = ({
   payload,
   optionMetadata,
@@ -70,6 +72,10 @@ const ContactsCollection = ({
         selectedFilters={selectedFilters}
         baseDownloadLink="/contacts/export"
         entityName="contact"
+        sanitizeFiltersForAnalytics={({ name, companyName }) => ({
+          ...sanitizeFilter(name),
+          ...sanitizeFilter(companyName),
+        })}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           <FilterToggleSection

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -36,6 +36,7 @@ import {
 } from './state'
 
 import ActivityFeedFilteredCollectionList from '../../../components/ActivityFeedFilteredCollectionList'
+import { sanitizeFilter } from '../../../../client/filters'
 
 const EventsCollection = ({
   payload,
@@ -108,6 +109,10 @@ const EventsCollection = ({
               entityNamePlural="events"
               addItemUrl="/events/create"
               useReactRouter={true}
+              sanitizeFiltersForAnalytics={({ name, organisers }) => ({
+                ...sanitizeFilter(name),
+                ...sanitizeFilter(organisers),
+              })}
             >
               <CollectionFilters taskProps={collectionListMetadataTask}>
                 <FilterToggleSection

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -36,6 +36,8 @@ import {
   TASK_GET_INTERACTIONS_TEAM_NAME,
 } from './state'
 
+import { sanitizeFilter } from '../../../../client/filters'
+
 const StyledCheckboxGroup = styled(Filters.CheckboxGroup)`
   /* This just tightens up the gap for when a single checkbox option group
   (with no label) is beneath a multiple checkbox option group */
@@ -116,6 +118,10 @@ const InteractionCollection = ({
         selectedFilters={selectedFilters}
         baseDownloadLink="/interactions/export"
         entityName="interaction"
+        sanitizeFiltersForAnalytics={({ advisers, teams }) => ({
+          ...sanitizeFilter(advisers),
+          ...sanitizeFilter(teams),
+        })}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           <Filters.CheckboxGroup


### PR DESCRIPTION
## Description of change
Currently when a user applies filters (company name, lead ITA, advisers, teams, etc) on the Collection Lists pages the filter value ends up in Google Analytics (GA). These type of filters need to be changed to the filter heading. For example, if the user applies a filter such Lead ITA and selects a name Joe Bloggs then Lead ITA should be sent to GA, not Joe Bloggs.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
