### PR TITLE
Use main branch for API containers

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -5,7 +5,7 @@ services:
       - api
 
   api:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:develop
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
     env_file: .env
     environment:
       DEBUG: 'False'
@@ -28,7 +28,7 @@ services:
     command: /app/setup-uat.sh || echo "all good"
 
   celery:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:develop
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
     env_file: .env
     depends_on:
       - postgres
@@ -38,7 +38,7 @@ services:
     command: celery -A config worker -l info -Q celery -B
 
   rq:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:develop
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
     env_file: .env
     depends_on:
       - postgres


### PR DESCRIPTION
## Description of change

Since we are no longer using `develop` branch for API, the containers used for end to end tests should be using `main` tag rather than `develop` as it is now outdated.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
