### PR TITLE
Write the SSO user `user_id` to the Google Tag Manager (GTM) data layer

### DIFF
--- a/src/middleware/__test__/user.test.js
+++ b/src/middleware/__test__/user.test.js
@@ -6,6 +6,7 @@ const user = {
   id: 'a47e6441-d414-75e6-9dc9-d80b41e872e0',
   name: 'Joe Bloggs',
   email: 'joe.bloggs@trade.gov.uk',
+  userId: 'd3dda5d2-b98f-41a6-9313-1e2c2d8db080',
 }
 
 describe('user middleware', () => {
@@ -68,6 +69,9 @@ describe('user middleware', () => {
       this.reqMock = {
         session: {
           token,
+          userProfile: {
+            user_id: 'd3dda5d2-b98f-41a6-9313-1e2c2d8db080',
+          },
         },
       }
       this.resMock = {

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -1,3 +1,5 @@
+const { get } = require('lodash')
+
 const config = require('../config')
 const { authorisedRequest } = require('../lib/authorised-request')
 
@@ -20,7 +22,15 @@ async function userMiddleware(req, res, next) {
       `${config.apiRoot}/whoami/`
     )
 
-    req.session.user = res.locals.user = userResponse
+    const userId = get(req.session, 'userProfile.user_id')
+
+    const user = {
+      ...userResponse,
+      userId,
+    }
+
+    req.session.user = res.locals.user = user
+
     next()
   } catch (error) {
     next(error)

--- a/src/templates/_includes/google-tag-manager-snippet.njk
+++ b/src/templates/_includes/google-tag-manager-snippet.njk
@@ -2,6 +2,7 @@
 <script>
  dataLayer = [{
     'userId': '{{user.id}}',
+    'userUserId': '{{user.userId}}'
   }];
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
     var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
## Description of change

We want to track users going from Data Hub to Data Workspace by writing their SSO user `user_id` (uuid) to the Google Tag Manager (GTM) data layer allowing us to report our findings.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
