### PR TITLE
Add details to the response view link

### DIFF
--- a/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
+++ b/src/apps/interactions/transformers/__test__/interaction-response-to-view.test.js
@@ -561,7 +561,7 @@ describe('#transformInteractionResponsetoViewRecord', () => {
           url: 'http://base/documents/123',
         },
         Event: {
-          url: '/events/4444',
+          url: '/events/4444/details',
           name: 'Event title',
         },
       })

--- a/src/apps/interactions/transformers/interaction-response-to-view.js
+++ b/src/apps/interactions/transformers/interaction-response-to-view.js
@@ -137,6 +137,7 @@ function transformInteractionResponseToViewRecord(
     event: transformEntityLink({
       entity: event,
       entityPath: 'events',
+      urlSuffix: '/details',
       noLinkText: defaultEventText,
     }),
 

--- a/test/functional/cypress/specs/interaction/details-spec.js
+++ b/test/functional/cypress/specs/interaction/details-spec.js
@@ -258,7 +258,7 @@ describe('Interaction details', () => {
         'Date of service delivery': '5 September 2017',
         'Adviser(s)': '',
         Event: {
-          href: '/events/bda12a57-433c-4a0c-a7ce-5ebd080e09e8',
+          href: '/events/bda12a57-433c-4a0c-a7ce-5ebd080e09e8/details',
           name: 'Grand exhibition',
         },
         Documents: 'View files and documents (will open another website)',


### PR DESCRIPTION
## Description of change

From Data Enhancement the url that goes to the event name is just missing a /details at the end

## Test instructions

Navigate to a view with servicetype interactions and event details e.g. https://www.datahub.dev.uktrade.io/interactions/1fc477ca-b121-49c5-ba02-fba464e55ba5

## Screenshots

<img width="902" alt="image" src="https://user-images.githubusercontent.com/19926221/190455378-eeaf612c-0ebb-44ea-afab-39d402b0096e.png">

<img width="873" alt="image" src="https://user-images.githubusercontent.com/19926221/190455453-98799bb4-6df6-4e4b-a9bc-fbd81e6903b1.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
