### PR TITLE
Fix browser console warnings

### DIFF
--- a/src/client/components/ArchiveForm/index.jsx
+++ b/src/client/components/ArchiveForm/index.jsx
@@ -51,7 +51,7 @@ const ArchiveForm = ({
 
   return (
     <div data-test={kebabCase(`archive-${type}-container`)}>
-      <SectionHeader type="archive">Archive {type}</SectionHeader>
+      <SectionHeader type="archive">{`Archive ${type}`}</SectionHeader>
 
       <p data-test="archive-hint">
         Archive this {type} if it is no longer required or active.

--- a/src/client/components/ArchivePanel/index.jsx
+++ b/src/client/components/ArchivePanel/index.jsx
@@ -29,7 +29,6 @@ const StyledReason = styled(StyledMessage)`
  * An extension of `StatusMessage` that is used to denote whether a record has been archived.
  */
 const ArchivePanel = ({
-  isArchived,
   archivedBy = null,
   archivedOn,
   archiveReason,
@@ -37,9 +36,6 @@ const ArchivePanel = ({
   onClick = null,
   type,
 }) => {
-  if (!isArchived) {
-    return null
-  }
   return (
     <StyledMain data-test="archive-panel">
       <StatusMessage>
@@ -62,10 +58,6 @@ const ArchivePanel = ({
 }
 
 ArchivePanel.propTypes = {
-  /**
-   * The archive status of the record. If set to `false`, the component will return `null` and will not render.
-   */
-  isArchived: PropTypes.bool.isRequired,
   /**
    * An object containg the first and last name of the person who archived the contact. If this is not defined, the automatic archive text will appear.
    */

--- a/src/client/components/ContactLocalHeader/index.jsx
+++ b/src/client/components/ContactLocalHeader/index.jsx
@@ -103,17 +103,18 @@ const ContactLocalHeader = ({ contact, writeFlashMessage }) => {
             </GridCol>
           )}
         </GridRow>
-        <ArchivePanel
-          isArchived={contact.archived}
-          archivedBy={contact.archived_by}
-          archivedOn={contact.archived_on}
-          archiveReason={contact.archived_reason}
-          unarchiveUrl={urls.contacts.unarchive(contact.id)}
-          onClick={() => {
-            writeFlashMessage('Contact record updated')
-          }}
-          type="contact"
-        />
+        {contact.archived && (
+          <ArchivePanel
+            archivedBy={contact.archived_by}
+            archivedOn={contact.archived_on}
+            archiveReason={contact.archived_reason}
+            unarchiveUrl={urls.contacts.unarchive(contact.id)}
+            onClick={() => {
+              writeFlashMessage('Contact record updated')
+            }}
+            type="contact"
+          />
+        )}
       </LocalHeader>
     </>
   )

--- a/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
+++ b/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
@@ -53,12 +53,11 @@ const ContactDetails = ({ contactId, companyAddress }) => {
             data-test="contact-details-table"
           >
             <SummaryTable.Row heading="Job title" children={contact.jobTitle} />
-            {contact.fullTelephoneNumber && (
-              <SummaryTable.Row
-                heading="Phone number"
-                children={contact.fullTelephoneNumber}
-              />
-            )}
+            <SummaryTable.Row
+              hideWhenEmpty={true}
+              heading="Phone number"
+              children={contact.fullTelephoneNumber}
+            />
             <SummaryTable.Row
               heading="Address"
               children={getAddress(contact, companyAddress)}


### PR DESCRIPTION
## Description of change
Fixes 4 browser console warnings when looking at contact details.

## Test instructions
Locally go to: `/contacts/<contact-uuid>/details` and open up dev tools to ensure there are no warnings in the console.

## Screenshots
<img width="1268" alt="Screenshot 2022-10-14 at 17 03 18" src="https://user-images.githubusercontent.com/964268/195891656-ba401377-f4fb-4a4e-9d57-ed5312778c7d.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
