### PR TITLE
Add new event type filter

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -669,6 +669,28 @@ describe('Activity feed controllers', () => {
       })
     })
 
+    context('check query builder when filtering on event type', () => {
+      const expectedQuery = (eventType) => [
+        {
+          terms: {
+            'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+          },
+        },
+        {
+          terms: {
+            'object.dit:eventType.id': eventType,
+          },
+        },
+      ]
+
+      it('builds the right query when a event type is selected', () => {
+        const eventType = ['an-event-type-id']
+        const actualQuery = eventsColListQueryBuilder({ eventType })
+
+        expect(expectedQuery(eventType)).to.deep.equal(actualQuery)
+      })
+    })
+
     context('check query builder when filtering on uk region', () => {
       const expectedQuery = (ukRegion) => [
         {

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -407,6 +407,7 @@ const eventsColListQueryBuilder = ({
   addressCountry,
   ukRegion,
   organiser,
+  eventType,
 }) => {
   const eventNameFilter = name
     ? {
@@ -462,10 +463,19 @@ const eventsColListQueryBuilder = ({
         },
       }
     : null
+
   const organiserFilter = organiser
     ? {
         terms: {
           'object.dit:organiser.id': organiser,
+        },
+      }
+    : null
+
+  const eventTypeFilter = eventType
+    ? {
+        terms: {
+          'object.dit:eventType.id': eventType,
         },
       }
     : null
@@ -477,6 +487,7 @@ const eventsColListQueryBuilder = ({
     countryFilter,
     ukRegionFilter,
     organiserFilter,
+    eventTypeFilter,
   ]
 
   const cleansedFiltersArray = filtersArray.filter((filter) => filter)
@@ -497,6 +508,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       organiser,
       page,
       addressCountry,
+      eventType,
     } = req.query
 
     const from = (page - 1) * ACTIVITIES_PER_PAGE
@@ -512,6 +524,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
           addressCountry,
           ukRegion,
           organiser,
+          eventType,
         }),
         from,
         size: ACTIVITIES_PER_PAGE,

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -273,6 +273,16 @@ const EventsCollection = ({
                   selectedOptions={selectedFilters.ukRegions.options}
                   data-test="uk-region-filter"
                 />
+                <Filters.CheckboxGroup
+                  maxScrollHeight={200}
+                  legend={LABELS.eventType}
+                  name="event_type"
+                  qsParam="event_type"
+                  options={optionMetadata.eventTypeOptions}
+                  selectedOptions={selectedFilters.eventTypes.options}
+                  data-test="event-type-filter"
+                  groupId="event-type-filter"
+                />
               </CollectionFilters>
             </ActivityFeedFilteredCollectionList>
           )

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -57,6 +57,7 @@ const getAllActivityFeedEvents = ({
   address_country,
   uk_region,
   organiser,
+  event_type,
   page,
 }) =>
   axios
@@ -71,6 +72,7 @@ const getAllActivityFeedEvents = ({
         organiser: organiser,
         page: page,
         addressCountry: address_country,
+        eventType: event_type,
       },
     })
     .then(({ data }) => data)

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -799,6 +799,10 @@ describe('events Collections Filter', () => {
           )
           cy.intercept(
             'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1`
+          ).as('eventTypeRequestNoFilter')
+          cy.intercept(
+            'GET',
             `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1&eventType[]=${
               eventType.id
             }`

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -799,10 +799,6 @@ describe('events Collections Filter', () => {
           )
           cy.intercept(
             'GET',
-            `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1`
-          ).as('eventTypeRequestNoFilter')
-          cy.intercept(
-            'GET',
             `${urls.events.activity.data()}?sortBy=modified_on:desc&page=1&eventType[]=${
               eventType.id
             }`

--- a/test/functional/cypress/support/tests.js
+++ b/test/functional/cypress/support/tests.js
@@ -8,6 +8,7 @@ import { selectFirstTypeaheadOption } from './actions'
 import {
   assertTypeaheadHints,
   assertTypeaheadOptionSelected,
+  assertCheckboxGroupOption,
 } from './assertions'
 
 /**
@@ -46,4 +47,14 @@ export const testRemoveChip = ({ element, placeholder = null }) => {
     .click({ multiple: true })
   cy.get('@filterChips').should('be.empty')
   placeholder && cy.get(element).should('contain', placeholder)
+}
+
+/**
+ * Tests that finding the checkbox option matching the value and clicking it will mark that option as selected
+ */
+export const testCheckBoxGroup = ({ element, value, checked = true }) => {
+  const checkbox = cy.get(element).find(`input[value="${value}"]`)
+  checkbox.first().click()
+
+  assertCheckboxGroupOption({ element, value, checked })
 }


### PR DESCRIPTION
## Description of change

Add a new event type checkbox filter on the events page

## Test instructions

This filter is only visible with an account that has the user-activity-stream-aventri feature flag enabled.
The new filter can be viewed from the /events page, it is the last one in the list of filters

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/201388462-0326eec8-bc30-408f-81e1-b72b750cbfec.png)
### After

![image](https://user-images.githubusercontent.com/102232401/201388867-05d97fab-3387-43c8-98f3-967217f32d3a.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
