### PR TITLE
Change Edit Export-countries form layout

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
@@ -9,6 +9,7 @@ import urls from '../../../../../../lib/urls'
 import {
   StatusMessage,
   FieldTypeahead,
+  FormLayout,
 } from '../../../../../../client/components/'
 
 const StyledH2 = styled.h2`
@@ -71,16 +72,18 @@ export default ({ companyId, countryOptions, fields }) => {
               return acc
             }, {})}
         >
-          {fields.map(({ label, name }) => (
-            <FieldTypeahead
-              key={name}
-              isMulti={true}
-              label={label}
-              name={name}
-              options={countryOptions}
-              placeholder="Search countries..."
-            />
-          ))}
+          <FormLayout setWidth="three-quarters">
+            {fields.map(({ label, name }) => (
+              <FieldTypeahead
+                key={name}
+                isMulti={true}
+                label={label}
+                name={name}
+                options={countryOptions}
+                placeholder="Search countries..."
+              />
+            ))}
+          </FormLayout>
         </Form>
       )}
     </Task.Status>


### PR DESCRIPTION
## Description of change

Changing `Edit Export-countries` form from full width into two-thirds of screen layout. To make it the form to be shorter and easily read what was entered.

## Test instructions

- Navigate to Companies -> click any company from collection list.
- Click `Export` navigation header tab
- Then click `Edit` for Export countries information.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/28296624/198552462-2977d21a-d84a-4ee2-979c-d96ae0006c7c.png)

### After

![image](https://user-images.githubusercontent.com/28296624/198552689-ffd98f12-c980-4edd-85c4-0ccbbdcfdfb6.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
