### PR TITLE
CPS-384: handle error when no Lead ITA on global HQ

### DIFF
--- a/src/apps/companies/apps/advisers/client/__test__/tasks.test.js
+++ b/src/apps/companies/apps/advisers/client/__test__/tasks.test.js
@@ -1,0 +1,56 @@
+import proxyquire from 'proxyquire'
+
+describe('updateAdviser', () => {
+  const adviserData = {
+    dit_participants: { value: '123' },
+    companyId: 'abc',
+  }
+  const adviserEmail = 'e@example.com'
+  let tasks
+
+  describe('when the update is succesful', () => {
+    beforeEach(() => {
+      tasks = proxyquire('../tasks', {
+        '../../../../../client/components/Task/utils': {
+          apiProxyAxios: {
+            get: () =>
+              Promise.resolve({
+                data: {
+                  one_list_group_global_account_manager: {
+                    contact_email: adviserEmail,
+                  },
+                },
+              }),
+            post: () => Promise.resolve(),
+          },
+        },
+      })
+    })
+    it('returns the lead ITA info', async () => {
+      const result = await tasks.updateAdviser(adviserData)
+      expect(result).to.deep.equal({
+        contact_email: adviserEmail,
+        email: adviserEmail,
+      })
+    })
+  })
+
+  describe('when there is no global lead ITA', () => {
+    beforeEach(() => {
+      tasks = proxyquire('../tasks', {
+        '../../../../../client/components/Task/utils': {
+          apiProxyAxios: {
+            get: () => Promise.resolve({ data: {} }),
+            post: () => Promise.resolve(),
+          },
+        },
+      })
+    })
+
+    it('returns an error message', async () => {
+      await expect(tasks.updateAdviser(adviserData)).to.be.rejectedWith(
+        "No global Lead ITAs were found for this company. Please note: it is not possible to add Lead ITAs to a subsidiary that are not attached to the company's Global Headquarters"
+      )
+    })
+  })
+})

--- a/src/apps/companies/apps/advisers/client/tasks.js
+++ b/src/apps/companies/apps/advisers/client/tasks.js
@@ -7,8 +7,14 @@ export async function updateAdviser({ dit_participants, companyId }) {
   )
   const { data } = await apiProxyAxios.get(`/v4/company/${companyId}`)
   const leadIta = data.one_list_group_global_account_manager
-  return {
-    ...leadIta,
-    email: leadIta.contact_email,
+  if (leadIta) {
+    return {
+      ...leadIta,
+      email: leadIta.contact_email,
+    }
+  } else {
+    return Promise.reject(
+      "No global Lead ITAs were found for this company. Please note: it is not possible to add Lead ITAs to a subsidiary that are not attached to the company's Global Headquarters"
+    )
   }
 }


### PR DESCRIPTION
## Description of change

Users were seeing the page hang when trying to add a Lead ITA to a company that was a subsidiary of a global headquarters. It should not be possible to do that, as only Lead ITAs on a global HQ can be added to the subsidiary company. This is a quick fix to handle the error more gracefully.

## Test instructions

If you try to add a Lead Adviser to the company on dev environment with id bfacd6e1-2c05-4dca-a1ef-1bad1bc0055f
You should see the error message pop up 
(because it has a global HQ without a Lead ITA)

## Screenshots

### Before

![Screenshot 2022-09-09 at 12 22 26](https://user-images.githubusercontent.com/16647486/189339158-070e4289-cfa0-4061-9312-1388976a2ce6.png)

### After

![Screenshot 2022-09-09 at 12 21 57](https://user-images.githubusercontent.com/16647486/189339088-2139d0a9-4c82-40af-8b94-fb7946a70a9f.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
