### PR TITLE
Remove pipeline tests for 404 error

### DIFF
--- a/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-archive-spec.js
@@ -48,17 +48,6 @@ function assertForm() {
 }
 
 describe('Archive pipeline item form', () => {
-  context('When the pipeline item id is incorrect', () => {
-    before(() => {
-      cy.visit(urls.pipeline.archive('INCORRECT-PIPELINE-ID'))
-    })
-
-    it('should render a 404 error message', () => {
-      cy.contains('Could not load PipelineItem')
-      cy.contains('Error: Not Found')
-    })
-  })
-
   context('When submitting the form without a reason', () => {
     before(() => {
       cy.visit(urls.pipeline.archive(firstItem.id))

--- a/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-delete-spec.js
@@ -26,17 +26,6 @@ function assertForm() {
 }
 
 describe('Delete pipeline item form', () => {
-  context('When the pipeline item id is incorrect', () => {
-    before(() => {
-      cy.visit(urls.pipeline.delete('INCORRECT-PIPELINE-ID'))
-    })
-
-    it('should render a 404 error message', () => {
-      cy.contains('Could not load PipelineItem')
-      cy.contains('Error: Not Found')
-    })
-  })
-
   context('With a valid id', () => {
     before(() => {
       cy.visit(urls.pipeline.delete('ARCHIVED'))

--- a/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-edit-spec.js
@@ -14,17 +14,6 @@ const formSelectors = selectors.pipelineForm
 const [firstItem, secondItem] = pipelineItemLambdaPlc.results
 
 describe('Pipeline edit form', () => {
-  xcontext('When pipeline id is incorrect', () => {
-    before(() => {
-      cy.visit(urls.pipeline.edit('INCORRECT_PIPELINE'))
-    })
-
-    it('should render 404 error message', () => {
-      cy.contains('Could not load PipelineItem')
-      cy.contains('Error: Not Found')
-    })
-  })
-
   context('When editing a pipeline item', () => {
     context('With values for only the mandatory fields', () => {
       before(() => {

--- a/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
+++ b/test/functional/cypress/specs/pipeline/my-pipeline-unarchive-spec.js
@@ -29,18 +29,7 @@ function assertForm() {
 }
 
 describe('Unarchive pipeline item form', () => {
-  context('When the pipeline item id is incorrect', () => {
-    before(() => {
-      cy.visit(urls.pipeline.unarchive('INCORRECT-PIPELINE-ID'))
-    })
-
-    it('should render a 404 error message', () => {
-      cy.contains('Could not load PipelineItem')
-      cy.contains('Error: Not Found')
-    })
-  })
-
-  context('With a valid id', () => {
+  context('When the form is loaded', () => {
     before(() => {
       cy.visit(urls.pipeline.unarchive('ARCHIVED'))
     })


### PR DESCRIPTION
## Description of change

I would like to remove the 404 error tests from the pipeline specs for the following reasons:
- We do not test for incorrect IDs in any other area of the codebase. There is nothing special about the pipelines page that requires this to be tested.
- They are repeatedly failing in `main` and in other branches. This is causing us to spend time re-running the functional suite when we shouldn't need to.
- The tests [don't refelect reality](https://www.datahub.dev.uktrade.io/my-pipeline/INCORRECT_PIPELINE/archive) since the new error handling was introduced.

Based on the above points I believe we can remove these tests.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
