### PR TITLE
Feature/DET-314 Add missing contact field

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -34,7 +34,7 @@ export default class Interaction extends React.PureComponent {
     }
 
     const advisers = CardUtils.getAdvisers(activity)
-
+    const contacts = CardUtils.getContacts(activity)
     const activityObject = activity.object
     const date = formatMediumDate(activityObject.startTime)
     const communicationChannel = transformed.communicationChannel
@@ -57,8 +57,24 @@ export default class Interaction extends React.PureComponent {
       )
     }
 
+    const formattedContactUrl = (contact) => {
+      return `/${contact.url.split('/').slice(3).join('/')}/details`
+    }
+
+    const formattedContacts = () => {
+      return (
+        !!contacts &&
+        contacts.map((contact) => (
+          <span key={contact.name}>
+            <Link href={formattedContactUrl(contact)}>{contact.name}</Link>
+          </span>
+        ))
+      )
+    }
+
     const metadata = [
       { label: 'Date', value: date },
+      { label: 'Contact(s)', value: formattedContacts() },
       { label: 'Communication channel', value: communicationChannel },
       { label: 'Adviser(s)', value: formattedAdvisers() },
       {

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -63,9 +63,10 @@ export default class Interaction extends React.PureComponent {
 
     const formattedContacts = () => {
       return (
-        !!contacts &&
-        contacts.map((contact) => (
+        !!contacts.length &&
+        contacts.map((contact, index) => (
           <span key={contact.name}>
+            {index ? ', ' : ''}
             <Link href={formattedContactUrl(contact)}>{contact.name}</Link>
           </span>
         ))

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -63,7 +63,12 @@ export default class Interaction extends React.PureComponent {
       contacts.map((contact, index) => (
         <span key={contact.name}>
           {index ? ', ' : ''}
-          <Link href={formattedContactUrl(contact)}>{contact.name}</Link>
+          <Link
+            data-test={`contact-link-${index}`}
+            href={formattedContactUrl(contact)}
+          >
+            {contact.name}
+          </Link>
         </span>
       ))
 

--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -46,32 +46,26 @@ export default class Interaction extends React.PureComponent {
     const serviceName = activityObject['dit:service']?.name
     const serviceNotes = activityObject.content
 
-    const formattedAdvisers = () => {
-      return (
-        !!advisers.length &&
-        advisers.map((adviser) => (
-          <span key={adviser.name}>
-            <AdviserActivityRenderer adviser={adviser} />
-          </span>
-        ))
-      )
-    }
+    const formattedAdvisers = () =>
+      !!advisers.length &&
+      advisers.map((adviser) => (
+        <span key={adviser.name}>
+          <AdviserActivityRenderer adviser={adviser} />
+        </span>
+      ))
 
     const formattedContactUrl = (contact) => {
       return `/${contact.url.split('/').slice(3).join('/')}/details`
     }
 
-    const formattedContacts = () => {
-      return (
-        !!contacts.length &&
-        contacts.map((contact, index) => (
-          <span key={contact.name}>
-            {index ? ', ' : ''}
-            <Link href={formattedContactUrl(contact)}>{contact.name}</Link>
-          </span>
-        ))
-      )
-    }
+    const formattedContacts = () =>
+      !!contacts.length &&
+      contacts.map((contact, index) => (
+        <span key={contact.name}>
+          {index ? ', ' : ''}
+          <Link href={formattedContactUrl(contact)}>{contact.name}</Link>
+        </span>
+      ))
 
     const metadata = [
       { label: 'Date', value: date },

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -24,6 +24,8 @@ const oneAdviserText =
   'Adviser(s): Bernard Harris-Patel  bernardharrispatel@test.com, Test Team  '
 const twoAdvisersText =
   'Adviser(s): Bernard Harris-Patel  bernardharrispatel@test.com, Test Team  Puck Head  puckhead@test.com, Test Team  '
+const oneContactText = 'Contact(s): Alexander Hamilton'
+const twoContactsText = 'Contact(s): Alexander Hamilton, Oliver Twist'
 const date = '2058-11-25T00:00:00Z'
 
 const adviser1 = {
@@ -50,13 +52,22 @@ const adviser2 = {
   type: ['Person', 'dit:Adviser'],
 }
 
-const contact = {
-  'dit:emailAddress': 'alex.ham@gov.uk',
+const contact1 = {
+  'dit:emailAddress': 'alex.ham@test.com',
   'dit:jobTitle': 'Chief Fun Officer',
   id: 'dit:DataHubContact:115b4d96-d2ea-40ff-a01d-812507093a98',
   name: 'Alexander Hamilton',
   type: ['Person', 'dit:Contact'],
   url: 'https://www.datahub.dev.uktrade.io/contacts/115b4d96-d2ea-40ff-a01d-812507093a98',
+}
+
+const contact2 = {
+  'dit:emailAddress': 'oliver@test.com',
+  'dit:jobTitle': 'Chief Fangin',
+  id: 'dit:DataHubContact:56cd5cd0-bb6f-440c-adae-0253f6d48d3b',
+  name: 'Oliver Twist',
+  type: ['Person', 'dit:Contact'],
+  url: 'https://www.datahub.dev.uktrade.io/contacts/56cd5cd0-bb6f-440c-adae-0253f6d48d3b',
 }
 
 const interactionThemes = ['export', 'investment', 'trade_agreement', 'other']
@@ -110,14 +121,14 @@ const buildAttributedTo = (numberOfAdvisers) => {
   const oneAdviser = noAdvisers.concat(adviser1)
 
   if (numberOfAdvisers === 1) {
-    return oneAdviser.concat(contact)
+    return oneAdviser.concat(contact1)
   }
 
   if (numberOfAdvisers === 2) {
-    return oneAdviser.concat(adviser2).concat(contact)
+    return oneAdviser.concat(adviser2).concat(contact1, contact2)
   }
 
-  return noAdvisers.concat(contact)
+  return noAdvisers
 }
 
 const buildAndMountActivity = (
@@ -238,9 +249,14 @@ describe('Interaction activity card', () => {
     })
 
     it('should render the contact label', () => {
-      assertText(
-        '[data-test=contact-s-label]',
-        'Contact(s): Alexander Hamilton'
+      assertText('[data-test=contact-s-label]', oneContactText)
+    })
+
+    it('should have the correct link for a contact', () => {
+      cy.get('[data-test=contact-s-label] > a').should(
+        'have.attr',
+        'href',
+        '/contacts/115b4d96-d2ea-40ff-a01d-812507093a98'
       )
     })
 
@@ -273,7 +289,7 @@ describe('Interaction activity card', () => {
       })
     })
 
-    context('When there are multiple advisers', () => {
+    context('When there are multiple contacts and advisers', () => {
       beforeEach(() => {
         buildAndMountActivity(
           interactionServices.specificDITService,
@@ -288,6 +304,10 @@ describe('Interaction activity card', () => {
 
       it('should render both advisers', () => {
         assertText('[data-test=adviser-s-label]', twoAdvisersText)
+      })
+
+      it('should render both contacts', () => {
+        assertText('[data-test=contact-s-label]', twoContactsText)
       })
     })
 

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -50,6 +50,14 @@ const adviser2 = {
   type: ['Person', 'dit:Adviser'],
 }
 
+const contact = {
+  id: 'dit:DataHubContact:115b4d96-d2ea-40ff-a01d-812507093a98',
+  url: 'https://www.datahub.dev.uktrade.io/contacts/115b4d96-d2ea-40ff-a01d-812507093a98',
+  name: 'Alexander Hamilton',
+  jobTitle: 'Chief Fun Officer',
+  type: 'Contact',
+}
+
 const interactionThemes = ['export', 'investment', 'trade_agreement', 'other']
 
 const interactionServices = {
@@ -101,14 +109,14 @@ const buildAttributedTo = (numberOfAdvisers) => {
   const oneAdviser = noAdvisers.concat(adviser1)
 
   if (numberOfAdvisers === 1) {
-    return oneAdviser
+    return oneAdviser.concat(contact)
   }
 
   if (numberOfAdvisers === 2) {
-    return oneAdviser.concat(adviser2)
+    return oneAdviser.concat(adviser2).concat(contact)
   }
 
-  return noAdvisers
+  return noAdvisers.concat(contact)
 }
 
 const buildAndMountActivity = (
@@ -226,6 +234,13 @@ describe('Interaction activity card', () => {
 
     it('should render the date label', () => {
       assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+    })
+
+    it('should render the contact label', () => {
+      assertText(
+        '[data-test=contact-s-label]',
+        'Contact(s): Alexander Hamilton'
+      )
     })
 
     it('should render the communication channel label', () => {

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -253,10 +253,10 @@ describe('Interaction activity card', () => {
     })
 
     it('should have the correct link for a contact', () => {
-      cy.get('[data-test=contact-s-label] > a').should(
+      cy.get('[data-test=contact-link-0]').should(
         'have.attr',
         'href',
-        '/contacts/115b4d96-d2ea-40ff-a01d-812507093a98'
+        '/contacts/115b4d96-d2ea-40ff-a01d-812507093a98/details'
       )
     })
 

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -51,11 +51,12 @@ const adviser2 = {
 }
 
 const contact = {
+  'dit:emailAddress': 'alex.ham@gov.uk',
+  'dit:jobTitle': 'Chief Fun Officer',
   id: 'dit:DataHubContact:115b4d96-d2ea-40ff-a01d-812507093a98',
-  url: 'https://www.datahub.dev.uktrade.io/contacts/115b4d96-d2ea-40ff-a01d-812507093a98',
   name: 'Alexander Hamilton',
-  jobTitle: 'Chief Fun Officer',
-  type: 'Contact',
+  type: ['Person', 'dit:Contact'],
+  url: 'https://www.datahub.dev.uktrade.io/contacts/115b4d96-d2ea-40ff-a01d-812507093a98',
 }
 
 const interactionThemes = ['export', 'investment', 'trade_agreement', 'other']


### PR DESCRIPTION
## Description of change
Adds the missing contact field to the new Interaction/Service Delivery activity cards.

## Test instructions

- Get this branch up locally
- Visit a company's activity feed, [One List Corp](http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity) is a good example
- You should now see the Contact(s) field 

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/191508938-525b3aca-2fb8-41f2-9171-d0110cf2dc36.png)


### After

![image](https://user-images.githubusercontent.com/83657534/191508787-65081bc5-ded2-4531-a270-ebc49f2789b9.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
