### PR TITLE
Add interaction form layout

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -16,6 +16,7 @@ import {
   TASK_GET_INTERACTION_INITIAL_VALUES,
 } from './state'
 import urls from '../../../../../lib/urls'
+import { FormLayout } from '../../../../../client/components'
 
 const getReturnLink = (
   companyId,
@@ -79,89 +80,93 @@ const InteractionDetailsForm = ({
               const contactCreated =
                 location.search.includes('new-contact-name')
               return (
-                <Form
-                  id={STATE_ID}
-                  submissionTaskName={TASK_SAVE_INTERACTION}
-                  analyticsFormName={
-                    interactionId ? 'editInteraction' : 'createInteraction'
-                  }
-                  analyticsData={(values) =>
-                    _.pick(
-                      values,
-                      'was_policy_feedback_provided',
-                      'were_countries_discussed'
-                    )
-                  }
-                  initialValuesPayload={{
-                    companyId,
-                    referral,
-                    investmentId,
-                    contactId,
-                    user,
-                    interactionId,
-                  }}
-                  initialValuesTaskName={TASK_GET_INTERACTION_INITIAL_VALUES}
-                  transformPayload={(values) => ({
-                    values,
-                    companyIds,
-                    referralId: referral?.id,
-                  })}
-                  initialStepIndex={contactCreated && !interactionId ? 1 : 0}
-                  redirectTo={({ data }) =>
-                    getReturnLink(
+                <FormLayout setWidth="three-quarters">
+                  <Form
+                    id={STATE_ID}
+                    submissionTaskName={TASK_SAVE_INTERACTION}
+                    analyticsFormName={
+                      interactionId ? 'editInteraction' : 'createInteraction'
+                    }
+                    analyticsData={(values) =>
+                      _.pick(
+                        values,
+                        'was_policy_feedback_provided',
+                        'were_countries_discussed'
+                      )
+                    }
+                    initialValuesPayload={{
                       companyId,
-                      referral?.id,
+                      referral,
                       investmentId,
                       contactId,
-                      data.id
-                    )
-                  }
-                  flashMessage={({ data }) =>
-                    getFlashMessage(
+                      user,
                       interactionId,
-                      data.was_policy_feedback_provided
-                    )
-                  }
-                  scrollToTopOnStep={true}
-                  showStepInUrl={true}
-                >
-                  {({ values, currentStep }) => (
-                    <>
-                      {/* Step registered if creating the interaction
+                    }}
+                    initialValuesTaskName={TASK_GET_INTERACTION_INITIAL_VALUES}
+                    transformPayload={(values) => ({
+                      values,
+                      companyIds,
+                      referralId: referral?.id,
+                    })}
+                    initialStepIndex={contactCreated && !interactionId ? 1 : 0}
+                    redirectTo={({ data }) =>
+                      getReturnLink(
+                        companyId,
+                        referral?.id,
+                        investmentId,
+                        contactId,
+                        data.id
+                      )
+                    }
+                    flashMessage={({ data }) =>
+                      getFlashMessage(
+                        interactionId,
+                        data.was_policy_feedback_provided
+                      )
+                    }
+                    scrollToTopOnStep={true}
+                    showStepInUrl={true}
+                  >
+                    {({ values, currentStep }) => (
+                      <>
+                        {/* Step registered if creating the interaction
                   and haven't come from an investment project */}
-                      {!interactionId && !investmentId && (
-                        <Step name="interaction_type">
-                          {() => <StepInteractionType />}
-                        </Step>
-                      )}
-
-                      <Step
-                        name="interaction_details"
-                        forwardButton={
-                          interactionId ? 'Save interaction' : 'Add interaction'
-                        }
-                      >
-                        {() => (
-                          <StepInteractionDetails
-                            companyId={companyId}
-                            onOpenContactForm={(e) => {
-                              e.preventDefault()
-                              openContactFormTask.start({
-                                payload: {
-                                  values,
-                                  currentStep,
-                                  companyId,
-                                  url: e.target.href,
-                                },
-                              })
-                            }}
-                            {...props}
-                          />
+                        {!interactionId && !investmentId && (
+                          <Step name="interaction_type">
+                            {() => <StepInteractionType />}
+                          </Step>
                         )}
-                      </Step>
-                    </>
-                  )}
-                </Form>
+
+                        <Step
+                          name="interaction_details"
+                          forwardButton={
+                            interactionId
+                              ? 'Save interaction'
+                              : 'Add interaction'
+                          }
+                        >
+                          {() => (
+                            <StepInteractionDetails
+                              companyId={companyId}
+                              onOpenContactForm={(e) => {
+                                e.preventDefault()
+                                openContactFormTask.start({
+                                  payload: {
+                                    values,
+                                    currentStep,
+                                    companyId,
+                                    url: e.target.href,
+                                  },
+                                })
+                              }}
+                              {...props}
+                            />
+                          )}
+                        </Step>
+                      </>
+                    )}
+                  </Form>
+                </FormLayout>
               )
             }}
           </Route>

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -75,12 +75,12 @@ const InteractionDetailsForm = ({
         const openContactFormTask = getTask(TASK_OPEN_CONTACT_FORM, STATE_ID)
         const companyIds = [companyId]
         return (
-          <Route>
-            {({ location }) => {
-              const contactCreated =
-                location.search.includes('new-contact-name')
-              return (
-                <FormLayout setWidth="three-quarters">
+          <FormLayout setWidth="three-quarters">
+            <Route>
+              {({ location }) => {
+                const contactCreated =
+                  location.search.includes('new-contact-name')
+                return (
                   <Form
                     id={STATE_ID}
                     submissionTaskName={TASK_SAVE_INTERACTION}
@@ -166,10 +166,10 @@ const InteractionDetailsForm = ({
                       </>
                     )}
                   </Form>
-                </FormLayout>
-              )
-            }}
-          </Route>
+                )
+              }}
+            </Route>
+          </FormLayout>
         )
       }}
     </Task>

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -50,7 +50,7 @@ describe('DA add Investment Project interaction', () => {
         .get(formSelectors.hasRelatedTradeAgreementsNo)
         .click()
         .get(formSelectors.contact)
-        .selectTypeaheadOption('Fred Peterson')
+        .selectTypeaheadOption('Mark Halomi')
         .get(formSelectors.communicationChannel)
         .selectTypeaheadOption('Email/Website')
         .get(formSelectors.subject)

--- a/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
@@ -49,7 +49,7 @@ describe('LEP add Investment Project interaction', () => {
         .get(formSelectors.hasRelatedTradeAgreementsNo)
         .click()
         .get(formSelectors.contact)
-        .selectTypeaheadOption('Fred Peterson')
+        .selectTypeaheadOption('Mark Halomi')
         .get(formSelectors.communicationChannel)
         .selectTypeaheadOption('Email/Website')
         .get(formSelectors.subject)

--- a/test/selectors/interaction-form.js
+++ b/test/selectors/interaction-form.js
@@ -4,7 +4,7 @@ const { EXPORT_INTEREST_STATUS } = require('../../src/apps/constants')
 module.exports = {
   form: 'form',
   subject: '#field-subject',
-  notes: '#field-notes',
+  notes: '#notes',
   dateOfInteractionYear: '#field-date_year',
   dateOfInteractionMonth: '#field-date_month',
   dateOfInteractionDay: '#field-date_day',
@@ -32,7 +32,7 @@ module.exports = {
   policyFeedbackYes: '#field-was_policy_feedback_provided [value=yes]',
   policyFeedbackNo: '#field-was_policy_feedback_provided [value=no]',
   policyArea: '#field-policy_areas',
-  policyFeedbackNotes: '#field-policy_feedback_notes',
+  policyFeedbackNotes: '#notes',
   teamSearch: '#dit_team__typeahead .multiselect__single',
   countriesDiscussed: {
     yes: '#field-were_countries_discussed [value=yes]',


### PR DESCRIPTION
## Description of change

_Document what the PR does and why the change is needed_

Navigate to Companies -> click Companies --> Add Interaction --> Select Trade agreement
Then display the Add Interaction form - Add Interaction form layout from full to two-thirds width.

_What should I see?_

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/74972011/201708934-f433f790-f5a5-4805-975d-469366989f37.png)

### After

![image](https://user-images.githubusercontent.com/74972011/201708979-796982ce-b0d4-4571-b8c3-dc527e66c2bd.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
