### PR TITLE
Release new card styling to all users 

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -8,11 +8,16 @@ const {
   EVENT_ACTIVITY_SORT_OPTIONS,
   EVENT_ATTENDEES_SORT_OPTIONS,
   EVENT_ALL_ACTIVITY,
+  CONTACT_ACTIVITY_FEATURE_FLAG,
 } = require('./constants')
 
 const { getGlobalUltimateHierarchy } = require('../../repos')
 const urls = require('../../../../lib/urls')
-const { fetchActivityFeed, fetchMatchingDataHubContact } = require('./repos')
+const {
+  fetchActivityFeed,
+  fetchMatchingDataHubContact,
+  fetchUserFeatureFlags,
+} = require('./repos')
 const config = require('../../../../config')
 
 const {
@@ -23,6 +28,9 @@ const {
   maxemailEmailSentQuery,
 } = require('./es-queries')
 const { contactActivityQuery } = require('./es-queries/contact-activity-query')
+const {
+  contactActivityQueryNoAventri,
+} = require('./es-queries/contact-activity-query-no-aventri')
 const allActivityFeedEventsQuery = require('./es-queries/activity-feed-all-events-query')
 const { ACTIVITIES_PER_PAGE } = require('../../../contacts/constants')
 const { aventriEventQuery } = require('./es-queries/aventri-event-query')
@@ -161,19 +169,50 @@ async function fetchActivitiesForContact(req, res, next) {
 
     const from = (req.query.page - 1) * ACTIVITIES_PER_PAGE
 
-    let results = await fetchActivityFeed(
-      req,
-      contactActivityQuery(
-        from,
-        ACTIVITIES_PER_PAGE,
-        contact.email,
-        contact.id,
-        DATA_HUB_AND_EXTERNAL_ACTIVITY,
-        CONTACT_ACTIVITY_SORT_SEARCH_OPTIONS[selectedSortBy]
-      )
-    ).catch((error) => {
-      next(error)
-    })
+    // This will be deleted when the feature flag is removed
+    // istanbul ignore next: Covered by functional tests
+    res.locals.userFeatures = await fetchUserFeatureFlags(req).catch(
+      // istanbul ignore next: Covered by functional tests
+      (error) => {
+        next(error)
+      }
+    )
+
+    // istanbul ignore next: Covered by functional tests
+    let isContactFeatureFlagEnabled = res.locals?.userFeatures?.includes(
+      CONTACT_ACTIVITY_FEATURE_FLAG
+    )
+
+    // istanbul ignore next: Covered by functional tests
+    let results = isContactFeatureFlagEnabled
+      ? await fetchActivityFeed(
+          req,
+          contactActivityQuery(
+            from,
+            ACTIVITIES_PER_PAGE,
+            contact.email,
+            contact.id,
+            DATA_HUB_AND_EXTERNAL_ACTIVITY,
+            CONTACT_ACTIVITY_SORT_SEARCH_OPTIONS[selectedSortBy]
+          )
+          // istanbul ignore next: Covered by functional tests
+        ).catch((error) => {
+          next(error)
+        })
+      : await fetchActivityFeed(
+          req,
+          contactActivityQueryNoAventri(
+            from,
+            ACTIVITIES_PER_PAGE,
+            contact.email,
+            contact.id,
+            DATA_HUB_AND_EXTERNAL_ACTIVITY,
+            CONTACT_ACTIVITY_SORT_SEARCH_OPTIONS[selectedSortBy]
+          )
+          // istanbul ignore next: Covered by functional tests
+        ).catch((error) => {
+          next(error)
+        })
 
     const total = results.hits.total.value
     let activities = results.hits.hits.map((hit) => hit._source)

--- a/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query-no-aventri.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query-no-aventri.js
@@ -1,0 +1,85 @@
+// to delete when contact feature flag is removed
+const contactActivityQueryNoAventri = (
+  from,
+  size,
+  email,
+  contactId,
+  objectTypes,
+  sortOrder
+) => {
+  return {
+    from,
+    size,
+    query: {
+      bool: {
+        must: [
+          {
+            bool: {
+              should: [
+                {
+                  bool: {
+                    must: [
+                      {
+                        terms: {
+                          'object.type': objectTypes,
+                        },
+                      },
+                      {
+                        terms: {
+                          'object.attributedTo.id': [
+                            `dit:DataHubContact:${contactId}`,
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  bool: {
+                    must: [
+                      {
+                        term: {
+                          'object.type': 'dit:maxemail:Email:Sent',
+                        },
+                      },
+                      {
+                        term: {
+                          'object.dit:emailAddress': {
+                            value: email,
+                            case_insensitive: true,
+                          },
+                        },
+                      },
+                      {
+                        terms: {
+                          'object.dit:registrationStatus': [
+                            'Attended',
+                            'Confirmed',
+                            'Cancelled',
+                            'Registered',
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    sort: [
+      {
+        published: {
+          order: sortOrder,
+          unmapped_type: 'long',
+        },
+      },
+    ],
+  }
+}
+
+module.exports = {
+  contactActivityQueryNoAventri,
+}

--- a/src/apps/companies/apps/activity-feed/repos.js
+++ b/src/apps/companies/apps/activity-feed/repos.js
@@ -1,5 +1,6 @@
 const config = require('../../../../config')
 const { authorisedRequest } = require('../../../../lib/authorised-request')
+const { get } = require('lodash')
 
 function fetchActivityFeed(req, body) {
   return authorisedRequest(req, {
@@ -16,8 +17,14 @@ function fetchMatchingDataHubContact(req, attendeeEmail) {
     url: `${config.apiRoot}/v3/contact?email=${attendeeEmail}`,
   })
 }
-
+// istanbul ignore next: Covered by functional tests
+async function fetchUserFeatureFlags(req) {
+  // istanbul ignore next: Covered by functional tests
+  const user = await authorisedRequest(req, `${config.apiRoot}/whoami/`)
+  return get(user, 'active_features', [])
+}
 module.exports = {
   fetchActivityFeed,
   fetchMatchingDataHubContact,
+  fetchUserFeatureFlags,
 }

--- a/src/apps/contacts/views/interactions.njk
+++ b/src/apps/contacts/views/interactions.njk
@@ -1,28 +1,8 @@
 {% extends "./template.njk" %}
 
 {% block main_grid_right_column %}
-{% if isContactActivitiesFeatureOn %}
   {% component 'react-slot', {
     id: 'contact-activity',
     props: props
   } %}
-{% else %}
-  <h2 class="govuk-heading-m">Contact interactions</h2>
-  <p>
-    An interaction could be a meeting, call, email or another activity where you have been in touch with a contact.
-  </p>
-  {% block xhr_content %}
-    <article data-xhr="31fa63e9-1923-4565-af98-93c07a4a4f0d">
-      {{
-        CollectionContent(results | assignCopy({
-          countLabel: 'interaction',
-          actionButtons: actionButtons,
-          sortForm: assign({}, sortForm, {action: CURRENT_PATH}),
-          query: QUERY
-        }))
-      }}
-    </article>
-  {% endblock %}
-{% endif %}
-
 {% endblock %}

--- a/src/client/components/ActivityFeed/ActivityFeed.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeed.jsx
@@ -6,7 +6,6 @@ import { SPACING } from '@govuk-react/constants'
 import Activity from './Activity'
 import ActivityFeedHeader from './ActivityFeedHeader'
 import ActivityFeedFilters from './ActivityFeedFilters'
-import ActivityFeedShowAll from './ActivityFeedShowAll'
 import ActivityFeedPagination from './ActivityFeedPagination'
 
 const ActivityFeedContainer = styled('div')`
@@ -66,7 +65,6 @@ export default class ActivityFeed extends React.Component {
     this.state = {
       activityTypeFilter: dataHubActivity ? dataHubActivity.value : '',
       showDnbHierarchy: false,
-      showDetails: false,
       activityTypeFilters: [
         dataHubAndExternalActivity,
         myActivity,
@@ -76,7 +74,6 @@ export default class ActivityFeed extends React.Component {
     }
 
     this.onActivityTypeFilterChange = this.onActivityTypeFilterChange.bind(this)
-    this.onShowDetailsClick = this.onShowDetailsClick.bind(this)
     this.showActivitiesFromAllCompanies =
       this.showActivitiesFromAllCompanies.bind(this)
   }
@@ -111,12 +108,6 @@ export default class ActivityFeed extends React.Component {
     })
   }
 
-  onShowDetailsClick(e) {
-    this.setState({
-      showDetails: e.target.checked,
-    })
-  }
-
   render() {
     const {
       activities,
@@ -131,12 +122,8 @@ export default class ActivityFeed extends React.Component {
       companyIsArchived,
     } = this.props
 
-    const {
-      activityTypeFilters,
-      activityTypeFilter,
-      showDetails,
-      showDnbHierarchy,
-    } = this.state
+    const { activityTypeFilters, activityTypeFilter, showDnbHierarchy } =
+      this.state
     return (
       <ActivityFeedContainer data-test="activity-feed">
         <ActivityFeedHeader
@@ -154,21 +141,11 @@ export default class ActivityFeed extends React.Component {
           />
         )}
 
-        {activities.length > 0 && (
-          <ActivityFeedShowAll
-            onChange={this.onShowDetailsClick}
-            checked={showDetails}
-          >
-            Show details for all activities
-          </ActivityFeedShowAll>
-        )}
-
         <ActivityFeedCardList>
           {activities.map((activity) => (
             <li key={activity.id}>
               <Activity
                 activity={activity}
-                showDetails={showDetails}
                 showDnbHierarchy={showDnbHierarchy}
               />
             </li>

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
@@ -2,17 +2,10 @@ import React from 'react'
 import { get } from 'lodash'
 
 import PropTypes from 'prop-types'
-import { Card, CardDetails, CardHeader, CardTable } from './card'
 
 import CardUtils from './card/CardUtils'
 import { currencyGBP } from '../../../utils/number-utils'
-import {
-  ACTIVITY_TYPE,
-  ANALYTICS_ACCORDION_TYPE,
-  SOURCE_TYPES,
-} from '../constants'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
+import { ACTIVITY_TYPE } from '../constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
@@ -35,11 +28,9 @@ export default class CompaniesHouseAccount extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
+    const { activity } = this.props
     const startTime = get(activity, 'object.startTime')
-    const taxonomy = get(activity, 'dit:taxonomy')
     const summary = get(activity, 'summary')
-    const company = CardUtils.getCompany(activity)
     const balanceSheetDate = format(
       get(activity, 'object.dit:balanceSheetDate')
     )
@@ -67,57 +58,16 @@ export default class CompaniesHouseAccount extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                company={showDnbHierarchy ? company : null}
-                heading={summary}
-                blockText="Companies House"
-                sourceType={SOURCE_TYPES.external}
-                subHeading="Accounts record"
-                startTime={startTime}
-              />
-
-              <CardDetails
-                summary="View key details for this account"
-                summaryVisuallyHidden={`${summary} in Companies House`}
-                link={{ taxonomy, text: 'Companies House accounts' }}
-                showDetails={showDetails}
-                analyticsAccordionType={
-                  ANALYTICS_ACCORDION_TYPE.COMPANIES_HOUSE
-                }
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Balance sheet date', content: balanceSheetDate },
-                    {
-                      header:
-                        'Net assets liabilities including pension asset liability',
-                      content: netAssetsLiabilities,
-                    },
-                    { header: 'Period start', content: periodStart },
-                    { header: 'Period end', content: periodEnd },
-                    { header: 'Shareholder funds', content: shareholderFunds },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="companies-house-account-activity">
-              <ActivityCardLabels
-                isExternalActivity={true}
-                theme="Companies House"
-                service="Accounts Record"
-                kind="Companies House Update"
-              ></ActivityCardLabels>
-              <ActivityCardSubject>{summary}</ActivityCardSubject>
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="companies-house-account-activity">
+        <ActivityCardLabels
+          isExternalActivity={true}
+          theme="Companies House"
+          service="Accounts Record"
+          kind="Companies House Update"
+        ></ActivityCardLabels>
+        <ActivityCardSubject>{summary}</ActivityCardSubject>
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
@@ -2,24 +2,8 @@ import React from 'react'
 import { get } from 'lodash'
 import PropTypes from 'prop-types'
 
-import {
-  Card,
-  CardDetails,
-  CardDetailsList,
-  CardHeader,
-  CardTable,
-} from './card'
-
-import { DefaultItemRenderer } from './card/item-renderers'
-
 import CardUtils from './card/CardUtils'
-import {
-  ACTIVITY_TYPE,
-  ANALYTICS_ACCORDION_TYPE,
-  SOURCE_TYPES,
-} from '../constants'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
+import { ACTIVITY_TYPE } from '../constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
@@ -42,9 +26,8 @@ export default class CompaniesHouseCompany extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
+    const { activity } = this.props
 
-    const company = CardUtils.getCompany(activity)
     const startTime = get(activity, 'object.startTime')
     const reference = get(activity, 'object.name')
 
@@ -68,12 +51,6 @@ export default class CompaniesHouseCompany extends React.PureComponent {
       get(activity, 'object.dit:returnsNextDueDate')
     )
     const sicCodes = get(activity, 'object.dit:sicCodes')
-    const sicCodesCollection = sicCodes.map((value) => {
-      return {
-        value,
-        id: value,
-      }
-    })
 
     const sicCodesList = sicCodes.map((value) => (
       <span key={value}>
@@ -115,80 +92,16 @@ export default class CompaniesHouseCompany extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                company={showDnbHierarchy ? company : null}
-                heading={summary}
-                blockText="Companies House"
-                sourceType={SOURCE_TYPES.external}
-                subHeading="Company record"
-                startTime={startTime}
-              />
-              <CardDetails
-                summary="View key details for this company"
-                summaryVisuallyHidden={`${summary} from Companies House`}
-                showDetails={showDetails}
-                analyticsAccordionType={
-                  ANALYTICS_ACCORDION_TYPE.COMPANIES_HOUSE
-                }
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Company name', content: reference },
-                    { header: 'Address', content: address },
-                    { header: 'Postcode', content: postcode },
-                    {
-                      header: 'Confirmation Statement last made up date',
-                      content: confStmtLastMadeUpDate,
-                    },
-                    {
-                      header: 'Confirmation Statement next due date',
-                      content: confStmtNextDueDate,
-                    },
-                    {
-                      header: 'Incorporation date',
-                      content: incorporationDate,
-                    },
-                    { header: 'Next due date', content: nextDueDate },
-                    {
-                      header: 'Returns last made up date',
-                      content: returnsLastMadeUpDate,
-                    },
-                    {
-                      header: 'Returns next due date',
-                      content: returnsNextDueDate,
-                    },
-                    {
-                      header: 'SIC code(s)',
-                      content: (
-                        <CardDetailsList
-                          itemPropName="value"
-                          itemRenderer={DefaultItemRenderer}
-                          items={sicCodesCollection}
-                        />
-                      ),
-                    },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="companies-house-company-activity">
-              <ActivityCardLabels
-                isExternalActivity={true}
-                theme="Companies House"
-                service="Company Record"
-                kind="Companies House Update"
-              ></ActivityCardLabels>
-              <ActivityCardSubject>{summary}</ActivityCardSubject>
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="companies-house-company-activity">
+        <ActivityCardLabels
+          isExternalActivity={true}
+          theme="Companies House"
+          service="Company Record"
+          kind="Companies House Update"
+        ></ActivityCardLabels>
+        <ActivityCardSubject>{summary}</ActivityCardSubject>
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
+++ b/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
@@ -2,11 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { get } from 'lodash'
 
-import { Card, CardDetails, CardHeader, CardTable } from './card'
-import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
+import { ACTIVITY_TYPE } from '../constants'
 import CardUtils from './card/CardUtils'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -14,10 +11,6 @@ import ActivityCardNotes from './card/ActivityCardNotes'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 
 import { format } from '../../../utils/date'
-
-const FORM_URL_TO_NAME_MAP = {
-  '/contact/export-advice/comment/': 'Export enquiry',
-}
 
 export default class DirectoryFormsApi extends React.PureComponent {
   static propTypes = {
@@ -29,13 +22,12 @@ export default class DirectoryFormsApi extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails } = this.props
+    const { activity } = this.props
     const sentDate = get(activity, 'object.published')
     const formData = get(
       activity,
       'object.dit:directoryFormsApi:Submission:Data'
     )
-    const formUrl = get(activity, 'object.url')
 
     const metadata = [
       { label: 'Date', value: format(sentDate) },
@@ -48,55 +40,16 @@ export default class DirectoryFormsApi extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                subHeading={FORM_URL_TO_NAME_MAP[formUrl]}
-                blockText="Great.gov.uk"
-                startTime={sentDate}
-                sourceType={SOURCE_TYPES.external}
-                badge={{ text: 'GREAT.GOV.UK', borderColour: '#006435' }}
-              />
-              <CardDetails
-                summary="View key details for this enquiry"
-                summaryVisuallyHidden={` on great.gov.uk, sent on ${format(
-                  sentDate
-                )}`}
-                showDetails={showDetails}
-              >
-                <CardTable
-                  rows={[
-                    {
-                      header: 'Comment',
-                      content: formData.comment,
-                      hasReadmore: true,
-                    },
-                    {
-                      header: 'Name',
-                      content: `${formData.first_name} ${formData.last_name}`,
-                    },
-                    { header: 'Position', content: formData.position },
-                    { header: 'Email', content: formData.email },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper>
-              <ActivityCardLabels
-                theme="great.gov.uk"
-                service="export"
-                kind="great.gov.uk Enquiry"
-              />
-              <ActivityCardSubject>Enquiry</ActivityCardSubject>
-              <ActivityCardNotes notes={formData.comment} />
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper>
+        <ActivityCardLabels
+          theme="great.gov.uk"
+          service="export"
+          kind="great.gov.uk Enquiry"
+        />
+        <ActivityCardSubject>Enquiry</ActivityCardSubject>
+        <ActivityCardNotes notes={formData.comment} />
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
+++ b/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
@@ -2,24 +2,8 @@ import React from 'react'
 import { get } from 'lodash'
 import PropTypes from 'prop-types'
 
-import {
-  Card,
-  CardDetails,
-  CardDetailsList,
-  CardHeader,
-  CardTable,
-} from './card'
-
-import { DefaultItemRenderer } from './card/item-renderers'
-
 import CardUtils from './card/CardUtils'
-import {
-  ACTIVITY_TYPE,
-  ANALYTICS_ACCORDION_TYPE,
-  SOURCE_TYPES,
-} from '../constants'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
+import { ACTIVITY_TYPE } from '../constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -39,19 +23,11 @@ export default class HmrcExporter extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
+    const { activity } = this.props
 
-    const company = CardUtils.getCompany(activity)
     const startTime = get(activity, 'object.startTime')
-    const reference = get(activity, 'object.attributedTo.name')
     const summary = get(activity, 'summary')
     const exportItemCodes = get(activity, 'object.dit:exportItemCodes')
-    const exportItemCodesCollection = exportItemCodes.map((value) => {
-      return {
-        value,
-        id: value,
-      }
-    })
 
     const exportItemCodesList = exportItemCodes.map((value) => (
       <span key={value}>
@@ -66,56 +42,16 @@ export default class HmrcExporter extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                company={showDnbHierarchy ? company : null}
-                blockText="HMRC"
-                subHeading="Exporters record"
-                heading={summary}
-                sourceType={SOURCE_TYPES.external}
-                startTime={startTime}
-              />
-
-              <CardDetails
-                summary="View key export details"
-                summaryVisuallyHidden={` for ${reference}`}
-                showDetails={showDetails}
-                analyticsAccordionType={ANALYTICS_ACCORDION_TYPE.HMRC}
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Company name', content: reference },
-                    {
-                      header: 'Export Item code(s)',
-                      content: (
-                        <CardDetailsList
-                          itemPropName="value"
-                          itemRenderer={DefaultItemRenderer}
-                          items={exportItemCodesCollection}
-                        />
-                      ),
-                    },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="hmrc-exporter-activity">
-              <ActivityCardLabels
-                isExternalActivity={true}
-                theme="HMRC"
-                service="Exporters Record"
-                kind="HMRC Update"
-              />
-              <ActivityCardSubject>{summary}</ActivityCardSubject>
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="hmrc-exporter-activity">
+        <ActivityCardLabels
+          isExternalActivity={true}
+          theme="HMRC"
+          service="Exporters Record"
+          kind="HMRC Update"
+        />
+        <ActivityCardSubject>{summary}</ActivityCardSubject>
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -2,20 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
 
-import {
-  Card,
-  CardDetails,
-  CardHeader,
-  CardTable,
-  CardDetailsList,
-} from './card'
-
-import {
-  ContactItemRenderer,
-  AdviserActivityRenderer,
-  AdviserItemRenderer,
-} from './card/item-renderers'
-import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
+import { AdviserActivityRenderer } from './card/item-renderers'
+import { ACTIVITY_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
 import InteractionUtils from './InteractionUtils'
@@ -26,8 +14,6 @@ import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardNotes from './card/ActivityCardNotes'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 
 export default class Interaction extends React.PureComponent {
   static propTypes = {
@@ -41,14 +27,12 @@ export default class Interaction extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
+    const { activity } = this.props
     const transformed = {
       ...CardUtils.transform(activity),
       ...InteractionUtils.transform(activity),
     }
 
-    const company = showDnbHierarchy && CardUtils.getCompany(activity)
-    const contacts = CardUtils.getContacts(activity)
     const advisers = CardUtils.getAdvisers(activity)
 
     const activityObject = activity.object
@@ -84,71 +68,16 @@ export default class Interaction extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <div data-test="interaction-activity">
-              <Card isUpcoming={transformed.isUpcoming}>
-                <CardHeader
-                  company={showDnbHierarchy ? company : null}
-                  heading={
-                    <Link href={transformed.url}>{transformed.subject}</Link>
-                  }
-                  startTime={transformed.startTime}
-                  badge={transformed.badge}
-                />
-                <CardDetails
-                  summary={`View ${transformed.typeText} details`}
-                  summaryVisuallyHidden={` for ${transformed.subject}`}
-                  link={{
-                    url: transformed.url,
-                    text: `You can view more on the ${transformed.typeText} detail page`,
-                  }}
-                  showDetails={showDetails}
-                  analyticsAccordionType={
-                    ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY
-                  }
-                >
-                  <CardTable
-                    rows={[
-                      {
-                        header: 'Company contact(s)',
-                        content: (
-                          <CardDetailsList
-                            itemRenderer={ContactItemRenderer}
-                            items={contacts}
-                          />
-                        ),
-                      },
-                      {
-                        header: 'Adviser(s)',
-                        content: (
-                          <CardDetailsList
-                            itemRenderer={AdviserItemRenderer}
-                            items={advisers}
-                          />
-                        ),
-                      },
-                      { header: 'Services', content: transformed.service },
-                    ]}
-                  />
-                </CardDetails>
-              </Card>
-            </div>
-          ) : (
-            <ActivityCardWrapper dataTest="interaction-activity">
-              <ActivityCardLabels theme={theme} service={service} kind={kind} />
-              <ActivityCardSubject>
-                <Link data-test="interaction-subject" href={transformed.url}>
-                  {transformed.subject}
-                </Link>
-              </ActivityCardSubject>
-              {serviceNotes && <ActivityCardNotes notes={serviceNotes} />}
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="interaction-activity">
+        <ActivityCardLabels theme={theme} service={service} kind={kind} />
+        <ActivityCardSubject>
+          <Link data-test="interaction-subject" href={transformed.url}>
+            {transformed.subject}
+          </Link>
+        </ActivityCardSubject>
+        {serviceNotes && <ActivityCardNotes notes={serviceNotes} />}
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
+++ b/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
@@ -3,31 +3,17 @@ import { get } from 'lodash'
 import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
 
-import {
-  Card,
-  CardDetails,
-  CardDetailsList,
-  CardHeader,
-  CardTable,
-} from './card'
-
 import { AdviserItemRenderer, ContactItemRenderer } from './card/item-renderers'
-import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
+import { ACTIVITY_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
 import { currencyGBP, decimal } from '../../../utils/number-utils'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 
 const { format } = require('../../../utils/date')
-
-const TITLES = {
-  add: 'New investment project added',
-}
 
 export default class InvestmentProject extends React.PureComponent {
   static propTypes = {
@@ -41,11 +27,7 @@ export default class InvestmentProject extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
-
-    const company = CardUtils.getCompany(activity)
-    const type = get(activity, 'type')
-    const title = TITLES[type.toLowerCase()]
+    const { activity } = this.props
     const url = get(activity, 'object.url')
     const name = get(activity, 'object.name')
     const investmentType = get(activity, 'object.dit:investmentType.name')
@@ -105,79 +87,17 @@ export default class InvestmentProject extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                company={showDnbHierarchy ? company : null}
-                heading={<Link href={url}>{name}</Link>}
-                startTime={published}
-                blockText={`${title} - ${investmentType}`}
-              />
-
-              <CardDetails
-                summary="Key details and people for this project"
-                summaryVisuallyHidden={` ${name}`}
-                showDetails={showDetails}
-                analyticsAccordionType={
-                  ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY
-                }
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Investment Type', content: investmentType },
-                    {
-                      header: 'Added by',
-                      content: adviser ? (
-                        <CardDetailsList
-                          itemRenderer={AdviserItemRenderer}
-                          items={[adviser]}
-                        />
-                      ) : null,
-                    },
-                    {
-                      header: 'Estimated land date',
-                      content: estimatedLandDate,
-                    },
-                    {
-                      header: 'Company contact(s)',
-                      content: (
-                        <CardDetailsList
-                          itemRenderer={ContactItemRenderer}
-                          items={contacts}
-                        />
-                      ),
-                    },
-                    { header: 'Total Investment', content: totalInvestment },
-                    {
-                      header: 'Capital expenditure value',
-                      content: foreignEquityInvestment,
-                    },
-                    {
-                      header: 'Gross value added (GVA)',
-                      content: grossValueAdded,
-                    },
-                    { header: 'Number of new jobs', content: numberNewJobs },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="investment-activity">
-              <ActivityCardLabels
-                theme="Investment"
-                service="Project - FDI"
-                kind="New Investment Project"
-              />
-              <ActivityCardSubject dataTest="investment-activity-card-subject">
-                <Link href={`${url}/details`}>{name}</Link>
-              </ActivityCardSubject>
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="investment-activity">
+        <ActivityCardLabels
+          theme="Investment"
+          service="Project - FDI"
+          kind="New Investment Project"
+        />
+        <ActivityCardSubject dataTest="investment-activity-card-subject">
+          <Link href={`${url}/details`}>{name}</Link>
+        </ActivityCardSubject>
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -4,19 +4,9 @@ import Link from '@govuk-react/link'
 import styled from 'styled-components'
 import { get } from 'lodash'
 
-import {
-  Card,
-  CardDetails,
-  CardDetailsList,
-  CardHeader,
-  CardTable,
-} from './card'
-import { ACTIVITY_TYPE, SOURCE_TYPES } from '../constants'
+import { ACTIVITY_TYPE } from '../constants'
 import CardUtils from './card/CardUtils'
 
-import { ContactItemRenderer } from './card/item-renderers'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -37,7 +27,7 @@ export default class MaxemailCampaign extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails } = this.props
+    const { activity } = this.props
     const published = get(activity, 'published')
     const name = get(activity, 'actor.name')
     const from = get(activity, 'actor.dit:emailAddress')
@@ -74,56 +64,17 @@ export default class MaxemailCampaign extends React.PureComponent {
     `
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                heading={emailSubject}
-                blockText="Email Campaign"
-                startTime={published}
-                sourceType={SOURCE_TYPES.external}
-              />
-
-              <CardDetails
-                summary="View details of this campaign"
-                summaryVisuallyHidden={` ${emailSubject}`}
-                showDetails={showDetails}
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Senders name', content: name },
-                    { header: 'Senders email', content: from },
-                    { header: 'Content', content },
-                    {
-                      header: 'Recipients',
-                      content: (
-                        <CardDetailsList
-                          itemPropName="email"
-                          itemRenderer={ContactItemRenderer}
-                          items={contacts}
-                        />
-                      ),
-                    },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="maxemail-campaign-activity">
-              <Row>
-                <LeftCol>
-                  <ActivityCardSubject>{emailSubject}</ActivityCardSubject>
-                  <ActivityCardMetadata metadata={metadata} />
-                </LeftCol>
-                <RightCol>
-                  <ActivityCardLabels kind="Email Campaign" />
-                </RightCol>
-              </Row>
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="maxemail-campaign-activity">
+        <Row>
+          <LeftCol>
+            <ActivityCardSubject>{emailSubject}</ActivityCardSubject>
+            <ActivityCardMetadata metadata={metadata} />
+          </LeftCol>
+          <RightCol>
+            <ActivityCardLabels kind="Email Campaign" />
+          </RightCol>
+        </Row>
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/Omis.jsx
+++ b/src/client/components/ActivityFeed/activities/Omis.jsx
@@ -3,20 +3,10 @@ import { get } from 'lodash'
 import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
 
-import {
-  Card,
-  CardDetails,
-  CardHeader,
-  CardTable,
-  CardDetailsList,
-} from './card'
-
 import { AdviserItemRenderer, ContactItemRenderer } from './card/item-renderers'
-import { ACTIVITY_TYPE, ANALYTICS_ACCORDION_TYPE } from '../constants'
+import { ACTIVITY_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -36,9 +26,8 @@ export default class Omis extends React.PureComponent {
   }
 
   render() {
-    const { activity, showDetails, showDnbHierarchy } = this.props
+    const { activity } = this.props
 
-    const company = CardUtils.getCompany(activity)
     const published = get(activity, 'published')
     const reference = get(activity, 'object.name')
     const country = get(activity, 'object.dit:country.name')
@@ -70,66 +59,17 @@ export default class Omis extends React.PureComponent {
     ]
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                company={showDnbHierarchy ? company : null}
-                heading={<Link href={url}>{reference}</Link>}
-                startTime={published}
-                blockText="New Order (OMIS) added"
-              />
-
-              <CardDetails
-                summary="View key details and people for this order"
-                summaryVisuallyHidden={` reference ${reference}`}
-                showDetails={showDetails}
-                analyticsAccordionType={
-                  ANALYTICS_ACCORDION_TYPE.DATA_HUB_ACTIVITY
-                }
-              >
-                <CardTable
-                  rows={[
-                    { header: 'Country', content: country },
-                    { header: 'UK region', content: ukRegion },
-                    {
-                      header: 'Added by',
-                      content: adviser ? (
-                        <CardDetailsList
-                          itemRenderer={AdviserItemRenderer}
-                          items={[adviser]}
-                        />
-                      ) : null,
-                    },
-                    {
-                      header: 'Company contact(s)',
-                      content: (
-                        <CardDetailsList
-                          itemRenderer={ContactItemRenderer}
-                          items={contacts}
-                        />
-                      ),
-                    },
-                  ]}
-                />
-              </CardDetails>
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="order-activity">
-              <ActivityCardLabels
-                theme="Orders (OMIS)"
-                service="Event"
-                kind="New Order"
-              />
-              <ActivityCardSubject dataTest="order-activity-card-subject">
-                <Link href={`${url}/work-order`}>{reference}</Link>
-              </ActivityCardSubject>
-              <ActivityCardMetadata metadata={metadata} />
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="order-activity">
+        <ActivityCardLabels
+          theme="Orders (OMIS)"
+          service="Event"
+          kind="New Order"
+        />
+        <ActivityCardSubject dataTest="order-activity-card-subject">
+          <Link href={`${url}/work-order`}>{reference}</Link>
+        </ActivityCardSubject>
+        <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
     )
   }
 }

--- a/src/client/components/ActivityFeed/activities/Referral.jsx
+++ b/src/client/components/ActivityFeed/activities/Referral.jsx
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
 
-import { Card, CardHeader, CardTable } from './card'
 import { ACTIVITY_TYPE } from '../constants'
 import CardUtils from './card/CardUtils'
 import ReferralUtils from './ReferralUtils'
-import CheckUserFeatureFlag from '../../CheckUserFeatureFlags'
-import { CONTACT_ACTIVITY_FEATURE_FLAG } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
@@ -79,51 +76,19 @@ export default class Referral extends React.PureComponent {
     `
 
     return (
-      <CheckUserFeatureFlag userFeatureFlagName={CONTACT_ACTIVITY_FEATURE_FLAG}>
-        {(isFeatureFlagEnabled) =>
-          !isFeatureFlagEnabled ? (
-            <Card>
-              <CardHeader
-                heading={<Link href={url}>{subject}</Link>}
-                startTime={startTime}
-                badge={badge}
-              />
-
-              <CardTable
-                isNotWrappedInDetails={true}
-                rows={[
-                  {
-                    header: 'Sending adviser',
-                    content: AdviserDetails(sender),
-                  },
-                  {
-                    header: 'Receiving adviser',
-                    content: AdviserDetails(recipient),
-                  },
-                  {
-                    header: 'Completed on',
-                    content: completedOn && format(completedOn),
-                  },
-                ]}
-              />
-            </Card>
-          ) : (
-            <ActivityCardWrapper dataTest="referral-activity">
-              <Row>
-                <LeftCol>
-                  <ActivityCardSubject dataTest="referral-activity-card-subject">
-                    <Link href={url}>{subject}</Link>
-                  </ActivityCardSubject>
-                  <ActivityCardMetadata metadata={metadata} />
-                </LeftCol>
-                <RightCol>
-                  <ActivityCardLabels kind={badge.text} />
-                </RightCol>
-              </Row>
-            </ActivityCardWrapper>
-          )
-        }
-      </CheckUserFeatureFlag>
+      <ActivityCardWrapper dataTest="referral-activity">
+        <Row>
+          <LeftCol>
+            <ActivityCardSubject dataTest="referral-activity-card-subject">
+              <Link href={url}>{subject}</Link>
+            </ActivityCardSubject>
+            <ActivityCardMetadata metadata={metadata} />
+          </LeftCol>
+          <RightCol>
+            <ActivityCardLabels kind={badge.text} />
+          </RightCol>
+        </Row>
+      </ActivityCardWrapper>
     )
   }
 }

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -185,17 +185,146 @@ const buildAndMountWithCustomService = (service) => {
 }
 
 describe('Interaction activity card', () => {
-  context('When the feature flag is on', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '**/whoami', {
+      active_features: CONTACT_ACTIVITY_FEATURE_FLAG,
+    })
+  })
+
+  context('When the card is rendered with a complete interaction', () => {
     beforeEach(() => {
-      cy.intercept('GET', '**/whoami', {
-        active_features: CONTACT_ACTIVITY_FEATURE_FLAG,
-      })
+      buildAndMountActivity(
+        interactionServices.specificDITService,
+        interactionThemes[0],
+        'Email/Fax',
+        typeInteraction,
+        shortNotes,
+        date
+      )
+      cy.get('[data-test=interaction-activity]').should('exist')
     })
 
-    context('When the card is rendered with a complete interaction', () => {
+    it('should render the theme label', () => {
+      assertThemeLabel()
+    })
+
+    it('should render the service label', () => {
+      assertServiceLabel()
+    })
+
+    it('should render the kind label', () => {
+      assertKindLabel()
+    })
+
+    it('should render the interaction subject', () => {
+      assertInteractionSubject()
+    })
+
+    it('should render the interaction notes', () => {
+      assertNotes()
+    })
+
+    it('should render the date label', () => {
+      assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+    })
+
+    it('should render the communication channel label', () => {
+      assertCommunicationChannelLabel()
+    })
+
+    it('should render the advisers label', () => {
+      assertText('[data-test=adviser-s-label]', oneAdviserText)
+    })
+
+    it('should render the full service label', () => {
+      assertBottomServiceLabel()
+    })
+
+    context('When the interaction has lengthy notes', () => {
       beforeEach(() => {
         buildAndMountActivity(
           interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          longNotes,
+          date
+        )
+      })
+
+      it('should render the truncated interaction notes', () => {
+        assertNotes(truncatedNotes)
+      })
+    })
+
+    context('When there are multiple advisers', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date,
+          2
+        )
+      })
+
+      it('should render both advisers', () => {
+        assertText('[data-test=adviser-s-label]', twoAdvisersText)
+      })
+    })
+
+    context('When the kind is set to service delivery', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeServiceDelivery,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct kind', () => {
+        assertKindLabel('service delivery')
+      })
+    })
+  })
+
+  context('When the card is rendered with an incomplete interaction', () => {
+    context('When the theme is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          null,
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should not render the theme label', () => {
+        cy.get('[data-test=activity-theme-label]').should('not.exist')
+      })
+
+      it('should render the service label', () => {
+        assertServiceLabel()
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+    })
+
+    context('When the service is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          null,
           interactionThemes[0],
           'Email/Fax',
           typeInteraction,
@@ -209,24 +338,30 @@ describe('Interaction activity card', () => {
         assertThemeLabel()
       })
 
-      it('should render the service label', () => {
-        assertServiceLabel()
+      it('should not render the service label', () => {
+        cy.get('[data-test=activity-service-label]').should('not.exist')
       })
 
       it('should render the kind label', () => {
         assertKindLabel()
       })
+    })
 
-      it('should render the interaction subject', () => {
-        assertInteractionSubject()
+    context('When the date is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          null
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
       })
 
-      it('should render the interaction notes', () => {
-        assertNotes()
-      })
-
-      it('should render the date label', () => {
-        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      it('should not render the date label', () => {
+        cy.get('[data-test=date-label]').should('not.exist')
       })
 
       it('should render the communication channel label', () => {
@@ -240,404 +375,240 @@ describe('Interaction activity card', () => {
       it('should render the full service label', () => {
         assertBottomServiceLabel()
       })
+    })
 
-      context('When the interaction has lengthy notes', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            longNotes,
-            date
-          )
-        })
-
-        it('should render the truncated interaction notes', () => {
-          assertNotes(truncatedNotes)
-        })
+    context('When the advisers are missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date,
+          0
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
       })
 
-      context('When there are multiple advisers', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            date,
-            2
-          )
-        })
-
-        it('should render both advisers', () => {
-          assertText('[data-test=adviser-s-label]', twoAdvisersText)
-        })
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
       })
 
-      context('When the kind is set to service delivery', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeServiceDelivery,
-            shortNotes,
-            date
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
 
-        it('should display the correct kind', () => {
-          assertKindLabel('service delivery')
-        })
+      it('should not render the advisers label', () => {
+        cy.get('[data-test=adviser-s-label]').should('not.exist')
+      })
+
+      it('should render the full service label', () => {
+        assertBottomServiceLabel()
       })
     })
 
-    context('When the card is rendered with an incomplete interaction', () => {
-      context('When the theme is missing', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            null,
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            date
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should not render the theme label', () => {
-          cy.get('[data-test=activity-theme-label]').should('not.exist')
-        })
-
-        it('should render the service label', () => {
-          assertServiceLabel()
-        })
-
-        it('should render the kind label', () => {
-          assertKindLabel()
-        })
+    context('When the communication channel is missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          interactionServices.specificDITService,
+          interactionThemes[0],
+          null,
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
       })
 
-      context('When the service is missing', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            null,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            date
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should render the theme label', () => {
-          assertThemeLabel()
-        })
-
-        it('should not render the service label', () => {
-          cy.get('[data-test=activity-service-label]').should('not.exist')
-        })
-
-        it('should render the kind label', () => {
-          assertKindLabel()
-        })
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
       })
 
-      context('When the date is missing', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            null
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should not render the date label', () => {
-          cy.get('[data-test=date-label]').should('not.exist')
-        })
-
-        it('should render the communication channel label', () => {
-          assertCommunicationChannelLabel()
-        })
-
-        it('should render the advisers label', () => {
-          assertText('[data-test=adviser-s-label]', oneAdviserText)
-        })
-
-        it('should render the full service label', () => {
-          assertBottomServiceLabel()
-        })
+      it('should not render the communication channel label', () => {
+        cy.get('[data-test=communication-channel-label]').should('not.exist')
       })
 
-      context('When the advisers are missing', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            date,
-            0
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should render the date label', () => {
-          assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
-        })
-
-        it('should render the communication channel label', () => {
-          assertCommunicationChannelLabel()
-        })
-
-        it('should not render the advisers label', () => {
-          cy.get('[data-test=adviser-s-label]').should('not.exist')
-        })
-
-        it('should render the full service label', () => {
-          assertBottomServiceLabel()
-        })
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
       })
 
-      context('When the communication channel is missing', () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            null,
-            typeInteraction,
-            shortNotes,
-            date
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should render the date label', () => {
-          assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
-        })
-
-        it('should not render the communication channel label', () => {
-          cy.get('[data-test=communication-channel-label]').should('not.exist')
-        })
-
-        it('should render the advisers label', () => {
-          assertText('[data-test=adviser-s-label]', oneAdviserText)
-        })
-
-        it('should render the full service label', () => {
-          assertBottomServiceLabel()
-        })
-      })
-    })
-
-    context('When the interaction has a different theme', () => {
-      context('When the theme is Investment', () => {
-        beforeEach(() => {
-          buildAndMountWithCustomTheme(interactionThemes[1])
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should display the correct theme', () => {
-          assertThemeLabel(interactionThemes[1])
-        })
-      })
-
-      context('When the theme is Trade Agreement', () => {
-        beforeEach(() => {
-          buildAndMountWithCustomTheme(interactionThemes[2])
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should display the correct theme', () => {
-          assertThemeLabel('trade agreement')
-        })
-      })
-
-      context('When the theme is Other', () => {
-        beforeEach(() => {
-          buildAndMountWithCustomTheme(interactionThemes[3])
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
-
-        it('should display the correct theme', () => {
-          assertThemeLabel(interactionThemes[3])
-        })
-      })
-    })
-
-    context('When the interaction has a different service', () => {
-      context('When the service is A Specific Service', () => {
-        assertService(interactionServices.specificService)
-      })
-
-      context('When the service is Account Management', () => {
-        assertService(interactionServices.accountManagement)
-      })
-
-      context('When the service is COP26', () => {
-        assertService(interactionServices.cop26)
-      })
-
-      context('When the service is a recieved enquiry', () => {
-        assertService(interactionServices.enquiry)
-      })
-
-      context('When the service is an Enquiry/Referral', () => {
-        assertService(interactionServices.enquiryOrReferral)
-      })
-
-      context('When the service is an Event', () => {
-        assertService(interactionServices.event)
-      })
-
-      context('When the service is an Export Win', () => {
-        assertService(interactionServices.exportWin)
-      })
-
-      context('When the service is Global Investment Summit (2021)', () => {
-        assertService(interactionServices.gis2021)
-      })
-
-      context('When the service is IST Aftercare', () => {
-        assertService(interactionServices.istAftercare)
-      })
-
-      context('When the service is an Investment Service', () => {
-        assertService(interactionServices.investmentServices)
-      })
-
-      context('When the service is an Investment Enquiry', () => {
-        assertService(interactionServices.investmentEnquiry)
-      })
-
-      context('When the service is an IST Specific Service', () => {
-        assertService(interactionServices.istSpecificService)
-      })
-
-      context('When the service is Proposition Development', () => {
-        assertService(interactionServices.propDevelopment)
-      })
-
-      context(
-        'When the service is a Trade Agreement Implementation Activity',
-        () => {
-          assertService(interactionServices.tradeAgreementImplementation)
-        }
-      )
-
-      context('When the service is Making Introductions', () => {
-        context('When the service is Making Export Introductions', () => {
-          assertService(interactionServices.exportIntros)
-        })
-
-        context('When the service is Making Investment Introductions', () => {
-          assertService(interactionServices.investmentIntros)
-        })
-      })
-
-      context('When the service is Providing Information', () => {
-        context('When the service is Providing Export Information', () => {
-          assertService(interactionServices.exportAI)
-        })
-
-        context('When the service is Providing Investment Information', () => {
-          assertService(interactionServices.investmentAI)
-        })
+      it('should render the full service label', () => {
+        assertBottomServiceLabel()
       })
     })
   })
-  context('When the feature flag is off', () => {
-    beforeEach(() => {
-      cy.intercept('GET', '**/whoami', {
-        active_features: 'i-am-a-fake-feature-flag',
+
+  context('When the interaction has a different theme', () => {
+    context('When the theme is Investment', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[1])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel(interactionThemes[1])
       })
     })
-    context(
-      'When the card is rendered with a complete interaction and flag is off',
-      () => {
-        beforeEach(() => {
-          buildAndMountActivity(
-            interactionServices.specificDITService,
-            interactionThemes[0],
-            'Email/Fax',
-            typeInteraction,
-            shortNotes,
-            date
-          )
-          cy.get('[data-test=interaction-activity]').should('exist')
-        })
 
-        it('should render the badge', () => {
-          assertText('[data-test=badge]', 'Interaction')
-        })
+    context('When the theme is Trade Agreement', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[2])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel('trade agreement')
+      })
+    })
+
+    context('When the theme is Other', () => {
+      beforeEach(() => {
+        buildAndMountWithCustomTheme(interactionThemes[3])
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should display the correct theme', () => {
+        assertThemeLabel(interactionThemes[3])
+      })
+    })
+  })
+
+  context('When the interaction has a different service', () => {
+    context('When the service is A Specific Service', () => {
+      assertService(interactionServices.specificService)
+    })
+
+    context('When the service is Account Management', () => {
+      assertService(interactionServices.accountManagement)
+    })
+
+    context('When the service is COP26', () => {
+      assertService(interactionServices.cop26)
+    })
+
+    context('When the service is a recieved enquiry', () => {
+      assertService(interactionServices.enquiry)
+    })
+
+    context('When the service is an Enquiry/Referral', () => {
+      assertService(interactionServices.enquiryOrReferral)
+    })
+
+    context('When the service is an Event', () => {
+      assertService(interactionServices.event)
+    })
+
+    context('When the service is an Export Win', () => {
+      assertService(interactionServices.exportWin)
+    })
+
+    context('When the service is Global Investment Summit (2021)', () => {
+      assertService(interactionServices.gis2021)
+    })
+
+    context('When the service is IST Aftercare', () => {
+      assertService(interactionServices.istAftercare)
+    })
+
+    context('When the service is an Investment Service', () => {
+      assertService(interactionServices.investmentServices)
+    })
+
+    context('When the service is an Investment Enquiry', () => {
+      assertService(interactionServices.investmentEnquiry)
+    })
+
+    context('When the service is an IST Specific Service', () => {
+      assertService(interactionServices.istSpecificService)
+    })
+
+    context('When the service is Proposition Development', () => {
+      assertService(interactionServices.propDevelopment)
+    })
+
+    context(
+      'When the service is a Trade Agreement Implementation Activity',
+      () => {
+        assertService(interactionServices.tradeAgreementImplementation)
       }
     )
+
+    context('When the service is Making Introductions', () => {
+      context('When the service is Making Export Introductions', () => {
+        assertService(interactionServices.exportIntros)
+      })
+
+      context('When the service is Making Investment Introductions', () => {
+        assertService(interactionServices.investmentIntros)
+      })
+    })
+
+    context('When the service is Providing Information', () => {
+      context('When the service is Providing Export Information', () => {
+        assertService(interactionServices.exportAI)
+      })
+
+      context('When the service is Providing Investment Information', () => {
+        assertService(interactionServices.investmentAI)
+      })
+    })
+  })
+})
+
+const assertText = (label, expectedText) => {
+  cy.get(label).should('exist').should('have.text', expectedText)
+}
+
+const assertThemeLabel = (expectedText = interactionThemes[0]) => {
+  assertText('[data-test=activity-theme-label]', expectedText)
+}
+
+const assertKindLabel = (expectedText = 'interaction') => {
+  assertText('[data-test=activity-kind-label]', expectedText)
+}
+
+const assertServiceLabel = (
+  service = interactionServices.specificDITService
+) => {
+  assertText('[data-test=activity-service-label]', getServiceText(service))
+}
+
+const assertNotes = (notes = shortNotes) => {
+  assertText('[data-test=activity-card-notes]', buildActualNotes(notes))
+}
+
+const assertCommunicationChannelLabel = () => {
+  assertText(
+    '[data-test=communication-channel-label]',
+    'Communication channel: Email/Fax'
+  )
+}
+
+const assertBottomServiceLabel = (
+  service = interactionServices.specificDITService
+) => {
+  assertText('[data-test=service-label]', buildServiceLabel(service))
+}
+
+const assertInteractionSubject = () => {
+  cy.get('[data-test=interaction-subject]')
+    .should('exist')
+    .should('have.text', subject)
+    .should('have.attr', 'href', interactionUrl)
+}
+
+function assertService(service) {
+  beforeEach(() => {
+    buildAndMountWithCustomService(service)
+    cy.get('[data-test=interaction-activity]').should('exist')
   })
 
-  const assertText = (label, expectedText) => {
-    cy.get(label).should('exist').should('have.text', expectedText)
-  }
+  it('should display the correct service', () => {
+    assertServiceLabel(service)
+  })
 
-  const assertThemeLabel = (expectedText = interactionThemes[0]) => {
-    assertText('[data-test=activity-theme-label]', expectedText)
-  }
-
-  const assertKindLabel = (expectedText = 'interaction') => {
-    assertText('[data-test=activity-kind-label]', expectedText)
-  }
-
-  const assertServiceLabel = (
-    service = interactionServices.specificDITService
-  ) => {
-    assertText('[data-test=activity-service-label]', getServiceText(service))
-  }
-
-  const assertNotes = (notes = shortNotes) => {
-    assertText('[data-test=activity-card-notes]', buildActualNotes(notes))
-  }
-
-  const assertCommunicationChannelLabel = () => {
-    assertText(
-      '[data-test=communication-channel-label]',
-      'Communication channel: Email/Fax'
-    )
-  }
-
-  const assertBottomServiceLabel = (
-    service = interactionServices.specificDITService
-  ) => {
-    assertText('[data-test=service-label]', buildServiceLabel(service))
-  }
-
-  const assertInteractionSubject = () => {
-    cy.get('[data-test=interaction-subject]')
-      .should('exist')
-      .should('have.text', subject)
-      .should('have.attr', 'href', interactionUrl)
-  }
-
-  function assertService(service) {
-    beforeEach(() => {
-      buildAndMountWithCustomService(service)
-      cy.get('[data-test=interaction-activity]').should('exist')
-    })
-
-    it('should display the correct service', () => {
-      assertServiceLabel(service)
-    })
-
-    it('should render the full service label', () => {
-      assertBottomServiceLabel(service)
-    })
-  }
-})
+  it('should render the full service label', () => {
+    assertBottomServiceLabel(service)
+  })
+}

--- a/test/end-to-end/cypress/specs/DIT/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/collection-spec.js
@@ -4,11 +4,7 @@ const {
   assertReactCollection,
 } = require('../../support/assertions')
 
-const {
-  companies,
-  contacts,
-  investments,
-} = require('../../../../../src/lib/urls')
+const { companies, investments } = require('../../../../../src/lib/urls')
 
 describe('Collection', () => {
   describe('contact', () => {
@@ -21,21 +17,6 @@ describe('Collection', () => {
 
     it('should return the results summary for orders collection', () => {
       assertReactCollection()
-    })
-  })
-
-  describe('contact interaction', () => {
-    const company = fixtures.company.create.lambda()
-    const contact = fixtures.contact.create(company.pk)
-
-    before(() => {
-      cy.loadFixture([company])
-      cy.loadFixture([contact])
-      cy.visit(contacts.contactActivities(contact.pk))
-    })
-
-    it('should return the results summary for contact interaction collection', () => {
-      assertCollection()
     })
   })
 

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -1,554 +1,191 @@
 const fixtures = require('../../fixtures')
-const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
-const {
-  CONTACT_ACTIVITY_FEATURE_FLAG,
-} = require('../../../../../src/apps/companies/apps/activity-feed/constants')
-
-const companyLocalHeader = selectors.companyLocalHeader()
-
-const assertTable = (selector, tableContents) => {
-  tableContents.forEach((row, index) => {
-    cy.get(`${selector} table tr:nth-child(${index + 1}) th`).should(
-      'have.text',
-      row.th
-    )
-  })
-}
 
 describe('Company activity feed', () => {
-  context('When the activity feed feature flag is turned off', () => {
-    context('when viewing Venus Ltd which has no activities', () => {
-      before(() => {
-        cy.visit(urls.companies.activity.index(fixtures.company.venusLtd.id))
-      })
+  before(() => {
+    cy.visit(
+      urls.companies.activity.index(fixtures.company.allActivitiesCompany.id)
+    )
+    cy.get('[data-test="activity-feed"] select').select(
+      'dataHubAndExternalActivity'
+    )
+  })
 
-      it('should render a meta title', () => {
-        cy.title().should(
-          'eq',
-          'Activities - Venus Ltd - Companies - DIT Data Hub'
-        )
-      })
+  context('Companies House Company', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="companies-house-company-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-kind-label"]')
+          .contains('Companies House Update', {
+            matchCase: false,
+          })
+      )
+    })
+  })
 
-      it('should display the activity header', () => {
-        cy.get(selectors.companyCollection().heading).should(
-          'have.text',
-          'Activities'
-        )
-      })
+  context('Companies House Account', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="companies-house-account-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-kind-label"]')
+          .contains('Companies House Update', {
+            matchCase: false,
+          })
+      )
+    })
+  })
 
-      it('should display "Add interaction" button', () => {
-        cy.get(
-          selectors
-            .companyCollection()
-            .interaction.addButton(fixtures.company.venusLtd.id)
-        ).should('have.text', 'Add interaction')
-      })
+  context('HMRC Exporter', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="hmrc-exporter-activity"]').within(() =>
+        cy.get('[data-test="activity-kind-label"]').contains('HMRC Update', {
+          matchCase: false,
+        })
+      )
+    })
+  })
 
-      it('should display "Refer this company" button', () => {
-        cy.get(
-          selectors
-            .companyCollection()
-            .interaction.referButton(fixtures.company.venusLtd.id)
-        ).should('have.text', 'Refer this company')
-      })
-
-      it('should not display the activity feed', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(1)).should(
-          'not.exist'
-        )
-      })
-
-      it('should display the "There are no activities to show." message', () => {
-        cy.get('[data-test="noActivites"]').should('be.visible')
-      })
+  context('Orders (OMIS)', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="order-activity"]').within(() =>
+        cy.get('[data-test="activity-kind-label"]').contains('New Order', {
+          matchCase: false,
+        })
+      )
     })
 
-    context('when viewing activity feed for an archived company', () => {
-      before(() => {
-        cy.visit(urls.companies.activity.index(fixtures.company.archivedLtd.id))
-      })
-
-      it('should display the badge', () => {
-        cy.get(companyLocalHeader.badge)
-          .first()
-          .should('have.text', 'Global HQ')
-      })
-
-      it('should display the One List tier', () => {
-        const expected =
-          'This is an account managed company (One List Tier A - Strategic Account)'
-        cy.get(companyLocalHeader.description.paragraph(1)).should(
-          'have.text',
-          expected
-        )
-      })
-
-      it('should display the Global Account Manager', () => {
-        const expected = 'Global Account Manager: Travis Greene View core team'
-        cy.get(companyLocalHeader.description.paragraph(2)).should(
-          'have.text',
-          expected
-        )
-      })
-
-      it('should not display the "Add interaction" button', () => {
-        cy.contains('Add interaction').should('not.exist')
-      })
-
-      it('should not display "Refer this company" button', () => {
-        cy.contains('Refer this company').should('not.exist')
-      })
-
-      it('should display the activity feed', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(1)).should(
-          'be.visible'
-        )
-      })
-
-      it('should not display the "There are no activities to show." message', () => {
-        cy.get('[data-test="noActivites"]').should('not.exist')
-      })
+    it('displays the correct topic label', () => {
+      cy.get('[data-test="order-activity"]').within(() =>
+        cy.get('[data-test="activity-theme-label"]').contains('Orders (OMIS)', {
+          matchCase: false,
+        })
+      )
     })
 
-    context('when company has a DUNS number (is matched)', () => {
-      before(() => {
-        cy.visit(urls.companies.activity.index(fixtures.company.dnbCorp.id))
-      })
-
-      it('should not display the prompt for company matching', () => {
-        cy.contains(
-          'Business details on this company record have not been verified and could be wrong.'
-        ).should('not.exist')
-      })
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="order-activity"]').within(() =>
+        cy.get('[data-test="activity-service-label"]').contains('Event', {
+          matchCase: false,
+        })
+      )
     })
 
-    context('when company does NOT have a DUNS number (is NOT matched)', () => {
-      before(() => {
-        cy.visit(urls.companies.activity.index(fixtures.company.lambdaPlc.id))
-      })
+    it('displays the order reference with link', () => {
+      cy.get('[data-test="order-activity"]').within(() =>
+        cy
+          .get('[data-test="order-activity-card-subject"]')
+          .should('exist')
+          .should('have.text', 'HAM100')
+          .get('a')
+          .should('have.attr', 'href', 'https://www.my-website.com/work-order')
+      )
+    })
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="order-activity"]').within(() =>
+        cy.get('[data-test="activity-service-label"]').contains('Event', {
+          matchCase: false,
+        })
+      )
+    })
+  })
 
-      it('should display the prompt for company matching', () => {
-        cy.contains(
-          'Business details on this company record have not been verified and could be wrong.'
-        )
-          .parent()
-          .next()
-          .should('match', 'details')
-          .should(
-            'have.text',
-            'Why verify?Using verified business details from a trusted third-party supplier' +
-              ' means we can keep certain information up to date automatically. This' +
-              ' helps reduce duplicate records, provide a shared view of complex' +
-              ' companies and make it more likely we can link other data sources' +
-              ' together.Verification can often be done in just 4 clicks.'
-          )
-          .next()
-          .should('have.text', 'Verify business details')
+  context('Investment project', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="investment-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-kind-label"]')
+          .contains('New Investment Project', {
+            matchCase: false,
+          })
+      )
+    })
+
+    it('displays the correct topic label', () => {
+      cy.get('[data-test="investment-activity"]').within(() =>
+        cy.get('[data-test="activity-theme-label"]').contains('Investment', {
+          matchCase: false,
+        })
+      )
+    })
+
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="investment-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-service-label"]')
+          .contains('Project - FDI', {
+            matchCase: false,
+          })
+      )
+    })
+
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="investment-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-service-label"]')
+          .contains('Project - FDI', {
+            matchCase: false,
+          })
+      )
+    })
+
+    it('displays the investment project name with link', () => {
+      cy.get('[data-test="investment-activity"]').within(() =>
+        cy
+          .get('[data-test="investment-activity-card-subject"]')
+          .should('exist')
+          .should('have.text', 'Marshmellow UK Takeover')
+          .get('a')
           .should(
             'have.attr',
             'href',
-            urls.companies.match.index(fixtures.company.lambdaPlc.id)
+            'https://www.datahub.trade.gov.uk/investments/projects/d9e25847-6199-e211-a939-e4115bead28a/details'
           )
-      })
-
-      it('should have the Analytics id', () => {
-        cy.get('#ga-company-details-matching-prompt').should('exist')
-      })
-
-      it('should not display the pending D&B investigation message', () => {
-        cy.get(selectors.companyActivity.pendingDnbInvestigationMessage).should(
-          'not.exist'
-        )
-      })
-    })
-
-    context('when company is pending D&B investigation', () => {
-      before(() => {
-        cy.visit(
-          urls.companies.activity.index(
-            fixtures.company.investigationLimited.id
-          )
-        )
-      })
-
-      it('should not display the prompt for company matching', () => {
-        cy.contains(
-          'There might be wrong information on this company page because' +
-            " it doesn't get updated automatically."
-        ).should('not.exist')
-      })
-
-      it('should display the pending D&B investigation message', () => {
-        cy.get(selectors.companyActivity.pendingDnbInvestigationMessage).should(
-          'be.visible'
-        )
-      })
-    })
-
-    context('when viewing an export enquiry in the activity feed', () => {
-      before(() => {
-        cy.visit(
-          urls.companies.activity.index(
-            fixtures.company.externalActivitiesLtd.id
-          )
-        )
-        cy.get('[data-test="activity-feed"] select').select('externalActivity')
-        cy.get(selectors.companyActivity.activityFeed.item(1)).as(
-          'exportEnquiry'
-        )
-      })
-      it('should display an export enquiry with truncated comment', () => {
-        const exportEnquiry = [
-          {
-            th: 'Comment',
-            td: 'We export fish products to South Korea. In 2011 we were issued an approved exporter authorisation number by HMRC to be able to export to South Korea. Does this number still stand for exporting to South Korea in 2021 or do we need a new number? Lorem... Read More',
-          },
-          {
-            th: 'Name',
-            td: 'Gary James',
-          },
-          {
-            th: 'Position',
-            td: 'Director',
-          },
-          {
-            th: 'Email',
-            td: 'gary.james@fish.com',
-          },
-        ]
-        cy.get('@exportEnquiry').find('h3').should('have.text', 'Great.gov.uk')
-        cy.get('@exportEnquiry')
-          .find('ul')
-          .should('have.text', '10 Nov 2020GREAT.GOV.UK')
-        cy.get('@exportEnquiry')
-          .find('details summary')
-          .should(
-            'have.text',
-            'View key details for this enquiry on great.gov.uk, sent on 10 Nov 2020'
-          )
-          .click()
-        assertTable(
-          selectors.companyActivity.activityFeed.item(1),
-          exportEnquiry
-        )
-      })
-      it('should be able to read the full comment', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(1)).as(
-          'exportEnquiry'
-        )
-        cy.get('@exportEnquiry').find('table tr:nth-child(1) td button').click()
-        cy.get('@exportEnquiry')
-          .find('table tr:nth-child(1) td')
-          .should(
-            'have.text',
-            'We export fish products to South Korea. In 2011 we were issued an approved exporter authorisation number by HMRC to be able to export to South Korea. Does this number still stand for exporting to South Korea in 2021 or do we need a new number? Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Show Less'
-          )
-      })
-    })
-
-    context('when viewing a Maxemail campaign in the Activity Feed', () => {
-      before(() => {
-        const companyId = fixtures.company.externalActivitiesLtd.id
-        const url = urls.companies.activity.index(companyId)
-
-        cy.visit(url)
-          .get('[data-test="activity-feed"] select')
-          .select('externalActivity')
-      })
-
-      it('should show campaign heading, email subject and date', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(2)).as(
-          'maxemailCampaign'
-        )
-
-        cy.get('@maxemailCampaign')
-          .find('h3')
-          .eq(0)
-          .should('have.text', 'Email Campaign')
-
-        cy.get('@maxemailCampaign')
-          .find('h3')
-          .eq(1)
-          .should(
-            'have.text',
-            'British Business Network Update - December 2020'
-          )
-
-        cy.get('@maxemailCampaign')
-          .find('ul')
-          .first()
-          .should('have.text', '15 Dec 2020')
-      })
-
-      it('should summarize the details of the campaign', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(2)).as(
-          'maxemailCampaign'
-        )
-
-        cy.get('@maxemailCampaign')
-          .find('details summary')
-          .should(
-            'have.text',
-            'View details of this campaign British Business Network Update - December 2020'
-          )
-          .click()
-
-        assertTable(selectors.companyActivity.activityFeed.item(2), [
-          {
-            th: 'Senders name',
-            td: 'Susannah Howen',
-          },
-          {
-            th: 'Senders email',
-            td: 'anz.newsletter@email.trade.gov.uk',
-          },
-          {
-            th: 'Content',
-            td: 'All the latest updates from around the BBN',
-          },
-        ])
-      })
-
-      it('should show a list of campaign email recipients', () => {
-        cy.get(selectors.companyActivity.activityFeed.item(2)).as(
-          'maxemailCampaign'
-        )
-
-        cy.get('@maxemailCampaign')
-          .find('table tbody tr')
-          .last()
-          .find('th')
-          .should('have.text', 'Recipients')
-
-        const recipients = [
-          {
-            text: 'Max Speed',
-            href: '/contacts/9136dd49-df67-4b2b-b241-6b64a662f1af/details',
-          },
-          {
-            text: 'Max Weight',
-            href: '/contacts/236f8b6c-afac-4fba-a8eb-5739aa14823a/details',
-          },
-          {
-            text: 'Max Height',
-            href: '/contacts/335369fc-b010-4730-97aa-10e66315b821/details',
-          },
-        ]
-
-        recipients.forEach((recipient, index) => {
-          cy.get('@maxemailCampaign')
-            .find('a')
-            .eq(index)
-            .should('have.text', recipient.text)
-            .and('have.attr', 'href', recipient.href)
-        })
-      })
+      )
     })
   })
 
-  context('When the activity feed feature flag is turned on', () => {
+  context('Referrals project', () => {
+    it('displays the correct referral type label', () => {
+      cy.get('[data-test="referral-activity"]').within(() =>
+        cy
+          .get('[data-test="activity-kind-label"]')
+          .contains('Outstanding Referral', {
+            matchCase: false,
+          })
+      )
+    })
+
+    it('displays the referral name with link', () => {
+      cy.get('[data-test="referral-activity"]').within(() =>
+        cy
+          .get('[data-test="referral-activity-card-subject"]')
+          .should('exist')
+          .should('have.text', 'Support needs in the Planet')
+          .get('a')
+          .should(
+            'have.attr',
+            'href',
+            '/companies/01e3366a-aa2b-40c0-aaf9-9013f714a671/referrals/fd6a151f-90db-41e3-841f-1ca0dd63b674'
+          )
+      )
+    })
+  })
+
+  context('Email Campaign (Maxemail)', () => {
     before(() => {
-      cy.setUserFeatures([CONTACT_ACTIVITY_FEATURE_FLAG])
-      cy.visit(
-        urls.companies.activity.index(fixtures.company.allActivitiesCompany.id)
+      const companyId = fixtures.company.externalActivitiesLtd.id
+      const url = urls.companies.activity.index(companyId)
+      cy.visit(url)
+        .get('[data-test="activity-feed"] select')
+        .select('externalActivity')
+    })
+
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="maxemail-campaign-activity"]').within(() =>
+        cy.get('[data-test="activity-kind-label"]').contains('Email Campaign', {
+          matchCase: false,
+        })
       )
-      cy.get('[data-test="activity-feed"] select').select(
-        'dataHubAndExternalActivity'
-      )
-    })
-
-    context('Companies House Company', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="companies-house-company-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('Companies House Update', {
-              matchCase: false,
-            })
-        )
-      })
-    })
-
-    context('Companies House Account', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="companies-house-account-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('Companies House Update', {
-              matchCase: false,
-            })
-        )
-      })
-    })
-
-    context('HMRC Exporter', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="hmrc-exporter-activity"]').within(() =>
-          cy.get('[data-test="activity-kind-label"]').contains('HMRC Update', {
-            matchCase: false,
-          })
-        )
-      })
-    })
-
-    context('Orders (OMIS)', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="order-activity"]').within(() =>
-          cy.get('[data-test="activity-kind-label"]').contains('New Order', {
-            matchCase: false,
-          })
-        )
-      })
-
-      it('displays the correct topic label', () => {
-        cy.get('[data-test="order-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-theme-label"]')
-            .contains('Orders (OMIS)', {
-              matchCase: false,
-            })
-        )
-      })
-
-      it('displays the correct sub-topic label', () => {
-        cy.get('[data-test="order-activity"]').within(() =>
-          cy.get('[data-test="activity-service-label"]').contains('Event', {
-            matchCase: false,
-          })
-        )
-      })
-
-      it('displays the order reference with link', () => {
-        cy.get('[data-test="order-activity"]').within(() =>
-          cy
-            .get('[data-test="order-activity-card-subject"]')
-            .should('exist')
-            .should('have.text', 'HAM100')
-            .get('a')
-            .should(
-              'have.attr',
-              'href',
-              'https://www.my-website.com/work-order'
-            )
-        )
-      })
-    })
-
-    context('Investment project', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="investment-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('New Investment Project', {
-              matchCase: false,
-            })
-        )
-      })
-
-      it('displays the correct sub-topic label', () => {
-        cy.get('[data-test="order-activity"]').within(() =>
-          cy.get('[data-test="activity-service-label"]').contains('Event', {
-            matchCase: false,
-          })
-        )
-      })
-    })
-
-    context('Investment project', () => {
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="investment-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('New Investment Project', {
-              matchCase: false,
-            })
-        )
-      })
-
-      it('displays the correct topic label', () => {
-        cy.get('[data-test="investment-activity"]').within(() =>
-          cy.get('[data-test="activity-theme-label"]').contains('Investment', {
-            matchCase: false,
-          })
-        )
-      })
-
-      it('displays the correct sub-topic label', () => {
-        cy.get('[data-test="investment-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-service-label"]')
-            .contains('Project - FDI', {
-              matchCase: false,
-            })
-        )
-      })
-
-      it('displays the investment project name with link', () => {
-        cy.get('[data-test="investment-activity"]').within(() =>
-          cy
-            .get('[data-test="investment-activity-card-subject"]')
-            .should('exist')
-            .should('have.text', 'Marshmellow UK Takeover')
-            .get('a')
-            .should(
-              'have.attr',
-              'href',
-              'https://www.datahub.trade.gov.uk/investments/projects/d9e25847-6199-e211-a939-e4115bead28a/details'
-            )
-        )
-      })
-    })
-
-    context('Referrals project', () => {
-      it('displays the correct referral type label', () => {
-        cy.get('[data-test="referral-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('Outstanding Referral', {
-              matchCase: false,
-            })
-        )
-      })
-
-      it('displays the referral name with link', () => {
-        cy.get('[data-test="referral-activity"]').within(() =>
-          cy
-            .get('[data-test="referral-activity-card-subject"]')
-            .should('exist')
-            .should('have.text', 'Support needs in the Planet')
-            .get('a')
-            .should(
-              'have.attr',
-              'href',
-              '/companies/01e3366a-aa2b-40c0-aaf9-9013f714a671/referrals/fd6a151f-90db-41e3-841f-1ca0dd63b674'
-            )
-        )
-      })
-    })
-
-    context('Email Campaign (Maxemail)', () => {
-      before(() => {
-        const companyId = fixtures.company.externalActivitiesLtd.id
-        const url = urls.companies.activity.index(companyId)
-        cy.visit(url)
-          .get('[data-test="activity-feed"] select')
-          .select('externalActivity')
-      })
-
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="maxemail-campaign-activity"]').within(() =>
-          cy
-            .get('[data-test="activity-kind-label"]')
-            .contains('Email Campaign', {
-              matchCase: false,
-            })
-        )
-      })
-    })
-
-    after(() => {
-      cy.resetUser()
     })
   })
 })

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -41,10 +41,6 @@ describe('Local header for company under dnb investigation', () => {
         assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}`)
       })
 
-      it('should display a badge', () => {
-        cy.get(companyLocalHeader.badge).should('exist')
-      })
-
       it('should not display "What does this mean?" details', () => {
         cy.get(companyLocalHeader.metaList).should('not.exist')
       })

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -3,224 +3,190 @@ const fixtures = require('../../fixtures')
 const dataHubActivities = require('../../../../sandbox/fixtures/v4/activity-feed/data-hub-activities.json')
 const errorContact = require('../../../../sandbox/fixtures/v3/contact/contact-by-id-uk.json')
 const { assertErrorDialog } = require('../../support/assertions')
-const {
-  CONTACT_ACTIVITY_FEATURE_FLAG,
-} = require('../../../../../src/apps/companies/apps/activity-feed/constants')
 
 describe('Contact activity', () => {
   const contactId = fixtures.contact.deanCox.id
   const errorContactId = errorContact.id
 
-  context('when the feature flag for activity stream is on', () => {
+  context('when viewing a contact with no activity', () => {
     before(() => {
-      cy.setUserFeatures([CONTACT_ACTIVITY_FEATURE_FLAG])
+      cy.intercept(
+        'GET',
+        `${urls.contacts.activity.data(
+          contactId
+        )}?page=1&selectedSortBy=newest`,
+        {
+          body: { activities: [] },
+        }
+      )
+      cy.visit(urls.contacts.contactActivities(contactId))
     })
 
-    context('when viewing a contact with no activity', () => {
-      before(() => {
-        cy.intercept(
-          'GET',
-          `${urls.contacts.activity.data(
-            contactId
-          )}?page=1&selectedSortBy=newest`,
-          {
-            body: { activities: [] },
-          }
-        )
-        cy.visit(urls.contacts.contactActivities(contactId))
-      })
-
-      it('should display 0 activities', () => {
-        cy.get('#contact-activity').contains('0 activities')
-      })
-    })
-
-    context('when viewing a contact with activities', () => {
-      before(() => {
-        cy.visit(urls.contacts.contactActivities(contactId))
-      })
-
-      it('should display the total number of activites', () => {
-        cy.get('#contact-activity').contains('1,233 activities')
-      })
-
-      it('should display the expected number of pages', () => {
-        cy.get('[data-test=pagination-summary]').contains('Page 1 of 124')
-        cy.get('[data-test=pagination]').should(
-          'have.attr',
-          'data-total-pages',
-          124
-        )
-      })
-
-      context('when using the sort by selector', () => {
-        beforeEach(() => {
-          cy.intercept(
-            'GET',
-            `${urls.contacts.activity.data(
-              contactId
-            )}?page=1&selectedSortBy=newest`
-          ).as('newestRequest')
-          cy.intercept(
-            'GET',
-            `${urls.contacts.activity.data(
-              contactId
-            )}?page=1&selectedSortBy=oldest`
-          ).as('oldestRequest')
-          cy.visit(urls.contacts.contactActivities(contactId))
-        })
-
-        after(() => {
-          cy.visit(urls.contacts.contactActivities(contactId))
-        })
-
-        it('should default to sort by newest', () => {
-          cy.wait('@newestRequest').then((request) => {
-            expect(request.response.statusCode).to.eql(200)
-          })
-          cy.get('[data-test=aventri-activity]').contains(
-            'EITA Test Event 2022'
-          )
-        })
-
-        it('should sort by oldest', () => {
-          const element = '[data-test="sortby"] select'
-          cy.get(element).select('Oldest')
-          cy.wait('@oldestRequest').then((request) => {
-            expect(request.response.statusCode).to.eql(200)
-          })
-          cy.get('[data-test="interaction-activity"]').contains(
-            'Meeting between Brendan Smith and Tyson Morar'
-          )
-        })
-      })
-
-      context('when viewing a Contact with Data Hub interaction', () => {
-        it('should display interaction activity kind label', () => {
-          cy.get('[data-test="interaction-activity"]').within(() => {
-            cy.get('[data-test=activity-kind-label]').contains('interaction', {
-              matchCase: false,
-            })
-          })
-        })
-
-        it('should display interaction activity theme label', () => {
-          cy.get('[data-test="interaction-activity"]').within(() => {
-            cy.get('[data-test=activity-theme-label]').contains('export', {
-              matchCase: false,
-            })
-          })
-        })
-
-        it('should display interaction activity service label', () => {
-          cy.get('[data-test="interaction-activity"]').within(() => {
-            cy.get('[data-test=activity-service-label]').contains(
-              'introduction',
-              { matchCase: false }
-            )
-          })
-        })
-        it('should display the subject', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            'Meeting between Brendan Smith and Tyson Morar'
-          )
-        })
-
-        it('should display the notes', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has ..."
-          )
-        })
-
-        it('should display the date', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            'Date: 10 Jun 2019'
-          )
-        })
-
-        it('should display the advisers with email', () => {
-          cy.get('[data-test=interaction-activity]')
-            .contains(
-              'Adviser(s): Brendan Smith Brendan.Smith@trade.gov.uk, Digital Data Hub - Live Service'
-            )
-            .contains('a', 'Brendan.Smith@trade.gov.uk')
-            .should('have.attr', 'href', 'mailto:Brendan.Smith@trade.gov.uk')
-        })
-
-        it('should display the service', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            'Service: Making Export Introductions : Someone else in DIT'
-          )
-        })
-
-        it('should display the communication channel', () => {
-          cy.get('[data-test=interaction-activity]').contains(
-            'Communication channel: Email/Website'
-          )
-        })
-
-        context('when optional data is missing', () => {
-          it('should render without missing data', () => {
-            cy.get('[data-test=interaction-activity]')
-              .eq(1)
-              .should('exist')
-              .should('not.contain', 'Communication channel: Email/Website')
-              .should('not.contain', 'Service: ')
-              .should('not.contain', 'Adviser(s): ')
-          })
-        })
-      })
-
-      context('When viewing a Contact with Aventri activities', () => {
-        it('should display the aventri activity', () => {
-          cy.get('[data-test="aventri-activity"]').should('exist')
-        })
-      })
-
-      context('when there are more than 10 activities', () => {
-        it('should be possible to page through', () => {
-          cy.get('[data-page-number="2"]').click()
-          cy.get('#contact-activity').contains(
-            `${dataHubActivities.hits.hits[0]._source.object['dit:subject']}`
-          )
-          cy.get('[data-test=aventri-activity]').should('not.exist')
-          cy.get('[data-test=pagination-summary').contains('Page 2 of 124')
-        })
-      })
-    })
-
-    context(
-      'viewing a contact when there is an error loading activities',
-      () => {
-        before(() => {
-          cy.visit(urls.contacts.contactActivities(errorContactId))
-        })
-
-        it('should render an error message', () => {
-          assertErrorDialog(
-            'TASK_GET_CONTACT_ACTIVITIES',
-            'Unable to load contact activity.'
-          )
-        })
-      }
-    )
-
-    after(() => {
-      cy.resetUser()
+    it('should display 0 activities', () => {
+      cy.get('#contact-activity').contains('0 activities')
     })
   })
 
-  context('when viewing a contact with the feature flag disabled', () => {
+  context('when viewing a contact with activities', () => {
     before(() => {
       cy.visit(urls.contacts.contactActivities(contactId))
     })
 
-    it('should not render the ActivityStream activities', () => {
-      cy.get('#contact-activity').should('not.exist')
+    it('should display the total number of activites', () => {
+      cy.get('#contact-activity').contains('1,233 activities')
     })
 
-    it('should only display Data Hub interactions', () => {
-      cy.get('[data-test=item-interaction-0]').should('exist')
+    it('should display the expected number of pages', () => {
+      cy.get('[data-test=pagination-summary]').contains('Page 1 of 124')
+      cy.get('[data-test=pagination]').should(
+        'have.attr',
+        'data-total-pages',
+        124
+      )
+    })
+
+    context('when using the sort by selector', () => {
+      beforeEach(() => {
+        cy.intercept(
+          'GET',
+          `${urls.contacts.activity.data(
+            contactId
+          )}?page=1&selectedSortBy=newest`
+        ).as('newestRequest')
+        cy.intercept(
+          'GET',
+          `${urls.contacts.activity.data(
+            contactId
+          )}?page=1&selectedSortBy=oldest`
+        ).as('oldestRequest')
+        cy.visit(urls.contacts.contactActivities(contactId))
+      })
+
+      after(() => {
+        cy.visit(urls.contacts.contactActivities(contactId))
+      })
+
+      it('should default to sort by newest', () => {
+        cy.wait('@newestRequest').then((request) => {
+          expect(request.response.statusCode).to.eql(200)
+        })
+        cy.get('[data-test=aventri-activity]').contains('EITA Test Event 2022')
+      })
+
+      it('should sort by oldest', () => {
+        const element = '[data-test="sortby"] select'
+        cy.get(element).select('Oldest')
+        cy.wait('@oldestRequest').then((request) => {
+          expect(request.response.statusCode).to.eql(200)
+        })
+        cy.get('[data-test="interaction-activity"]').contains(
+          'Meeting between Brendan Smith and Tyson Morar'
+        )
+      })
+    })
+
+    context('when viewing a Contact with Data Hub interaction', () => {
+      it('should display interaction activity kind label', () => {
+        cy.get('[data-test="interaction-activity"]').within(() => {
+          cy.get('[data-test=activity-kind-label]').contains('interaction', {
+            matchCase: false,
+          })
+        })
+      })
+
+      it('should display interaction activity theme label', () => {
+        cy.get('[data-test="interaction-activity"]').within(() => {
+          cy.get('[data-test=activity-theme-label]').contains('export', {
+            matchCase: false,
+          })
+        })
+      })
+
+      it('should display interaction activity service label', () => {
+        cy.get('[data-test="interaction-activity"]').within(() => {
+          cy.get('[data-test=activity-service-label]').contains(
+            'introduction',
+            { matchCase: false }
+          )
+        })
+      })
+      it('should display the subject', () => {
+        cy.get('[data-test=interaction-activity]').contains(
+          'Meeting between Brendan Smith and Tyson Morar'
+        )
+      })
+
+      it('should display the notes', () => {
+        cy.get('[data-test=interaction-activity]').contains(
+          "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has ..."
+        )
+      })
+
+      it('should display the date', () => {
+        cy.get('[data-test=interaction-activity]').contains('Date: 10 Jun 2019')
+      })
+
+      it('should display the advisers with email', () => {
+        cy.get('[data-test=interaction-activity]')
+          .contains(
+            'Adviser(s): Brendan Smith Brendan.Smith@trade.gov.uk, Digital Data Hub - Live Service'
+          )
+          .contains('a', 'Brendan.Smith@trade.gov.uk')
+          .should('have.attr', 'href', 'mailto:Brendan.Smith@trade.gov.uk')
+      })
+
+      it('should display the service', () => {
+        cy.get('[data-test=interaction-activity]').contains(
+          'Service: Making Export Introductions : Someone else in DIT'
+        )
+      })
+
+      it('should display the communication channel', () => {
+        cy.get('[data-test=interaction-activity]').contains(
+          'Communication channel: Email/Website'
+        )
+      })
+
+      context('when optional data is missing', () => {
+        it('should render without missing data', () => {
+          cy.get('[data-test=interaction-activity]')
+            .eq(1)
+            .should('exist')
+            .should('not.contain', 'Communication channel: Email/Website')
+            .should('not.contain', 'Service: ')
+            .should('not.contain', 'Adviser(s): ')
+        })
+      })
+    })
+
+    context('When viewing a Contact with Aventri activities', () => {
+      it('should display the aventri activity', () => {
+        cy.get('[data-test="aventri-activity"]').should('exist')
+      })
+    })
+
+    context('when there are more than 10 activities', () => {
+      it('should be possible to page through', () => {
+        cy.get('[data-page-number="2"]').click()
+        cy.get('#contact-activity').contains(
+          `${dataHubActivities.hits.hits[0]._source.object['dit:subject']}`
+        )
+        cy.get('[data-test=aventri-activity]').should('not.exist')
+        cy.get('[data-test=pagination-summary').contains('Page 2 of 124')
+      })
+    })
+  })
+
+  context('viewing a contact when there is an error loading activities', () => {
+    before(() => {
+      cy.visit(urls.contacts.contactActivities(errorContactId))
+    })
+
+    it('should render an error message', () => {
+      assertErrorDialog(
+        'TASK_GET_CONTACT_ACTIVITIES',
+        'Unable to load contact activity.'
+      )
     })
   })
 })

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -1010,10 +1010,9 @@ describe('Adding an interaction from a contact', () => {
 describe('Editing an interaction from a contact', () => {
   it('should be able to edit an interaction from a contact', () => {
     cy.visit(urls.contacts.interactions.index(fixtures.contact.deanCox.id))
-
-    cy.contains('a', 'totam|f19f5014-8bb1-4645-a224-27a4c8db5336').click()
+    cy.contains('a', 'Meeting between Brendan Smith and Tyson Morar').click()
     cy.contains('a', 'Edit interaction').click()
-    cy.contains('h1', 'Edit interaction for Zboncak Group')
+    cy.contains('h1', 'Edit interaction for Venus Ltd')
     cy.contains('button', 'Save interaction').click()
     cy.get('[data-test="status-message"]').should(
       'have.text',

--- a/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/data-hub-and-external-activities.json
@@ -79,7 +79,7 @@
           "type": "dit:aventri:Attendee"
         },
         "sort": [1645702137000]
-    },
+      },
       {
         "_index": "activities__feed_id_datahub-interactions__date_2019-06-20__timestamp_1561034480__batch_id_xputyeio__",
         "_type": "_doc",
@@ -128,7 +128,7 @@
                 "id": "dit:DataHubContact:e2eee6cd-acf6-454a-a4a8-f6c8fa604fde",
                 "name": "Tyson Morar",
                 "type": ["Person", "dit:Contact"],
-                "url": "https://www.datahub.dev.uktrade.io/contacts/e2eee6cd-acf6-454a-a4a8-f6c8fa604fde"
+                "url": "http://localhost:3000/contacts/e2eee6cd-acf6-454a-a4a8-f6c8fa604fde"
               }
             ],
             "dit:archived": false,
@@ -148,7 +148,7 @@
               "dit:datahub:theme:export"
             ],
             "content": "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.",
-            "url": "https://www.datahub.dev.uktrade.io/interactions/856b95f1-c221-4c41-9649-625e2a7d5262"
+            "url": "http://localhost:3000/interactions/856b95f1-c221-4c41-9649-625e2a7d5262"
           },
           "published": "2019-06-17T16:02:28.796549Z",
           "type": "Announce"
@@ -175,14 +175,14 @@
                 "name": "Lambda plc",
                 "type": ["Organization", "dit:Company"]
               },
-    
+
               {
                 "dit:emailAddress": "Tyson.Morar@example.com",
                 "dit:jobTitle": "Product Metrics Associate",
                 "id": "dit:DataHubContact:e2eee6cd-acf6-454a-a4a8-f6c8fa604fde",
                 "name": "Tyson Morar",
                 "type": ["Person", "dit:Contact"],
-                "url": "https://www.datahub.dev.uktrade.io/contacts/e2eee6cd-acf6-454a-a4a8-f6c8fa604fde"
+                "url": "http://localhost:3000/contacts/e2eee6cd-acf6-454a-a4a8-f6c8fa604fde"
               }
             ],
             "dit:archived": false,
@@ -195,7 +195,7 @@
               "dit:ServiceDelivery",
               "dit:datahub:theme:trade_agreement"
             ],
-            "url": "https://www.datahub.dev.uktrade.io/interactions/856b95f1-c221-4c41-9649-625e2a7d5262"
+            "url": "http://localhost:3000/interactions/856b95f1-c221-4c41-9649-625e2a7d5262"
           },
           "published": "2020-06-17T16:02:28.796549Z",
           "type": "Announce"


### PR DESCRIPTION
## Description of change

We want to release the new Card stylings to all users.

These cards are for Data Hub activities (Interaction, Service Delivery, Investment Project, OMIS Order, Company Referral) and external activity (Companies House Accounts, Companies House Company, HMRC Exporter). This is for the company activity feed and contact activity feed.

This styling work was carried out in #4854 

We also removed the 'Show details for all activities' checkbox on the company activity feed as this is now redundant.

## Test instructions

-Make sure your `user-contact-activities` feature flag is **off** 
-Check out this branch
-Visit a contact's activity feed, [Joe Doe](http://localhost:3000/contacts/68be55fc-544d-4d9c-a264-977b917f1fd3/interactions?page=1) is a good example: 
-You should now see the new card stylings 
-Visit a company's activity feed, [One List Corp](http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity) is a good example
-You should also see the new stylings here

## Screenshots

### Before

Contact activity feed
![image](https://user-images.githubusercontent.com/83657534/188863689-cb84b791-b013-4dea-97c7-69aae6d19e83.png)

Company activity feed
![image](https://user-images.githubusercontent.com/83657534/188864551-91ebdbca-a0aa-4bbe-9e03-e0cf7290c85d.png)


### After

Contact activity feed
![image](https://user-images.githubusercontent.com/83657534/188863868-792270a2-63e3-49a0-bbdc-b89a865c470a.png)

Company activity feed
![image](https://user-images.githubusercontent.com/83657534/189372136-507005fa-7361-41b7-b617-eacd1ced2264.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
