### PR TITLE
Fine tune event name filter on new events col page

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -524,7 +524,7 @@ describe('Activity feed controllers', () => {
             },
           },
           {
-            match: {
+            match_phrase_prefix: {
               'object.name': name,
             },
           },
@@ -692,7 +692,7 @@ describe('Activity feed controllers', () => {
                   },
                 },
                 {
-                  match: {
+                  match_phrase_prefix: {
                     'object.name': name,
                   },
                 },

--- a/src/apps/companies/apps/activity-feed/__test__/query.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/query.test.js
@@ -45,7 +45,7 @@ describe('#activityFeedEventsQuery', () => {
       )
     })
 
-    it('should return the right query when "recently updated" filter is selected', () => {
+    it('should return the right query when "Recently updated" sort by is selected', () => {
       const sortBy = 'modified_on:asc'
       expect(expectedEsQuery('asc')).to.deep.equal(
         activityFeedEventsQuery({
@@ -57,7 +57,7 @@ describe('#activityFeedEventsQuery', () => {
       )
     })
 
-    it('should return the right query when "least recently updated" filter is selected', () => {
+    it('should return the right query when "Least recently updated" sort by is selected', () => {
       const sortBy = 'modified_on:desc'
       expect(expectedEsQuery('desc')).to.deep.equal(
         activityFeedEventsQuery({
@@ -93,7 +93,7 @@ describe('#activityFeedEventsQuery', () => {
       },
     })
 
-    it('should return the right query when "name" ', () => {
+    it('should return the right query when "Event name A-Z" sort by is selected ', () => {
       const sortBy = 'name:asc'
       expect(expectedEsQuery('asc')).to.deep.equal(
         activityFeedEventsQuery({
@@ -129,7 +129,7 @@ describe('#activityFeedEventsQuery', () => {
       },
     })
 
-    it('should return the right query when "earliest start date" filter is selected', () => {
+    it('should return the right query when "Earliest start date" sort by is selected', () => {
       const sortBy = 'start_date:asc'
       expect(expectedEsQuery('asc')).to.deep.equal(
         activityFeedEventsQuery({
@@ -141,7 +141,7 @@ describe('#activityFeedEventsQuery', () => {
       )
     })
 
-    it('should return the right query when "latest start date" filter is selected', () => {
+    it('should return the right query when "Latest start date" sort by is selected', () => {
       const sortBy = 'start_date:desc'
       expect(expectedEsQuery('desc')).to.deep.equal(
         activityFeedEventsQuery({

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -408,7 +408,7 @@ const eventsColListQueryBuilder = ({
 }) => {
   const eventNameFilter = name
     ? {
-        match: {
+        match_phrase_prefix: {
           'object.name': name,
         },
       }


### PR DESCRIPTION
## Description of change
The current iteration of the new events collection page event name filter provides too many matches. 

This means with the default sort by of most recently updated, the top result may or may not be the most relevant one, depending on how many words were used in the search term (the longer the event name, the less relevant the results that appear at the top as there are more matches).

This PR changes the type of query to `match_phrase_prefix` https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase-prefix.html to hopefully provide more relevant results. 

## Test instructions

- In Django dev API, add the user feature flag `user-activity-stream-aventri` to your adviser profile and point your frontend towards the dev API.
- Go to http://localhost:3000/events and type 'Grow Your Business with Export: Networking Event' into the Event Name filter and enter. 
- It should come back with 1 result. 
- If you repeat the same on main branch, you will end up with 20 events and the top event is not relevant to the search.


## Screenshots

### Before
![image](https://user-images.githubusercontent.com/70902973/192249094-008cecb5-64cc-4e12-8748-c981d16f1f35.png)

### After
![image](https://user-images.githubusercontent.com/70902973/192249272-1bb3fd16-8249-4044-91f7-7ad3c96cdc62.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
