### PR TITLE
Remove unnecessary blank space if kind and service labels are missing for Interaction cards 

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
+import styled from 'styled-components'
 
 import { AdviserActivityRenderer } from './card/item-renderers'
 import { ACTIVITY_TYPE } from '../constants'
@@ -83,7 +84,19 @@ export default class Interaction extends React.PureComponent {
       },
     ]
 
-    return (
+    const Row = styled('div')`
+      display: flex;
+    `
+
+    const LeftCol = styled('div')`
+      flex: 75%;
+    `
+
+    const RightCol = styled('div')`
+      flex: 25%;
+    `
+
+    return theme || service ? (
       <ActivityCardWrapper dataTest="interaction-activity">
         <ActivityCardLabels theme={theme} service={service} kind={kind} />
         <ActivityCardSubject>
@@ -93,6 +106,23 @@ export default class Interaction extends React.PureComponent {
         </ActivityCardSubject>
         {serviceNotes && <ActivityCardNotes notes={serviceNotes} />}
         <ActivityCardMetadata metadata={metadata} />
+      </ActivityCardWrapper>
+    ) : (
+      <ActivityCardWrapper dataTest="interaction-activity">
+        <Row>
+          <LeftCol>
+            <ActivityCardSubject>
+              <Link data-test="interaction-subject" href={transformed.url}>
+                {transformed.subject}
+              </Link>
+            </ActivityCardSubject>
+            {serviceNotes && <ActivityCardNotes notes={serviceNotes} />}
+            <ActivityCardMetadata metadata={metadata} />
+          </LeftCol>
+          <RightCol>
+            <ActivityCardLabels kind={kind} />
+          </RightCol>
+        </Row>
       </ActivityCardWrapper>
     )
   }

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.test.jsx
@@ -383,6 +383,64 @@ describe('Interaction activity card', () => {
       })
     })
 
+    context('When the theme and service are missing', () => {
+      beforeEach(() => {
+        buildAndMountActivity(
+          null,
+          null,
+          'Email/Fax',
+          typeInteraction,
+          shortNotes,
+          date
+        )
+        cy.get('[data-test=interaction-activity]').should('exist')
+      })
+
+      it('should not render the theme label', () => {
+        cy.get('[data-test=activity-theme-label]').should('not.exist')
+      })
+
+      it('should not render the service label', () => {
+        cy.get('[data-test=activity-service-label]').should('not.exist')
+      })
+
+      it('should render the kind label', () => {
+        assertKindLabel()
+      })
+
+      it('should render the interaction subject', () => {
+        assertInteractionSubject()
+      })
+
+      it('should render the interaction notes', () => {
+        assertNotes()
+      })
+
+      it('should render the date label', () => {
+        assertText('[data-test=date-label]', 'Date: 25 Nov 2058')
+      })
+
+      it('should render the contact label', () => {
+        assertText('[data-test=contact-s-label]', oneContactText)
+      })
+
+      it('should have the correct link for a contact', () => {
+        cy.get('[data-test=contact-link-0]').should(
+          'have.attr',
+          'href',
+          '/contacts/115b4d96-d2ea-40ff-a01d-812507093a98/details'
+        )
+      })
+
+      it('should render the communication channel label', () => {
+        assertCommunicationChannelLabel()
+      })
+
+      it('should render the advisers label', () => {
+        assertText('[data-test=adviser-s-label]', oneAdviserText)
+      })
+    })
+
     context('When the date is missing', () => {
       beforeEach(() => {
         buildAndMountActivity(


### PR DESCRIPTION
## Description of change

On Interaction cards, currently, if there are no kind and service labels, there is a large blank space where the labels normally would be. This PR removes this unnecessary blank space.

## Test instructions

- Check out this branch
- Visit a company with an Interaction without a kind and service. [RAF Limited ](http://localhost:3000/companies/2dc416eb-19b5-48f1-83a9-928ea66f5c2f/activity) is a good example.
- You shouldn't see a large space

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/83657534/192288674-cee09755-4c0c-47a5-b7df-2d9b3c886842.png)

### After

![image](https://user-images.githubusercontent.com/83657534/192288546-97b3fe5a-7fe1-4f9a-8e5a-764f65b4b633.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
