### PR TITLE
Expand settings depending on the reminder url you come from

### DIFF
--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -45,8 +45,17 @@ const StyledHomeLink = styled(Link)({
 const RemindersSettings = () => {
   const location = useLocation()
   const qsParams = qs.parse(location.search.slice(1))
-  const openESL = get(qsParams, 'estimated_land_date', false)
-  const openNRI = get(qsParams, 'no_recent_interaction', false)
+  const previousURL = document.referrer
+  const estimatedLandDateExpand =
+    previousURL && previousURL.includes('estimated-land-date')
+  const noRecentInteractionExpand =
+    previousURL && previousURL.includes('no-recent-interaction')
+  const openESL = get(qsParams, 'estimated_land_date', estimatedLandDateExpand)
+  const openNRI = get(
+    qsParams,
+    'no_recent_interaction',
+    noRecentInteractionExpand
+  )
   return (
     <DefaultLayout
       heading="Reminders and email notifications settings"

--- a/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
@@ -1,0 +1,62 @@
+import urls from '../../../../../../src/lib/urls'
+
+const selectors = {
+  collectionItem: '[data-test="item-content"]',
+  reminderSettings: 'a[data-test="reminders-settings-link"]',
+  ELDSettingsClose: '#estimated-land-date-toggle-toggle-button-close',
+  ELDSettingsOpen: '#estimated-land-date-toggle-toggle-button-open',
+  ELDEdit: '[data-test="estimated-land-date-link"]',
+  NRISettingsClose: '#no-recent-interaction-toggle-toggle-button-close',
+  NRISettingsOpen: '#no-recent-interaction-toggle-toggle-button-open',
+  NRIEdit: '[data-test="no-recent-interaction-link"]',
+}
+
+describe('Notification settings', () => {
+  context('when in estimated land date page', () => {
+    before(() => {
+      cy.visit(urls.reminders.estimatedLandDate())
+      cy.get(selectors.collectionItem).should('be.visible')
+      cy.get(selectors.reminderSettings).eq(1).should('be.visible').click()
+    })
+
+    it('should have approaching estimated land date settings expanded', () => {
+      cy.get(selectors.ELDSettingsClose).should('be.visible')
+    })
+
+    it('should have no recent interaction settings collapsed', () => {
+      cy.get(selectors.NRISettingsOpen).should('be.visible')
+    })
+
+    it('should have approaching estimated land date settings expanded after edit', () => {
+      cy.get(selectors.ELDEdit).click()
+      cy.contains('Save').click()
+
+      cy.contains('Settings updated').should('be.visible')
+      cy.get(selectors.ELDSettingsClose).should('be.visible')
+    })
+  })
+
+  context('when in no recent interaction page', () => {
+    beforeEach(() => {
+      cy.visit(urls.reminders.noRecentInteraction())
+      cy.contains('days since last interaction').should('be.visible')
+      cy.get(selectors.reminderSettings).eq(1).should('be.visible').click()
+    })
+
+    it('should have no recent interaction settings expanded', () => {
+      cy.get(selectors.NRISettingsClose).should('be.visible')
+    })
+
+    it('should have approaching estimated land date settings collapsed', () => {
+      cy.get(selectors.ELDSettingsOpen).should('be.visible')
+    })
+
+    it('should have no recent interaction settings expanded after edit', () => {
+      cy.get(selectors.NRIEdit).click()
+      cy.contains('Save').click()
+
+      cy.contains('Settings updated').should('be.visible')
+      cy.get(selectors.NRISettingsClose).should('be.visible')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

The intent of this PR is to ensure the according settings is expanded depending on the URL you come from.

## Test instructions

Included functional tests, all functional tests should pass.

## Screenshots

### Before

<img width="929" alt="Screenshot 2022-09-12 at 09 06 04" src="https://user-images.githubusercontent.com/105509190/189603672-a617916a-2d8c-4b6a-aae9-83e0c6f39596.png">


### After

<img width="964" alt="Screenshot 2022-09-12 at 09 06 16" src="https://user-images.githubusercontent.com/105509190/189603693-071fb72a-4805-449c-9859-22e3943ba438.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
