### PR TITLE
WIP: Update investment reminders component to accommodate new design

### DIFF
--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -2,139 +2,126 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { H3 } from '@govuk-react/heading'
-import { LINK_COLOUR, RED, TEXT_COLOUR } from 'govuk-colours'
+import { H5 } from '@govuk-react/heading'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
-import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
 import urls from '../../../lib/urls'
-import { DARK_GREY } from '../../utils/colors'
 
-const {
-  formatWithoutParsing,
-  getDifferenceInDaysLabel,
-} = require('../../utils/date')
-
-const StyledSubHeading = styled(H3)`
-  color: ${RED};
-  font-size: ${FONT_SIZE.SIZE_19};
-  font-weight: ${FONT_WEIGHTS.regular};
+const StyledSubHeading = styled(H5)`
+  font-size: ${FONT_SIZE.SIZE_10};
+  font-weight: ${FONT_WEIGHTS.bold};
   margin-top: ${SPACING.SCALE_2};
   margin-bottom: ${SPACING.SCALE_2};
 `
 
-const StyledSubHeadingEmpty = styled(StyledSubHeading)`
-  color: ${DARK_GREY};
-  margin: 0;
+const StyledDivListItems = styled('div')`
+  padding-left: ${SPACING.SCALE_2};
+  margin-bottom: ${SPACING.SCALE_5};
 `
 
-const StyledProjectLink = styled('a')`
-  display: block;
-  font-size: ${FONT_SIZE.SIZE_19};
-  color: ${LINK_COLOUR};
+const StyledTextLink = styled('a')`
+  position: relative;
+  margin-left: ${SPACING.SCALE_1};
+  margin-right: ${SPACING.SCALE_1};
 `
 
-const StyledProjectCode = styled('div')`
-  margin: ${SPACING.SCALE_1} 0;
-  font-size: ${FONT_SIZE.SIZE_16};
-  color: ${DARK_GREY};
-`
-
-const StyledDueDate = styled('span')`
-  font-size: ${FONT_SIZE.SIZE_16};
-  color: ${TEXT_COLOUR};
-`
-
-const StyledDueCountdown = styled('span')`
+const StyledDivItem = styled('div')`
+  display: list-item;
+  list-style-type: disc;
   margin-top: ${SPACING.SCALE_1};
-  text-align: right;
-  white-space: nowrap;
-  font-size: ${FONT_SIZE.SIZE_16};
-  color: ${TEXT_COLOUR};
+  margin-bottom: ${SPACING.SCALE_1};
 `
 
-const StyledList = styled('ul')`
-  list-style-type: none;
-  padding: 0;
-  margin: 0;
-`
+const checkRemindersLoaded = (reminders) => {
+  return reminders || { count: 0 }
+}
 
-const StyledListItem = styled('li')`
-  margin-bottom: ${SPACING.SCALE_4};
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: space-between;
-  align-items: flex-end;
-`
+const investmentRemindersListItems = (
+  investmentELD,
+  investmentNRI,
+  investmentOP
+) => {
+  return [
+    {
+      href: urls.reminders.investments.estimatedLandDate(),
+      text: 'Approaching estimated land dates',
+      count: checkRemindersLoaded(investmentELD).count,
+      dataTestId: 'investment-eld',
+    },
+    {
+      href: urls.reminders.investments.noRecentInteraction(),
+      text: 'Projects with no recent interactions',
+      count: checkRemindersLoaded(investmentNRI).count,
+      dataTestId: 'investment-nri',
+    },
+    {
+      href: urls.reminders.investments.outstandingPropositions(),
+      text: 'Outstanding propositions',
+      count: checkRemindersLoaded(investmentOP).count,
+      dataTestId: 'investment-op',
+    },
+  ]
+}
 
-const StyledDetails = styled('div')`
-  padding-right: ${SPACING.SCALE_3};
-`
+const exportRemindersListItems = (investmentELD) => {
+  return [
+    {
+      href: urls.reminders.investments.noRecentInteraction(),
+      text: 'Companies with no recent interactions',
+      count: checkRemindersLoaded(investmentELD).count,
+      dataTestId: 'export-nri',
+    },
+    {
+      href: urls.reminders.investments.estimatedLandDate(),
+      text: 'Companies with new interactions',
+      count: checkRemindersLoaded(investmentELD).count,
+      dataTestId: 'export-ni',
+    },
+  ]
+}
 
-const OutstandingPropositions = ({ results, count }) => (
+const OutstandingPropositions = ({
+  investmentELD,
+  investmentNRI,
+  investmentOP,
+}) => (
   <>
-    {!!results.length ? (
-      <div data-test="outstanding-propositions">
-        <StyledSubHeading data-test="outstanding-propositions-heading">
-          Outstanding propositions ({count})
-        </StyledSubHeading>
-        <StyledList data-test="outstanding-propositions-list">
-          {results.map(({ id, investment_project, name, deadline }) => (
-            <StyledListItem key={id}>
-              <StyledDetails>
-                <StyledProjectLink
-                  href={urls.investments.projects.propositions(
-                    investment_project.id
-                  )}
-                >
-                  {name}
-                </StyledProjectLink>
-                <StyledProjectCode data-test="outstanding-proposition-project-code">
-                  {investment_project.project_code}
-                </StyledProjectCode>
-                <StyledDueDate data-test="outstanding-proposition-deadline">
-                  Due{' '}
-                  {formatWithoutParsing(
-                    new Date(deadline),
-                    DATE_DAY_LONG_FORMAT
-                  )}
-                </StyledDueDate>
-              </StyledDetails>
-              <StyledDueCountdown data-test="outstanding-proposition-countdown">
-                {getDifferenceInDaysLabel(deadline)}
-              </StyledDueCountdown>
-            </StyledListItem>
-          ))}
-        </StyledList>
-      </div>
-    ) : (
-      <StyledSubHeadingEmpty data-test="outstanding-propositions-empty">
-        Projects with propositions due will be displayed here.
-      </StyledSubHeadingEmpty>
-    )}
+    <div data-test="outstanding-propositions">
+      <StyledSubHeading data-test="investment-heading">
+        Investment
+      </StyledSubHeading>
+      <StyledDivListItems>
+        {investmentRemindersListItems(
+          investmentELD,
+          investmentNRI,
+          investmentOP
+        ).map((item) => (
+          <StyledDivItem>
+            <StyledTextLink href={item.href}>{item.text}</StyledTextLink>(
+            <span data-testid={item.dataTestId}>{item.count}</span>)
+          </StyledDivItem>
+        ))}
+      </StyledDivListItems>
+      <StyledSubHeading data-test="export-heading">Export</StyledSubHeading>
+      <StyledDivListItems>
+        {exportRemindersListItems(investmentELD).map((item) => (
+          <StyledDivItem>
+            <StyledTextLink href={item.href}>{item.text}</StyledTextLink>(
+            <span data-testid={item.dataTestId}>{item.count}</span>)
+          </StyledDivItem>
+        ))}
+      </StyledDivListItems>
+      <StyledTextLink href={urls.reminders.settings.index()}>
+        Reminders and email notification section
+      </StyledTextLink>
+    </div>
   </>
 )
 
 OutstandingPropositions.propTypes = {
-  count: PropTypes.number.isRequired,
-  results: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      investment_project: PropTypes.shape({
-        id: PropTypes.string.is_required,
-        name: PropTypes.string.isRequired,
-        project_code: PropTypes.string.isRequired,
-      }),
-      deadline: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-      adviser: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        first_name: PropTypes.string.isRequired,
-        last_name: PropTypes.string.isRequired,
-      }),
-    })
-  ).isRequired,
+  investmentELD: PropTypes.object.isRequired,
+  investmentNRI: PropTypes.object.isRequired,
+  investmentOP: PropTypes.object.isRequired,
 }
 
 export default OutstandingPropositions

--- a/src/client/components/InvestmentReminders/__stories__/InvestmentReminders.stories.jsx
+++ b/src/client/components/InvestmentReminders/__stories__/InvestmentReminders.stories.jsx
@@ -10,7 +10,63 @@ const adviser = {
   id: 'adviser-1',
 }
 
-const outstandingPropositions = {
+const investmentELD = {
+  count: 2,
+  results: [
+    {
+      id: '123',
+      investment_project: {
+        name: 'New restaurant',
+        project_code: 'DHP-00000004',
+        id: 'project-a',
+      },
+      adviser,
+      deadline: '2021-04-01',
+      name: 'Restaurant proposition',
+    },
+    {
+      id: '456',
+      investment_project: {
+        name: 'Univeristy',
+        project_code: 'DHP-00000005',
+        id: 'project-b',
+      },
+      adviser,
+      deadline: '2021-04-01',
+      name: 'Univeristy proposition',
+    },
+  ],
+}
+
+const investmentNRI = {
+  count: 2,
+  results: [
+    {
+      id: '123',
+      investment_project: {
+        name: 'New restaurant',
+        project_code: 'DHP-00000004',
+        id: 'project-a',
+      },
+      adviser,
+      deadline: '2021-04-01',
+      name: 'Restaurant proposition',
+    },
+    {
+      id: '456',
+      investment_project: {
+        name: 'Univeristy',
+        project_code: 'DHP-00000005',
+        id: 'project-b',
+      },
+      adviser,
+      deadline: '2021-04-01',
+      name: 'Univeristy proposition',
+    },
+  ],
+}
+
+const investmentOP = {
   count: 2,
   results: [
     {
@@ -43,6 +99,8 @@ storiesOf('InvestmentReminders', module)
   .add('Default', () => (
     <InvestmentReminders
       adviser={adviser}
-      outstandingPropositions={outstandingPropositions}
+      investmentELD={investmentELD}
+      investmentNRI={investmentNRI}
+      investmentOP={investmentOP}
     />
   ))

--- a/src/client/components/InvestmentReminders/index.jsx
+++ b/src/client/components/InvestmentReminders/index.jsx
@@ -11,7 +11,12 @@ import Task from '../Task'
 /**
  * Shows reminders of upcoming propositions for an adviser to deal with.
  */
-const InvestmentReminders = ({ adviser, results, count }) => (
+const InvestmentReminders = ({
+  adviser,
+  investmentELD,
+  investmentNRI,
+  investmentOP,
+}) => (
   <div data-test="investment-reminders">
     <Task.Status
       name={TASK_GET_OUTSTANDING_PROPOSITIONS}
@@ -22,7 +27,13 @@ const InvestmentReminders = ({ adviser, results, count }) => (
         onSuccessDispatch: OUTSTANDING_PROPOSITIONS__LOADED,
       }}
     >
-      {() => <OutstandingPropositions results={results} count={count} />}
+      {() => (
+        <OutstandingPropositions
+          investmentELD={investmentELD}
+          investmentNRI={investmentNRI}
+          investmentOP={investmentOP}
+        />
+      )}
     </Task.Status>
   </div>
 )
@@ -34,25 +45,9 @@ InvestmentReminders.propTypes = {
   adviser: PropTypes.shape({
     id: PropTypes.string.isRequired,
   }).isRequired,
-  count: PropTypes.number.isRequired,
-  results: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      investment_project: PropTypes.shape({
-        id: PropTypes.string.is_required,
-        name: PropTypes.string.isRequired,
-        project_code: PropTypes.string.isRequired,
-      }),
-      deadline: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-      adviser: PropTypes.shape({
-        id: PropTypes.string.isRequired,
-        name: PropTypes.string.isRequired,
-        first_name: PropTypes.string.isRequired,
-        last_name: PropTypes.string.isRequired,
-      }),
-    })
-  ).isRequired,
+  investmentELD: PropTypes.object.isRequired,
+  investmentNRI: PropTypes.object.isRequired,
+  investmentOP: PropTypes.object.isRequired,
 }
 
 export default connect(state2props)(InvestmentReminders)

--- a/src/client/components/InvestmentReminders/reducer.js
+++ b/src/client/components/InvestmentReminders/reducer.js
@@ -8,10 +8,12 @@ const initialState = {
 export default (state = initialState, { type, result }) => {
   switch (type) {
     case OUTSTANDING_PROPOSITIONS__LOADED:
-      const { results, count } = result
+      const { count, investmentELD, investmentNRI, investmentOP } = result
       return {
-        results,
         count,
+        investmentELD,
+        investmentNRI,
+        investmentOP,
       }
     default:
       return state

--- a/src/client/components/InvestmentReminders/tasks.js
+++ b/src/client/components/InvestmentReminders/tasks.js
@@ -1,13 +1,34 @@
 import { apiProxyAxios } from '../Task/utils'
 
-export const fetchOutstandingPropositions = ({ adviser }) =>
-  apiProxyAxios
-    .get('/v4/proposition', {
+export const fetchOutstandingPropositions = async ({ adviser }) => {
+  const investmentELDResponse = await apiProxyAxios.get(
+    '/v4/reminder/estimated-land-date',
+    {
       params: {
         adviser_id: adviser.id,
-        status: 'ongoing',
-        sortby: 'deadline',
-        limit: 3,
       },
-    })
-    .then(({ data }) => data)
+    }
+  )
+
+  const investmentNRIResponse = await apiProxyAxios.get(
+    '/v4/reminder/no-recent-investment-interaction',
+    {
+      params: {
+        adviser_id: adviser.id,
+      },
+    }
+  )
+
+  const investmentOPResponse = await apiProxyAxios.get('/v4/proposition', {
+    params: {
+      adviser_id: adviser.id,
+    },
+  })
+
+  const investmentELD = investmentELDResponse.data
+  const investmentNRI = investmentNRIResponse.data
+  const investmentOP = investmentOPResponse.data
+  const count = investmentELD.count + investmentNRI.count + investmentOP.count
+
+  return { count, investmentELD, investmentNRI, investmentOP }
+}

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -1,31 +1,9 @@
-const {
-  addDays,
-  formatWithoutParsing,
-} = require('../../../../../src/client/utils/date')
-const { DATE_DAY_LONG_FORMAT } = require('../../../../../src/common/constants')
-
-import { faker } from '@faker-js/faker'
 import urls from '../../../../../src/lib/urls'
-import {
-  propositionFaker,
-  propositionListFaker,
-} from '../../fakers/propositions'
 
 describe('Dashboard reminders', () => {
-  const tomorrow = addDays(new Date(), 1)
-  const proposition1 = propositionFaker({
-    name: 'University Proposition',
-    investment_project: {
-      name: 'University buildings',
-      project_code: 'DHP-00007004',
-      id: faker.datatype.uuid(),
-    },
-    deadline: tomorrow,
-  })
-  const myPropositions = [proposition1, ...propositionListFaker(2)]
-
   before(() => {
     cy.setUserFeatures(['personalised-dashboard'])
+    cy.visit('/')
   })
 
   after(() => {
@@ -43,108 +21,50 @@ describe('Dashboard reminders', () => {
   })
 
   context('View reminders', () => {
-    before(() => {
-      cy.intercept('GET', '/api-proxy/v4/proposition*', {
-        body: {
-          count: myPropositions.length,
-          results: myPropositions,
-        },
-      }).as('apiRequest')
-      cy.visit('/')
-      cy.wait('@apiRequest')
-    })
-
     beforeEach(() => {
-      cy.get('[data-test="outstanding-propositions"]')
-        .as('outstandingPropositions')
-        .find('[data-test="outstanding-propositions-list"]')
-        .as('outstandingPropositionsList')
       cy.get('[data-test="notification-badge"]').as('notificationBadge')
     })
 
     it('should contain a notification badge in the reminders heading', () => {
       cy.get('@investmentRemindersHeading').should('contain.text', 'Reminders')
-      cy.get('@notificationBadge').should('have.text', '3')
+      cy.get('@notificationBadge').should('have.text', '32')
     })
 
-    it('should contain elements in the correct order', () => {
-      cy.get('@investmentReminders')
-        .find('[data-test="outstanding-propositions"]')
-        .should('have.length', 1)
-        .find('[data-test="outstanding-propositions-list"]')
-        .should('have.length', 1)
-    })
+    it('should count reminder links', () => {
+      cy.get('@investmentRemindersToggleButton').click()
 
-    it('should contain a heading', () => {
-      cy.get('[data-test="outstanding-propositions-heading"]')
-        .should('have.text', 'Outstanding propositions (3)')
-        .should('have.css', 'color', 'rgb(212, 53, 28)')
-    })
-
-    it('should display each of the outstanding propositions', () => {
-      cy.get('@outstandingPropositionsList')
-        .find('li')
-        .should('have.length', '3')
-        .first()
-        .as('outstandingProposition')
-
-      cy.get('@outstandingProposition')
-        .find('a')
-        .should('have.text', proposition1.name)
-        .should(
+      cy.contains('Approaching estimated land dates')
+        .should('be.visible')
+        .and(
           'have.attr',
           'href',
-          urls.investments.projects.propositions(
-            proposition1.investment_project.id
-          )
+          urls.reminders.investments.estimatedLandDate()
         )
 
-      cy.get('@outstandingProposition')
-        .find('[data-test="outstanding-proposition-project-code"]')
-        .should('have.text', proposition1.investment_project.project_code)
-
-      cy.get('@outstandingProposition')
-        .find('[data-test="outstanding-proposition-deadline"]')
-        .should(
-          'have.text',
-          `Due ${formatWithoutParsing(tomorrow, DATE_DAY_LONG_FORMAT)}`
+      cy.contains('Projects with no recent interactions')
+        .should('be.visible')
+        .and(
+          'have.attr',
+          'href',
+          urls.reminders.investments.noRecentInteraction()
         )
 
-      cy.get('@outstandingProposition')
-        .find('[data-test="outstanding-proposition-countdown"]')
-        .should('have.text', '1 day')
-    })
-  })
-
-  context('View empty reminders', () => {
-    before(() => {
-      cy.intercept('GET', '/api-proxy/v4/proposition*', {
-        body: {
-          count: 0,
-          results: [],
-        },
-      }).as('apiRequest')
-      cy.visit('/')
-      cy.wait('@apiRequest')
-    })
-
-    it('should contain a heading', () => {
-      cy.get('[data-test="outstanding-propositions-empty"]')
-        .should(
-          'have.text',
-          'Projects with propositions due will be displayed here.'
+      cy.contains('Outstanding propositions')
+        .should('be.visible')
+        .and(
+          'have.attr',
+          'href',
+          urls.reminders.investments.outstandingPropositions()
         )
-        .should('have.css', 'color', 'rgb(80, 90, 95)')
     })
 
-    it('should not contain a notification badge in the reminders heading', () => {
-      cy.get('[data-test="investment-reminders-section"]')
-        .find('[data-test="notification-badge"]')
-        .should('not.exist')
-    })
+    it('should have reminders count', () => {
+      cy.get('[data-testid="investment-eld"]').should('have.text', 14)
+      cy.get('[data-testid="investment-nri"]').should('have.text', 15)
+      cy.get('[data-testid="investment-op"]').should('have.text', 3)
 
-    it('should not contain a list', () => {
-      cy.get('[data-test="outstanding-propositions-list"]').should('not.exist')
+      cy.get('[data-testid="export-nri"]').should('have.text', 14)
+      cy.get('[data-testid="export-ni"]').should('have.text', 14)
     })
   })
 


### PR DESCRIPTION
## Description of change

Update reminders component displayed in the new dashboard
- component shall no longer display individual reminders
- component total count should be for all reminders (export and investment) instead of investment proposition only
- link to reminder collections should be displayed for all reminders type for both export and investment
- reminder total count for each reminder collection link should be shown next to the links

Remaining tasks:

- add export call to collect reminders count and update reminders collection page url for export
- add functional tests for export collection counts along with mocked endpoints
- refactor naming convention now that component is no longer for outstanding propositions only

## Test instructions

Functional tests updated and added for this feature

## Screenshots

### Before

_Add a screenshot_

### After

<img width="365" alt="Screenshot 2022-11-14 at 18 45 23" src="https://user-images.githubusercontent.com/105509190/201740856-eceadbf5-aacd-4a74-b1fc-0f5f847880c6.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
