### PR TITLE
Fix bug in ArchivePanel

### DIFF
--- a/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
+++ b/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
@@ -71,14 +71,15 @@ const CompanyBusinessDetails = ({
         <Link href={urls.companyEditHistory}>Edit history page</Link>.
       </div>
       {lastUpdated && <div>Last updated on: {format(lastUpdated)}</div>}
-      <ArchivePanel
-        isArchived={isArchived}
-        archivedBy={businessDetails.archived_by}
-        archivedOn={businessDetails.archived_on}
-        archiveReason={businessDetails.archived_reason}
-        unarchiveUrl={urls.companyUnarchive}
-        type="company"
-      />
+      {isArchived && (
+        <ArchivePanel
+          archivedBy={businessDetails.archived_by}
+          archivedOn={businessDetails.archived_on}
+          archiveReason={businessDetails.archived_reason}
+          unarchiveUrl={urls.companyUnarchive}
+          type="company"
+        />
+      )}
       <Task.Status
         name={DNB__CHECK_PENDING_REQUEST}
         id={CHECK_PENDING_REQUEST_ID}

--- a/src/client/components/ArchivePanel/index.jsx
+++ b/src/client/components/ArchivePanel/index.jsx
@@ -59,7 +59,7 @@ const ArchivePanel = ({
 
 ArchivePanel.propTypes = {
   /**
-   * An object containg the first and last name of the person who archived the contact. If this is not defined, the automatic archive text will appear.
+   * An object containg the first and last name of the person who archived the record. If this is not defined, the automatic archive text will appear.
    */
   archivedBy: PropTypes.object,
   /**

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -200,14 +200,15 @@ const CompanyLocalHeader = ({
         </p>
       </LocalHeader>
 
-      <ArchivePanel
-        isArchived={company.archived}
-        archivedBy={company.archived_by}
-        archivedOn={company.archived_on}
-        archiveReason={company.archived_reason}
-        unarchiveUrl={urls.companies.unarchive(company.id)}
-        type="company"
-      />
+      {company.archived && (
+        <ArchivePanel
+          archivedBy={company.archived_by}
+          archivedOn={company.archived_on}
+          archiveReason={company.archived_reason}
+          unarchiveUrl={urls.companies.unarchive(company.id)}
+          type="company"
+        />
+      )}
 
       {company.pending_dnb_investigation && (
         <StyledMain data-test="investigationMessage">

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -43,6 +43,147 @@ const assertAddress = ({ address, registeredAddress }) => {
   }
 }
 
+const assertBusinessDetailsBreadcrumbs = (company) => {
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [company.name]: urls.companies.detail(company.id),
+      'Business details': null,
+    })
+  })
+}
+
+const assertBusinessDetailsHeading = () => {
+  it('should display the "Business details" heading', () => {
+    cy.get(selectors.localHeader().heading).should(
+      'have.text',
+      'Business details'
+    )
+  })
+}
+
+const assertLastUpdatedParagraph = (date) => {
+  const paragraphText = 'Last updated on: ' + date
+  it('should display the "Last updated" paragraph', () => {
+    cy.contains(paragraphText).should('be.visible')
+  })
+}
+
+const assertAreDetailsRight = () => {
+  it('should display the "Are these business details right?" details summary', () => {
+    cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
+      'be.visible'
+    )
+  })
+}
+
+const assertAreDetailsRightNotVisible = () => {
+  it('should not display the "Are these business details right?" details summary', () => {
+    cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
+      'not.exist'
+    )
+  })
+}
+
+const assertUnarchiveLinkNotVisible = () => {
+  it('should not display the "Unarchive" link', () => {
+    cy.get(selectors.companyBusinessDetails().unarchiveLink).should('not.exist')
+  })
+}
+
+const assertAddressContainer = (showEdit) => {
+  it('should display the "Addresses" details container', () => {
+    assertSummaryTable({
+      dataTest: 'addressesDetailsContainer',
+      heading: 'Addresses',
+      showEditLink: showEdit,
+    })
+  })
+}
+
+const assertRegionContainerNotVisible = () => {
+  it('should not display the "DIT region" details container', () => {
+    cy.get(
+      selectors.detailsContainer('regionDetailsContainer').container
+    ).should('not.exist')
+  })
+}
+
+const assertSectorContainer = (showLink, content = ['Retail']) => {
+  it('should display the "DIT sector" details container', () => {
+    assertSummaryTable({
+      dataTest: 'sectorDetailsContainer',
+      heading: 'DIT sector',
+      showEditLink: showLink,
+      content: content,
+    })
+  })
+}
+
+const assertAccountManagerContainer = (showLink) => {
+  it('should display the "Global Account Manager - One List" details container', () => {
+    assertSummaryTable({
+      dataTest: 'oneListDetailsContainer',
+      heading: 'Global Account Manager – One List',
+      showEditLink: showLink,
+      content: {
+        'One List tier': 'Tier A - Strategic Account',
+        'Global Account Manager':
+          'Travis GreeneIST - Sector Advisory ServicesLondon',
+      },
+    })
+  })
+}
+
+const assertCDMSContainerNotVisible = () => {
+  it('should not display the "Documents from CDMS" details container', () => {
+    cy.get(
+      selectors.detailsContainer('documentsDetailsContainer').container
+    ).should('not.exist')
+  })
+}
+
+const assertArchiveContainerNotVisible = () => {
+  it('should not display the "Archive company" details container', () => {
+    cy.get('[data-test=archive-company-container]').should('not.exist')
+  })
+}
+
+const assertRegionContainer = (region) => {
+  it('should display the "DIT region" details container', () => {
+    assertSummaryTable({
+      dataTest: 'regionDetailsContainer',
+      heading: 'DIT region',
+      showEditLink: true,
+      content: region,
+    })
+  })
+}
+
+const assertHierarchyContainer = (showLink, content) => {
+  it('should display the "Business hierarchy" details container', () => {
+    assertSummaryTable({
+      dataTest: 'businessHierarchyDetailsContainer',
+      heading: 'Business hierarchy',
+      showEditLink: showLink,
+      content: content,
+    })
+  })
+}
+
+const assertArchiveContainerVisible = () => {
+  it('should display the "Archive company" details container', () => {
+    cy.get('[data-test=archive-company-container]').should('be.visible')
+  })
+}
+
+const assertArchivePanelNotVisible = () => {
+  it('should not render the archive panel', () => {
+    cy.get('[data-test=archive-panel]').should('not.exist')
+  })
+}
+
 describe('Companies business details', () => {
   context(
     'when viewing business details for a Dun & Bradstreet GHQ company on the One List not in the UK',
@@ -56,27 +197,10 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard(),
-          Companies: urls.companies.index(),
-          [fixtures.company.oneListCorp.name]: urls.companies.detail(
-            fixtures.company.oneListCorp.id
-          ),
-          'Business details': null,
-        })
-      })
-
-      it('should display the "Business details" heading', () => {
-        cy.get(selectors.localHeader().heading).should(
-          'have.text',
-          'Business details'
-        )
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 26 Nov 2017').should('be.visible')
-      })
+      assertBusinessDetailsBreadcrumbs(fixtures.company.oneListCorp)
+      assertArchivePanelNotVisible()
+      assertBusinessDetailsHeading()
+      assertLastUpdatedParagraph('26 Nov 2017')
 
       it('should not display the "Pending Change Request" box', () => {
         cy.contains(
@@ -84,17 +208,8 @@ describe('Companies business details', () => {
         ).should('not.exist')
       })
 
-      it('should display the "Are these business details right?" details summary', () => {
-        cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
-          'be.visible'
-        )
-      })
-
-      it('should not display the "Unarchive" link', () => {
-        cy.get(selectors.companyBusinessDetails().unarchiveLink).should(
-          'not.exist'
-        )
-      })
+      assertAreDetailsRight()
+      assertUnarchiveLinkNotVisible()
 
       it('should display the "About" details container', () => {
         assertSummaryTable({
@@ -114,13 +229,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Addresses" details container', () => {
-        assertSummaryTable({
-          dataTest: 'addressesDetailsContainer',
-          heading: 'Addresses',
-          showEditLink: false,
-        })
-      })
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddress({
@@ -134,33 +243,9 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should not display the "DIT region" details container', () => {
-        cy.get(
-          selectors.detailsContainer('regionDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should display the "DIT sector" details container', () => {
-        assertSummaryTable({
-          dataTest: 'sectorDetailsContainer',
-          heading: 'DIT sector',
-          showEditLink: true,
-          content: ['Retail'],
-        })
-      })
-
-      it('should display the "Global Account Manager - One List" details container', () => {
-        assertSummaryTable({
-          dataTest: 'oneListDetailsContainer',
-          heading: 'Global Account Manager – One List',
-          showEditLink: false,
-          content: {
-            'One List tier': 'Tier A - Strategic Account',
-            'Global Account Manager':
-              'Travis GreeneIST - Sector Advisory ServicesLondon',
-          },
-        })
-      })
+      assertRegionContainerNotVisible()
+      assertSectorContainer(true)
+      assertAccountManagerContainer(false)
 
       it('should display the "Business hierarchy" details container heading', () => {
         assertSummaryTable({
@@ -177,15 +262,8 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should not display the "Documents from CDMS" details container', () => {
-        cy.get(
-          selectors.detailsContainer('documentsDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should not display the "Archive company" details container', () => {
-        cy.get('[data-test=archive-company-container]').should('not.exist')
-      })
+      assertCDMSContainerNotVisible()
+      assertArchiveContainerNotVisible()
     }
   )
 
@@ -258,39 +336,12 @@ describe('Companies business details', () => {
         cy.contains('Checking for pending change requests').should('not.exist')
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard(),
-          Companies: urls.companies.index(),
-          [fixtures.company.venusLtd.name]: urls.companies.detail(
-            fixtures.company.venusLtd.id
-          ),
-          'Business details': null,
-        })
-      })
-
-      it('should display the "Business details" heading', () => {
-        cy.get(selectors.localHeader().heading).should(
-          'have.text',
-          'Business details'
-        )
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 15 Jul 2016').should('be.visible')
-      })
-
-      it('should not display the "Are these business details right?" details summary', () => {
-        cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
-          'not.exist'
-        )
-      })
-
-      it('should not display the "Unarchive" link', () => {
-        cy.get(selectors.companyBusinessDetails().unarchiveLink).should(
-          'not.exist'
-        )
-      })
+      assertBusinessDetailsBreadcrumbs(fixtures.company.venusLtd)
+      assertArchivePanelNotVisible()
+      assertBusinessDetailsHeading()
+      assertLastUpdatedParagraph('15 Jul 2016')
+      assertAreDetailsRightNotVisible()
+      assertUnarchiveLinkNotVisible()
 
       it('should display the "About" details container', () => {
         assertSummaryTable({
@@ -311,13 +362,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Addresses" details container', () => {
-        assertSummaryTable({
-          dataTest: 'addressesDetailsContainer',
-          heading: 'Addresses',
-          showEditLink: true,
-        })
-      })
+      assertAddressContainer(true)
 
       it('should display the address', () => {
         assertAddress({
@@ -331,52 +376,14 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "DIT region" details container', () => {
-        assertSummaryTable({
-          dataTest: 'regionDetailsContainer',
-          heading: 'DIT region',
-          showEditLink: true,
-          content: ['North West'],
-        })
+      assertRegionContainer(['North West'])
+      assertSectorContainer(true)
+      assertAccountManagerContainer(true)
+      assertHierarchyContainer(true, {
+        [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
+        'Global HQ': 'Archived LtdRemove link',
       })
-
-      it('should display the "DIT sector" details container', () => {
-        assertSummaryTable({
-          dataTest: 'sectorDetailsContainer',
-          heading: 'DIT sector',
-          showEditLink: true,
-          content: ['Retail'],
-        })
-      })
-
-      it('should display the "Global Account Manager - One List" details container', () => {
-        assertSummaryTable({
-          dataTest: 'oneListDetailsContainer',
-          heading: 'Global Account Manager – One List',
-          showEditLink: true,
-          content: {
-            'One List tier': 'Tier A - Strategic Account',
-            'Global Account Manager':
-              'Travis GreeneIST - Sector Advisory ServicesLondon',
-          },
-        })
-      })
-
-      it('should display the "Business hierarchy" details container', () => {
-        assertSummaryTable({
-          dataTest: 'businessHierarchyDetailsContainer',
-          heading: 'Business hierarchy',
-          showEditLink: true,
-          content: {
-            [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
-            'Global HQ': 'Archived LtdRemove link',
-          },
-        })
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 15 Jul 2016').should('be.visible')
-      })
+      assertLastUpdatedParagraph('15 Jul 2016')
 
       it('should display the "Documents from CDMS" details container', () => {
         assertSummaryTable({
@@ -387,9 +394,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Archive company" details container', () => {
-        cy.get('[data-test=archive-company-container]').should('be.visible')
-      })
+      assertArchiveContainerVisible()
     }
   )
 
@@ -403,39 +408,12 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard(),
-          Companies: urls.companies.index(),
-          [fixtures.company.dnbCorp.name]: urls.companies.detail(
-            fixtures.company.dnbCorp.id
-          ),
-          'Business details': null,
-        })
-      })
-
-      it('should display the "Business details" heading', () => {
-        cy.get(selectors.localHeader().heading).should(
-          'have.text',
-          'Business details'
-        )
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 26 Oct 2018').should('be.visible')
-      })
-
-      it('should display the "Are these business details right?" details summary', () => {
-        cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
-          'be.visible'
-        )
-      })
-
-      it('should not display the "Unarchive" link', () => {
-        cy.get(selectors.companyBusinessDetails().unarchiveLink).should(
-          'not.exist'
-        )
-      })
+      assertBusinessDetailsBreadcrumbs(fixtures.company.dnbCorp)
+      assertArchivePanelNotVisible()
+      assertBusinessDetailsHeading()
+      assertLastUpdatedParagraph('26 Oct 2018')
+      assertAreDetailsRight()
+      assertUnarchiveLinkNotVisible()
 
       it('should display the "About" details container', () => {
         assertSummaryTable({
@@ -457,13 +435,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Addresses" details container', () => {
-        assertSummaryTable({
-          dataTest: 'addressesDetailsContainer',
-          heading: 'Addresses',
-          showEditLink: false,
-        })
-      })
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddress({
@@ -472,20 +444,8 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should not display the "DIT region" details container', () => {
-        cy.get(
-          selectors.detailsContainer('regionDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should display the "DIT sector" details container', () => {
-        assertSummaryTable({
-          dataTest: 'sectorDetailsContainer',
-          heading: 'DIT sector',
-          showEditLink: true,
-          content: ['Retail'],
-        })
-      })
+      assertRegionContainerNotVisible()
+      assertSectorContainer(true)
 
       it('should not display the "Global Account Manager - One List" details container', () => {
         cy.get(
@@ -493,27 +453,13 @@ describe('Companies business details', () => {
         ).should('not.exist')
       })
 
-      it('should display the "Business hierarchy" details container', () => {
-        assertSummaryTable({
-          dataTest: 'businessHierarchyDetailsContainer',
-          heading: 'Business hierarchy',
-          showEditLink: false,
-          content: [
-            HIERARCHY_STRINGS.dnbDescription,
-            HIERARCHY_STRINGS.dnbEmpty,
-          ],
-        })
-      })
+      assertHierarchyContainer(false, [
+        HIERARCHY_STRINGS.dnbDescription,
+        HIERARCHY_STRINGS.dnbEmpty,
+      ])
 
-      it('should not display the "Documents from CDMS" details container', () => {
-        cy.get(
-          selectors.detailsContainer('documentsDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should not display the "Archive company" details container', () => {
-        cy.get('[data-test=archive-company-container]').should('not.exist')
-      })
+      assertCDMSContainerNotVisible()
+      assertArchiveContainerNotVisible()
     }
   )
 
@@ -549,33 +495,10 @@ describe('Companies business details', () => {
         )
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard(),
-          Companies: urls.companies.index(),
-          [fixtures.company.archivedLtd.name]: urls.companies.detail(
-            fixtures.company.archivedLtd.id
-          ),
-          'Business details': null,
-        })
-      })
-
-      it('should display the "Business details" heading', () => {
-        cy.get(selectors.localHeader().heading).should(
-          'have.text',
-          'Business details'
-        )
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 16 Jul 2017').should('be.visible')
-      })
-
-      it('should not display the "Are these business details right?" details summary', () => {
-        cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
-          'not.exist'
-        )
-      })
+      assertBusinessDetailsBreadcrumbs(fixtures.company.archivedLtd)
+      assertBusinessDetailsHeading()
+      assertLastUpdatedParagraph('16 Jul 2017')
+      assertAreDetailsRightNotVisible()
 
       it('should display the date the company was archived and by whom', () => {
         cy.contains(
@@ -610,13 +533,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Addresses" details container', () => {
-        assertSummaryTable({
-          dataTest: 'addressesDetailsContainer',
-          heading: 'Addresses',
-          showEditLink: false,
-        })
-      })
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddress({
@@ -625,56 +542,16 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should not display the "DIT region" details container', () => {
-        cy.get(
-          selectors.detailsContainer('regionDetailsContainer').container
-        ).should('not.exist')
+      assertRegionContainerNotVisible()
+      assertSectorContainer(false)
+      assertAccountManagerContainer(false)
+      assertHierarchyContainer(false, {
+        [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
+        'Headquarter type': 'Global HQ',
+        Subsidiaries: '2 subsidiaries',
       })
-
-      it('should display the "DIT sector" details container', () => {
-        assertSummaryTable({
-          dataTest: 'sectorDetailsContainer',
-          heading: 'DIT sector',
-          showEditLink: false,
-          content: ['Retail'],
-        })
-      })
-
-      it('should display the "Global Account Manager - One List" details container', () => {
-        assertSummaryTable({
-          dataTest: 'oneListDetailsContainer',
-          heading: 'Global Account Manager – One List',
-          showEditLink: false,
-          content: {
-            'One List tier': 'Tier A - Strategic Account',
-            'Global Account Manager':
-              'Travis GreeneIST - Sector Advisory ServicesLondon',
-          },
-        })
-      })
-
-      it('should display the "Business hierarchy" details container', () => {
-        assertSummaryTable({
-          dataTest: 'businessHierarchyDetailsContainer',
-          heading: 'Business hierarchy',
-          showEditLink: false,
-          content: {
-            [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
-            'Headquarter type': 'Global HQ',
-            Subsidiaries: '2 subsidiaries',
-          },
-        })
-      })
-
-      it('should not display the "Documents from CDMS" details container', () => {
-        cy.get(
-          selectors.detailsContainer('documentsDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should not display the "Archive company" details container', () => {
-        cy.get('[data-test=archive-company-container]').should('not.exist')
-      })
+      assertCDMSContainerNotVisible()
+      assertArchiveContainerNotVisible()
     }
   )
 
@@ -689,39 +566,12 @@ describe('Companies business details', () => {
         )
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: urls.dashboard(),
-          Companies: urls.companies.index(),
-          [fixtures.company.minimallyMinimalLtd.name]: urls.companies.detail(
-            fixtures.company.minimallyMinimalLtd.id
-          ),
-          'Business details': null,
-        })
-      })
-
-      it('should display the "Business details" heading', () => {
-        cy.get(selectors.localHeader().heading).should(
-          'have.text',
-          'Business details'
-        )
-      })
-
-      it('should display the "Last updated" paragraph', () => {
-        cy.contains('Last updated on: 11 Dec 2015').should('be.visible')
-      })
-
-      it('should not display the "Are these business details right?" details summary', () => {
-        cy.get(selectors.companyBusinessDetails().whereDoesInformation).should(
-          'not.exist'
-        )
-      })
-
-      it('should not display the "Unarchive" link', () => {
-        cy.get(selectors.companyBusinessDetails().unarchiveLink).should(
-          'not.exist'
-        )
-      })
+      assertBusinessDetailsBreadcrumbs(fixtures.company.minimallyMinimalLtd)
+      assertArchivePanelNotVisible()
+      assertBusinessDetailsHeading()
+      assertLastUpdatedParagraph('11 Dec 2015')
+      assertAreDetailsRightNotVisible()
+      assertUnarchiveLinkNotVisible()
 
       it('should display the "About" details container', () => {
         assertSummaryTable({
@@ -740,13 +590,7 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "Addresses" details container', () => {
-        assertSummaryTable({
-          dataTest: 'addressesDetailsContainer',
-          heading: 'Addresses',
-          showEditLink: true,
-        })
-      })
+      assertAddressContainer(true)
 
       it('should display the address', () => {
         assertAddress({
@@ -755,23 +599,8 @@ describe('Companies business details', () => {
         })
       })
 
-      it('should display the "DIT region" details container', () => {
-        assertSummaryTable({
-          dataTest: 'regionDetailsContainer',
-          heading: 'DIT region',
-          showEditLink: true,
-          content: ['Not set'],
-        })
-      })
-
-      it('should display the "DIT sector" details container', () => {
-        assertSummaryTable({
-          dataTest: 'sectorDetailsContainer',
-          heading: 'DIT sector',
-          showEditLink: true,
-          content: ['Advanced Engineering'],
-        })
-      })
+      assertRegionContainer(['Not set'])
+      assertSectorContainer(true, ['Advanced Engineering'])
 
       it('should not display the "Global Account Manager - One List" details container heading', () => {
         cy.get(
@@ -779,27 +608,12 @@ describe('Companies business details', () => {
         ).should('not.exist')
       })
 
-      it('should display the "Business hierarchy" details container', () => {
-        assertSummaryTable({
-          dataTest: 'businessHierarchyDetailsContainer',
-          heading: 'Business hierarchy',
-          showEditLink: true,
-          content: {
-            [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
-            'Global HQ': 'NoneLink to the Global HQ',
-          },
-        })
+      assertHierarchyContainer(true, {
+        [HIERARCHY_STRINGS.manualHierarchyDescription]: null,
+        'Global HQ': 'NoneLink to the Global HQ',
       })
-
-      it('should not display the "Documents from CDMS" details container', () => {
-        cy.get(
-          selectors.detailsContainer('documentsDetailsContainer').container
-        ).should('not.exist')
-      })
-
-      it('should display the "Archive company" details container', () => {
-        cy.get('[data-test=archive-company-container]').should('be.visible')
-      })
+      assertCDMSContainerNotVisible()
+      assertArchiveContainerVisible()
     }
   )
 })

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -11,6 +11,7 @@ const {
   assertViewFullBusinessDetails,
   assertOneListTierA,
   assertCoreTeam,
+  assertArchivePanelNotVisible,
 } = require('../../../support/company-local-header-assertions')
 
 const companyLocalHeader = selectors.companyLocalHeader()
@@ -32,6 +33,10 @@ describe('Local header for global ultimate company', () => {
     })
 
     assertBreadcrumbs(company.name, detailsUrl, 'Activity Feed')
+
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
 
     it('should display the company name', () => {
       assertCompanyName(company.name)
@@ -103,6 +108,10 @@ describe('Local header for global ultimate company', () => {
 
     assertBreadcrumbs(company.name, detailsUrl, 'Core Team')
 
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
+
     it('should display the company name', () => {
       assertCompanyName(company.name)
     })
@@ -139,6 +148,10 @@ describe('Local header for global ultimate company', () => {
       })
 
       assertBreadcrumbs(company.name, detailsUrl, 'Investment')
+
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
 
       it('should display the company name', () => {
         assertCompanyName(company.name)
@@ -180,6 +193,10 @@ describe('Local header for global ultimate company', () => {
 
       assertBreadcrumbs(company.name, detailsUrl, 'Investment')
 
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
+
       it('should display the company name', () => {
         assertCompanyName(company.name)
       })
@@ -218,6 +235,10 @@ describe('Local header for global ultimate company', () => {
 
     assertBreadcrumbs(company.name, detailsUrl, 'Exports')
 
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
+
     it('should display the company name', () => {
       assertCompanyName(company.name)
     })
@@ -252,6 +273,10 @@ describe('Local header for global ultimate company', () => {
     })
 
     assertExportCountryHistoryBreadcrumbs(company, detailsUrl)
+
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
 
     it('should display the company name', () => {
       assertCompanyName(company.name)
@@ -289,6 +314,10 @@ describe('Local header for global ultimate company', () => {
     })
 
     assertBreadcrumbs(company.name, detailsUrl, 'Orders (OMIS)')
+
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
 
     it('should display the company name', () => {
       assertCompanyName(company.name)

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -8,6 +8,7 @@ const {
   assertExportCountryHistoryBreadcrumbs,
   assertButtons,
   assertViewFullBusinessDetails,
+  assertArchivePanelNotVisible,
 } = require('../../../support/company-local-header-assertions')
 
 const companyLocalHeader = selectors.companyLocalHeader()
@@ -28,6 +29,10 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       assertBreadcrumbs(company.name, detailsUrl, 'Activity Feed')
+
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
 
       it('should display the company name', () => {
         assertCompanyName(company.name)
@@ -66,6 +71,10 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       assertBreadcrumbs(company.name, detailsUrl, 'Contacts')
+
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
 
       it('should display the company name', () => {
         assertCompanyName(company.name)
@@ -111,6 +120,10 @@ describe('Local header for company under dnb investigation', () => {
 
       assertBreadcrumbs(company.name, detailsUrl, 'Lead adviser')
 
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
+
       it('should display the company name', () => {
         assertCompanyName(company.name)
       })
@@ -155,6 +168,10 @@ describe('Local header for company under dnb investigation', () => {
 
       assertBreadcrumbs(company.name, detailsUrl, 'Investment')
 
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
+
       it('should display the company name', () => {
         assertCompanyName(company.name)
       })
@@ -194,6 +211,10 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       assertBreadcrumbs(company.name, detailsUrl, 'Investment')
+
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
 
       it('should display the company name', () => {
         assertCompanyName(company.name)
@@ -237,6 +258,10 @@ describe('Local header for company under dnb investigation', () => {
 
     assertBreadcrumbs(company.name, detailsUrl, 'Exports')
 
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
+
     it('should display the company name', () => {
       assertCompanyName(company.name)
     })
@@ -277,6 +302,10 @@ describe('Local header for company under dnb investigation', () => {
       })
 
       assertExportCountryHistoryBreadcrumbs(company, detailsUrl)
+
+      it('should not display the archive panel', () => {
+        assertArchivePanelNotVisible()
+      })
 
       it('should display the company name', () => {
         assertCompanyName(company.name)
@@ -319,6 +348,10 @@ describe('Local header for company under dnb investigation', () => {
     })
 
     assertBreadcrumbs(company.name, detailsUrl, 'Orders (OMIS)')
+
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
 
     it('should display the company name', () => {
       assertCompanyName(company.name)

--- a/test/functional/cypress/support/company-local-header-assertions.js
+++ b/test/functional/cypress/support/company-local-header-assertions.js
@@ -84,6 +84,10 @@ const assertCoreTeam = (paragraphNumber, advisersUrl) => {
     .should('have.attr', 'href', advisersUrl)
 }
 
+const assertArchivePanelNotVisible = () => {
+  cy.get('[data-test-archive-panel]').should('not.exist')
+}
+
 module.exports = {
   assertCompanyName,
   assertCompanyAddress,
@@ -94,4 +98,5 @@ module.exports = {
   assertViewFullBusinessDetails,
   assertOneListTierA,
   assertCoreTeam,
+  assertArchivePanelNotVisible,
 }


### PR DESCRIPTION
## Description of change

During the dev huddle I noticed that the archive panel was appearing on all companies, including those where the company was not archived. This has now been fixed.

## Test instructions

The archive panel should only appear for archived companies.

## Screenshots

### Before

<img width="857" alt="Screenshot 2022-10-18 at 13 19 44" src="https://user-images.githubusercontent.com/36161814/196427682-3b619cf3-43ea-43d1-9b7a-b114c441e625.png">


### After

<img width="837" alt="Screenshot 2022-10-18 at 13 19 52" src="https://user-images.githubusercontent.com/36161814/196427707-f153df78-752c-4529-a7b4-b40cbba4c726.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
