### PR TITLE
Add 'no recent export interactions' to notification settings list

### DIFF
--- a/docs/Feature flags.md
+++ b/docs/Feature flags.md
@@ -59,4 +59,16 @@ router.get(
 
 ## Adding feature flags in Sandbox
 
-To add a feature flag in Sandbox for functional testing you just need to add your feature flag name to this JSON file https://github.com/uktrade/data-hub-frontend/blob/main/test/sandbox/fixtures/v3/feature-flag/feature-flag.json
+### Nunjucks feature flags
+To add a feature flag in Sandbox for functional testing you just need to add your feature flag name to this JSON file: https://github.com/uktrade/data-hub-frontend/blob/main/test/sandbox/fixtures/v3/feature-flag/feature-flag.json . 
+
+### React feature flags
+To add a React-built feature flag to Sandbox for testing, add it to the `active_features` array at the end of this JSON file: https://github.com/uktrade/data-hub-frontend/blob/main/test/sandbox/fixtures/whoami.json .
+
+Alternatively, in Cypress, you can intercept and update the feature flag request, for example: 
+
+```
+cy.intercept('GET', '/api-proxy/whoami', {
+    active_features: ['your-flag-name'],
+  })
+```

--- a/src/client/components/ToggleSection/RemindersToggleSection.jsx
+++ b/src/client/components/ToggleSection/RemindersToggleSection.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { Link as RouterLink } from 'react-router-dom'
-// TODO: find out if I need this as RouterLink for clarity, as there's no 'Link'
 
 import styled from 'styled-components'
 import { SPACING, MEDIA_QUERIES, FONT_WEIGHTS } from '@govuk-react/constants'

--- a/src/client/components/ToggleSection/RemindersToggleSection.jsx
+++ b/src/client/components/ToggleSection/RemindersToggleSection.jsx
@@ -1,6 +1,12 @@
+import React from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+// TODO: find out if I need this as RouterLink for clarity, as there's no 'Link'
+
 import styled from 'styled-components'
-import { SPACING, FONT_WEIGHTS } from '@govuk-react/constants'
+import { SPACING, MEDIA_QUERIES, FONT_WEIGHTS } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
+
+import Table from '@govuk-react/table'
 
 import {
   ToggleButton,
@@ -8,7 +14,7 @@ import {
   MultiInstanceToggleSection,
 } from './BaseToggleSection'
 
-export const RemindersToggleSection = styled(MultiInstanceToggleSection)`
+const StyledMultiInstanceToggleSection = styled(MultiInstanceToggleSection)`
   border-top: 1px solid ${GREY_2};
   ${({ borderBottom }) => borderBottom && `border-bottom: 1px solid ${GREY_2};`}
 
@@ -22,5 +28,48 @@ export const RemindersToggleSection = styled(MultiInstanceToggleSection)`
     font-weight: ${FONT_WEIGHTS.bold};
   }
 `
+
+const StyledTable = styled(Table)({
+  marginTop: 0,
+  marginLeft: SPACING.SCALE_1,
+})
+
+const StyledCellHeader = styled(Table.CellHeader)({
+  [MEDIA_QUERIES.TABLET]: {
+    width: '33%',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '33%',
+  },
+})
+
+const StyledRouterLink = styled(RouterLink)({
+  marginBottom: SPACING.SCALE_5,
+  display: 'block',
+})
+
+const RemindersToggleSection = ({ dataName, data, to, ...props }) => {
+  return (
+    <StyledMultiInstanceToggleSection {...props}>
+      <StyledTable data-test={`${dataName}-table`}>
+        <Table.Row>
+          <StyledCellHeader>Reminders</StyledCellHeader>
+          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <StyledCellHeader>Email notifications</StyledCellHeader>
+          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+        </Table.Row>
+      </StyledTable>
+      <StyledRouterLink
+        data-test={`${dataName}-link`}
+        to={to}
+        aria-label="edit"
+      >
+        Edit
+      </StyledRouterLink>
+    </StyledMultiInstanceToggleSection>
+  )
+}
 
 export default RemindersToggleSection

--- a/src/client/components/ToggleSection/RemindersToggleSection.jsx
+++ b/src/client/components/ToggleSection/RemindersToggleSection.jsx
@@ -1,11 +1,6 @@
-import React from 'react'
-import { Link as RouterLink } from 'react-router-dom'
-
 import styled from 'styled-components'
-import { SPACING, MEDIA_QUERIES, FONT_WEIGHTS } from '@govuk-react/constants'
+import { SPACING, FONT_WEIGHTS } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
-
-import Table from '@govuk-react/table'
 
 import {
   ToggleButton,
@@ -13,7 +8,7 @@ import {
   MultiInstanceToggleSection,
 } from './BaseToggleSection'
 
-const StyledMultiInstanceToggleSection = styled(MultiInstanceToggleSection)`
+export const RemindersToggleSection = styled(MultiInstanceToggleSection)`
   border-top: 1px solid ${GREY_2};
   ${({ borderBottom }) => borderBottom && `border-bottom: 1px solid ${GREY_2};`}
 
@@ -27,48 +22,5 @@ const StyledMultiInstanceToggleSection = styled(MultiInstanceToggleSection)`
     font-weight: ${FONT_WEIGHTS.bold};
   }
 `
-
-const StyledTable = styled(Table)({
-  marginTop: 0,
-  marginLeft: SPACING.SCALE_1,
-})
-
-const StyledCellHeader = styled(Table.CellHeader)({
-  [MEDIA_QUERIES.TABLET]: {
-    width: '33%',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '33%',
-  },
-})
-
-const StyledRouterLink = styled(RouterLink)({
-  marginBottom: SPACING.SCALE_5,
-  display: 'block',
-})
-
-const RemindersToggleSection = ({ dataName, data, to, ...props }) => {
-  return (
-    <StyledMultiInstanceToggleSection {...props}>
-      <StyledTable data-test={`${dataName}-table`}>
-        <Table.Row>
-          <StyledCellHeader>Reminders</StyledCellHeader>
-          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <StyledCellHeader>Email notifications</StyledCellHeader>
-          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
-        </Table.Row>
-      </StyledTable>
-      <StyledRouterLink
-        data-test={`${dataName}-link`}
-        to={to}
-        aria-label="edit"
-      >
-        Edit
-      </StyledRouterLink>
-    </StyledMultiInstanceToggleSection>
-  )
-}
 
 export default RemindersToggleSection

--- a/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
@@ -23,28 +23,22 @@ const StyledRouterLink = styled(RouterLink)({
   display: 'block',
 })
 
-const RemindersSettingsTable = ({ dataName, data, to }) => {
-  return (
-    <>
-      <StyledTable data-test={`${dataName}-table`}>
-        <Table.Row>
-          <StyledCellHeader>Reminders</StyledCellHeader>
-          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <StyledCellHeader>Email notifications</StyledCellHeader>
-          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
-        </Table.Row>
-      </StyledTable>
-      <StyledRouterLink
-        data-test={`${dataName}-link`}
-        to={to}
-        aria-label="edit"
-      >
-        Edit
-      </StyledRouterLink>
-    </>
-  )
-}
+const RemindersSettingsTable = ({ dataName, data, to }) => (
+  <>
+    <StyledTable data-test={`${dataName}-table`}>
+      <Table.Row>
+        <StyledCellHeader>Reminders</StyledCellHeader>
+        <Table.Cell>{data.formattedReminderDays}</Table.Cell>
+      </Table.Row>
+      <Table.Row>
+        <StyledCellHeader>Email notifications</StyledCellHeader>
+        <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+      </Table.Row>
+    </StyledTable>
+    <StyledRouterLink data-test={`${dataName}-link`} to={to} aria-label="edit">
+      Edit
+    </StyledRouterLink>
+  </>
+)
 
 export default RemindersSettingsTable

--- a/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Link as RouterLink } from 'react-router-dom'
+import styled from 'styled-components'
+import Table from '@govuk-react/table'
+import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
+
+const StyledTable = styled(Table)({
+  marginTop: 0,
+  marginLeft: SPACING.SCALE_1,
+})
+
+const StyledCellHeader = styled(Table.CellHeader)({
+  [MEDIA_QUERIES.TABLET]: {
+    width: '33%',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '33%',
+  },
+})
+
+const StyledRouterLink = styled(RouterLink)({
+  marginBottom: SPACING.SCALE_5,
+  display: 'block',
+})
+
+const RemindersSettingsTable = ({ dataName, data, to }) => {
+  return (
+    <>
+      <StyledTable data-test={`${dataName}-table`}>
+        <Table.Row>
+          <StyledCellHeader>Reminders</StyledCellHeader>
+          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <StyledCellHeader>Email notifications</StyledCellHeader>
+          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+        </Table.Row>
+      </StyledTable>
+      <StyledRouterLink
+        data-test={`${dataName}-link`}
+        to={to}
+        aria-label="edit"
+      >
+        Edit
+      </StyledRouterLink>
+    </>
+  )
+}
+
+export default RemindersSettingsTable

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -8,6 +8,7 @@ import { get } from 'lodash'
 import qs from 'qs'
 
 import { DefaultLayout, RemindersToggleSection } from '../../../components'
+import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import Resource from '../../../components/Resource'
 import urls from '../../../../lib/urls'
 
@@ -61,9 +62,6 @@ const RemindersSettings = () => {
           exportNoRecentInteractions,
         }) => (
           <>
-            {/* TODO: Confirm H2 size */}
-            {/* TODO: check the spacing around the home link */}
-            {/* TODO: are we updating no-recent-interaction in this or a future ticket? */}
             <H2 size={LEVEL_SIZE[3]}>Investment</H2>
             <ToggleSectionContainer>
               <RemindersToggleSection
@@ -86,19 +84,27 @@ const RemindersSettings = () => {
                 to={urls.reminders.settings.investments.noRecentInteraction()}
               />
             </ToggleSectionContainer>
-            <H2 size={LEVEL_SIZE[3]}>Export</H2>
-            <ToggleSectionContainer>
-              <RemindersToggleSection
-                label="Companies with no recent interaction settings"
-                id="export-no-recent-interactions-toggle"
-                data-test="export-no-recent-interactions-toggle"
-                isOpen={openENRI}
-                borderBottom={true}
-                dataName={'export-no-recent-interactions'}
-                data={exportNoRecentInteractions}
-                to={urls.reminders.settings.exports.noRecentInteraction()}
-              />
-            </ToggleSectionContainer>
+            <CheckUserFeatureFlag userFeatureFlagName="export-email-reminders">
+              {(isFeatureFlagEnabled) =>
+                isFeatureFlagEnabled && (
+                  <>
+                    <H2 size={LEVEL_SIZE[3]}>Export</H2>
+                    <ToggleSectionContainer>
+                      <RemindersToggleSection
+                        label="Companies with no recent interaction settings"
+                        id="export-no-recent-interactions-toggle"
+                        data-test="export-no-recent-interactions-toggle"
+                        isOpen={openENRI}
+                        borderBottom={true}
+                        dataName={'export-no-recent-interactions'}
+                        data={exportNoRecentInteractions}
+                        to={urls.reminders.settings.exports.noRecentInteraction()}
+                      />
+                    </ToggleSectionContainer>
+                  </>
+                )
+              }
+            </CheckUserFeatureFlag>
             <StyledHomeLink href={urls.dashboard()} aria-label="Home">
               Home
             </StyledHomeLink>

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react'
-import { useLocation } from 'react-router-dom'
+import { useLocation, Link as RouterLink } from 'react-router-dom'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
+import Table from '@govuk-react/table'
 import { H2 } from '@govuk-react/heading'
-import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
+import { SPACING, MEDIA_QUERIES, LEVEL_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 import qs from 'qs'
 
@@ -19,11 +20,55 @@ const ToggleSectionContainer = styled('div')({
   marginBottom: '40px',
 })
 
+const StyledTable = styled(Table)({
+  marginTop: 0,
+  marginLeft: SPACING.SCALE_1,
+})
+
+const StyledCellHeader = styled(Table.CellHeader)({
+  [MEDIA_QUERIES.TABLET]: {
+    width: '33%',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: '33%',
+  },
+})
+
+const StyledRouterLink = styled(RouterLink)({
+  marginBottom: SPACING.SCALE_5,
+  display: 'block',
+})
+
 const StyledHomeLink = styled(Link)({
   marginTop: SPACING.SCALE_5,
   marginBottom: SPACING.SCALE_5,
   display: 'block',
 })
+
+// TODO: move this to RemindersToggleSelection.jsx
+const ReminderTable = ({ dataName, data, to }) => {
+  return (
+    <>
+      <StyledTable data-test={`${dataName}-table`}>
+        <Table.Row>
+          <StyledCellHeader>Reminders</StyledCellHeader>
+          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
+        </Table.Row>
+        <Table.Row>
+          <StyledCellHeader>Email notifications</StyledCellHeader>
+          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+        </Table.Row>
+      </StyledTable>
+      <StyledRouterLink
+        data-test={`${dataName}-link`}
+        to={to}
+        aria-label="edit"
+      >
+        Edit
+      </StyledRouterLink>
+    </>
+  )
+}
 
 const openSettings = (queryParamType, qsParams) => {
   const settingsExpand = get(qsParams, queryParamType, false)
@@ -69,20 +114,26 @@ const RemindersSettings = () => {
                 id="estimated-land-date-toggle"
                 data-test="estimated-land-date-toggle"
                 isOpen={openESL}
-                dataName={'estimated-land-date'}
-                data={estimatedLandDate}
-                to={urls.reminders.settings.investments.estimatedLandDate()}
-              />
+              >
+                <ReminderTable
+                  dataName={'estimated-land-date'}
+                  data={estimatedLandDate}
+                  to={urls.reminders.settings.investments.estimatedLandDate()}
+                />
+              </RemindersToggleSection>
               <RemindersToggleSection
                 label="Projects with no recent interaction settings"
                 id="no-recent-interaction-toggle"
                 data-test="no-recent-interaction-toggle"
                 isOpen={openNRI}
                 borderBottom={true}
-                dataName={'no-recent-interaction'}
-                data={noRecentInteraction}
-                to={urls.reminders.settings.investments.noRecentInteraction()}
-              />
+              >
+                <ReminderTable
+                  dataName={'no-recent-interaction'}
+                  data={noRecentInteraction}
+                  to={urls.reminders.settings.investments.noRecentInteraction()}
+                />
+              </RemindersToggleSection>
             </ToggleSectionContainer>
             <CheckUserFeatureFlag userFeatureFlagName="export-email-reminders">
               {(isFeatureFlagEnabled) =>
@@ -96,10 +147,13 @@ const RemindersSettings = () => {
                         data-test="export-no-recent-interactions-toggle"
                         isOpen={openENRI}
                         borderBottom={true}
-                        dataName={'export-no-recent-interactions'}
-                        data={exportNoRecentInteractions}
-                        to={urls.reminders.settings.exports.noRecentInteraction()}
-                      />
+                      >
+                        <ReminderTable
+                          dataName={'export-no-recent-interactions'}
+                          data={exportNoRecentInteractions}
+                          to={urls.reminders.settings.exports.noRecentInteraction()}
+                        />
+                      </RemindersToggleSection>
                     </ToggleSectionContainer>
                   </>
                 )

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { useLocation, Link as RouterLink } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
-import Table from '@govuk-react/table'
 import { H2 } from '@govuk-react/heading'
-import { SPACING, MEDIA_QUERIES, LEVEL_SIZE } from '@govuk-react/constants'
+import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 import qs from 'qs'
 
 import { DefaultLayout, RemindersToggleSection } from '../../../components'
+import RemindersSettingsTable from './RemindersSettingsTable'
 import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import Resource from '../../../components/Resource'
 import urls from '../../../../lib/urls'
@@ -20,55 +20,11 @@ const ToggleSectionContainer = styled('div')({
   marginBottom: '40px',
 })
 
-const StyledTable = styled(Table)({
-  marginTop: 0,
-  marginLeft: SPACING.SCALE_1,
-})
-
-const StyledCellHeader = styled(Table.CellHeader)({
-  [MEDIA_QUERIES.TABLET]: {
-    width: '33%',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '33%',
-  },
-})
-
-const StyledRouterLink = styled(RouterLink)({
-  marginBottom: SPACING.SCALE_5,
-  display: 'block',
-})
-
 const StyledHomeLink = styled(Link)({
   marginTop: SPACING.SCALE_5,
   marginBottom: SPACING.SCALE_5,
   display: 'block',
 })
-
-// TODO: move this to RemindersToggleSelection.jsx
-const ReminderTable = ({ dataName, data, to }) => {
-  return (
-    <>
-      <StyledTable data-test={`${dataName}-table`}>
-        <Table.Row>
-          <StyledCellHeader>Reminders</StyledCellHeader>
-          <Table.Cell>{data.formattedReminderDays}</Table.Cell>
-        </Table.Row>
-        <Table.Row>
-          <StyledCellHeader>Email notifications</StyledCellHeader>
-          <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
-        </Table.Row>
-      </StyledTable>
-      <StyledRouterLink
-        data-test={`${dataName}-link`}
-        to={to}
-        aria-label="edit"
-      >
-        Edit
-      </StyledRouterLink>
-    </>
-  )
-}
 
 const openSettings = (queryParamType, qsParams) => {
   const settingsExpand = get(qsParams, queryParamType, false)
@@ -115,7 +71,7 @@ const RemindersSettings = () => {
                 data-test="estimated-land-date-toggle"
                 isOpen={openESL}
               >
-                <ReminderTable
+                <RemindersSettingsTable
                   dataName={'estimated-land-date'}
                   data={estimatedLandDate}
                   to={urls.reminders.settings.investments.estimatedLandDate()}
@@ -128,7 +84,7 @@ const RemindersSettings = () => {
                 isOpen={openNRI}
                 borderBottom={true}
               >
-                <ReminderTable
+                <RemindersSettingsTable
                   dataName={'no-recent-interaction'}
                   data={noRecentInteraction}
                   to={urls.reminders.settings.investments.noRecentInteraction()}
@@ -148,7 +104,7 @@ const RemindersSettings = () => {
                         isOpen={openENRI}
                         borderBottom={true}
                       >
-                        <ReminderTable
+                        <RemindersSettingsTable
                           dataName={'export-no-recent-interactions'}
                           data={exportNoRecentInteractions}
                           to={urls.reminders.settings.exports.noRecentInteraction()}

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -66,7 +66,7 @@ const RemindersSettings = () => {
             <H2 size={LEVEL_SIZE[3]}>Investment</H2>
             <ToggleSectionContainer>
               <RemindersToggleSection
-                label="Approaching estimated land date settings"
+                label="Approaching estimated land date"
                 id="estimated-land-date-toggle"
                 data-test="estimated-land-date-toggle"
                 isOpen={openESL}
@@ -78,7 +78,7 @@ const RemindersSettings = () => {
                 />
               </RemindersToggleSection>
               <RemindersToggleSection
-                label="Projects with no recent interaction settings"
+                label="Projects with no recent interaction"
                 id="no-recent-interaction-toggle"
                 data-test="no-recent-interaction-toggle"
                 isOpen={openNRI}
@@ -98,7 +98,7 @@ const RemindersSettings = () => {
                     <H2 size={LEVEL_SIZE[3]}>Export</H2>
                     <ToggleSectionContainer>
                       <RemindersToggleSection
-                        label="Companies with no recent interaction settings"
+                        label="Companies with no recent interaction"
                         id="export-no-recent-interactions-toggle"
                         data-test="export-no-recent-interactions-toggle"
                         isOpen={openENRI}

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -3,7 +3,8 @@ import { useLocation, Link as RouterLink } from 'react-router-dom'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
 import Table from '@govuk-react/table'
-import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
+import { H2 } from '@govuk-react/heading'
+import { SPACING, MEDIA_QUERIES, LEVEL_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 import qs from 'qs'
 
@@ -39,6 +40,7 @@ const StyledRouterLink = styled(RouterLink)({
 
 const StyledHomeLink = styled(Link)({
   marginTop: SPACING.SCALE_5,
+  marginBottom: SPACING.SCALE_5,
   display: 'block',
 })
 
@@ -53,6 +55,7 @@ const RemindersSettings = () => {
   const qsParams = qs.parse(location.search.slice(1))
   const openESL = openSettings('investments_estimated_land_date', qsParams)
   const openNRI = openSettings('investments_no_recent_interaction', qsParams)
+  const openENRI = openSettings('exports_no_recent_interactions', qsParams)
 
   return (
     <DefaultLayout
@@ -72,69 +75,112 @@ const RemindersSettings = () => {
         name={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
         id={TASK_GET_ALL_REMINDER_SUBSCRIPTIONS}
       >
-        {({ estimatedLandDate, noRecentInteraction }) => (
-          <ToggleSectionContainer>
-            <RemindersToggleSection
-              label="Approaching estimated land date settings"
-              id="estimated-land-date-toggle"
-              data-test="estimated-land-date-toggle"
-              isOpen={openESL}
-            >
-              <StyledTable data-test="estimated-land-date-table">
-                <Table.Row>
-                  <StyledCellHeader>Reminders</StyledCellHeader>
-                  <Table.Cell>
-                    {estimatedLandDate.formattedReminderDays}
-                  </Table.Cell>
-                </Table.Row>
-                <Table.Row>
-                  <StyledCellHeader>Email notifications</StyledCellHeader>
-                  <Table.Cell>
-                    {estimatedLandDate.emailRemindersOnOff}
-                  </Table.Cell>
-                </Table.Row>
-              </StyledTable>
-              <StyledRouterLink
-                data-test="estimated-land-date-link"
-                to={urls.reminders.settings.investments.estimatedLandDate()}
-                aria-label="edit"
+        {({
+          estimatedLandDate,
+          noRecentInteraction,
+          exportNoRecentInteractions,
+        }) => (
+          <div>
+            {/* TODO: check if div is the correct wrapper in this codebase */}
+            {/* TODO: Confirm H2 size */}
+            {/* TODO: check the spacing around the home link */}
+            {/* TODO: are we updating no-recent-interaction in this or a future ticket? */}
+            <H2 size={LEVEL_SIZE[3]}>Investment</H2>
+            <ToggleSectionContainer>
+              <RemindersToggleSection
+                label="Approaching estimated land date settings"
+                id="estimated-land-date-toggle"
+                data-test="estimated-land-date-toggle"
+                isOpen={openESL}
               >
-                Edit
-              </StyledRouterLink>
-            </RemindersToggleSection>
-            <RemindersToggleSection
-              label="No recent interaction settings"
-              id="no-recent-interaction-toggle"
-              data-test="no-recent-interaction-toggle"
-              isOpen={openNRI}
-              borderBottom={true}
-            >
-              <StyledTable data-test="no-recent-interaction-table">
-                <Table.Row>
-                  <StyledCellHeader>Reminders</StyledCellHeader>
-                  <Table.Cell>
-                    {noRecentInteraction.formattedReminderDays}
-                  </Table.Cell>
-                </Table.Row>
-                <Table.Row>
-                  <StyledCellHeader>Email notifications</StyledCellHeader>
-                  <Table.Cell>
-                    {noRecentInteraction.emailRemindersOnOff}
-                  </Table.Cell>
-                </Table.Row>
-              </StyledTable>
-              <StyledRouterLink
-                data-test="no-recent-interaction-link"
-                to={urls.reminders.settings.investments.noRecentInteraction()}
-                aria-label="edit"
+                <StyledTable data-test="estimated-land-date-table">
+                  <Table.Row>
+                    <StyledCellHeader>Reminders</StyledCellHeader>
+                    <Table.Cell>
+                      {estimatedLandDate.formattedReminderDays}
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <StyledCellHeader>Email notifications</StyledCellHeader>
+                    <Table.Cell>
+                      {estimatedLandDate.emailRemindersOnOff}
+                    </Table.Cell>
+                  </Table.Row>
+                </StyledTable>
+                <StyledRouterLink
+                  data-test="estimated-land-date-link"
+                  to={urls.reminders.settings.investments.estimatedLandDate()}
+                  aria-label="edit"
+                >
+                  Edit
+                </StyledRouterLink>
+              </RemindersToggleSection>
+              <RemindersToggleSection
+                label="Projects with no recent interaction settings"
+                id="no-recent-interaction-toggle"
+                data-test="no-recent-interaction-toggle"
+                isOpen={openNRI}
+                borderBottom={true}
               >
-                Edit
-              </StyledRouterLink>
-            </RemindersToggleSection>
+                <StyledTable data-test="no-recent-interaction-table">
+                  <Table.Row>
+                    <StyledCellHeader>Reminders</StyledCellHeader>
+                    <Table.Cell>
+                      {noRecentInteraction.formattedReminderDays}
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <StyledCellHeader>Email notifications</StyledCellHeader>
+                    <Table.Cell>
+                      {noRecentInteraction.emailRemindersOnOff}
+                    </Table.Cell>
+                  </Table.Row>
+                </StyledTable>
+                <StyledRouterLink
+                  data-test="no-recent-interaction-link"
+                  to={urls.reminders.settings.investments.noRecentInteraction()}
+                  aria-label="edit"
+                >
+                  Edit
+                </StyledRouterLink>
+              </RemindersToggleSection>
+            </ToggleSectionContainer>
+            <H2 size={LEVEL_SIZE[3]}>Export</H2>
+            <ToggleSectionContainer>
+              <RemindersToggleSection
+                label="Companies with no recent interaction settings"
+                id="export-no-recent-interactions-toggle"
+                data-test="export-no-recent-interactions-toggle"
+                isOpen={openENRI}
+                borderBottom={true}
+              >
+                <StyledTable data-test="export-no-recent-interactions-table">
+                  <Table.Row>
+                    <StyledCellHeader>Reminders</StyledCellHeader>
+                    <Table.Cell>
+                      {exportNoRecentInteractions.formattedReminderDays}
+                    </Table.Cell>
+                  </Table.Row>
+                  <Table.Row>
+                    <StyledCellHeader>Email notifications</StyledCellHeader>
+                    <Table.Cell>
+                      {exportNoRecentInteractions.emailRemindersOnOff}
+                    </Table.Cell>
+                  </Table.Row>
+                </StyledTable>
+                <StyledRouterLink
+                  data-test="export-no-recent-interactions-link"
+                  to={urls.reminders.settings.exports.noRecentInteraction()}
+                  aria-label="edit"
+                >
+                  Edit
+                </StyledRouterLink>
+              </RemindersToggleSection>
+            </ToggleSectionContainer>
             <StyledHomeLink href={urls.dashboard()} aria-label="Home">
               Home
             </StyledHomeLink>
-          </ToggleSectionContainer>
+          </div>
         )}
       </Resource>
     </DefaultLayout>

--- a/src/client/modules/Reminders/Settings/index.jsx
+++ b/src/client/modules/Reminders/Settings/index.jsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { useLocation, Link as RouterLink } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
-import Table from '@govuk-react/table'
 import { H2 } from '@govuk-react/heading'
-import { SPACING, MEDIA_QUERIES, LEVEL_SIZE } from '@govuk-react/constants'
+import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 import qs from 'qs'
 
@@ -17,25 +16,6 @@ import { TASK_GET_ALL_REMINDER_SUBSCRIPTIONS } from '../state'
 const ToggleSectionContainer = styled('div')({
   marginTop: SPACING.SCALE_3,
   marginBottom: '40px',
-})
-
-const StyledTable = styled(Table)({
-  marginTop: 0,
-  marginLeft: SPACING.SCALE_1,
-})
-
-const StyledCellHeader = styled(Table.CellHeader)({
-  [MEDIA_QUERIES.TABLET]: {
-    width: '33%',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    width: '33%',
-  },
-})
-
-const StyledRouterLink = styled(RouterLink)({
-  marginBottom: SPACING.SCALE_5,
-  display: 'block',
 })
 
 const StyledHomeLink = styled(Link)({
@@ -80,8 +60,7 @@ const RemindersSettings = () => {
           noRecentInteraction,
           exportNoRecentInteractions,
         }) => (
-          <div>
-            {/* TODO: check if div is the correct wrapper in this codebase */}
+          <>
             {/* TODO: Confirm H2 size */}
             {/* TODO: check the spacing around the home link */}
             {/* TODO: are we updating no-recent-interaction in this or a future ticket? */}
@@ -92,58 +71,20 @@ const RemindersSettings = () => {
                 id="estimated-land-date-toggle"
                 data-test="estimated-land-date-toggle"
                 isOpen={openESL}
-              >
-                <StyledTable data-test="estimated-land-date-table">
-                  <Table.Row>
-                    <StyledCellHeader>Reminders</StyledCellHeader>
-                    <Table.Cell>
-                      {estimatedLandDate.formattedReminderDays}
-                    </Table.Cell>
-                  </Table.Row>
-                  <Table.Row>
-                    <StyledCellHeader>Email notifications</StyledCellHeader>
-                    <Table.Cell>
-                      {estimatedLandDate.emailRemindersOnOff}
-                    </Table.Cell>
-                  </Table.Row>
-                </StyledTable>
-                <StyledRouterLink
-                  data-test="estimated-land-date-link"
-                  to={urls.reminders.settings.investments.estimatedLandDate()}
-                  aria-label="edit"
-                >
-                  Edit
-                </StyledRouterLink>
-              </RemindersToggleSection>
+                dataName={'estimated-land-date'}
+                data={estimatedLandDate}
+                to={urls.reminders.settings.investments.estimatedLandDate()}
+              />
               <RemindersToggleSection
                 label="Projects with no recent interaction settings"
                 id="no-recent-interaction-toggle"
                 data-test="no-recent-interaction-toggle"
                 isOpen={openNRI}
                 borderBottom={true}
-              >
-                <StyledTable data-test="no-recent-interaction-table">
-                  <Table.Row>
-                    <StyledCellHeader>Reminders</StyledCellHeader>
-                    <Table.Cell>
-                      {noRecentInteraction.formattedReminderDays}
-                    </Table.Cell>
-                  </Table.Row>
-                  <Table.Row>
-                    <StyledCellHeader>Email notifications</StyledCellHeader>
-                    <Table.Cell>
-                      {noRecentInteraction.emailRemindersOnOff}
-                    </Table.Cell>
-                  </Table.Row>
-                </StyledTable>
-                <StyledRouterLink
-                  data-test="no-recent-interaction-link"
-                  to={urls.reminders.settings.investments.noRecentInteraction()}
-                  aria-label="edit"
-                >
-                  Edit
-                </StyledRouterLink>
-              </RemindersToggleSection>
+                dataName={'no-recent-interaction'}
+                data={noRecentInteraction}
+                to={urls.reminders.settings.investments.noRecentInteraction()}
+              />
             </ToggleSectionContainer>
             <H2 size={LEVEL_SIZE[3]}>Export</H2>
             <ToggleSectionContainer>
@@ -153,34 +94,15 @@ const RemindersSettings = () => {
                 data-test="export-no-recent-interactions-toggle"
                 isOpen={openENRI}
                 borderBottom={true}
-              >
-                <StyledTable data-test="export-no-recent-interactions-table">
-                  <Table.Row>
-                    <StyledCellHeader>Reminders</StyledCellHeader>
-                    <Table.Cell>
-                      {exportNoRecentInteractions.formattedReminderDays}
-                    </Table.Cell>
-                  </Table.Row>
-                  <Table.Row>
-                    <StyledCellHeader>Email notifications</StyledCellHeader>
-                    <Table.Cell>
-                      {exportNoRecentInteractions.emailRemindersOnOff}
-                    </Table.Cell>
-                  </Table.Row>
-                </StyledTable>
-                <StyledRouterLink
-                  data-test="export-no-recent-interactions-link"
-                  to={urls.reminders.settings.exports.noRecentInteraction()}
-                  aria-label="edit"
-                >
-                  Edit
-                </StyledRouterLink>
-              </RemindersToggleSection>
+                dataName={'export-no-recent-interactions'}
+                data={exportNoRecentInteractions}
+                to={urls.reminders.settings.exports.noRecentInteraction()}
+              />
             </ToggleSectionContainer>
             <StyledHomeLink href={urls.dashboard()} aria-label="Home">
               Home
             </StyledHomeLink>
-          </div>
+          </>
         )}
       </Resource>
     </DefaultLayout>

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -3,7 +3,7 @@ import { apiProxyAxios } from '../../components/Task/utils'
 import { formatDays, transformReminderDaysToForm } from './transformers'
 import { settings } from './constants'
 
-const transformAllSubscriptions = ([eld, nri]) => ({
+const transformAllSubscriptions = ([eld, nri, enri]) => ({
   estimatedLandDate: {
     formattedReminderDays: formatDays(
       eld.data.reminder_days.sort((a, b) => a - b).reverse(),
@@ -23,9 +23,14 @@ const transformAllSubscriptions = ([eld, nri]) => ({
       : settings.OFF,
   },
   exportNoRecentInteractions: {
-    formattedReminderDays: 10,
-    emailRemindersOnOff: settings.OFF,
-  }
+    formattedReminderDays: formatDays(
+      enri.data.reminder_days.sort((a, b) => a - b),
+      'days after the last interaction'
+    ),
+    emailRemindersOnOff: enri.data.email_reminders_enabled
+      ? settings.ON
+      : settings.OFF,
+  },
 })
 
 export const getAllSubscriptions = () =>
@@ -34,6 +39,7 @@ export const getAllSubscriptions = () =>
     apiProxyAxios.get(
       '/v4/reminder/subscription/no-recent-investment-interaction'
     ),
+    apiProxyAxios.get('/v4/reminder/subscription/no-recent-export-interaction'),
   ]).then(transformAllSubscriptions)
 
 export const getEldSubscriptions = () =>

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -22,6 +22,10 @@ const transformAllSubscriptions = ([eld, nri]) => ({
       ? settings.ON
       : settings.OFF,
   },
+  exportNoRecentInteractions: {
+    formattedReminderDays: 10,
+    emailRemindersOnOff: settings.OFF,
+  }
 })
 
 export const getAllSubscriptions = () =>

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -3,6 +3,16 @@ import { apiProxyAxios } from '../../components/Task/utils'
 import { formatDays, transformReminderDaysToForm } from './transformers'
 import { settings } from './constants'
 
+const transformNoRecentInteractionsSubscriptionSummary = (data) => ({
+  formattedReminderDays: formatDays(
+    data.reminder_days.sort((a, b) => a - b),
+    'days after the last interaction'
+  ),
+  emailRemindersOnOff: data.email_reminders_enabled
+    ? settings.ON
+    : settings.OFF,
+})
+
 const transformAllSubscriptions = ([eld, nri, enri]) => ({
   estimatedLandDate: {
     formattedReminderDays: formatDays(
@@ -13,24 +23,12 @@ const transformAllSubscriptions = ([eld, nri, enri]) => ({
       ? settings.ON
       : settings.OFF,
   },
-  noRecentInteraction: {
-    formattedReminderDays: formatDays(
-      nri.data.reminder_days.sort((a, b) => a - b),
-      'days after the last interaction'
-    ),
-    emailRemindersOnOff: nri.data.email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
-  exportNoRecentInteractions: {
-    formattedReminderDays: formatDays(
-      enri.data.reminder_days.sort((a, b) => a - b),
-      'days after the last interaction'
-    ),
-    emailRemindersOnOff: enri.data.email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
+  noRecentInteraction: transformNoRecentInteractionsSubscriptionSummary(
+    nri.data
+  ),
+  exportNoRecentInteractions: transformNoRecentInteractionsSubscriptionSummary(
+    enri.data
+  ),
 })
 
 export const getAllSubscriptions = () =>

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -3,45 +3,42 @@ import { apiProxyAxios } from '../../components/Task/utils'
 import { formatDays, transformReminderDaysToForm } from './transformers'
 import { settings } from './constants'
 
-// TODO: unpick this transformer once the API has been updated to a single request
-const transformAllSubscriptions = ([eld, nri, enri]) => ({
+const transformAllSubscriptions = ({ data }) => ({
   estimatedLandDate: {
     formattedReminderDays: formatDays(
-      eld.data.reminder_days.sort((a, b) => a - b).reverse(),
+      data.estimated_land_date.reminder_days.sort((a, b) => a - b).reverse(),
       'days before the estimated land date'
     ),
-    emailRemindersOnOff: eld.data.email_reminders_enabled
+    emailRemindersOnOff: data.estimated_land_date.email_reminders_enabled
       ? settings.ON
       : settings.OFF,
   },
   noRecentInteraction: {
     formattedReminderDays: formatDays(
-      nri.data.reminder_days.sort((a, b) => a - b),
+      data.no_recent_investment_interaction.reminder_days.sort((a, b) => a - b),
       'days after the last interaction'
     ),
-    emailRemindersOnOff: nri.data.email_reminders_enabled
+    emailRemindersOnOff: data.no_recent_investment_interaction
+      .email_reminders_enabled
       ? settings.ON
       : settings.OFF,
   },
   exportNoRecentInteractions: {
     formattedReminderDays: formatDays(
-      enri.data.reminder_days.sort((a, b) => a - b),
+      data.no_recent_export_interaction.reminder_days.sort((a, b) => a - b),
       'days after the last interaction'
     ),
-    emailRemindersOnOff: enri.data.email_reminders_enabled
+    emailRemindersOnOff: data.no_recent_export_interaction
+      .email_reminders_enabled
       ? settings.ON
       : settings.OFF,
   },
 })
 
 export const getAllSubscriptions = () =>
-  Promise.all([
-    apiProxyAxios.get('/v4/reminder/subscription/estimated-land-date'),
-    apiProxyAxios.get(
-      '/v4/reminder/subscription/no-recent-investment-interaction'
-    ),
-    apiProxyAxios.get('/v4/reminder/subscription/no-recent-export-interaction'),
-  ]).then(transformAllSubscriptions)
+  apiProxyAxios
+    .get('/v4/reminder/subscription/summary')
+    .then(transformAllSubscriptions)
 
 export const getEldSubscriptions = () =>
   apiProxyAxios

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -3,16 +3,7 @@ import { apiProxyAxios } from '../../components/Task/utils'
 import { formatDays, transformReminderDaysToForm } from './transformers'
 import { settings } from './constants'
 
-const transformNoRecentInteractionsSubscriptionSummary = (data) => ({
-  formattedReminderDays: formatDays(
-    data.reminder_days.sort((a, b) => a - b),
-    'days after the last interaction'
-  ),
-  emailRemindersOnOff: data.email_reminders_enabled
-    ? settings.ON
-    : settings.OFF,
-})
-
+// TODO: unpick this transformer once the API has been updated to a single request
 const transformAllSubscriptions = ([eld, nri, enri]) => ({
   estimatedLandDate: {
     formattedReminderDays: formatDays(
@@ -23,12 +14,24 @@ const transformAllSubscriptions = ([eld, nri, enri]) => ({
       ? settings.ON
       : settings.OFF,
   },
-  noRecentInteraction: transformNoRecentInteractionsSubscriptionSummary(
-    nri.data
-  ),
-  exportNoRecentInteractions: transformNoRecentInteractionsSubscriptionSummary(
-    enri.data
-  ),
+  noRecentInteraction: {
+    formattedReminderDays: formatDays(
+      nri.data.reminder_days.sort((a, b) => a - b),
+      'days after the last interaction'
+    ),
+    emailRemindersOnOff: nri.data.email_reminders_enabled
+      ? settings.ON
+      : settings.OFF,
+  },
+  exportNoRecentInteractions: {
+    formattedReminderDays: formatDays(
+      enri.data.reminder_days.sort((a, b) => a - b),
+      'days after the last interaction'
+    ),
+    emailRemindersOnOff: enri.data.email_reminders_enabled
+      ? settings.ON
+      : settings.OFF,
+  },
 })
 
 export const getAllSubscriptions = () =>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -500,6 +500,11 @@ module.exports = {
           '/reminders/settings/investments-no-recent-interaction'
         ),
       },
+      exports: {
+        noRecentInteraction: url(
+          '/reminders/settings/exports-no-recent-interactions'
+        ),
+      },
     },
   },
 }

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -26,6 +26,8 @@ const ALLOWLIST = [
   '/v4/company/:id/assign-one-list-tier-and-global-account-manager',
   '/v4/reminder/subscription/estimated-land-date',
   '/v4/reminder/subscription/no-recent-investment-interaction',
+  // TODO: Confirm endpoint with BE devs
+  '/v4/reminder/subscription/no-recent-export-interaction',
   '/v4/reminder/estimated-land-date',
   '/v4/reminder/no-recent-investment-interaction',
   '/v4/company/:id/remove-from-one-list',

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -26,8 +26,8 @@ const ALLOWLIST = [
   '/v4/company/:id/assign-one-list-tier-and-global-account-manager',
   '/v4/reminder/subscription/estimated-land-date',
   '/v4/reminder/subscription/no-recent-investment-interaction',
-  // TODO: Update this and the related task when the API is updated
   '/v4/reminder/subscription/no-recent-export-interaction',
+  '/v4/reminder/subscription/summary',
   '/v4/reminder/estimated-land-date',
   '/v4/reminder/no-recent-investment-interaction',
   '/v4/company/:id/remove-from-one-list',

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -26,7 +26,7 @@ const ALLOWLIST = [
   '/v4/company/:id/assign-one-list-tier-and-global-account-manager',
   '/v4/reminder/subscription/estimated-land-date',
   '/v4/reminder/subscription/no-recent-investment-interaction',
-  // TODO: Confirm endpoint with BE devs
+  // TODO: Update this and the related task when the API is updated
   '/v4/reminder/subscription/no-recent-export-interaction',
   '/v4/reminder/estimated-land-date',
   '/v4/reminder/no-recent-investment-interaction',

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -10,17 +10,13 @@ const nriEndpoint =
 const enriEndpoint =
   '/api-proxy/v4/reminder/subscription/no-recent-export-interaction'
 
-const eslToggle = '[data-test="estimated-land-date-toggle"]'
-const nriToggle = '[data-test="no-recent-interaction-toggle"]'
-const enriToggle = '[data-test="export-no-recent-interactions-toggle"]'
+const eslDataTest = 'estimated-land-date'
+const nriDataTest = 'no-recent-interaction'
+const enriDataTest = 'export-no-recent-interactions'
 
-const eslTable = '[data-test="estimated-land-date-table"]'
-const nriTable = '[data-test="no-recent-interaction-table"]'
-const enriTable = '[data-test="export-no-recent-interactions-table"]'
-
-const eslLink = '[data-test="estimated-land-date-link"]'
-const nriLink = '[data-test="no-recent-interaction-link"]'
-const enriLink = '[data-test="export-no-recent-interactions-link"]'
+const getToggle = (dataTest) => `[data-test="${dataTest}-toggle"]`
+const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
+const getLink = (dataTest) => `[data-test="${dataTest}-link"]`
 
 const interceptAPICalls = ({
   esl_reminder_days = [30, 60],
@@ -56,6 +52,44 @@ const waitForAPICalls = () => {
   cy.wait('@enriApiRequest')
 }
 
+const assertSettingsTableVisible = (title, dataTest) => {
+  it(`should show the ${title} settings table and edit link`, () => {
+    cy.get(getTable(dataTest)).should('be.visible')
+    cy.get(getLink(dataTest)).should('be.visible')
+  })
+}
+const assertSettingsTableNotVisible = (title, dataTest) => {
+  it(`should hide the ${title} settings table and edit link`, () => {
+    cy.get(getTable(dataTest)).should('not.be.visible')
+    cy.get(getLink(dataTest)).should('not.be.visible')
+  })
+}
+
+const assertSettingsTableToggles = ({
+  title,
+  dataTest,
+  reminderText,
+  buttonText,
+}) => {
+  it(`should render the ${title} settings table`, () => {
+    assertKeyValueTable(`${dataTest}-table`, {
+      Reminders: reminderText,
+      'Email notifications': 'On',
+    })
+  })
+
+  it(`should hide the ${title} settings table on toggle`, () => {
+    cy.get(getToggle(dataTest))
+      .find('button')
+      .contains(buttonText)
+      .click()
+      .get(getTable(dataTest))
+      .should('not.be.visible')
+      .get(getLink(dataTest))
+      .should('not.be.visible')
+  })
+}
+
 describe('Reminders Settings', () => {
   context('Breadcrumbs and title', () => {
     before(() => {
@@ -86,14 +120,9 @@ describe('Reminders Settings', () => {
       waitForAPICalls()
     })
 
-    it('should hide all settings tables and edit links', () => {
-      cy.get(eslTable).should('not.be.visible')
-      cy.get(eslLink).should('not.be.visible')
-      cy.get(nriTable).should('not.be.visible')
-      cy.get(nriLink).should('not.be.visible')
-      cy.get(enriTable).should('not.be.visible')
-      cy.get(enriLink).should('not.be.visible')
-    })
+    assertSettingsTableNotVisible('ELD', eslDataTest)
+    assertSettingsTableNotVisible('NRI', nriDataTest)
+    assertSettingsTableNotVisible('ENRI', enriDataTest)
   })
 
   context(
@@ -106,37 +135,15 @@ describe('Reminders Settings', () => {
         waitForAPICalls()
       })
 
-      it('should show the ELD settings table and edit link', () => {
-        cy.get(eslTable).should('be.visible')
-        cy.get(eslLink).should('be.visible')
-      })
+      assertSettingsTableVisible('ELD', eslDataTest)
+      assertSettingsTableNotVisible('NRI', nriDataTest)
+      assertSettingsTableNotVisible('ENRI', enriDataTest)
 
-      it('should hide the NRI settings table and edit link', () => {
-        cy.get(nriTable).should('not.be.visible')
-        cy.get(nriLink).should('not.be.visible')
-      })
-
-      it('should hide the ENRI settings table and edit link', () => {
-        cy.get(enriTable).should('not.be.visible')
-        cy.get(enriLink).should('not.be.visible')
-      })
-
-      it('should render the ELD settings table', () => {
-        assertKeyValueTable('estimated-land-date-table', {
-          Reminders: '60 and 30 days before the estimated land date',
-          'Email notifications': 'On',
-        })
-      })
-
-      it('should hide the ELD settings table on toggle', () => {
-        cy.get(eslToggle)
-          .find('button')
-          .contains('Approaching estimated land date settings')
-          .click()
-          .get(eslTable)
-          .should('not.be.visible')
-          .get(eslLink)
-          .should('not.be.visible')
+      assertSettingsTableToggles({
+        title: 'ELD',
+        dataTest: eslDataTest,
+        reminderText: '60 and 30 days before the estimated land date',
+        buttonText: 'Approaching estimated land date settings',
       })
     }
   )
@@ -151,119 +158,51 @@ describe('Reminders Settings', () => {
         waitForAPICalls()
       })
 
-      it('should hide the ELD settings table and edit link', () => {
-        cy.get(eslTable).should('not.be.visible')
-        cy.get(eslLink).should('not.be.visible')
-      })
+      assertSettingsTableNotVisible('ELD', eslDataTest)
+      assertSettingsTableVisible('NRI', nriDataTest)
+      assertSettingsTableNotVisible('ENRI', enriDataTest)
 
-      it('should show the NRI settings table and edit link', () => {
-        cy.get(nriTable).should('be.visible')
-        cy.get(nriLink).should('be.visible')
-      })
-
-      it('should hide the ENRI settings table and edit link', () => {
-        cy.get(enriTable).should('not.be.visible')
-        cy.get(enriLink).should('not.be.visible')
-      })
-
-      it('should render the NRI settings table', () => {
-        assertKeyValueTable('no-recent-interaction-table', {
-          Reminders: '30, 50 and 70 days after the last interaction',
-          'Email notifications': 'On',
-        })
-      })
-
-      it('should hide the NRI settings table on toggle', () => {
-        cy.get(nriToggle)
-          .find('button')
-          .contains('Projects with no recent interaction settings')
-          .click()
-          .get(nriTable)
-          .should('not.be.visible')
-          .get(nriLink)
-          .should('not.be.visible')
+      assertSettingsTableToggles({
+        title: 'NRI',
+        dataTest: nriDataTest,
+        reminderText: '30, 50 and 70 days after the last interaction',
+        buttonText: 'Projects with no recent interaction settings',
       })
     }
   )
 
-<<<<<<< HEAD
-  context(
-    'When both estimated land settings and no recent interaction settings are visible',
-    () => {
-      const queryParams =
-        'investments_estimated_land_date=true&investments_no_recent_interaction=true'
-      before(() => {
-        interceptAPICalls()
-        cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
-        waitForAPICalls()
-      })
-=======
   context('When only no recent export interaction settings are visible', () => {
-    const queryParams = 'export_no_recent_interactions=true'
+    const queryParams = 'exports_no_recent_interactions=true'
     before(() => {
       interceptAPICalls()
       cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
       waitForAPICalls()
     })
->>>>>>> 2f3bd4089 (Add calls to no recent export interaction endpoint)
 
-    it('should hide the ELD settings table and edit link', () => {
-      cy.get(eslTable).should('not.be.visible')
-      cy.get(eslLink).should('not.be.visible')
-    })
+    assertSettingsTableNotVisible('ELD', eslDataTest)
+    assertSettingsTableNotVisible('NRI', nriDataTest)
+    assertSettingsTableVisible('ENRI', enriDataTest)
 
-    it('should show the NRI settings table and edit link', () => {
-      cy.get(nriTable).should('not.be.visible')
-      cy.get(nriLink).should('not.be.visible')
-    })
-
-    it('should hide the ENRI settings table and edit link', () => {
-      cy.get(enriTable).should('be.visible')
-      cy.get(enriLink).should('be.visible')
-    })
-
-    it('should render the ENRI settings table', () => {
-      assertKeyValueTable('export-no-recent-interactions-table', {
-        Reminders: '10, 30 and 40 days after the last interaction',
-        'Email notifications': 'On',
-      })
-    })
-
-    it('should hide the ENRI settings table on toggle', () => {
-      cy.get(enriToggle)
-        .find('button')
-        .contains('Companies with no recent interaction settings')
-        .click()
-        .get(enriTable)
-        .should('not.be.visible')
-        .get(enriLink)
-        .should('not.be.visible')
+    assertSettingsTableToggles({
+      title: 'ENRI',
+      dataTest: enriDataTest,
+      reminderText: '10, 30 and 40 days after the last interaction',
+      buttonText: 'Companies with no recent interaction settings',
     })
   })
 
   context('When all settings are visible', () => {
     const queryParams =
-      'estimated_land_date=true&no_recent_interaction=true&export_no_recent_interactions=true'
+      'investments_estimated_land_date=true&investments_no_recent_interaction=true&exports_no_recent_interactions=true'
     before(() => {
       interceptAPICalls()
       cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
       waitForAPICalls()
     })
 
-    it('should show the estimated land date settings table and edit link', () => {
-      cy.get(eslTable).should('be.visible')
-      cy.get(eslLink).should('be.visible')
-    })
-
-    it('should show the no recent interaction settings table and edit link', () => {
-      cy.get(nriTable).should('be.visible')
-      cy.get(nriLink).should('be.visible')
-    })
-
-    it('should show the no recent export interaction settings table and edit link', () => {
-      cy.get(enriTable).should('be.visible')
-      cy.get(enriLink).should('be.visible')
-    })
+    assertSettingsTableVisible('ELD', eslDataTest)
+    assertSettingsTableVisible('NRI', nriDataTest)
+    assertSettingsTableVisible('ENRI', enriDataTest)
   })
 
   context('When no settings have been set - the default', () => {

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -4,6 +4,7 @@ import {
 } from '../../../support/assertions'
 import urls from '../../../../../../src/lib/urls'
 
+const userEndpoint = '/api-proxy/whoami'
 const eslEndpoint = '/api-proxy/v4/reminder/subscription/estimated-land-date'
 const nriEndpoint =
   '/api-proxy/v4/reminder/subscription/no-recent-investment-interaction'
@@ -26,6 +27,9 @@ const interceptAPICalls = ({
   enri_reminder_days = [10, 40, 30],
   enri_email_reminders_enabled = true,
 } = {}) => {
+  cy.intercept('GET', userEndpoint, {
+    active_features: 'export-email-reminders',
+  })
   cy.intercept('GET', eslEndpoint, {
     body: {
       reminder_days: esl_reminder_days,

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -7,20 +7,28 @@ import urls from '../../../../../../src/lib/urls'
 const eslEndpoint = '/api-proxy/v4/reminder/subscription/estimated-land-date'
 const nriEndpoint =
   '/api-proxy/v4/reminder/subscription/no-recent-investment-interaction'
+const enriEndpoint =
+  '/api-proxy/v4/reminder/subscription/no-recent-export-interaction'
 
 const eslToggle = '[data-test="estimated-land-date-toggle"]'
 const nriToggle = '[data-test="no-recent-interaction-toggle"]'
+const enriToggle = '[data-test="export-no-recent-interactions-toggle"]'
+
 const eslTable = '[data-test="estimated-land-date-table"]'
+const nriTable = '[data-test="no-recent-interaction-table"]'
+const enriTable = '[data-test="export-no-recent-interactions-table"]'
 
 const eslLink = '[data-test="estimated-land-date-link"]'
-const nriTable = '[data-test="no-recent-interaction-table"]'
 const nriLink = '[data-test="no-recent-interaction-link"]'
+const enriLink = '[data-test="export-no-recent-interactions-link"]'
 
 const interceptAPICalls = ({
   esl_reminder_days = [30, 60],
   esl_email_reminders_enabled = true,
   nri_reminder_days = [50, 30, 70],
   nri_email_reminders_enabled = true,
+  enri_reminder_days = [10, 40, 30],
+  enri_email_reminders_enabled = true,
 } = {}) => {
   cy.intercept('GET', eslEndpoint, {
     body: {
@@ -34,11 +42,18 @@ const interceptAPICalls = ({
       email_reminders_enabled: nri_email_reminders_enabled,
     },
   }).as('nriApiRequest')
+  cy.intercept('GET', enriEndpoint, {
+    body: {
+      reminder_days: enri_reminder_days,
+      email_reminders_enabled: enri_email_reminders_enabled,
+    },
+  }).as('enriApiRequest')
 }
 
 const waitForAPICalls = () => {
   cy.wait('@eslApiRequest')
   cy.wait('@nriApiRequest')
+  cy.wait('@enriApiRequest')
 }
 
 describe('Reminders Settings', () => {
@@ -64,23 +79,22 @@ describe('Reminders Settings', () => {
     })
   })
 
-  context(
-    'When both estimated land date and no recent interaction settings are hidden',
-    () => {
-      before(() => {
-        interceptAPICalls()
-        cy.visit(urls.reminders.settings.index())
-        waitForAPICalls()
-      })
+  context('When all settings are hidden', () => {
+    before(() => {
+      interceptAPICalls()
+      cy.visit(urls.reminders.settings.index())
+      waitForAPICalls()
+    })
 
-      it('should hide both settings tables and edit links', () => {
-        cy.get(eslTable).should('not.be.visible')
-        cy.get(eslLink).should('not.be.visible')
-        cy.get(nriTable).should('not.be.visible')
-        cy.get(nriLink).should('not.be.visible')
-      })
-    }
-  )
+    it('should hide all settings tables and edit links', () => {
+      cy.get(eslTable).should('not.be.visible')
+      cy.get(eslLink).should('not.be.visible')
+      cy.get(nriTable).should('not.be.visible')
+      cy.get(nriLink).should('not.be.visible')
+      cy.get(enriTable).should('not.be.visible')
+      cy.get(enriLink).should('not.be.visible')
+    })
+  })
 
   context(
     'When estimated land settings are visible and no recent interaction settings are hidden',
@@ -102,14 +116,19 @@ describe('Reminders Settings', () => {
         cy.get(nriLink).should('not.be.visible')
       })
 
-      it('should render the settings table', () => {
+      it('should hide the ENRI settings table and edit link', () => {
+        cy.get(enriTable).should('not.be.visible')
+        cy.get(enriLink).should('not.be.visible')
+      })
+
+      it('should render the ELD settings table', () => {
         assertKeyValueTable('estimated-land-date-table', {
           Reminders: '60 and 30 days before the estimated land date',
           'Email notifications': 'On',
         })
       })
 
-      it('should hide the settings table on toggle', () => {
+      it('should hide the ELD settings table on toggle', () => {
         cy.get(eslToggle)
           .find('button')
           .contains('Approaching estimated land date settings')
@@ -123,7 +142,7 @@ describe('Reminders Settings', () => {
   )
 
   context(
-    'When estimated land settings are hidden and no recent interaction settings are visible',
+    'When only no recent investment interaction settings are visible',
     () => {
       const queryParams = 'investments_no_recent_interaction=true'
       before(() => {
@@ -142,26 +161,32 @@ describe('Reminders Settings', () => {
         cy.get(nriLink).should('be.visible')
       })
 
-      it('should render the settings table', () => {
+      it('should hide the ENRI settings table and edit link', () => {
+        cy.get(enriTable).should('not.be.visible')
+        cy.get(enriLink).should('not.be.visible')
+      })
+
+      it('should render the NRI settings table', () => {
         assertKeyValueTable('no-recent-interaction-table', {
           Reminders: '30, 50 and 70 days after the last interaction',
           'Email notifications': 'On',
         })
       })
 
-      it('should hide the no recent interaction settings table on toggle', () => {
+      it('should hide the NRI settings table on toggle', () => {
         cy.get(nriToggle)
           .find('button')
           .contains('Projects with no recent interaction settings')
           .click()
-          .get(eslTable)
+          .get(nriTable)
           .should('not.be.visible')
-          .get(eslLink)
+          .get(nriLink)
           .should('not.be.visible')
       })
     }
   )
 
+<<<<<<< HEAD
   context(
     'When both estimated land settings and no recent interaction settings are visible',
     () => {
@@ -172,18 +197,74 @@ describe('Reminders Settings', () => {
         cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
         waitForAPICalls()
       })
+=======
+  context('When only no recent export interaction settings are visible', () => {
+    const queryParams = 'export_no_recent_interactions=true'
+    before(() => {
+      interceptAPICalls()
+      cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
+      waitForAPICalls()
+    })
+>>>>>>> 2f3bd4089 (Add calls to no recent export interaction endpoint)
 
-      it('should show the estimated land date settings table and edit link', () => {
-        cy.get(eslTable).should('be.visible')
-        cy.get(eslLink).should('be.visible')
-      })
+    it('should hide the ELD settings table and edit link', () => {
+      cy.get(eslTable).should('not.be.visible')
+      cy.get(eslLink).should('not.be.visible')
+    })
 
-      it('should show the no recent interaction settings table and edit link', () => {
-        cy.get(nriTable).should('be.visible')
-        cy.get(nriLink).should('be.visible')
+    it('should show the NRI settings table and edit link', () => {
+      cy.get(nriTable).should('not.be.visible')
+      cy.get(nriLink).should('not.be.visible')
+    })
+
+    it('should hide the ENRI settings table and edit link', () => {
+      cy.get(enriTable).should('be.visible')
+      cy.get(enriLink).should('be.visible')
+    })
+
+    it('should render the ENRI settings table', () => {
+      assertKeyValueTable('export-no-recent-interactions-table', {
+        Reminders: '10, 30 and 40 days after the last interaction',
+        'Email notifications': 'On',
       })
-    }
-  )
+    })
+
+    it('should hide the ENRI settings table on toggle', () => {
+      cy.get(enriToggle)
+        .find('button')
+        .contains('Companies with no recent interaction settings')
+        .click()
+        .get(enriTable)
+        .should('not.be.visible')
+        .get(enriLink)
+        .should('not.be.visible')
+    })
+  })
+
+  context('When all settings are visible', () => {
+    const queryParams =
+      'estimated_land_date=true&no_recent_interaction=true&export_no_recent_interactions=true'
+    before(() => {
+      interceptAPICalls()
+      cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
+      waitForAPICalls()
+    })
+
+    it('should show the estimated land date settings table and edit link', () => {
+      cy.get(eslTable).should('be.visible')
+      cy.get(eslLink).should('be.visible')
+    })
+
+    it('should show the no recent interaction settings table and edit link', () => {
+      cy.get(nriTable).should('be.visible')
+      cy.get(nriLink).should('be.visible')
+    })
+
+    it('should show the no recent export interaction settings table and edit link', () => {
+      cy.get(enriTable).should('be.visible')
+      cy.get(enriLink).should('be.visible')
+    })
+  })
 
   context('When no settings have been set - the default', () => {
     before(() => {
@@ -192,20 +273,29 @@ describe('Reminders Settings', () => {
         esl_email_reminders_enabled: false,
         nri_reminder_days: [],
         nri_email_reminders_enabled: false,
+        enri_reminder_days: [],
+        enri_email_reminders_enabled: false,
       })
       cy.visit(urls.reminders.settings.index())
       waitForAPICalls()
     })
 
-    it('should render the settings table with Off', () => {
+    it('should render the ELD settings table with Off', () => {
       assertKeyValueTable('estimated-land-date-table', {
         Reminders: 'Off',
         'Email notifications': 'Off',
       })
     })
 
-    it('should render the settings table', () => {
+    it('should render the NRI settings table with Off', () => {
       assertKeyValueTable('no-recent-interaction-table', {
+        Reminders: 'Off',
+        'Email notifications': 'Off',
+      })
+    })
+
+    it('should render the ENRI settings table with Off', () => {
+      assertKeyValueTable('export-no-recent-interactions-table', {
         Reminders: 'Off',
         'Email notifications': 'Off',
       })

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -152,7 +152,7 @@ describe('Reminders Settings', () => {
       it('should hide the no recent interaction settings table on toggle', () => {
         cy.get(nriToggle)
           .find('button')
-          .contains('No recent interaction settings')
+          .contains('Projects with no recent interaction settings')
           .click()
           .get(eslTable)
           .should('not.be.visible')

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -147,7 +147,7 @@ describe('Reminders Settings', () => {
         title: 'ELD',
         dataTest: eslDataTest,
         reminderText: '60 and 30 days before the estimated land date',
-        buttonText: 'Approaching estimated land date settings',
+        buttonText: 'Approaching estimated land date',
       })
     }
   )
@@ -170,7 +170,7 @@ describe('Reminders Settings', () => {
         title: 'NRI',
         dataTest: nriDataTest,
         reminderText: '30, 50 and 70 days after the last interaction',
-        buttonText: 'Projects with no recent interaction settings',
+        buttonText: 'Projects with no recent interaction',
       })
     }
   )
@@ -191,7 +191,7 @@ describe('Reminders Settings', () => {
       title: 'ENRI',
       dataTest: enriDataTest,
       reminderText: '10, 30 and 40 days after the last interaction',
-      buttonText: 'Companies with no recent interaction settings',
+      buttonText: 'Companies with no recent interaction',
     })
   })
 

--- a/test/functional/cypress/specs/reminders/settings/settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/settings-spec.js
@@ -5,11 +5,7 @@ import {
 import urls from '../../../../../../src/lib/urls'
 
 const userEndpoint = '/api-proxy/whoami'
-const eslEndpoint = '/api-proxy/v4/reminder/subscription/estimated-land-date'
-const nriEndpoint =
-  '/api-proxy/v4/reminder/subscription/no-recent-investment-interaction'
-const enriEndpoint =
-  '/api-proxy/v4/reminder/subscription/no-recent-export-interaction'
+const summaryEndpoint = '/api-proxy/v4/reminder/subscription/summary'
 
 const eslDataTest = 'estimated-land-date'
 const nriDataTest = 'no-recent-interaction'
@@ -29,31 +25,28 @@ const interceptAPICalls = ({
 } = {}) => {
   cy.intercept('GET', userEndpoint, {
     active_features: 'export-email-reminders',
-  })
-  cy.intercept('GET', eslEndpoint, {
+  }).as('userRequest')
+  cy.intercept('GET', summaryEndpoint, {
     body: {
-      reminder_days: esl_reminder_days,
-      email_reminders_enabled: esl_email_reminders_enabled,
+      estimated_land_date: {
+        email_reminders_enabled: esl_email_reminders_enabled,
+        reminder_days: esl_reminder_days,
+      },
+      no_recent_investment_interaction: {
+        email_reminders_enabled: nri_email_reminders_enabled,
+        reminder_days: nri_reminder_days,
+      },
+      no_recent_export_interaction: {
+        email_reminders_enabled: enri_email_reminders_enabled,
+        reminder_days: enri_reminder_days,
+      },
     },
-  }).as('eslApiRequest')
-  cy.intercept('GET', nriEndpoint, {
-    body: {
-      reminder_days: nri_reminder_days,
-      email_reminders_enabled: nri_email_reminders_enabled,
-    },
-  }).as('nriApiRequest')
-  cy.intercept('GET', enriEndpoint, {
-    body: {
-      reminder_days: enri_reminder_days,
-      email_reminders_enabled: enri_email_reminders_enabled,
-    },
-  }).as('enriApiRequest')
+  }).as('summaryRequest')
 }
 
 const waitForAPICalls = () => {
-  cy.wait('@eslApiRequest')
-  cy.wait('@nriApiRequest')
-  cy.wait('@enriApiRequest')
+  cy.wait('@userRequest')
+  cy.wait('@summaryRequest')
 }
 
 const assertSettingsTableVisible = (title, dataTest) => {

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -26,6 +26,13 @@ exports.saveNoRecentInteractionsSubscriptions = function (req, res) {
   })
 }
 
+exports.getExportNoRecentInteractionsSubscriptions = function (req, res) {
+  res.json({
+    reminder_days: [60, 90],
+    email_reminders_enabled: true,
+  })
+}
+
 exports.getEstimatedLandDateReminders = function (req, res) {
   res.json({
     count: 14,

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -33,6 +33,23 @@ exports.getExportNoRecentInteractionsSubscriptions = function (req, res) {
   })
 }
 
+exports.getReminderSubscriptionsSummary = function (req, res) {
+  res.json({
+    estimated_land_date: {
+      email_reminders_enabled: true,
+      reminder_days: [10, 20, 40],
+    },
+    no_recent_investment_interaction: {
+      email_reminders_enabled: true,
+      reminder_days: [10, 20, 40],
+    },
+    no_recent_export_interaction: {
+      email_reminders_enabled: true,
+      reminder_days: [10, 20, 40],
+    },
+  })
+}
+
 exports.getEstimatedLandDateReminders = function (req, res) {
   res.json({
     count: 14,

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -511,6 +511,11 @@ app.get(
 )
 
 app.get(
+  '/v4/reminder/subscription/summary',
+  v4Reminders.getReminderSubscriptionsSummary
+)
+
+app.get(
   '/v4/reminder/estimated-land-date',
   v4Reminders.getEstimatedLandDateReminders
 )

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -506,6 +506,11 @@ app.patch(
 )
 
 app.get(
+  '/v4/reminder/subscription/no-recent-export-interaction',
+  v4Reminders.getExportNoRecentInteractionsSubscriptions
+)
+
+app.get(
   '/v4/reminder/estimated-land-date',
   v4Reminders.getEstimatedLandDateReminders
 )


### PR DESCRIPTION
## Description of change

Divides the 'Reminders and email notifications settings' page into two sections, one for Investment and one for Exports. The Exports section is visible behind a feature flag. It contains a toggle component titled 'Companies with no recent interaction settings', which: 
- allows users to review their existing notification settings
- contains a link to the edit notifications form (not yet created)

## Test instructions
If running locally, visit: http://localhost:3000/reminders/settings?estimated_land_date=true . You should see the same view as before, except for a new heading 'Investment'.

To view the Exports changes, you will need to add a `export-email-reminders` feature flag, or watch the `test/functional/cypress/specs/reminders/settings/settings-spec.js` Cypress test.

## Screenshots

### Before
<img width="1007" alt="Screenshot 2022-11-02 at 14 25 48" src="https://user-images.githubusercontent.com/23265724/199489115-0ae9f00f-c345-47c3-8e4c-9e3e1350b42a.png">


### After
<img width="673" alt="Screenshot 2022-11-02 at 14 15 11" src="https://user-images.githubusercontent.com/23265724/199489032-ce3680f1-7726-48fe-b5f4-bb933a46426e.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
