### PR TITLE
WIP - Feature/det 263 ukregions filter

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -691,138 +691,143 @@ describe('Activity feed controllers', () => {
       })
     })
   })
-})
 
-describe('#fetchAllActivityFeedEvents', () => {
-  before(() => {
-    fetchAllActivityFeedEventsStub = sinon
-      .stub()
-      .resolves(allActivityFeedEvents)
-    controllers = proxyquire(
-      '../../src/apps/companies/apps/activity-feed/controllers',
-      {
-        './repos': {
-          fetchActivityFeed: fetchAllActivityFeedEventsStub,
-        },
-      }
-    )
-  })
-
-  context('when filtering for the events collection page', () => {
-    before(async () => {
-      middlewareParameters = buildMiddlewareParameters({
-        requestQuery: {
-          sortBy: 'name:asc',
-          name: 'project zeus',
-          earliestStartDate: '2020-11-01',
-          latestStartDate: '2020-11-10',
-          page: 1,
-          aventriId: 123456789,
-          addressCountry: ['Canada', 'United Kingdom'],
-        },
-      })
-
-      await controllers.fetchAllActivityFeedEvents(
-        middlewareParameters.reqMock,
-        middlewareParameters.resMock,
-        middlewareParameters.nextSpy
+  describe('#fetchAllActivityFeedEvents', () => {
+    before(() => {
+      fetchAllActivityFeedEventsStub = sinon
+        .stub()
+        .resolves(allActivityFeedEvents)
+      controllers = proxyquire(
+        '../../src/apps/companies/apps/activity-feed/controllers',
+        {
+          './repos': {
+            fetchActivityFeed: fetchAllActivityFeedEventsStub,
+          },
+        }
       )
     })
 
-    it('should call fetchAllActivityFeedEvents with the right params', async () => {
-      const name = 'project zeus'
-      const from = 0
-      const size = 10
-      const earliestStartDate = '2020-11-01'
-      const latestStartDate = '2020-11-10'
-      const transformedAventriId = 'dit:aventri:Event:123456789:Create'
-      const addressCountry = ['Canada', 'United Kingdom']
-      const ukRegion = ['1718e330-6095-e211-a939-e4115bead28a']
+    context('when filtering for the events collection page', () => {
+      const requestQuery = {
+        sortBy: 'name:asc',
+        name: 'project zeus',
+        earliestStartDate: '2020-11-01',
+        latestStartDate: '2020-11-10',
+        page: 1,
+        aventriId: 123456789,
+        addressCountry: ['Canada', 'United Kingdom'],
+        ukRegion: ['1718e330-6095-e211-a939-e4115bead28a'],
+      }
 
-      const expectedEsQuery = {
-        from,
-        size,
-        query: {
-          bool: {
-            must: [
-              {
-                terms: {
-                  'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
-                },
-              },
-              {
-                match_phrase_prefix: {
-                  'object.name': name,
-                },
-              },
-              {
-                range: {
-                  'object.startTime': {
-                    gte: earliestStartDate,
-                    lte: latestStartDate,
+      before(async () => {
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery,
+        })
+
+        await controllers.fetchAllActivityFeedEvents(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
+      })
+
+      it('should call fetchAllActivityFeedEvents with the right params', async () => {
+        const from = 0
+        const size = 10
+        const transformedAventriId = `dit:aventri:Event:${requestQuery.aventriId}:Create`
+
+        const expectedEsQuery = {
+          from,
+          size,
+          query: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
                   },
                 },
-              },
-              {
-                term: {
-                  id: transformedAventriId,
+                {
+                  match_phrase_prefix: {
+                    'object.name': requestQuery.name,
+                  },
                 },
-              },
-              {
-                bool: {
-                  should: [
-                    {
-                      terms: {
-                        'object.dit:address_country.name': addressCountry,
-                      },
+                {
+                  range: {
+                    'object.startTime': {
+                      gte: requestQuery.earliestStartDate,
+                      lte: requestQuery.latestStartDate,
                     },
-                    {
-                      terms: {
-                        'object.dit:aventri:location_country': addressCountry,
-                      },
-                    },
-                  ],
+                  },
                 },
-              },
-            ],
+                {
+                  term: {
+                    id: transformedAventriId,
+                  },
+                },
+                {
+                  bool: {
+                    should: [
+                      {
+                        terms: {
+                          'object.dit:address_country.name':
+                            requestQuery.addressCountry,
+                        },
+                      },
+                      {
+                        terms: {
+                          'object.dit:aventri:location_country':
+                            requestQuery.addressCountry,
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  terms: {
+                    'object.dit:ukRegion.id': requestQuery.ukRegion,
+                  },
+                },
+              ],
+            },
           },
-        },
-        sort: {
-          'object.name.raw': {
-            order: 'asc',
-            unmapped_type: 'string',
+          sort: {
+            'object.name.raw': {
+              order: 'asc',
+              unmapped_type: 'string',
+            },
           },
-        },
+        }
+
+        expect(fetchAllActivityFeedEventsStub).to.be.calledWith(
+          middlewareParameters.reqMock,
+          expectedEsQuery
+        )
+      })
+    })
+
+    context('when the endpoint returns error', () => {
+      const error = {
+        status: 500,
       }
 
-      expect(fetchAllActivityFeedEventsStub).to.be.calledWith(
-        middlewareParameters.reqMock,
-        expectedEsQuery
-      )
-    })
-  })
+      before(async () => {
+        fetchAllActivityFeedEventsStub.rejects(error)
+        middlewareParameters = buildMiddlewareParameters({
+          requestQuery: {},
+        })
 
-  context('when the endpoint returns error', () => {
-    const error = {
-      status: 500,
-    }
-
-    before(async () => {
-      fetchAllActivityFeedEventsStub.rejects(error)
-      middlewareParameters = buildMiddlewareParameters({
-        requestQuery: {},
+        await controllers.fetchAllActivityFeedEvents(
+          middlewareParameters.reqMock,
+          middlewareParameters.resMock,
+          middlewareParameters.nextSpy
+        )
       })
 
-      await controllers.fetchAllActivityFeedEvents(
-        middlewareParameters.reqMock,
-        middlewareParameters.resMock,
-        middlewareParameters.nextSpy
-      )
-    })
-
-    it('should call next with an error', async () => {
-      expect(middlewareParameters.resMock.json).to.not.have.been.called
-      expect(middlewareParameters.nextSpy).to.have.been.calledWith(error)
+      it('should call next with an error', async () => {
+        expect(middlewareParameters.resMock.json).to.not.have.been.called
+        expect(middlewareParameters.nextSpy).to.have.been.calledWith(error)
+      })
     })
   })
 })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -405,6 +405,7 @@ const eventsColListQueryBuilder = ({
   latestStartDate,
   aventriId,
   addressCountry,
+  ukRegion,
 }) => {
   const eventNameFilter = name
     ? {
@@ -453,11 +454,20 @@ const eventsColListQueryBuilder = ({
       }
     : null
 
+  const ukRegionFilter = ukRegion
+    ? {
+        terms: {
+          'object.dit:ukRegion.id': ukRegion,
+        },
+      }
+    : null
+
   const filtersArray = [
     eventNameFilter,
     dateFilter,
     aventriIdFilter,
     countryFilter,
+    ukRegionFilter,
   ]
 
   const cleansedFiltersArray = filtersArray.filter((filter) => filter)
@@ -474,6 +484,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       earliestStartDate,
       latestStartDate,
       aventriId,
+      ukRegion,
       page,
       addressCountry,
     } = req.query
@@ -489,6 +500,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
           latestStartDate,
           aventriId,
           addressCountry,
+          ukRegion,
         }),
         from,
         size: ACTIVITIES_PER_PAGE,

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -16,6 +16,7 @@ const {
 
 router.get('/create', renderEventsView)
 router.get(urls.events.activity.data.route, fetchAllActivityFeedEvents)
+console.log('>>>route', urls.events.activity.data.route)
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
 router.get('/aventri/:aventriEventId/details', renderEventsView)

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -16,7 +16,6 @@ const {
 
 router.get('/create', renderEventsView)
 router.get(urls.events.activity.data.route, fetchAllActivityFeedEvents)
-console.log('>>>route', urls.events.activity.data.route)
 router.use(handleRoutePermissions(APP_PERMISSIONS))
 
 router.get('/aventri/:aventriEventId/details', renderEventsView)

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -261,7 +261,6 @@ const EventsCollection = ({
                   options={optionMetadata.ukRegionOptions}
                   selectedOptions={selectedFilters.ukRegions.options}
                   data-test="uk-region-filter"
-                  labelAsQueryParam={true}
                 />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -252,6 +252,17 @@ const EventsCollection = ({
                   data-test="country-filter"
                   labelAsQueryParam={true}
                 />
+                <Filters.Typeahead
+                  isMulti={true}
+                  label={LABELS.ukRegion}
+                  name="uk_region"
+                  qsParam="uk_region"
+                  placeholder="Search UK region"
+                  options={optionMetadata.ukRegionOptions}
+                  selectedOptions={selectedFilters.ukRegions.options}
+                  data-test="uk-region-filter"
+                  labelAsQueryParam={true}
+                />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>
           )

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -56,6 +56,7 @@ const getAllActivityFeedEvents = ({
   latest_start_date,
   aventri_id,
   address_country,
+  uk_region,
   page,
 }) =>
   axios
@@ -66,6 +67,7 @@ const getAllActivityFeedEvents = ({
         earliestStartDate: earliest_start_date,
         latestStartDate: latest_start_date,
         aventriId: aventri_id,
+        ukRegion: uk_region,
         page: page,
         addressCountry: address_country,
       },

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -24,7 +24,6 @@ import {
 } from '../../support/assertions'
 import { testTypeahead, testTypeaheadOptionsLength } from '../../support/tests'
 import { ukRegionFaker, ukRegionListFaker } from '../../fakers/regions'
-import { userFaker } from '../../fakers/users'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
@@ -43,7 +42,6 @@ const minimumPayload = {
 const searchEndpoint = '/api-proxy/v3/search/event'
 const eventTypeEndpoint = '/api-proxy/v4/metadata/event-type'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
-const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('events Collections Filter', () => {
   context('with the events activity stream feature flag disabled', () => {
@@ -691,16 +689,6 @@ describe('events Collections Filter', () => {
 
       context('should filter from user input and apply filter chips', () => {
         before(() => {
-          cy.intercept(
-            {
-              method: 'GET',
-              pathname: whoAmIEndpoint,
-            },
-            {
-              body: userFaker(),
-            }
-          ).as('whoAmIApiRequest')
-
           cy.intercept(
             'GET',
             `${urls.events.activity.data()}?sortBy=modified_on:desc&ukRegion[]=${ukRegion}&page=1`

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -24,6 +24,7 @@ import {
 } from '../../support/assertions'
 import { testTypeahead, testTypeaheadOptionsLength } from '../../support/tests'
 import { ukRegionFaker, ukRegionListFaker } from '../../fakers/regions'
+import { userFaker } from '../../fakers/users'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({
@@ -42,6 +43,7 @@ const minimumPayload = {
 const searchEndpoint = '/api-proxy/v3/search/event'
 const eventTypeEndpoint = '/api-proxy/v4/metadata/event-type'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('events Collections Filter', () => {
   context('with the events activity stream feature flag disabled', () => {
@@ -680,59 +682,69 @@ describe('events Collections Filter', () => {
       })
     })
 
-    after(() => {
-      cy.resetUser()
+    context('UkRegion', () => {
+      const element = '[data-test="uk-region-filter"]'
+      const queryParamWithUkRegion =
+        'uk_region%5B0%5D=1718e330-6095-e211-a939-e4115bead28a'
+      const ukRegion = '1718e330-6095-e211-a939-e4115bead28a'
+      const ukRegionLabel = 'All'
+
+      context('should filter from user input and apply filter chips', () => {
+        before(() => {
+          cy.intercept(
+            {
+              method: 'GET',
+              pathname: whoAmIEndpoint,
+            },
+            {
+              body: userFaker(),
+            }
+          ).as('whoAmIApiRequest')
+
+          cy.intercept(
+            'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&ukRegion[]=${ukRegion}&page=1`
+          ).as('ukRegionRequest')
+        })
+
+        it('should pass the uk Region to the controller', () => {
+          testTypeahead({
+            element,
+            label: 'UK region',
+            input: 'all',
+            placeholder: 'Search UK region',
+            expectedOption: ukRegionLabel,
+          })
+          cy.wait('@ukRegionRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
+        it('should pass the Uk region from user input to query param', () => {
+          cy.url().should('include', queryParamWithUkRegion)
+        })
+
+        it('should show filter chips', () => {
+          cy.get('[data-test="typeahead-chip"]').should(
+            'contain',
+            ukRegionLabel
+          )
+        })
+
+        context('should remove Uk Region selection', () => {
+          it('should remove filter chips', () => {
+            cy.get('[data-test="typeahead-chip"] > button').click()
+          })
+
+          it('should remove the Uk Region from the url', () => {
+            cy.url().should('not.include', queryParamWithUkRegion)
+          })
+        })
+      })
     })
   })
 
-  context('UkRegion', () => {
-    const element = '[data-test="uk-region-filter"]'
-    const queryParamWithUkRegion =
-      'uk_region%5B0%5D=1718e330-6095-e211-a939-e4115bead28a'
-    const ukRegion = '1718e330-6095-e211-a939-e4115bead28a'
-
-    context('should filter from user input and apply filter chips', () => {
-      before(() => {
-        cy.intercept(
-          'GET',
-          `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1&uk_region[]={ukRegion}`
-        ).as('ukRegionRequest')
-      })
-
-      it.only('should pass the uk Region to the controller', () => {
-        testTypeahead({
-          element,
-          label: 'Uk region',
-          input: 'all',
-          placeholder: 'Search UK Region',
-          expectedOption: 'All',
-        })
-        cy.wait('@ukRegionRequest').then((request) => {
-          expect(request.response.statusCode).to.eql(200)
-        })
-      })
-
-      // it('should pass the Uk region from user input to query param', () => {
-      //   cy.url().should('include', queryParamWithUkRegion)
-      // })
-
-      // it('should show filter chips', () => {
-      //   cy.get('[data-test="typeahead-chip"]').should('contain', ukRegion)
-      // })
-
-      // context('should remove Uk Region selection', () => {
-      //   it('should remove filter chips', () => {
-      //     cy.get('[data-test="typeahead-chip"] > button').click()
-      //   })
-
-      //   it('should remove the Uk Region from the url', () => {
-      //     cy.url().should('not.include', queryParamWithUkRegion)
-      //   })
-      // })
-    })
-
-    after(() => {
-      cy.resetUser()
-    })
+  after(() => {
+    cy.resetUser()
   })
 })

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -684,4 +684,55 @@ describe('events Collections Filter', () => {
       cy.resetUser()
     })
   })
+
+  context('UkRegion', () => {
+    const element = '[data-test="uk-region-filter"]'
+    const queryParamWithUkRegion =
+      'uk_region%5B0%5D=1718e330-6095-e211-a939-e4115bead28a'
+    const ukRegion = '1718e330-6095-e211-a939-e4115bead28a'
+
+    context('should filter from user input and apply filter chips', () => {
+      before(() => {
+        cy.intercept(
+          'GET',
+          `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1&uk_region[]={ukRegion}`
+        ).as('ukRegionRequest')
+      })
+
+      it.only('should pass the uk Region to the controller', () => {
+        testTypeahead({
+          element,
+          label: 'Uk region',
+          input: 'all',
+          placeholder: 'Search UK Region',
+          expectedOption: 'All',
+        })
+        cy.wait('@ukRegionRequest').then((request) => {
+          expect(request.response.statusCode).to.eql(200)
+        })
+      })
+
+      // it('should pass the Uk region from user input to query param', () => {
+      //   cy.url().should('include', queryParamWithUkRegion)
+      // })
+
+      // it('should show filter chips', () => {
+      //   cy.get('[data-test="typeahead-chip"]').should('contain', ukRegion)
+      // })
+
+      // context('should remove Uk Region selection', () => {
+      //   it('should remove filter chips', () => {
+      //     cy.get('[data-test="typeahead-chip"] > button').click()
+      //   })
+
+      //   it('should remove the Uk Region from the url', () => {
+      //     cy.url().should('not.include', queryParamWithUkRegion)
+      //   })
+      // })
+    })
+
+    after(() => {
+      cy.resetUser()
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

Add a new typeahead filter for UK regions on the events page

## Test instructions

This filter is only visible with an account that has the `user-activity-stream-aventri` feature flag enabled. 
The new filter can be viewed from the `/events` page, it is the last one in the list of filters

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/201109738-b4268fac-a3e1-4fa8-9f04-3faa98d7cf1b.png)

### After

![image](https://user-images.githubusercontent.com/102232401/201109849-971278f1-cd27-4806-bb11-8d80e91dc63f.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
