### PR TITLE
Fix Add Event form.

### DIFF
--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -32,7 +32,9 @@ export const EventFormFields = ({ values }) => (
         >
           more information
         </Link>{' '}
-        about selecting trade agreements. This will open in a new window.
+        about selecting trade agreements.
+        <br />
+        This will open in a new window.
       </p>
     </article>
     <FieldRadios

--- a/src/client/modules/Events/EventForm/index.jsx
+++ b/src/client/modules/Events/EventForm/index.jsx
@@ -8,6 +8,7 @@ import Form from '../../../components/Form'
 import { TASK_GET_EVENTS_FORM_AND_METADATA, TASK_SAVE_EVENT } from './state'
 import { EventFormFields } from './EventFormFields'
 import { transformEventFormForAPIRequest } from './transformers'
+import { FormLayout } from '../../../../client/components'
 
 const DISPLAY_EDIT_EVENT = 'Edit event'
 const DISPLAY_ADD_EVENT = 'Add event'
@@ -46,30 +47,32 @@ const EventForm = () => {
       breadcrumbs={breadcrumbs}
       useReactRouter={true}
     >
-      <Form
-        id="event-form"
-        submissionTaskName={TASK_SAVE_EVENT}
-        analyticsFormName={id ? 'editEvent' : 'createEvent'}
-        initialValuesTaskName={TASK_GET_EVENTS_FORM_AND_METADATA}
-        initialValuesPayload={{
-          eventId: id,
-        }}
-        redirectTo={({ data }) => urls.events.details(data.id)}
-        redirectMode="soft"
-        flashMessage={flashMessage}
-        submitButtonLabel={id ? DISPLAY_SAVE : DISPLAY_ADD_EVENT}
-        transformPayload={transformEventFormForAPIRequest}
-        cancelButtonLabel={DISPLAY_CANCEL}
-        cancelRedirectTo={() =>
-          id ? urls.events.details(id) : urls.events.index()
-        } //this originally used the react to: instead of a hard redirect, so it might break after being switched, watch out
-      >
-        {({ values }) => {
-          if (Object.keys(values).length !== 0) {
-            return <EventFormFields values={values} />
-          }
-        }}
-      </Form>
+      <FormLayout setWidth="three-quarters">
+        <Form
+          id="event-form"
+          submissionTaskName={TASK_SAVE_EVENT}
+          analyticsFormName={id ? 'editEvent' : 'createEvent'}
+          initialValuesTaskName={TASK_GET_EVENTS_FORM_AND_METADATA}
+          initialValuesPayload={{
+            eventId: id,
+          }}
+          redirectTo={({ data }) => urls.events.details(data.id)}
+          redirectMode="soft"
+          flashMessage={flashMessage}
+          submitButtonLabel={id ? DISPLAY_SAVE : DISPLAY_ADD_EVENT}
+          transformPayload={transformEventFormForAPIRequest}
+          cancelButtonLabel={DISPLAY_CANCEL}
+          cancelRedirectTo={() =>
+            id ? urls.events.details(id) : urls.events.index()
+          } //this originally used the react to: instead of a hard redirect, so it might break after being switched, watch out
+        >
+          {({ values }) => {
+            if (Object.keys(values).length !== 0) {
+              return <EventFormFields values={values} />
+            }
+          }}
+        </Form>
+      </FormLayout>
     </DefaultLayout>
   )
 }

--- a/test/functional/cypress/support/event-assertions.js
+++ b/test/functional/cypress/support/event-assertions.js
@@ -16,7 +16,7 @@ const assertTradeAgreementArticle = (articleElement) => {
     'Select a trade agreement and then a related event.'
   )
   assertTextVisible(
-    'Find more information about selecting trade agreements. This will open in a new window'
+    'Find more information about selecting trade agreements.This will open in a new window'
   )
   cy.contains('more information')
     .should('have.attr', 'href')


### PR DESCRIPTION
## Description of change

This updates layout of Add Event form so that it take two thirds of space instead of full width.

## Test instructions

You could go to `/events/create` URL and see that the add event form no longer has the full width.

Alternatively you can go to `Events` and then try to edit an existing event. 

## Screenshots

### Before

<img width="509" alt="event before" src="https://user-images.githubusercontent.com/5889630/202141506-2cf6f15d-d7d3-4f22-ab80-cb4ce1fddde2.png">

### After

<img width="500" alt="event after" src="https://user-images.githubusercontent.com/5889630/202141546-cce36bbc-6ba5-4314-92db-3a7830eeeab4.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
