### PR TITLE
Fix CSV formula regex

### DIFF
--- a/src/apps/companies/apps/add-company/client/constants.js
+++ b/src/apps/companies/apps/add-company/client/constants.js
@@ -18,5 +18,4 @@ export const NON_ASCII_REGEX = /[^$|\x00-\x7F]/
 // 1st Case: anything beginning with =,@,+,tab or carriage return
 // 2nd Case: if there is a comma with one of those symbols after it (see owasp suggestions)
 // https://owasp.org/www-community/attacks/CSV_Injection
-export const CSV_FORMULA_INJECTION_REGEX =
-  /(^[=@+\t\r-])|((?<=[,;'"])[\s\S]*[=@+-])/
+export const CSV_FORMULA_INJECTION_REGEX = /(^[=@+\t\r-])|([,;'"][\s\S]*[=@+-])/


### PR DESCRIPTION

## Description of change

Safari and some older browsers do not support negative look behinds in regex... It doesn't seem that this regex needed it anyway!

## Test instructions

Events/Companies/Interactions tabs should all render on Safari without failing :)

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
