### PR TITLE
CPS 393 Fix search string to use dynamic query

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -99,10 +99,8 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
                 (searchString) =>
                   apiProxyAxios
                     .post('/v4/search/company', {
-                      params: {
-                        autocomplete: searchString,
-                        archived: false,
-                      },
+                      name: searchString,
+                      archived: false,
                     })
                     .then(({ data: { results } }) =>
                       idNamesToValueLabels(results)


### PR DESCRIPTION
## Description of change

Fix to show all opportunity details for Promoters field in Investments > UK opportunities > [Opportunity] > Opportunity details > [Edit] > Promoters

Currently only the first 100 results are loaded and then the filter is applied. The fixed code loads the results dynamically based on the characters inputted into the lookup field.

See details [CPS-393](https://uktrade.atlassian.net/jira/people/610a61c4b704b4006809a36f/boards/322?modal=detail&selectedIssue=CPS-393)

_Document what the PR does and why the change is needed_

## Test instructions

When entering a company name it should be shown in the drop down.

## Screenshots

### Before

Searching on the dev site for Interaction shows:

<img width="895" alt="image" src="https://user-images.githubusercontent.com/699259/193838915-6b260b9a-af92-415a-9d7b-88f765b194e5.png">

### After

<img width="896" alt="image" src="https://user-images.githubusercontent.com/699259/193855234-f12ca5d5-9f2a-49f2-b6b7-9fa672051554.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
