### PR TITLE
Change edit company list form layout

### DIFF
--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -8,6 +8,7 @@ import {
   FieldRadios,
   Step,
   FieldAdvisersTypeahead,
+  FormLayout,
 } from '../../../../../client/components'
 import Form from '../../../../../client/components/Form'
 import { TASK_SAVE_ONE_LIST_DETAILS } from './state'
@@ -61,18 +62,20 @@ function EditOneListForm({
             </Step>
 
             {values.one_list_tier !== NONE && (
-              <Step name="oneListAdvisers">
-                <FieldAdvisersTypeahead
-                  name={ACCOUNT_MANAGER_FIELD_NAME}
-                  label="Global Account Manager"
-                  required="Select at least one adviser"
-                />
-                <FieldAdvisersTypeahead
-                  name={ONE_LIST_TEAM_FIELD_NAME}
-                  label="Advisers on the core team (optional)"
-                  isMulti={true}
-                />
-              </Step>
+              <FormLayout setWidth="three-quarters">
+                <Step name="oneListAdvisers">
+                  <FieldAdvisersTypeahead
+                    name={ACCOUNT_MANAGER_FIELD_NAME}
+                    label="Global Account Manager"
+                    required="Select at least one adviser"
+                  />
+                  <FieldAdvisersTypeahead
+                    name={ONE_LIST_TEAM_FIELD_NAME}
+                    label="Advisers on the core team (optional)"
+                    isMulti={true}
+                  />
+                </Step>
+              </FormLayout>
             )}
           </Main>
         </>


### PR DESCRIPTION
## Description of change

Changing `Edit One List Information` form from full width into two-thirds of screen layout. To make it the form to be shorter and easily read what was entered.

## Test instructions

- Navigate to Companies -> click any company from collection list.
- Click `View full business details` link
- At business details page, click `Edit One List Information` button.

## Screenshots

### Before
Full Width(≈960px)
![image](https://user-images.githubusercontent.com/28296624/199688564-c952e6d8-a418-4cef-874d-d1d340ebd0fe.png)

### After
Two-thirds Width(≈640px)
![image](https://user-images.githubusercontent.com/28296624/199696330-530dde32-c71c-4eac-b59a-8b74a4209cd8.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
