### PR TITLE
Consolidate StyledSectionHeader instances into a single component

### DIFF
--- a/src/client/components/ArchiveForm/index.jsx
+++ b/src/client/components/ArchiveForm/index.jsx
@@ -1,20 +1,13 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
 import { BLACK, GREY_3 } from 'govuk-colours'
 import Button from '@govuk-react/button'
-import { typography } from '@govuk-react/lib'
-import { SPACING } from '@govuk-react/constants'
 import { kebabCase } from 'lodash'
 
-import { FieldRadios, FieldInput } from '..'
+import { FieldRadios, FieldInput, SectionHeader } from '..'
 
 import Form from '../Form'
 
-const StyledSectionHeader = styled('div')`
-  ${typography.font({ size: 24, weight: 'bold' })};
-  margin-bottom: ${SPACING.SCALE_4};
-`
 const buttonText = 'Archive'
 
 const buildOptions = (type, options) => {
@@ -58,9 +51,7 @@ const ArchiveForm = ({
 
   return (
     <div data-test={kebabCase(`archive-${type}-container`)}>
-      <StyledSectionHeader data-test="archive-heading">
-        Archive {type}
-      </StyledSectionHeader>
+      <SectionHeader type="archive">Archive {type}</SectionHeader>
 
       <p data-test="archive-hint">
         Archive this {type} if it is no longer required or active.

--- a/src/client/components/DocumentsSection/index.jsx
+++ b/src/client/components/DocumentsSection/index.jsx
@@ -1,22 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
-import { SPACING } from '@govuk-react/constants'
-import { typography } from '@govuk-react/lib'
 
-import NewWindowLink from '../NewWindowLink'
-
-const StyledSectionHeader = styled('div')`
-  ${typography.font({ size: 24, weight: 'bold' })};
-  margin-bottom: ${SPACING.SCALE_4};
-`
+import { NewWindowLink, SectionHeader } from '../../components'
 
 const DocumentsSection = ({ fileBrowserRoot, documentPath }) => {
   return (
     <>
-      <StyledSectionHeader data-test="document-heading">
-        Documents
-      </StyledSectionHeader>
+      <SectionHeader type="document">Documents</SectionHeader>
       {documentPath ? (
         <NewWindowLink
           href={fileBrowserRoot + documentPath}

--- a/src/client/components/SectionHeader/index.jsx
+++ b/src/client/components/SectionHeader/index.jsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+import { typography } from '@govuk-react/lib'
+import { kebabCase } from 'lodash'
+
+const StyledSectionHeader = styled('div')`
+  ${typography.font({ size: 24, weight: 'bold' })};
+  margin-bottom: ${SPACING.SCALE_4};
+`
+
+const SectionHeader = ({ type, children }) => (
+  <StyledSectionHeader data-test={kebabCase(`${type}-header`)}>
+    {children}
+  </StyledSectionHeader>
+)
+
+SectionHeader.propTypes = {
+  type: PropTypes.string.isRequired,
+  children: PropTypes.string.isRequired,
+}
+
+export default SectionHeader

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -87,3 +87,4 @@ export { default as InvestmentProjectLocalHeader } from './InvestmentProjectLoca
 export { default as Filters } from './Filters'
 export { default as ContactLocalHeader } from './ContactLocalHeader'
 export { default as SearchLocalHeader } from './SearchLocalHeader'
+export { default as SectionHeader } from './SectionHeader'

--- a/src/client/modules/Contacts/ContactActivity/ContactActivity.jsx
+++ b/src/client/modules/Contacts/ContactActivity/ContactActivity.jsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
-import { SPACING } from '@govuk-react/constants'
 import { GridRow, GridCol } from 'govuk-react'
-import { typography } from '@govuk-react/lib'
 
 import { TASK_GET_CONTACT_ACTIVITIES, ID, state2props } from './state'
 import { CONTACTS__ACTIVITIES_LOADED } from '../../../actions'
@@ -13,15 +10,11 @@ import {
   CollectionHeader,
   CollectionSort,
   RoutedPagination,
+  SectionHeader,
 } from '../../../components'
 import { ACTIVITIES_PER_PAGE } from '../../../../apps/contacts/constants'
 import { CONTACT_ACTIVITY_SORT_SELECT_OPTIONS } from '../../../../apps/companies/apps/activity-feed/constants'
 import ActivityList from '../../../components/ActivityFeed/activities/card/ActivityList'
-
-const StyledSectionHeader = styled('div')`
-  ${typography.font({ size: 24, weight: 'bold' })};
-  margin-bottom: ${SPACING.SCALE_4};
-`
 
 const ContactActivity = ({
   contactId,
@@ -35,7 +28,7 @@ const ContactActivity = ({
   return (
     <GridRow>
       <GridCol setWidth="full">
-        <StyledSectionHeader>Contact activity</StyledSectionHeader>
+        <SectionHeader type="contact-activity">Contact activity</SectionHeader>
 
         <p>
           An activity could include a meeting, call, email, event or other

--- a/src/client/modules/Contacts/ContactAuditHistory/ContactAuditHistory.jsx
+++ b/src/client/modules/Contacts/ContactAuditHistory/ContactAuditHistory.jsx
@@ -1,9 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
-import { SPACING } from '@govuk-react/constants'
-import { typography } from '@govuk-react/lib'
 
 import ContactAuditHistoryResource from '../../../components/Resource/ContactAuditHistory'
 import { transformResponseToCollection } from './transformers'
@@ -12,13 +9,9 @@ import {
   CollectionList,
   CollectionSort,
   RoutedPagination,
+  SectionHeader,
 } from '../../../components'
 import { state2props } from './state'
-
-const StyledSectionHeader = styled('div')`
-  ${typography.font({ size: 24, weight: 'bold' })};
-  margin-bottom: ${SPACING.SCALE_4};
-`
 
 function getTotalPages(totalItems, pageSize) {
   return Math.ceil(totalItems / pageSize)
@@ -35,9 +28,7 @@ const ContactAuditHistory = ({ contactId, page = 1, pageSize = 10 }) => (
   >
     {(contactAuditHistory) => (
       <>
-        <StyledSectionHeader data-test="audit-heading">
-          Audit history
-        </StyledSectionHeader>
+        <SectionHeader type="audit">Audit history</SectionHeader>
         <CollectionHeader
           totalItems={contactAuditHistory.count}
           collectionName="result"

--- a/test/functional/cypress/specs/contacts/audit-spec.js
+++ b/test/functional/cypress/specs/contacts/audit-spec.js
@@ -26,7 +26,7 @@ describe('Contact audit history', () => {
     })
 
     it('should render the subheading', () => {
-      cy.get('[data-test=audit-heading]')
+      cy.get('[data-test=audit-header]')
         .should('exist')
         .should('have.text', 'Audit history')
     })
@@ -111,7 +111,7 @@ describe('Contact audit history', () => {
     })
 
     it('should render the subheading', () => {
-      cy.get('[data-test=audit-heading]')
+      cy.get('[data-test=audit-header]')
         .should('exist')
         .should('have.text', 'Audit history')
     })
@@ -173,7 +173,7 @@ describe('Contact audit history', () => {
     })
 
     it('should render the subheading', () => {
-      cy.get('[data-test=audit-heading]')
+      cy.get('[data-test=audit-header]')
         .should('exist')
         .should('have.text', 'Audit history')
     })

--- a/test/functional/cypress/specs/contacts/details-spec.js
+++ b/test/functional/cypress/specs/contacts/details-spec.js
@@ -61,7 +61,7 @@ describe('View contact details', () => {
 
     it('should render the archive container', () => {
       cy.get('[data-test=archive-contact-container]').should('exist')
-      cy.get('[data-test=archive-heading]')
+      cy.get('[data-test=archive-header]')
         .should('exist')
         .should('have.text', 'Archive contact')
       cy.get('[data-test=archive-hint]')

--- a/test/functional/cypress/specs/contacts/documents-spec.js
+++ b/test/functional/cypress/specs/contacts/documents-spec.js
@@ -18,7 +18,7 @@ describe('Contact Documents', () => {
     })
 
     it('should display appropriate message when there is a link to a document', () => {
-      cy.get('[data-test=document-heading]').should('contain', 'Documents')
+      cy.get('[data-test=document-header]').should('contain', 'Documents')
       cy.get('[data-test=document-link]').should(
         'contain',
         'View files and documents'
@@ -41,7 +41,7 @@ describe('Contact Documents', () => {
     })
 
     it('should display appropriate message when there is not a link to a document', () => {
-      cy.get('[data-test=document-heading]').should('contain', 'Document')
+      cy.get('[data-test=document-header]').should('contain', 'Document')
       cy.get('[data-test=no-documents-message]').should(
         'contain',
         'There are no files or documents'

--- a/test/functional/cypress/specs/investments/project-document-spec.js
+++ b/test/functional/cypress/specs/investments/project-document-spec.js
@@ -25,7 +25,7 @@ describe('Investment Project Documents', () => {
     })
 
     it('should display appropriate message when there is a link to a document', () => {
-      cy.get('[data-test=document-heading]').should('contain', 'Document')
+      cy.get('[data-test=document-header]').should('contain', 'Document')
       cy.get('[data-test=document-link]').should(
         'contain',
         'View files and documents'
@@ -55,7 +55,7 @@ describe('Investment Project Documents', () => {
     })
 
     it('should display appropriate message when there is not a link to a document', () => {
-      cy.get('[data-test=document-heading]').should('contain', 'Document')
+      cy.get('[data-test=document-header]').should('contain', 'Document')
       cy.get('[data-test=document-link]').should('not.exist')
       cy.get('[data-test=no-documents-message]').should(
         'contain',


### PR DESCRIPTION
## Description of change

Whilst doing the work to reactify the contact audit log page I noticed that there were several instances of the same header in use. In order to reduce duplication I have consolidated all these into a single component.

## Test instructions

Nothing should change.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
