### PR TITLE
Change Add company - Find Company Form Layout

### DIFF
--- a/src/client/components/Form/elements/FieldDnbCompany/index.jsx
+++ b/src/client/components/Form/elements/FieldDnbCompany/index.jsx
@@ -22,6 +22,7 @@ import useEntitySearch from '../../../EntityList/useEntitySearch'
 import useDnbSearch from '../../../EntityList/useDnbSearch'
 import FormActions from '../FormActions'
 import EntityList from '../../../EntityList'
+import FormLayout from '../../../Layout/FormLayout'
 
 const COMPANY_NAME_MIN_LENGTH = 2
 const COMPANY_NAME_MAX_LENGTH = 30
@@ -80,91 +81,98 @@ const FieldDnbCompany = ({
   useEffect(() => setIsLoading(searching), [searching])
 
   return (
-    <FieldWrapper {...{ name, label, legend, hint }}>
-      {country && (
-        <FieldUneditable
-          legend="Country"
-          name="dnbCountry"
-          onChangeClick={goBack}
-        >
-          {country}
-        </FieldUneditable>
-      )}
+    <FormLayout setWidth="three-quarters">
+      <FieldWrapper {...{ name, label, legend, hint }}>
+        {country && (
+          <FieldUneditable
+            legend="Country"
+            name="dnbCountry"
+            onChangeClick={goBack}
+          >
+            {country}
+          </FieldUneditable>
+        )}
 
-      <FieldInput
-        label="Company name"
-        name="dnbCompanyName"
-        type="search"
-        required="Enter company name"
-        validate={[
-          validateMinLength(COMPANY_NAME_MIN_LENGTH),
-          validateMaxLength(COMPANY_NAME_MAX_LENGTH),
-        ]}
-      />
+        <FieldInput
+          label="Company name"
+          name="dnbCompanyName"
+          type="search"
+          required="Enter company name"
+          validate={[
+            validateMinLength(COMPANY_NAME_MIN_LENGTH),
+            validateMaxLength(COMPANY_NAME_MAX_LENGTH),
+          ]}
+        />
 
-      <FieldInput
-        label="Company postcode (optional)"
-        name="dnbPostalCode"
-        style={{ width: WIDTHS['one-third'] }}
-        type="search"
-      />
+        <FieldInput
+          label="Company postcode (optional)"
+          name="dnbPostalCode"
+          style={{ width: WIDTHS['one-third'] }}
+          type="search"
+        />
 
-      <FormActions>
-        <Button icon={<Search />} onClick={onSearchClick}>
-          Find company
-        </Button>
-      </FormActions>
+        <FormActions>
+          <Button icon={<Search />} onClick={onSearchClick}>
+            Find company
+          </Button>
+        </FormActions>
 
-      {searched && (
-        <>
-          {entities.length > 0 && (
-            <>
-              {searchResultsMessage && (
-                <StatusMessage>{searchResultsMessage}</StatusMessage>
-              )}
+        {searched && (
+          <>
+            {entities.length > 0 && (
+              <>
+                {searchResultsMessage && (
+                  <StatusMessage>{searchResultsMessage}</StatusMessage>
+                )}
 
-              <EntityList entities={entities} entityRenderer={entityRenderer} />
-            </>
-          )}
-
-          {!error && entities.length === 0 && (
-            <StatusMessage>
-              No match found. Try one of the options below.
-            </StatusMessage>
-          )}
-
-          {error && (
-            <StatusMessage>
-              Error occurred while searching for company.
-            </StatusMessage>
-          )}
-
-          <Details summary="I can't find what I'm looking for">
-            <Paragraph>Try:</Paragraph>
-
-            <StyledUnorderedList>
-              <ListItem>checking or removing the postcode</ListItem>
-              <ListItem>
-                removing &quot;limited&quot; or &quot;ltd&quot;
-              </ListItem>
-              <ListItem>checking for spelling errors</ListItem>
-              {country && (
-                <ListItem>checking if the right country was selected</ListItem>
-              )}
-              <ListItem>
-                check you&apos;re using the company&apos;s registered name
-              </ListItem>
-            </StyledUnorderedList>
-
-            {onCannotFind && (
-              <ButtonLink onClick={onCannotFind}>
-                I still can&apos;t find what I&apos;m looking for
-              </ButtonLink>
+                <EntityList
+                  entities={entities}
+                  entityRenderer={entityRenderer}
+                />
+              </>
             )}
-          </Details>
-        </>
-      )}
-    </FieldWrapper>
+
+            {!error && entities.length === 0 && (
+              <StatusMessage>
+                No match found. Try one of the options below.
+              </StatusMessage>
+            )}
+
+            {error && (
+              <StatusMessage>
+                Error occurred while searching for company.
+              </StatusMessage>
+            )}
+
+            <Details summary="I can't find what I'm looking for">
+              <Paragraph>Try:</Paragraph>
+
+              <StyledUnorderedList>
+                <ListItem>checking or removing the postcode</ListItem>
+                <ListItem>
+                  removing &quot;limited&quot; or &quot;ltd&quot;
+                </ListItem>
+                <ListItem>checking for spelling errors</ListItem>
+                {country && (
+                  <ListItem>
+                    checking if the right country was selected
+                  </ListItem>
+                )}
+                <ListItem>
+                  check you&apos;re using the company&apos;s registered name
+                </ListItem>
+              </StyledUnorderedList>
+
+              {onCannotFind && (
+                <ButtonLink onClick={onCannotFind}>
+                  I still can&apos;t find what I&apos;m looking for
+                </ButtonLink>
+              )}
+            </Details>
+          </>
+        )}
+      </FieldWrapper>
+    </FormLayout>
   )
 }
 

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -144,8 +144,19 @@ describe('Match a company', () => {
         'have.text',
         'Company name'
       )
-      cy.get('[data-test="field-dnbPostalCode"]')
-        .should('have.text', 'Company postcode (optional)')
+      cy.get('[data-test="dnb-company-name-input"]').should(
+        'have.attr',
+        'type',
+        'search'
+      )
+      cy.get('[data-test="field-dnbPostalCode"]').should(
+        'have.text',
+        'Company postcode (optional)'
+      )
+      cy.get('[data-test="dnb-postal-code-input"]')
+        .should('have.attr', 'type', 'search')
+        .parent()
+        .parent()
         .next()
         .contains('Find company')
         .and('match', 'button')

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -139,20 +139,13 @@ describe('Match a company', () => {
     it('should render both search input fields and a button', () => {
       cy.contains('Search third party supplier for business details')
         .and('match', 'h2')
-        .next()
-        .children()
         .first()
-        .should('have.text', 'Company name')
-        .find('input')
-        .should('have.attr', 'type', 'search')
-        .parent()
-        .parent()
-        .next()
+      cy.get('[data-test="field-dnbCompanyName"]').should(
+        'have.text',
+        'Company name'
+      )
+      cy.get('[data-test="field-dnbPostalCode"]')
         .should('have.text', 'Company postcode (optional)')
-        .find('input')
-        .should('have.attr', 'type', 'search')
-        .parent()
-        .parent()
         .next()
         .contains('Find company')
         .and('match', 'button')


### PR DESCRIPTION
## Description of change

Changing `Add Company - Find Company` form from full width into two-thirds of screen layout. To make it the form to be shorter and easily read what was entered.

## Test instructions
- Navigate to Companies -> click Add company button from collection list.
- Select any radio button either United Kingdom and Overseas
- Then display the Add company - Find Company form layout from full to two-thirds width.

## Screenshots

### Before
Full Width(≈960px)
![image](https://user-images.githubusercontent.com/28296624/196926855-c7e2b924-71b6-4b76-93c9-3ba8d1307a1e.png)

### After
Two-thirds Width(≈640px)
![image](https://user-images.githubusercontent.com/28296624/196926954-52d1a983-3278-47e8-8c21-2e81f0c94bd8.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
