### PR TITLE
Write feature flag names to GTM data layer instead of query params

### DIFF
--- a/docker-compose.mock.yml
+++ b/docker-compose.mock.yml
@@ -13,6 +13,7 @@ services:
       ZEN_TICKETS_URL: http://mock-api:8000/zendesk/tickets
       # Our functional tests still make a real postcode lookup call
       POSTCODE_KEY: ${POSTCODE_KEY}
+      GOOGLE_TAG_MANAGER_KEY: GTM-MOCK
       ACCOUNT_PLAN_URLS: '{"000000001": "/some-test-account-plan-url", "123456789": "/some-other-test-account-plan-url"}'
 
   mock-api:

--- a/src/client/components/CheckUserFeatureFlags/index.jsx
+++ b/src/client/components/CheckUserFeatureFlags/index.jsx
@@ -1,46 +1,46 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+
 import Resource from '../Resource'
+import Analytics from '../Analytics'
 import { ID, TASK_GET_USER_FEATURE_FLAGS } from './state'
 
-/** 
+/**
 This component enables the checking of a particular user feature flag in React.
 It can be used in a react component to conditionally render children or take
 action based on whether the user feature is enabled. e.g.
 
-<CheckUserFeature userFeatureFlagName="my-user-feature">
-{(isFeatureFlagEnabled) 
-  => {isFeatureFlagEnabled && <MyNewComponent />}} 
-</CheckUserFeature />
-
+<CheckUserFeatureFlag userFeatureFlagName="my-user-feature">
+{(isFeatureFlagEnabled)
+  => {isFeatureFlagEnabled && <MyNewComponent />}}
+</CheckUserFeatureFlag />
 */
-export default function CheckUserFeatureFlag({
-  children,
-  userFeatureFlagName,
-}) {
-  const setSearchParams = () => {
-    const url = new URL(window.location)
-    url.searchParams.set('featureTesting', userFeatureFlagName)
-    window.history.replaceState(null, '', url.toString())
-  }
 
-  return (
-    <Resource
-      name={TASK_GET_USER_FEATURE_FLAGS}
-      id={ID}
-      payload={userFeatureFlagName}
-    >
-      {(isFeatureFlagEnabled) => {
-        if (isFeatureFlagEnabled) {
-          setSearchParams()
-        }
-        return children(isFeatureFlagEnabled)
-      }}
-    </Resource>
-  )
-}
-
+const CheckUserFeatureFlag = ({ children, userFeatureFlagName }) => (
+  <Resource
+    name={TASK_GET_USER_FEATURE_FLAGS}
+    id={ID}
+    payload={userFeatureFlagName}
+  >
+    {(isFeatureFlagEnabled) => (
+      <Analytics>
+        {(pushAnalytics) => {
+          isFeatureFlagEnabled &&
+            pushAnalytics({
+              event: 'featureFlag',
+              extra: {
+                name: userFeatureFlagName,
+              },
+            })
+          return children(isFeatureFlagEnabled)
+        }}
+      </Analytics>
+    )}
+  </Resource>
+)
 CheckUserFeatureFlag.propTypes = {
   children: PropTypes.func,
   userFeatureFlagName: PropTypes.string.isRequired,
 }
+
+export default CheckUserFeatureFlag

--- a/src/client/components/CheckUserFeatureFlags/tasks.js
+++ b/src/client/components/CheckUserFeatureFlags/tasks.js
@@ -1,6 +1,6 @@
 import { apiProxyAxios } from '../Task/utils'
 
-const handleError = () => Promise.reject()
+const handleError = (error) => Promise.reject(Error(error.response.data.detail))
 
 export const getUserFeatureFlags = async (userFeatureFlagName) =>
   apiProxyAxios

--- a/src/client/components/PersonalisedDashboard/tasks.js
+++ b/src/client/components/PersonalisedDashboard/tasks.js
@@ -1,5 +1,4 @@
 import { apiProxyAxios } from '../Task/utils'
-
 import { summaryToDataRange } from '../MyInvestmentProjects/transformers'
 
 export const checkForInvestments = ({ adviser }) =>
@@ -14,6 +13,10 @@ export const checkForInvestments = ({ adviser }) =>
       hasInvestmentProjects: !!results.length,
     }))
 
+// This API call doesn't go through the conventional /api-proxy endpoint.
+// Instead, it goes through a another piece of middleware where the path
+// also starts with /api-proxy and requires the env var HELP_CENTRE_API_FEED
+// to be set. The middleware can be found in help-centre-api-proxy.js
 export const checkDataHubFeed = () =>
   apiProxyAxios.get('/api-proxy/help-centre/feed').then(({ data }) => ({
     dataHubFeed: data,

--- a/src/middleware/__test__/user-features.test.js
+++ b/src/middleware/__test__/user-features.test.js
@@ -19,23 +19,25 @@ describe('user-features middleware', () => {
     next = sinon.spy()
   })
 
-  describe('when the flag is actives for the user', () => {
-    it('redirects to url with featuretesting param', () => {
+  describe('when the flag is active for the user', () => {
+    it('sets isFeatureTesting to true', () => {
       res.locals.userFeatures = [featureFlagName]
       userFeatures(featureFlagName)(req, res, next)
-      expect(res.redirect).to.have.been.calledWith(
-        `?featureTesting=${featureFlagName}`
-      )
+      expect(res.locals.userFeatureGTMEvent).to.deep.equal({
+        name: featureFlagName,
+        event: 'featureFlag',
+      })
       expect(res.locals.isFeatureTesting).to.be.true
+      expect(next).to.have.been.called
     })
   })
 
   describe('when the flag is not active for the user', () => {
-    it('redirects to url with featuretesting param', () => {
+    it('sets isFeatureTesting to false', () => {
       userFeatures(featureFlagName)(req, res, next)
-      expect(res.redirect).to.not.have.been.called
-      expect(next).to.have.been.called
+      expect(res.locals.userFeatureGTMEvent).to.be.undefined
       expect(res.locals.isFeatureTesting).to.be.false
+      expect(next).to.have.been.called
     })
   })
 })

--- a/src/templates/_includes/google-tag-manager-snippet.njk
+++ b/src/templates/_includes/google-tag-manager-snippet.njk
@@ -1,15 +1,22 @@
 {% if GOOGLE_TAG_MANAGER_KEY %}
 <script>
- dataLayer = [{
-    'userId': '{{user.id}}',
-    'userUserId': '{{user.userId}}'
-  }];
-  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
-    var f=d.getElementsByTagName(s)[0],
-        j=d.createElement(s),
-        dl=l!='dataLayer'?'&l='+l:'';
-    j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
-    f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER_KEY }}');
+window.dataLayer = window.dataLayer || []
+window.dataLayer.push({
+  userId: '{{user.id}}',
+  userUserId: '{{user.userId}}',
+})
+if ('{{userFeatureGTMEvent}}') {
+  window.dataLayer.push({
+    name: '{{userFeatureGTMEvent.name}}',
+    event: '{{userFeatureGTMEvent.event}}',
+  })
+}
+(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});
+  var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),
+      dl=l!='dataLayer'?'&l='+l:'';
+  j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+  f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','{{ GOOGLE_TAG_MANAGER_KEY }}');
 </script>
 {% endif %}

--- a/test/component/cypress/specs/CheckUserFeatureFlags.test.jsx
+++ b/test/component/cypress/specs/CheckUserFeatureFlags.test.jsx
@@ -4,10 +4,6 @@ import DataHubProvider from './provider'
 import CheckUserFeatureFlag from '../../../../src/client/components/CheckUserFeatureFlags'
 import { TASK_GET_USER_FEATURE_FLAGS } from '../../../../src/client/components/CheckUserFeatureFlags/state'
 import { getUserFeatureFlags } from '../../../../src/client/components/CheckUserFeatureFlags/tasks'
-import {
-  assertNotQueryParams,
-  assertQueryParams,
-} from '../../../functional/cypress/support/assertions'
 
 describe('CheckUserFeatureFlags', () => {
   const Component = ({ userFeatureFlagName }) => (
@@ -43,10 +39,6 @@ describe('CheckUserFeatureFlags', () => {
     it('should pass false to its children', () => {
       cy.contains('feature flag is not enabled')
     })
-
-    it('should not set the flag in the url', () => {
-      assertNotQueryParams('featureTesting', disabledFlag)
-    })
   })
 
   context('when the feature flag is enabled', () => {
@@ -56,10 +48,6 @@ describe('CheckUserFeatureFlags', () => {
 
     it('should pass true to the children', () => {
       cy.contains('feature flag is enabled')
-    })
-
-    it('should set the flag in the url', () => {
-      assertQueryParams('featureTesting', enabledFlag)
     })
   })
 })

--- a/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/feature-flag-spec.js
@@ -8,14 +8,9 @@ describe('Dashboard - feature flag', () => {
       cy.resetUser()
       cy.visit('/')
     })
+
     it('should show the default dashboard layout', () => {
       cy.get('[data-test="dashboard"]').should('not.exist')
-    })
-    it('should NOT append a query param for GA tracking', () => {
-      cy.url('[data-test="dashboard"]').should(
-        'not.contain',
-        '?featureTesting=personalised-dashboard'
-      )
     })
   })
 
@@ -24,14 +19,21 @@ describe('Dashboard - feature flag', () => {
       cy.setUserFeatures(['personalised-dashboard'])
       cy.visit('/')
     })
+
     it('should show an alternative layout', () => {
       cy.get('[data-test="dashboard"]').should('be.visible')
     })
-    it('should append a query param for GA tracking', () => {
-      cy.url('[data-test="dashboard"]').should(
-        'contain',
-        '?featureTesting=personalised-dashboard'
-      )
+
+    it('should write to the GTM data layer', () => {
+      cy.window().then((win) => {
+        const data = win.dataLayer.find(
+          ({ name }) => name === 'personalised-dashboard'
+        )
+        expect(data).to.deep.equal({
+          name: 'personalised-dashboard',
+          event: 'featureFlag',
+        })
+      })
     })
   })
 
@@ -46,13 +48,6 @@ describe('Dashboard - feature flag', () => {
 
     it('should show an alternative layout', () => {
       cy.get('[data-test="dashboard"]').should('be.visible')
-    })
-
-    it('should maintain the query param for GA tracking', () => {
-      cy.url('[data-test="dashboard"]').should(
-        'contain',
-        'company-lists?featureTesting=personalised-dashboard'
-      )
     })
   })
 })

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -462,13 +462,13 @@ describe('events Collections Filter', () => {
     context('Event name', () => {
       const element = '[data-test="event-name-filter"]'
       const eventName = 'Big Event'
-      const queryParamWithName = 'name=Big+Event'
+      const queryParamWithName = qs.stringify({ name: 'Big Event' })
 
       context('should filter from user input', () => {
         before(() => {
           cy.intercept(
             'GET',
-            `${urls.events.activity.data()}?sortBy=modified_on:desc&name=Big+Event&page=1`
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1`
           ).as('nameRequest')
         })
 
@@ -492,7 +492,7 @@ describe('events Collections Filter', () => {
       context('should filter from url', () => {
         it('should add name from url to filter', () => {
           cy.visit(
-            `/events?page=1&sortby=modified_on%3Adesc&featureTesting=user-activity-stream-aventri&${queryParamWithName}`
+            `/events?page=1&sortby=modified_on%3Adesc&${queryParamWithName}`
           )
           cy.get(element).should('have.value', eventName)
         })
@@ -560,7 +560,7 @@ describe('events Collections Filter', () => {
       context('should filter from url', () => {
         it('should add the earliest and latest start date to the url', () => {
           cy.visit(
-            `/events?page=1&sortby=modified_on%3Adesc&featureTesting=user-activity-stream-aventri&${queryParamWithEarliestStartDate}&${queryParamWithLatestStartDate}`
+            `/events?page=1&sortby=modified_on%3Adesc&${queryParamWithEarliestStartDate}&${queryParamWithLatestStartDate}`
           )
           cy.get(earliestStartElement).should('have.value', earliestStartDate)
           cy.get(latestStartElement).should('have.value', latestStartDate)
@@ -622,7 +622,7 @@ describe('events Collections Filter', () => {
       context('should filter from url', () => {
         it('should add aventri id from url to filter', () => {
           cy.visit(
-            `events?page=1&sortby=modified_on%3Adesc&featureTesting=user-event-activities&${queryParamWithAventriId}`
+            `events?page=1&sortby=modified_on%3Adesc&${queryParamWithAventriId}`
           )
           cy.get(element).should('have.value', aventriId)
         })


### PR DESCRIPTION
## Description of change

At present we have two implementations that check if a specific user has a feature flag enabled allowing them to view a new feature. One of the implementations is express middleware, the other implementation is a react component.
Both make an API call to the `/whoami` endpoint to ascertain if the current feature flag name is present in the user's `active_features` list (set within Django), if so, a flag is set to `true` and the new feature is displayed to the user, the feature flag name is also added to the end of the URL as query params for Google Analytics (GA) purposes.

Both work well, independently of one another. However, they don't work well together as the react component overwrites the query params that have been set by the express middleware (the original implementation). For example, if the user wants the new dashboard (page level) then the express middleware will manage that and adds the query params `featureTesting=personalised-dashboard`. If we want to test a new reminders summary component on the new dashboard (component level) then the react implementation manages that and adds the query params `featureTesting=reminders-summary` inadvertently overwriting the existing query param, as a consequence GA reporting becomes skewed.

**Rather than polluting the end of the URL with additional query params, as they tend to be quite long, we can simply push the feature flag name along with an event name `feaureFlag` to the Google Tag Manager data layer for both implementations, ensuring they both work in harmony, ensuring a cleaner URL and correct GA reporting.**

Once we have a Single Page Application (SPA) at some point in the future then the express middleware function would become redundant.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
