### PR TITLE
Refactoring aventri id filter validation

### DIFF
--- a/src/client/components/RoutedInput/index.jsx
+++ b/src/client/components/RoutedInput/index.jsx
@@ -24,8 +24,6 @@ const RoutedInput = ({
   staticContext,
   id,
   type,
-  maxLength,
-  isAventriIdFilter,
   ...props
 }) => {
   // This is the only way we can reset the value when the query string param is
@@ -35,12 +33,6 @@ const RoutedInput = ({
       reset()
     }
   }, [selectedValue, qsValue])
-
-  const maxLengthAventriIdValidation = (e) => {
-    if (e.target.value.length > maxLength) {
-      e.target.value = e.target.value.slice(0, maxLength)
-    }
-  }
 
   return (
     <Route>
@@ -59,7 +51,6 @@ const RoutedInput = ({
             {...props}
             value={value}
             type={type}
-            onInput={isAventriIdFilter ? maxLengthAventriIdValidation : null}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
@@ -78,12 +69,6 @@ const RoutedInput = ({
 RoutedInput.propTypes = {
   qsParam: PropTypes.string.isRequired,
   type: PropTypes.string,
-  maxLength: PropTypes.number,
-  isAventriIdFilter: PropTypes.bool,
-}
-
-RoutedInput.defaultProps = {
-  isAventriIdFilter: false,
 }
 
 export default multiInstance({

--- a/src/client/modules/Events/CollectionList/constants.js
+++ b/src/client/modules/Events/CollectionList/constants.js
@@ -11,6 +11,8 @@ export const LABELS = {
   aventriId: 'Aventri ID',
 }
 
+export const AVENTRI_ID_MAX_LENGTH = 9
+
 export const SORT_OPTIONS = [
   {
     name: 'Event name A-Z',

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -24,7 +24,11 @@ import {
   ToggleHeadingPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
-import { LABELS, COLLECTION_LIST_SORT_SELECT_OPTIONS } from './constants'
+import {
+  LABELS,
+  COLLECTION_LIST_SORT_SELECT_OPTIONS,
+  AVENTRI_ID_MAX_LENGTH,
+} from './constants'
 
 import {
   ID,
@@ -92,6 +96,12 @@ const EventsCollection = ({
       payload: payload,
       onSuccessDispatch: EVENTS__ALL_ACTIVITY_FEED_EVENTS_LOADED,
     },
+  }
+
+  const maxLengthAventriIdValidation = (e) => {
+    if (e.target.value.length > AVENTRI_ID_MAX_LENGTH) {
+      e.target.value = e.target.value.slice(0, AVENTRI_ID_MAX_LENGTH)
+    }
   }
 
   return (
@@ -228,8 +238,7 @@ const EventsCollection = ({
                   qsParam="aventri_id"
                   hintText="For example, 100100100"
                   type="number"
-                  maxLength={9}
-                  isAventriIdFilter={true}
+                  onInput={maxLengthAventriIdValidation}
                   data-test="aventri-id-filter"
                 />
                 <Filters.Typeahead


### PR DESCRIPTION
## Description of change

Moving the aventri id filter validation out from the routed input component to the events collection list level, and then passing the validation callback function in as props. 

This is because ideally we don't want field specific props on a shared component. 

## Test instructions
(No functionality change to [original aventri id filter PR](https://github.com/uktrade/data-hub-frontend/pull/4904))
- In Django dev API, add the user feature flag user-event-activities to your adviser profile.
- Bring up this branch on your local dev frontend and navigate to http://localhost:3000/events
- You should see an 'Aventri ID' filter on the left hand side.
- It should only allow you to input numbers, and it should not let you type more than 9 digits. 

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
