### PR TITLE
Add `Created by` field to Investment Project details

### DIFF
--- a/src/apps/investments/middleware/__test__/shared.test.js
+++ b/src/apps/investments/middleware/__test__/shared.test.js
@@ -20,6 +20,50 @@ const adviserData = {
   },
 }
 
+const investmentStatus = {
+  company: {
+    name: 'Investor Company ltd.',
+    url: '/companies/6c388e5b-a098-e211-a939-e4115bead28a',
+  },
+  currentStage: {
+    incompleteFields: [],
+    isComplete: false,
+    messages: [],
+    name: 'Prospect',
+  },
+  id: 'f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7',
+  meta: [
+    {
+      label: 'Status',
+      url: '/investments/projects/f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7/status',
+      urlLabel: 'change',
+      value: '',
+    },
+    {
+      label: 'Project code',
+      value: 'DHP-00000003',
+    },
+    {
+      label: 'Valuation',
+      value: 'Not yet valued',
+    },
+    {
+      label: 'Created on',
+      value: '14 Jun 2017, 2:52pm',
+    },
+    {
+      label: 'Created by',
+      value: 'Little Britain',
+    },
+  ],
+  nextStage: {
+    name: 'Assign PM',
+    disabled_on: null,
+    exclude_from_investment_flow: false,
+    id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+  },
+}
+
 const getInvestmentData = (ukCompanyId, clientRelationshipManagerId) => {
   return merge({}, investmentData, {
     uk_company: {
@@ -130,49 +174,7 @@ describe('Investment shared middleware', () => {
         ])
       })
       it('should set investment status on locals', () => {
-        const expectedInvestmentStatus = {
-          company: {
-            name: 'Investor Company ltd.',
-            url: '/companies/6c388e5b-a098-e211-a939-e4115bead28a',
-          },
-          currentStage: {
-            incompleteFields: [],
-            isComplete: false,
-            messages: [],
-            name: 'Prospect',
-          },
-          id: 'f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7',
-          meta: [
-            {
-              label: 'Status',
-              url: '/investments/projects/f22ae6ac-b269-4fe5-aeba-d6a605b9a7a7/status',
-              urlLabel: 'change',
-              value: '',
-            },
-            {
-              label: 'Project code',
-              value: 'DHP-00000003',
-            },
-            {
-              label: 'Valuation',
-              value: 'Not yet valued',
-            },
-            {
-              label: 'Created on',
-              value: '14 Jun 2017, 2:52pm',
-            },
-          ],
-          nextStage: {
-            name: 'Assign PM',
-            disabled_on: null,
-            exclude_from_investment_flow: false,
-            id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
-          },
-        }
-
-        expect(resMock.locals.investmentStatus).to.deep.equal(
-          expectedInvestmentStatus
-        )
+        expect(resMock.locals.investmentStatus).to.deep.equal(investmentStatus)
       })
       it('should set the breadcrumb', () => {
         expect(resMock.breadcrumb).to.be.calledWithExactly(
@@ -183,6 +185,36 @@ describe('Investment shared middleware', () => {
       })
       it('should call next once', () => {
         expect(nextSpy).to.have.been.calledOnce
+      })
+      it('should call next without errors', () => {
+        expect(nextSpy.firstCall.args.length).to.equal(0)
+      })
+    })
+
+    context('when DIT team is not provided', () => {
+      before(async () => {
+        const middleware = createMiddleware(
+          {
+            ...getInvestmentData(null, 3),
+            created_by: {
+              name: 'Andy Pipkin',
+            },
+          },
+          adviserData,
+          companyData
+        )
+
+        await middleware.getInvestmentDetails(reqMock, resMock, nextSpy)
+      })
+
+      it('should set investment status on locals', () => {
+        expect(resMock.locals.investmentStatus).to.deep.equal({
+          ...investmentStatus,
+          meta: investmentStatus.meta.slice(0, -1),
+        })
+      })
+      it('should call next', () => {
+        expect(nextSpy).to.have.been.called
       })
       it('should call next without errors', () => {
         expect(nextSpy.firstCall.args.length).to.equal(0)

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -120,6 +120,10 @@ async function getInvestmentDetails(req, res, next) {
           label: 'Created on',
           value: formatMediumDateTime(investment.created_on),
         },
+        {
+          label: 'Created by',
+          value: investment.created_by.dit_team.name,
+        },
       ],
       company: {
         name: investment.investor_company.name,

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -120,10 +120,14 @@ async function getInvestmentDetails(req, res, next) {
           label: 'Created on',
           value: formatMediumDateTime(investment.created_on),
         },
-        {
-          label: 'Created by',
-          value: investment.created_by.dit_team.name,
-        },
+        ...(investment.created_by?.dit_team?.name
+          ? [
+              {
+                label: 'Created by',
+                value: investment.created_by.dit_team.name,
+              },
+            ]
+          : []),
       ],
       company: {
         name: investment.investor_company.name,

--- a/src/client/components/InvestmentProjectLocalHeader/__stories__/InvestmentProjectLocalHeader.stories.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/__stories__/InvestmentProjectLocalHeader.stories.jsx
@@ -13,6 +13,12 @@ const investment = {
   project_code: 'DHP-00000356',
   value_complete: false,
   created_on: '2022-02-25T15:37:23.331204Z',
+  created_by: {
+    name: 'Andy Pipkin',
+    dit_team: {
+      name: 'Little Britain',
+    },
+  },
   stage: {
     name: 'Prospect',
   },
@@ -143,6 +149,15 @@ storiesOf('InvestmentProjectLocalHeader', module)
       investment={{
         ...investment,
         value_complete: true,
+      }}
+      breadcrumbs={breadcrumbs}
+    />
+  ))
+  .add('Created by: no DIT team', () => (
+    <InvestmentProjectLocalHeader
+      investment={{
+        ...investment,
+        created_by: {},
       }}
       breadcrumbs={breadcrumbs}
     />

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -80,9 +80,11 @@ const InvestmentProjectLocalHeader = ({ investment, breadcrumbs }) => (
       <MetaListItem text="Created on">
         {formatMediumDateTime(investment.created_on)}
       </MetaListItem>
-      <MetaListItem text="Created by">
-        {formatMediumDateTime(investment.created_by.dit_team.name)}
-      </MetaListItem>
+      {investment.created_by?.dit_team?.name && (
+        <MetaListItem text="Created by">
+          {investment.created_by.dit_team.name}
+        </MetaListItem>
+      )}
     </MetaList>
     <ThemeProvider theme={timelineTheme}>
       <Timeline stages={STAGES} currentStage={investment.stage.name} />

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -80,6 +80,9 @@ const InvestmentProjectLocalHeader = ({ investment, breadcrumbs }) => (
       <MetaListItem text="Created on">
         {formatMediumDateTime(investment.created_on)}
       </MetaListItem>
+      <MetaListItem text="Created by">
+        {formatMediumDateTime(investment.created_by.dit_team.name)}
+      </MetaListItem>
     </MetaList>
     <ThemeProvider theme={timelineTheme}>
       <Timeline stages={STAGES} currentStage={investment.stage.name} />

--- a/test/sandbox/fixtures/v3/investment/project.json
+++ b/test/sandbox/fixtures/v3/investment/project.json
@@ -101,6 +101,13 @@
   "archived_on": null,
   "archived_reason": null,
   "archived_by": null,
+  "created_by": {
+    "name": "Andy Pipkin",
+    "contact_email": "andy.pipkin@gov.uk",
+    "dit_team": {
+      "name": "Little Britain"
+    }
+  },
   "created_on": "2017-06-07T10:00:00Z",
   "modified_on": "2017-06-07T10:00:00Z",
   "comments": "",

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -105,6 +105,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-10-08T10:00:00Z",
       "modified_on": "2017-11-08T10:00:00Z",
       "comments": "",
@@ -290,6 +297,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-08-16T10:00:00Z",
       "modified_on": "2017-09-18T13:00:00Z",
       "comments": "",
@@ -494,6 +508,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-08-16T10:00:00Z",
       "modified_on": "2017-09-18T13:00:00Z",
       "comments": "",
@@ -698,6 +719,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-08-05T10:00:00Z",
       "modified_on": "2017-08-05T10:00:00Z",
       "comments": "",
@@ -877,6 +905,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-07-05T10:00:00Z",
       "modified_on": "2017-07-05T10:00:00Z",
       "comments": "",
@@ -1033,6 +1068,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-06-15T10:00:00Z",
       "modified_on": "2017-06-15T15:30:00Z",
       "comments": "",
@@ -1256,6 +1298,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-06-07T10:00:00Z",
       "modified_on": "2017-06-07T10:00:00Z",
       "comments": "",
@@ -1401,6 +1450,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-17T15:12:00Z",
       "modified_on": "2017-06-05T10:00:00Z",
       "comments": "",
@@ -1559,6 +1615,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-17T15:12:00Z",
       "modified_on": "2017-06-05T10:00:00Z",
       "comments": "",
@@ -1731,6 +1794,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -1908,6 +1978,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-03-05T15:00:00Z",
       "comments": "",
@@ -2104,6 +2181,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2016-01-05T15:00:00Z",
       "modified_on": "2016-01-05T19:00:00Z",
       "comments": "",
@@ -2290,6 +2374,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2016-01-05T15:00:00Z",
       "modified_on": "2016-01-05T19:00:00Z",
       "comments": "",
@@ -2476,6 +2567,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2016-01-05T15:00:00Z",
       "modified_on": "2016-01-05T19:00:00Z",
       "comments": "",
@@ -2662,6 +2760,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2016-01-05T15:00:00Z",
       "modified_on": "2016-01-05T19:00:00Z",
       "comments": "",
@@ -2873,6 +2978,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-06-07T10:00:00Z",
       "modified_on": "2017-06-07T10:00:00Z",
       "comments": "",
@@ -3042,6 +3154,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -3230,6 +3349,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -3418,6 +3544,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -3606,6 +3739,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -3794,6 +3934,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-05-05T10:00:00Z",
       "comments": "",
@@ -3968,6 +4115,13 @@
       "archived_on": null,
       "archived_reason": null,
       "archived_by": null,
+      "created_by": {
+        "name": "Andy Pipkin",
+        "contact_email": "andy.pipkin@gov.uk",
+        "dit_team": {
+          "name": "Little Britain"
+        }
+      },
       "created_on": "2017-03-05T12:00:00Z",
       "modified_on": "2017-03-05T15:00:00Z",
       "comments": "",

--- a/test/unit/data/investment/investment-data-account-manager.json
+++ b/test/unit/data/investment/investment-data-account-manager.json
@@ -82,7 +82,14 @@
   "archived_on": null,
   "archived_reason": null,
   "archived_by": null,
-  "created_on": null,
+  "created_by": {
+    "name": "Andy Pipkin",
+    "contact_email": "andy.pipkin@gov.uk",
+    "dit_team": {
+      "name": "Little Britain"
+    }
+  },
+  "created_on": "2017-06-14T14:52:46.618779",
   "modified_on": "2017-06-14T14:52:46.618779",
   "total_investment": "100000",
   "foreign_equity_investment": "50000",

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -108,6 +108,13 @@
   "archived_on": null,
   "archived_reason": null,
   "archived_by": null,
+  "created_by": {
+    "name": "Andy Pipkin",
+    "contact_email": "andy.pipkin@gov.uk",
+    "dit_team": {
+      "name": "Little Britain"
+    }
+  },
   "created_on": "2017-06-14T14:52:46.618779",
   "modified_on": "2017-06-14T14:52:46.618779",
   "total_investment": "100000",


### PR DESCRIPTION
## Description of change

This adds `Created on` field to Investment Project details page.
If DIT team is not available, then `Created on` is not shown.

## Test instructions

After opening investment project details page, you should be able to see name of the team that created it.

## Screenshots

### Before

<img width="807" alt="Screenshot 2022-09-27 at 09 11 00" src="https://user-images.githubusercontent.com/5889630/192471601-085e0795-c553-4de1-8cc6-24df152c8911.png">

### After

<img width="828" alt="Screenshot 2022-09-27 at 09 06 19" src="https://user-images.githubusercontent.com/5889630/192471641-ac44c404-a07a-4168-8584-0789c8905d48.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
