### PR TITLE
Fix flashmessage error with duns_number

### DIFF
--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -43,7 +43,7 @@ function EditCompanyForm({
       flashMessage={(result) => {
         if (
           result.company?.duns_number ||
-          result.dnbChangeRequest?.company.duns_number
+          result.dnbChangeRequest?.duns_number
         ) {
           return [
             'Change requested.',

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -472,9 +472,9 @@ describe('Company edit', () => {
     const company = fixtures.company.dnbLtd
 
     before(() => {
-      cy.intercept('POST', urls.companies.edit(company.id) + '*').as(
-        'editCompanyResponse'
-      )
+      cy.intercept('POST', urls.companies.edit(company.id) + '*', {
+        body: { company: company },
+      }).as('editCompanyResponse')
       cy.visit(urls.companies.edit(company.id))
     })
 
@@ -514,6 +514,43 @@ describe('Company edit', () => {
     })
 
     it('displays the "Change requested. Thanks for keeping Data Hub running smoothly" flash message and the ID used in GA', () => {
+      cy.contains(
+        'Change requested.Thanks for keeping Data Hub running smoothly.'
+      ).should('have.attr', 'data-test', 'status-message')
+    })
+  })
+
+  context('when form is submitted with dnb change request', () => {
+    const company = fixtures.company.dnbLtd
+
+    before(() => {
+      cy.intercept('POST', urls.companies.edit(company.id) + '*', {
+        body: { dnbChangeRequest: { duns_number: company.duns_number } },
+      }).as('editCompanyResponse')
+      cy.visit(urls.companies.edit(company.id))
+    })
+
+    it('should display the "Change requested. Thanks for keeping Data Hub running smoothly"', () => {
+      cy.contains('Company name')
+        .next()
+        .find('input')
+        .clear()
+        .type('Test company name')
+
+      cy.contains('Trading name')
+        .next()
+        .find('input')
+        .clear()
+        .type('Test company trading name')
+
+      cy.contains('Website (optional)')
+        .next()
+        .find('input')
+        .clear()
+        .type('example.com')
+
+      cy.contains('Submit').click()
+
       cy.contains(
         'Change requested.Thanks for keeping Data Hub running smoothly.'
       ).should('have.attr', 'data-test', 'status-message')


### PR DESCRIPTION
## Description of change

Editing company is expected to notify user of changes with DNB record and save without issues

## Test instructions

Edit the address details https://www.datahub.dev.uktrade.io/companies/c9c6b965-1782-49e9-95e7-9e0851311ec5/business-details and there should be no error but a message to say DNB are working on this.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
