### PR TITLE
Fix hint text for event filters

### DIFF
--- a/src/client/components/RoutedAventriIdField/Filter.jsx
+++ b/src/client/components/RoutedAventriIdField/Filter.jsx
@@ -2,33 +2,30 @@ import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import HintText from '@govuk-react/hint-text'
-import { FONT_SIZE, SPACING } from '@govuk-react/constants'
-import { GREY_1 } from 'govuk-colours'
+import { SPACING } from '@govuk-react/constants'
 
 import RoutedFilterInput from '../RoutedInput/Filter'
 import FilterLabel from '../FilterLabel'
 
 const StyledFilterLabel = styled(FilterLabel)({
-  marginBottom: SPACING.SCALE_2,
+  marginBottom: SPACING.SCALE_5,
 })
 
 const StyledHintText = styled(HintText)({
-  fontSize: FONT_SIZE.SIZE_16,
-  color: GREY_1,
   marginBottom: SPACING.SCALE_2,
 })
 
-const RoutedAventriIdFieldFilter = ({ label, hintText, ...props }) => (
+const RoutedAventriIdFieldFilter = ({ label, hint, ...props }) => (
   <StyledFilterLabel>
     {label}
-    <StyledHintText>{hintText}</StyledHintText>
+    <StyledHintText>{hint}</StyledHintText>
     <RoutedFilterInput {...props} />
   </StyledFilterLabel>
 )
 
 RoutedAventriIdFieldFilter.propTypes = {
   label: PropTypes.node.isRequired,
-  hintText: PropTypes.string,
+  hint: PropTypes.string,
 }
 
 export default RoutedAventriIdFieldFilter

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -216,7 +216,6 @@ const EventsCollection = ({
                   qsParam="name"
                   name="name"
                   label={LABELS.eventName}
-                  placeholder="Search event name"
                   data-test="event-name-filter"
                 />
                 <Filters.Date
@@ -224,12 +223,14 @@ const EventsCollection = ({
                   name="earliest_start_date"
                   qsParamName="earliest_start_date"
                   data-test="earliest-start-date-filter"
+                  hint="For example, 21/11/2019"
                 />
                 <Filters.Date
                   label={LABELS.latestStartDate}
                   name="latest_start_date"
                   qsParamName="latest_start_date"
                   data-test="latest-start-date-filter"
+                  hint="For example, 21/11/2019"
                 />
                 <Filters.AdvisersTypeahead
                   isMulti={true}
@@ -247,7 +248,7 @@ const EventsCollection = ({
                   label={LABELS.aventriId}
                   name="aventri_id"
                   qsParam="aventri_id"
-                  hintText="For example, 100100100"
+                  hint="For example, 100100100"
                   type="number"
                   onInput={maxLengthAventriIdValidation}
                   data-test="aventri-id-filter"
@@ -257,7 +258,7 @@ const EventsCollection = ({
                   label={LABELS.country}
                   name="address_country"
                   qsParam="address_country"
-                  placeholder="Search country"
+                  placeholder=""
                   options={optionMetadata.countryOptions}
                   selectedOptions={selectedFilters.countries.options}
                   data-test="country-filter"

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -243,16 +243,6 @@ const EventsCollection = ({
                   selectedOptions={selectedFilters.organisers.options}
                   data-test="organiser-filter"
                 />
-                <Filters.AventriId
-                  id="EventsCollection.aventriId"
-                  label={LABELS.aventriId}
-                  name="aventri_id"
-                  qsParam="aventri_id"
-                  hint="For example, 100100100"
-                  type="number"
-                  onInput={maxLengthAventriIdValidation}
-                  data-test="aventri-id-filter"
-                />
                 <Filters.Typeahead
                   isMulti={true}
                   label={LABELS.country}
@@ -283,6 +273,16 @@ const EventsCollection = ({
                   selectedOptions={selectedFilters.eventTypes.options}
                   data-test="event-type-filter"
                   groupId="event-type-filter"
+                />
+                <Filters.AventriId
+                  id="EventsCollection.aventriId"
+                  label={LABELS.aventriId}
+                  name="aventri_id"
+                  qsParam="aventri_id"
+                  hint="For example, 100100100"
+                  type="number"
+                  onInput={maxLengthAventriIdValidation}
+                  data-test="aventri-id-filter"
                 />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -657,7 +657,7 @@ describe('events Collections Filter', () => {
             element,
             label: 'Country',
             input: 'braz',
-            placeholder: 'Search country',
+            placeholder: '',
             expectedOption: 'Brazil',
           })
 


### PR DESCRIPTION
## Description of change

- Increase aventri margin so spacing matches other input components 
- Changed the aventri hint styling to match the hint styling for the rest of the components in the website
- Renamed `hintText` property to `hint` to match other components 
- Add hints for the start and end date fields
- Remove the placeholder text from event name and country to match designs
- Moved aventri to bottom of list to match designs

## Test instructions

Navigate to the /events page, and the filter for Aventri ID will now have a hint text that matches the hint text styling in the rest of the website. This does not match the GDS hint styling, however it does match the styling for all other input fields

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/201354075-fc84392c-7903-410c-b67b-6af2f1eb682b.png)

### After

![image](https://user-images.githubusercontent.com/102232401/201692194-0ba10ee8-2ed8-435b-a39e-911e7419b559.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
