### PR TITLE
Change collection list label metadata grey tone

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -7,6 +7,7 @@ import { H3 } from '@govuk-react/heading'
 import Link from '@govuk-react/link'
 import { HEADING_SIZES, MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
+import { DARK_GREY } from '../../utils/colors'
 import Badge from '../Badge/'
 import Metadata from '../../components/Metadata/'
 
@@ -46,7 +47,7 @@ const StyledLinkHeader = styled(StyledHeader)`
 const StyledSubheading = styled('h4')`
   font-size: 14px;
   line-height: 20px;
-  color: #6f777b;
+  color: ${DARK_GREY};
   font-weight: normal;
   margin: -${SPACING.SCALE_3} 0 ${SPACING.SCALE_2} 0;
 `

--- a/src/client/components/CollectionList/CollectionSort.jsx
+++ b/src/client/components/CollectionList/CollectionSort.jsx
@@ -4,13 +4,12 @@ import { Route } from 'react-router-dom'
 import qs from 'qs'
 
 import styled from 'styled-components'
-import { GREY_1 } from 'govuk-colours'
-
+import { DARK_GREY } from '../../utils/colors'
 import CollectionHeaderRow from './CollectionHeaderRow'
 import RoutedSelect from '../RoutedSelect'
 
 const StyledSpan = styled('span')`
-  color: ${GREY_1};
+  color: ${DARK_GREY};
 `
 
 const CollectionSort = ({ sortOptions, totalPages }) => {

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { BLACK, GREY_1 } from 'govuk-colours'
+import { BLACK } from 'govuk-colours'
+import { DARK_GREY } from '../../utils/colors'
 
 const StyledMetaWrapper = styled('div')`
   color: ${BLACK};
 `
 
 const StyledItemLabel = styled('span')`
-  color: ${GREY_1};
+  color: ${DARK_GREY};
 `
 
 function MetadataItem({ label, children }) {


### PR DESCRIPTION
## Description of change

The intent of this PR is make the grey tone in collection list more readable for the users.

## Test instructions

Non functional change.

## Screenshots

### Before

<img width="347" alt="Screenshot 2022-09-26 at 07 55 15" src="https://user-images.githubusercontent.com/105509190/192212211-719f831c-b912-4a6c-b330-c9a18961c2fa.png">


### After

<img width="353" alt="Screenshot 2022-09-26 at 07 54 24" src="https://user-images.githubusercontent.com/105509190/192212089-bdf130aa-f005-48f2-9a77-008846de52f3.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
