### PR TITLE
Amended Event name query parameters

### DIFF
--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -468,7 +468,7 @@ describe('events Collections Filter', () => {
         before(() => {
           cy.intercept(
             'GET',
-            `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1`
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&name=Big+Event&page=1`
           ).as('nameRequest')
         })
 


### PR DESCRIPTION
## Description of change

Fixed a failing test for Event name parameter query.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
