### PR TITLE
Remove duplicate flash message on create list creation

### DIFF
--- a/src/apps/company-lists/controllers/__test__/create.test.js
+++ b/src/apps/company-lists/controllers/__test__/create.test.js
@@ -24,12 +24,6 @@ describe('Creating company lists', () => {
         )
       })
 
-      it('should send a success message', () => {
-        expect(
-          global.middlewareParameters.reqMock.flash
-        ).to.have.been.calledWith('success', 'Company list created')
-      })
-
       it('should then send the response', () => {
         expect(global.middlewareParameters.resMock.send).to.have.been.called
       })

--- a/src/apps/company-lists/controllers/create.js
+++ b/src/apps/company-lists/controllers/create.js
@@ -4,7 +4,6 @@ async function createCompanyList(req, res, next) {
   const { id, name } = req.body
   try {
     await createUserCompanyList(req, id, name)
-    req.flash('success', 'Company list created')
     res.send()
   } catch (error) {
     req.flash('error', 'Could not create list')

--- a/test/functional/cypress/specs/company-lists/create-spec.js
+++ b/test/functional/cypress/specs/company-lists/create-spec.js
@@ -90,7 +90,7 @@ describe('Create a company list', () => {
     it('should display a success message', () => {
       cy.get(selectors.companyList.create.input).type('New list name')
       cy.get(selectors.companyList.create.submit).click()
-      cy.get(selectors.localHeader().flash).should(
+      cy.get('[data-test="status-message"]').should(
         'contain.text',
         'Company list created'
       )


### PR DESCRIPTION
## Description of change

The intent of this PR is to remove the duplicate flash message displayed to the user when a new company list is added.

## Test instructions

Pipeline tests should pass as usual.

## Screenshots

### Before

<img width="1134" alt="image-20220825-095753" src="https://user-images.githubusercontent.com/105509190/190979218-f3945018-8b6d-4eb1-9875-7a96c05f57c7.png">


### After

<img width="871" alt="Screenshot 2022-09-19 at 09 33 52" src="https://user-images.githubusercontent.com/105509190/190979257-4782e9cb-0ce6-48e2-93f8-018d21b72117.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
