### PR TITLE
Add country filter to new events collection page

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -635,6 +635,39 @@ describe('Activity feed controllers', () => {
         expect(expectedQuery(transformedAventriId)).to.deep.equal(actualQuery)
       })
     })
+
+    context('check query builder when filtering on country', () => {
+      const expectedQuery = (addressCountry) => [
+        {
+          terms: {
+            'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+          },
+        },
+        {
+          bool: {
+            should: [
+              {
+                terms: {
+                  'object.dit:address_country.name': addressCountry,
+                },
+              },
+              {
+                terms: {
+                  'object.dit:aventri:location_country': addressCountry,
+                },
+              },
+            ],
+          },
+        },
+      ]
+
+      it('builds the right query when a country is selected', () => {
+        const addressCountry = ['Canada']
+        const actualQuery = eventsColListQueryBuilder({ addressCountry })
+
+        expect(expectedQuery(addressCountry)).to.deep.equal(actualQuery)
+      })
+    })
   })
 
   describe('#fetchAllActivityFeedEvents', () => {
@@ -662,6 +695,7 @@ describe('Activity feed controllers', () => {
             latestStartDate: '2020-11-10',
             page: 1,
             aventriId: 123456789,
+            addressCountry: ['Canada', 'United Kingdom'],
           },
         })
 
@@ -679,6 +713,7 @@ describe('Activity feed controllers', () => {
         const earliestStartDate = '2020-11-01'
         const latestStartDate = '2020-11-10'
         const transformedAventriId = 'dit:aventri:Event:123456789:Create'
+        const addressCountry = ['Canada', 'United Kingdom']
 
         const expectedEsQuery = {
           from,
@@ -707,6 +742,22 @@ describe('Activity feed controllers', () => {
                 {
                   term: {
                     id: transformedAventriId,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        terms: {
+                          'object.dit:address_country.name': addressCountry,
+                        },
+                      },
+                      {
+                        terms: {
+                          'object.dit:aventri:location_country': addressCountry,
+                        },
+                      },
+                    ],
                   },
                 },
               ],

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -404,6 +404,7 @@ const eventsColListQueryBuilder = ({
   earliestStartDate,
   latestStartDate,
   aventriId,
+  addressCountry,
 }) => {
   const eventNameFilter = name
     ? {
@@ -425,6 +426,25 @@ const eventsColListQueryBuilder = ({
         }
       : null
 
+  const countryFilter = addressCountry
+    ? {
+        bool: {
+          should: [
+            {
+              terms: {
+                'object.dit:address_country.name': addressCountry,
+              },
+            },
+            {
+              terms: {
+                'object.dit:aventri:location_country': addressCountry,
+              },
+            },
+          ],
+        },
+      }
+    : null
+
   const aventriIdFilter = aventriId
     ? {
         term: {
@@ -433,7 +453,12 @@ const eventsColListQueryBuilder = ({
       }
     : null
 
-  const filtersArray = [eventNameFilter, dateFilter, aventriIdFilter]
+  const filtersArray = [
+    eventNameFilter,
+    dateFilter,
+    aventriIdFilter,
+    countryFilter,
+  ]
 
   const cleansedFiltersArray = filtersArray.filter((filter) => filter)
 
@@ -450,6 +475,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       latestStartDate,
       aventriId,
       page,
+      addressCountry,
     } = req.query
 
     const from = (page - 1) * ACTIVITIES_PER_PAGE
@@ -462,6 +488,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
           earliestStartDate,
           latestStartDate,
           aventriId,
+          addressCountry,
         }),
         from,
         size: ACTIVITIES_PER_PAGE,

--- a/src/client/components/RoutedInput/index.jsx
+++ b/src/client/components/RoutedInput/index.jsx
@@ -25,7 +25,7 @@ const RoutedInput = ({
   id,
   type,
   maxLength,
-  isAventriIdfilter,
+  isAventriIdFilter,
   ...props
 }) => {
   // This is the only way we can reset the value when the query string param is
@@ -59,7 +59,7 @@ const RoutedInput = ({
             {...props}
             value={value}
             type={type}
-            onInput={isAventriIdfilter ? maxLengthAventriIdValidation : null}
+            onInput={isAventriIdFilter ? maxLengthAventriIdValidation : null}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
@@ -79,11 +79,11 @@ RoutedInput.propTypes = {
   qsParam: PropTypes.string.isRequired,
   type: PropTypes.string,
   maxLength: PropTypes.number,
-  isAventriIdfilter: PropTypes.bool,
+  isAventriIdFilter: PropTypes.bool,
 }
 
 RoutedInput.defaultProps = {
-  isAventriIdfilter: false,
+  isAventriIdFilter: false,
 }
 
 export default multiInstance({

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -36,7 +36,7 @@ const RoutedTypeahead = ({
   loadOptions,
   noOptionsMessage,
   options,
-  isDataHubAndAventriFilter,
+  labelAsQueryParam,
   ...props
 }) => (
   <Route>
@@ -61,7 +61,7 @@ const RoutedTypeahead = ({
               history.push({
                 search: qs.stringify({
                   ...qsParams,
-                  ...(!isDataHubAndAventriFilter
+                  ...(!labelAsQueryParam
                     ? getParamIds(qsParam, pickedOptions)
                     : getParamLabels(qsParam, pickedOptions)),
                   page: 1,
@@ -78,10 +78,10 @@ const RoutedTypeahead = ({
 RoutedTypeahead.propTypes = {
   name: PropTypes.string.isRequired,
   qsParam: PropTypes.string.isRequired,
-  isDataHubAndAventriFilter: PropTypes.bool,
+  labelAsQueryParam: PropTypes.bool,
 }
 
 RoutedTypeahead.defaultProps = {
-  isDataHubAndAventriFilter: false,
+  labelAsQueryParam: false,
 }
 export default RoutedTypeahead

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -20,6 +20,10 @@ const getParamIds = (qsParam, pickedOptions) => ({
   [qsParam]: pickedOptions ? pickedOptions.map(({ value }) => value) : [],
 })
 
+const getParamLabels = (qsParam, pickedOptions) => ({
+  [qsParam]: pickedOptions ? pickedOptions.map(({ label }) => label) : [],
+})
+
 const RoutedTypeahead = ({
   name,
   qsParam,
@@ -32,6 +36,7 @@ const RoutedTypeahead = ({
   loadOptions,
   noOptionsMessage,
   options,
+  isDataHubAndAventriFilter,
   ...props
 }) => (
   <Route>
@@ -56,7 +61,9 @@ const RoutedTypeahead = ({
               history.push({
                 search: qs.stringify({
                   ...qsParams,
-                  ...getParamIds(qsParam, pickedOptions),
+                  ...(!isDataHubAndAventriFilter
+                    ? getParamIds(qsParam, pickedOptions)
+                    : getParamLabels(qsParam, pickedOptions)),
                   page: 1,
                 }),
               })
@@ -71,6 +78,10 @@ const RoutedTypeahead = ({
 RoutedTypeahead.propTypes = {
   name: PropTypes.string.isRequired,
   qsParam: PropTypes.string.isRequired,
+  isDataHubAndAventriFilter: PropTypes.bool,
 }
 
+RoutedTypeahead.defaultProps = {
+  isDataHubAndAventriFilter: false,
+}
 export default RoutedTypeahead

--- a/src/client/modules/Events/CollectionList/constants.js
+++ b/src/client/modules/Events/CollectionList/constants.js
@@ -6,6 +6,9 @@ export const LABELS = {
   country: 'Country',
   ukRegion: 'UK region',
   eventType: 'Type of event',
+  earliestStartDate: 'Earliest start date',
+  latestStartDate: 'Latest start date',
+  aventriId: 'Aventri ID',
 }
 
 export const SORT_OPTIONS = [

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -210,20 +210,20 @@ const EventsCollection = ({
                   data-test="event-name-filter"
                 />
                 <Filters.Date
-                  label="Earliest start date"
+                  label={LABELS.earliestStartDate}
                   name="earliest_start_date"
                   qsParamName="earliest_start_date"
                   data-test="earliest-start-date-filter"
                 />
                 <Filters.Date
-                  label="Latest start date"
+                  label={LABELS.latestStartDate}
                   name="latest_start_date"
                   qsParamName="latest_start_date"
                   data-test="latest-start-date-filter"
                 />
                 <Filters.AventriId
                   id="EventsCollection.aventriId"
-                  label="Aventri ID"
+                  label={LABELS.aventriId}
                   name="aventri_id"
                   qsParam="aventri_id"
                   hintText="For example, 100100100"
@@ -241,38 +241,7 @@ const EventsCollection = ({
                   options={optionMetadata.countryOptions}
                   selectedOptions={selectedFilters.countries.options}
                   data-test="country-filter"
-                  isDataHubAndAventriFilter={true}
-                />
-                <Filters.Typeahead
-                  isMulti={true}
-                  label={LABELS.ukRegion}
-                  name="uk_region"
-                  qsParam="uk_region"
-                  placeholder="Search UK region"
-                  options={optionMetadata.ukRegionOptions}
-                  selectedOptions={selectedFilters.ukRegions.options}
-                  data-test="uk-region-filter"
-                />
-                <Filters.CheckboxGroup
-                  maxScrollHeight={345}
-                  legend={LABELS.eventType}
-                  name="event_type"
-                  qsParam="event_type"
-                  options={optionMetadata.eventTypeOptions}
-                  selectedOptions={selectedFilters.eventTypes.options}
-                  data-test="event-type-filter"
-                  groupId="event-type-filter"
-                />
-                <Filters.AdvisersTypeahead
-                  isMulti={true}
-                  taskProps={organisersTask}
-                  label={LABELS.organiser}
-                  name="organiser"
-                  qsParam="organiser"
-                  placeholder="Search organiser"
-                  noOptionsMessage="No organisers found"
-                  selectedOptions={selectedFilters.organisers.options}
-                  data-test="organiser-filter"
+                  labelAsQueryParam={true}
                 />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -200,7 +200,7 @@ const EventsCollection = ({
               total={total}
               addItemURL={'/events/create'}
             >
-              <CollectionFilters>
+              <CollectionFilters taskProps={collectionListMetadataTask}>
                 <Filters.Input
                   id="EventsCollection.name"
                   qsParam="name"
@@ -232,6 +232,47 @@ const EventsCollection = ({
                   isAventriIdfilter={true}
                   data-test="aventri-id-filter"
                 />
+                <Filters.Typeahead
+                  isMulti={true}
+                  label={LABELS.country}
+                  name="address_country"
+                  qsParam="address_country"
+                  placeholder="Search country"
+                  options={optionMetadata.countryOptions}
+                  selectedOptions={selectedFilters.countries.options}
+                  data-test="country-filter"
+                />
+                {/* <Filters.Typeahead
+                  isMulti={true}
+                  label={LABELS.ukRegion}
+                  name="uk_region"
+                  qsParam="uk_region"
+                  placeholder="Search UK region"
+                  options={optionMetadata.ukRegionOptions}
+                  selectedOptions={selectedFilters.ukRegions.options}
+                  data-test="uk-region-filter"
+                />
+                <Filters.CheckboxGroup
+                  maxScrollHeight={345}
+                  legend={LABELS.eventType}
+                  name="event_type"
+                  qsParam="event_type"
+                  options={optionMetadata.eventTypeOptions}
+                  selectedOptions={selectedFilters.eventTypes.options}
+                  data-test="event-type-filter"
+                  groupId="event-type-filter"
+                />
+                <Filters.AdvisersTypeahead
+                  isMulti={true}
+                  taskProps={organisersTask}
+                  label={LABELS.organiser}
+                  name="organiser"
+                  qsParam="organiser"
+                  placeholder="Search organiser"
+                  noOptionsMessage="No organisers found"
+                  selectedOptions={selectedFilters.organisers.options}
+                  data-test="organiser-filter"
+                /> */}
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>
           )

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -241,6 +241,7 @@ const EventsCollection = ({
                   options={optionMetadata.countryOptions}
                   selectedOptions={selectedFilters.countries.options}
                   data-test="country-filter"
+                  isDataHubAndAventriFilter={true}
                 />
                 <Filters.Typeahead
                   isMulti={true}

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -229,7 +229,7 @@ const EventsCollection = ({
                   hintText="For example, 100100100"
                   type="number"
                   maxLength={9}
-                  isAventriIdfilter={true}
+                  isAventriIdFilter={true}
                   data-test="aventri-id-filter"
                 />
                 <Filters.Typeahead

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -242,7 +242,7 @@ const EventsCollection = ({
                   selectedOptions={selectedFilters.countries.options}
                   data-test="country-filter"
                 />
-                {/* <Filters.Typeahead
+                <Filters.Typeahead
                   isMulti={true}
                   label={LABELS.ukRegion}
                   name="uk_region"
@@ -272,7 +272,7 @@ const EventsCollection = ({
                   noOptionsMessage="No organisers found"
                   selectedOptions={selectedFilters.organisers.options}
                   data-test="organiser-filter"
-                /> */}
+                />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>
           )

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -56,9 +56,6 @@ const getAllActivityFeedEvents = ({
   latest_start_date,
   aventri_id,
   address_country,
-  uk_region,
-  event_type,
-  organiser,
   page,
 }) =>
   axios
@@ -71,9 +68,6 @@ const getAllActivityFeedEvents = ({
         aventriId: aventri_id,
         page: page,
         addressCountry: address_country,
-        ukRegion: uk_region,
-        eventType: event_type,
-        organiser: organiser,
       },
     })
     .then(({ data }) => data)

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -55,6 +55,10 @@ const getAllActivityFeedEvents = ({
   earliest_start_date,
   latest_start_date,
   aventri_id,
+  address_country,
+  uk_region,
+  event_type,
+  organiser,
   page,
 }) =>
   axios
@@ -66,6 +70,10 @@ const getAllActivityFeedEvents = ({
         latestStartDate: latest_start_date,
         aventriId: aventri_id,
         page: page,
+        addressCountry: address_country,
+        ukRegion: uk_region,
+        eventType: event_type,
+        organiser: organiser,
       },
     })
     .then(({ data }) => data)

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -594,14 +594,14 @@ describe('events Collections Filter', () => {
             expect(request.response.statusCode).to.eql(200)
           })
         })
-      })
 
-      context('should filter from user input', () => {
         it('should add an aventri ID from user input to query param', () => {
           cy.get(element).type(`${aventriId}{enter}`)
           cy.url().should('include', queryParamWithAventriId)
         })
+      })
 
+      context('should apply validation', () => {
         it('should not add anything to the query param if the name is backspaced', () => {
           cy.get(element).type(`{selectAll}{backspace}{enter}`)
           cy.url().should('not.include', queryParamWithAventriId)
@@ -625,6 +625,57 @@ describe('events Collections Filter', () => {
             `events?page=1&sortby=modified_on%3Adesc&featureTesting=user-event-activities&${queryParamWithAventriId}`
           )
           cy.get(element).should('have.value', aventriId)
+        })
+      })
+
+      after(() => {
+        cy.get(element).clear()
+      })
+    })
+
+    context('Country', () => {
+      const element = '[data-test="country-filter"]'
+      const queryParamWithCountry = 'address_country%5B0%5D=Brazil'
+      const countryName = 'Brazil'
+
+      context('should filter from user input and apply filter chips', () => {
+        before(() => {
+          cy.intercept(
+            'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1&addressCountry[]=${countryName}`
+          ).as('countryRequest')
+        })
+
+        it('should pass the country to the controller', () => {
+          testTypeahead({
+            element,
+            label: 'Country',
+            input: 'braz',
+            placeholder: 'Search country',
+            expectedOption: 'Brazil',
+          })
+
+          cy.wait('@countryRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
+        it('should pass the country from user input to query param', () => {
+          cy.url().should('include', queryParamWithCountry)
+        })
+
+        it('should show filter chips', () => {
+          cy.get('[data-test="typeahead-chip"]').should('contain', countryName)
+        })
+      })
+
+      context('should remove country selection', () => {
+        it('should remove filter chips', () => {
+          cy.get('[data-test="typeahead-chip"] > button').click()
+        })
+
+        it('should remove the country from the url', () => {
+          cy.url().should('not.include', queryParamWithCountry)
         })
       })
     })


### PR DESCRIPTION
## Description of change

Part of the work to rebuild the new events collection page.
The country filter has been added - this filters on data hub and aventri events.

## Test instructions
- In Django dev API, add the user feature flag `user-activity-stream-aventri` to your adviser profile and point your frontend towards the dev API.
- Checkout this branch and try out the new country filter on `/events` page

## Screenshots

### Before
No country filter visible. 

### After
![image](https://user-images.githubusercontent.com/70902973/193056141-a6759375-6ecb-4ed4-8e8b-f26a0e7501b1.png)

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
