### PR TITLE
Added organiser filter to the events page

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -690,6 +690,28 @@ describe('Activity feed controllers', () => {
         expect(expectedQuery(ukRegion)).to.deep.equal(actualQuery)
       })
     })
+
+    context('check query builder when filtering on organiser', () => {
+      const expectedQuery = (organiser) => [
+        {
+          terms: {
+            'object.type': ['dit:aventri:Event', 'dit:dataHub:Event'],
+          },
+        },
+        {
+          terms: {
+            'object.dit:organiser.id': organiser,
+          },
+        },
+      ]
+
+      it('builds the right query when an organiser is selected', () => {
+        const organiser = ['org-id-guid']
+        const actualQuery = eventsColListQueryBuilder({ organiser })
+
+        expect(expectedQuery(organiser)).to.deep.equal(actualQuery)
+      })
+    })
   })
 
   describe('#fetchAllActivityFeedEvents', () => {

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -406,6 +406,7 @@ const eventsColListQueryBuilder = ({
   aventriId,
   addressCountry,
   ukRegion,
+  organiser,
 }) => {
   const eventNameFilter = name
     ? {
@@ -461,6 +462,13 @@ const eventsColListQueryBuilder = ({
         },
       }
     : null
+  const organiserFilter = organiser
+    ? {
+        terms: {
+          'object.dit:organiser.id': organiser,
+        },
+      }
+    : null
 
   const filtersArray = [
     eventNameFilter,
@@ -468,6 +476,7 @@ const eventsColListQueryBuilder = ({
     aventriIdFilter,
     countryFilter,
     ukRegionFilter,
+    organiserFilter,
   ]
 
   const cleansedFiltersArray = filtersArray.filter((filter) => filter)
@@ -485,6 +494,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
       latestStartDate,
       aventriId,
       ukRegion,
+      organiser,
       page,
       addressCountry,
     } = req.query
@@ -501,6 +511,7 @@ async function fetchAllActivityFeedEvents(req, res, next) {
           aventriId,
           addressCountry,
           ukRegion,
+          organiser,
         }),
         from,
         size: ACTIVITIES_PER_PAGE,

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -231,6 +231,17 @@ const EventsCollection = ({
                   qsParamName="latest_start_date"
                   data-test="latest-start-date-filter"
                 />
+                <Filters.AdvisersTypeahead
+                  isMulti={true}
+                  taskProps={organisersTask}
+                  label={LABELS.organiser}
+                  name="organiser"
+                  qsParam="organiser"
+                  placeholder=""
+                  noOptionsMessage="No organisers found"
+                  selectedOptions={selectedFilters.organisers.options}
+                  data-test="organiser-filter"
+                />
                 <Filters.AventriId
                   id="EventsCollection.aventriId"
                   label={LABELS.aventriId}

--- a/src/client/modules/Events/CollectionList/tasks.js
+++ b/src/client/modules/Events/CollectionList/tasks.js
@@ -56,6 +56,7 @@ const getAllActivityFeedEvents = ({
   aventri_id,
   address_country,
   uk_region,
+  organiser,
   page,
 }) =>
   axios
@@ -67,6 +68,7 @@ const getAllActivityFeedEvents = ({
         latestStartDate: latest_start_date,
         aventriId: aventri_id,
         ukRegion: uk_region,
+        organiser: organiser,
         page: page,
         addressCountry: address_country,
       },

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -730,6 +730,55 @@ describe('events Collections Filter', () => {
         })
       })
     })
+
+    context('Organiser', () => {
+      const element = '[data-test="organiser-filter"]'
+      const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
+      const queryParamWithAdvisor = `organiser%5B0%5D=${adviserId}`
+      const adviserName = 'Puck Head'
+
+      context('should filter from user input and apply filter chips', () => {
+        before(() => {
+          cy.intercept('POST', searchEndpoint).as('apiRequest')
+          cy.intercept(
+            'GET',
+            `${urls.events.activity.data()}?sortBy=modified_on:desc&organiser[]=${adviserId}&page=1`
+          ).as('organiserRequest')
+        })
+
+        it('should pass the organiser to the controller', () => {
+          testTypeahead({
+            element,
+            label: 'Organiser',
+            input: 'puc',
+            placeholder: '',
+            expectedOption: adviserName,
+          })
+
+          cy.wait('@organiserRequest').then((request) => {
+            expect(request.response.statusCode).to.eql(200)
+          })
+        })
+
+        it('should pass the organiser from user input to query param', () => {
+          cy.url().should('include', queryParamWithAdvisor)
+        })
+
+        it('should show filter chips', () => {
+          cy.get('[data-test="typeahead-chip"]').should('contain', adviserName)
+        })
+      })
+
+      context('should remove organiser selection', () => {
+        it('should remove filter chips', () => {
+          cy.get('[data-test="typeahead-chip"] > button').click()
+        })
+
+        it('should remove the organiser from the url', () => {
+          cy.url().should('not.include', queryParamWithAdvisor)
+        })
+      })
+    })
   })
 
   after(() => {


### PR DESCRIPTION
## Description of change

Add a new organiser filter on the events page

## Test instructions

This filter is only visible with an account that has the user-activity-stream-aventri feature flag enabled.
The new filter can be viewed from the /events page

## Screenshots

![image](https://user-images.githubusercontent.com/102232401/201656505-dad3cc0a-29cb-41e1-9c78-ca26d00e9396.png)

_Add a screenshot_

### After

![image](https://user-images.githubusercontent.com/102232401/201656426-9892164b-f2e1-4a07-b87a-f3cac61f37f8.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
