### PR TITLE
Feature/det 293 add links to cards

### DIFF
--- a/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
+++ b/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
@@ -170,7 +170,9 @@ export default class InvestmentProject extends React.PureComponent {
                 service="Project - FDI"
                 kind="New Investment Project"
               />
-              <ActivityCardSubject>{name}</ActivityCardSubject>
+              <ActivityCardSubject>
+                <Link href={`${url}/details`}>{name}</Link>
+              </ActivityCardSubject>
               <ActivityCardMetadata metadata={metadata} />
             </ActivityCardWrapper>
           )

--- a/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
+++ b/src/client/components/ActivityFeed/activities/InvestmentProject.jsx
@@ -170,7 +170,7 @@ export default class InvestmentProject extends React.PureComponent {
                 service="Project - FDI"
                 kind="New Investment Project"
               />
-              <ActivityCardSubject>
+              <ActivityCardSubject dataTest="investment-activity-card-subject">
                 <Link href={`${url}/details`}>{name}</Link>
               </ActivityCardSubject>
               <ActivityCardMetadata metadata={metadata} />

--- a/src/client/components/ActivityFeed/activities/Omis.jsx
+++ b/src/client/components/ActivityFeed/activities/Omis.jsx
@@ -122,7 +122,9 @@ export default class Omis extends React.PureComponent {
                 service="Event"
                 kind="New Order"
               />
-              <ActivityCardSubject>{reference}</ActivityCardSubject>
+              <ActivityCardSubject>
+                <Link href={`${url}/work-order`}>{reference}</Link>
+              </ActivityCardSubject>
               <ActivityCardMetadata metadata={metadata} />
             </ActivityCardWrapper>
           )

--- a/src/client/components/ActivityFeed/activities/Omis.jsx
+++ b/src/client/components/ActivityFeed/activities/Omis.jsx
@@ -122,7 +122,7 @@ export default class Omis extends React.PureComponent {
                 service="Event"
                 kind="New Order"
               />
-              <ActivityCardSubject>
+              <ActivityCardSubject dataTest="order-activity-card-subject">
                 <Link href={`${url}/work-order`}>{reference}</Link>
               </ActivityCardSubject>
               <ActivityCardMetadata metadata={metadata} />

--- a/src/client/components/ActivityFeed/activities/Referral.jsx
+++ b/src/client/components/ActivityFeed/activities/Referral.jsx
@@ -111,7 +111,9 @@ export default class Referral extends React.PureComponent {
             <ActivityCardWrapper>
               <Row>
                 <LeftCol>
-                  <ActivityCardSubject>{subject}</ActivityCardSubject>
+                  <ActivityCardSubject>
+                    <Link href={url}>{subject}</Link>
+                  </ActivityCardSubject>
                   <ActivityCardMetadata metadata={metadata} />
                 </LeftCol>
                 <RightCol>

--- a/src/client/components/ActivityFeed/activities/Referral.jsx
+++ b/src/client/components/ActivityFeed/activities/Referral.jsx
@@ -108,10 +108,10 @@ export default class Referral extends React.PureComponent {
               />
             </Card>
           ) : (
-            <ActivityCardWrapper>
+            <ActivityCardWrapper dataTest="referral-activity">
               <Row>
                 <LeftCol>
-                  <ActivityCardSubject>
+                  <ActivityCardSubject dataTest="referral-activity-card-subject">
                     <Link href={url}>{subject}</Link>
                   </ActivityCardSubject>
                   <ActivityCardMetadata metadata={metadata} />

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -418,6 +418,21 @@ describe('Company activity feed', () => {
           })
         )
       })
+
+      it('displays the order reference with link', () => {
+        cy.get('[data-test="order-activity"]').within(() =>
+          cy
+            .get('[data-test="order-activity-card-subject"]')
+            .should('exist')
+            .should('have.text', 'HAM100')
+            .get('a')
+            .should(
+              'have.attr',
+              'href',
+              'https://www.my-website.com/work-order'
+            )
+        )
+      })
     })
 
     context('Investment project', () => {
@@ -468,6 +483,21 @@ describe('Company activity feed', () => {
             })
         )
       })
+
+      it('displays the investment project name with link', () => {
+        cy.get('[data-test="investment-activity"]').within(() =>
+          cy
+            .get('[data-test="investment-activity-card-subject"]')
+            .should('exist')
+            .should('have.text', 'Marshmellow UK Takeover')
+            .get('a')
+            .should(
+              'have.attr',
+              'href',
+              'https://www.datahub.trade.gov.uk/investments/projects/d9e25847-6199-e211-a939-e4115bead28a/details'
+            )
+        )
+      })
     })
 
     context('Email Campaign (Maxemail)', () => {
@@ -488,6 +518,10 @@ describe('Company activity feed', () => {
             })
         )
       })
+    })
+
+    context('Referrals', () => {
+      // TO DO: Implements referral activity test coverage
     })
 
     after(() => {

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -500,6 +500,33 @@ describe('Company activity feed', () => {
       })
     })
 
+    context('Referrals project', () => {
+      it('displays the correct referral type label', () => {
+        cy.get('[data-test="referral-activity"]').within(() =>
+          cy
+            .get('[data-test="activity-kind-label"]')
+            .contains('Outstanding Referral', {
+              matchCase: false,
+            })
+        )
+      })
+
+      it('displays the referral name with link', () => {
+        cy.get('[data-test="referral-activity"]').within(() =>
+          cy
+            .get('[data-test="referral-activity-card-subject"]')
+            .should('exist')
+            .should('have.text', 'Support needs in the Planet')
+            .get('a')
+            .should(
+              'have.attr',
+              'href',
+              '/companies/01e3366a-aa2b-40c0-aaf9-9013f714a671/referrals/fd6a151f-90db-41e3-841f-1ca0dd63b674'
+            )
+        )
+      })
+    })
+
     context('Email Campaign (Maxemail)', () => {
       before(() => {
         const companyId = fixtures.company.externalActivitiesLtd.id
@@ -518,10 +545,6 @@ describe('Company activity feed', () => {
             })
         )
       })
-    })
-
-    context('Referrals', () => {
-      // TO DO: Implements referral activity test coverage
     })
 
     after(() => {

--- a/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
@@ -250,7 +250,91 @@
           "published": "2011-11-23T00:00:00Z",
           "type": "Add"
         }
-      }
+      },
+      {
+        "_index":"activities__feed_id_datahub-company-referral__date_2022-09-05__timestamp_1662387965__batch_id_laz6yy2m__",
+        "_type":"_doc",
+        "_id":"dit:DataHubCompanyReferral:fd6a151f-90db-41e3-841f-1ca0dd63b674:Announce",
+        "_score":1.0,
+        "_source":{
+           "generator":{
+              "name":"dit:dataHub",
+              "type":"Application"
+           },
+           "id":"dit:DataHubCompanyReferral:fd6a151f-90db-41e3-841f-1ca0dd63b674:Announce",
+           "object":{
+              "attributedTo":[
+                 {
+                    "dit:companiesHouseNumber":"12468736",
+                    "dit:dunsNumber":"225713780",
+                    "id":"dit:DataHubCompany:01e3366a-aa2b-40c0-aaf9-9013f714a671",
+                    "name":"Limited Company (UK) LTD",
+                    "type":[
+                       "Organization",
+                       "dit:Company"
+                    ]
+                 },
+                 {
+                    "dit:DataHubCompanyReferral:role":"sender",
+                    "dit:emailAddress":"mail.email@gov.uk",
+                    "dit:team":{
+                       "id":"dit:DataHubTeam:63d616b6-9698-e211-a939-e4115bead28a",
+                       "name":"Planet Consulate General",
+                       "type":[
+                          "Group",
+                          "dit:Team"
+                       ]
+                    },
+                    "id":"dit:DataHubAdviser:799602fe-12d1-4ad3-92a6-54a3bcd6ae1e",
+                    "name":"John Doe",
+                    "type":[
+                       "Person",
+                       "dit:Adviser"
+                    ]
+                 },
+                 {
+                    "dit:DataHubCompanyReferral:role":"recipient",
+                    "dit:emailAddress":"john.doe@gov.uk",
+                    "dit:team":{
+                       "id":"dit:DataHubTeam:4bd616b6-9698-e211-a939-e4115bead28a",
+                       "name":"Planet Embassy",
+                       "type":[
+                          "Group",
+                          "dit:Team"
+                       ]
+                    },
+                    "id":"dit:DataHubAdviser:5228483d-6d23-449c-b800-af70aa9056ac",
+                    "name":"John Taylorme",
+                    "type":[
+                       "Person",
+                       "dit:Adviser"
+                    ]
+                 },
+                 {
+                    "dit:emailAddress":"john.doe@gov.uk",
+                    "dit:jobTitle":null,
+                    "id":"dit:DataHubContact:8da658fe-85fe-4737-b4fb-a0b25fcea3c2",
+                    "name":"John Me",
+                    "type":[
+                       "Person",
+                       "dit:Contact"
+                    ],
+                    "url":"https://www.datahub.trade.gov.uk/contacts/8da658fe-85fe-4737-b4fb-a0b25fcea3c2"
+                 }
+              ],
+              "dit:status":"outstanding",
+              "dit:subject":"Support needs in the Planet",
+              "id":"dit:DataHubCompanyReferral:fd6a151f-90db-41e3-841f-1ca0dd63b674",
+              "startTime":"2020-05-21T17:43:47.957561Z",
+              "type":[
+                 "dit:CompanyReferral"
+              ],
+              "url":"https://www.datahub.trade.gov.uk/company-referrals/fd6a151f-90db-41e3-841f-1ca0dd63b674"
+           },
+           "published":"2020-05-21T17:43:47.957585Z",
+           "type":"Announce"
+        }
+     }
     ]
   }
 }


### PR DESCRIPTION
## Description of change

This PR adds the links to OMIS,Investment and Referrals

## Test instructions

We should see the Links are added for OMIS,Investment and Referral

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/74972011/188598977-6193f9fd-dc94-4f11-bce1-221d2fcc75a5.png)
![image](https://user-images.githubusercontent.com/74972011/188599009-d17a8939-9e13-4b01-a094-b4876f6c7be3.png)

### After

![image](https://user-images.githubusercontent.com/28296624/188599889-fb07a197-f709-4e09-b4c4-b2b9e424e91f.png)

![image](https://user-images.githubusercontent.com/28296624/188599959-48dc7a13-879f-4034-84a3-edbf4f5da569.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
