### PR TITLE
Add export to summary reminders

### DIFF
--- a/src/client/components/ReminderSummary/Summary.jsx
+++ b/src/client/components/ReminderSummary/Summary.jsx
@@ -83,6 +83,7 @@ const reminderType = PropTypes.arrayOf(
 Summary.propTypes = {
   count: PropTypes.number,
   investment: reminderType,
+  export: reminderType,
 }
 
 export default Summary

--- a/src/client/components/ReminderSummary/Summary.jsx
+++ b/src/client/components/ReminderSummary/Summary.jsx
@@ -4,9 +4,17 @@ import styled from 'styled-components'
 import { kebabCase } from 'lodash'
 
 import { LINK_COLOUR } from 'govuk-colours'
-import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+import { H5 } from '@govuk-react/heading'
+import { FONT_SIZE, SPACING, FONT_WEIGHTS } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
+
+const StyledSubHeading = styled(H5)`
+  font-size: ${FONT_SIZE.SIZE_10};
+  font-weight: ${FONT_WEIGHTS.bold};
+  margin-top: ${SPACING.SCALE_2};
+  margin-bottom: ${SPACING.SCALE_2};
+`
 
 const StyledReminderLink = styled('a')`
   display: inline;
@@ -26,12 +34,30 @@ const StyledListItem = styled('li')(() => ({
 
 const Summary = ({ summary }) => (
   <>
+    <StyledSubHeading data-test="investment-heading">
+      Investment
+    </StyledSubHeading>
     <StyledList>
       {summary &&
         summary.investment.map((reminder) => (
           <StyledListItem
             key={reminder.name}
             data-test={`investment-${kebabCase(reminder.name)}`}
+          >
+            <StyledReminderLink href={reminder.url}>
+              {reminder.name}
+            </StyledReminderLink>
+            &nbsp;({reminder.count})
+          </StyledListItem>
+        ))}
+    </StyledList>
+    <StyledSubHeading data-test="export-heading">Export</StyledSubHeading>
+    <StyledList>
+      {summary &&
+        summary.export.map((reminder) => (
+          <StyledListItem
+            key={reminder.name}
+            data-test={`export-${kebabCase(reminder.name)}`}
           >
             <StyledReminderLink href={reminder.url}>
               {reminder.name}

--- a/src/client/components/ReminderSummary/reducer.js
+++ b/src/client/components/ReminderSummary/reducer.js
@@ -3,6 +3,7 @@ import { REMINDER_SUMMARY__LOADED } from '../../actions'
 const initialState = {
   count: 0,
   investment: [],
+  export: [],
 }
 
 export default (state = initialState, { type, result }) => {

--- a/src/client/components/ReminderSummary/tasks.js
+++ b/src/client/components/ReminderSummary/tasks.js
@@ -6,18 +6,25 @@ const transformSummaryData = ({ data }) => ({
   investment: [
     {
       name: 'Approaching estimated land dates',
-      url: urls.reminders.estimatedLandDate(),
+      url: urls.reminders.investments.estimatedLandDate(),
       count: data.investment.estimated_land_date,
     },
     {
       name: 'Projects with no recent interaction',
-      url: urls.reminders.noRecentInteraction(),
+      url: urls.reminders.investments.noRecentInteraction(),
       count: data.investment.no_recent_interaction,
     },
     {
       name: 'Outstanding propositions',
-      url: urls.reminders.outstandingPropositions(),
+      url: urls.reminders.investments.outstandingPropositions(),
       count: data.investment.outstanding_propositions,
+    },
+  ],
+  export: [
+    {
+      name: 'Companies with no recent interactions',
+      url: urls.reminders.investments.noRecentInteraction(),
+      count: data.export.no_recent_interaction,
     },
   ],
 })

--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -21,11 +21,14 @@ describe('Dashboard reminder summary', () => {
     before(() => {
       cy.intercept('GET', '/api-proxy/v4/reminder/summary', {
         body: {
-          count: 8,
+          count: 12,
           investment: {
             estimated_land_date: 1,
             no_recent_interaction: 2,
             outstanding_propositions: 5,
+          },
+          export: {
+            no_recent_interaction: 4,
           },
         },
       }).as('apiRequest')
@@ -41,15 +44,17 @@ describe('Dashboard reminder summary', () => {
       cy.get('[data-test="notification-badge"]').as('notificationBadge')
     })
 
-    it('should contain a notification badge in the reminders heading', () => {
-      cy.get('@reminderSummaryHeading').should('contain.text', 'Reminders')
-      cy.get('@notificationBadge').should('have.text', '8')
+    it('should contain headers', () => {
+      cy.get('[data-test="investment-heading"]').should(
+        'have.text',
+        'Investment'
+      )
+      cy.get('[data-test="export-heading"]').should('have.text', 'Export')
     })
 
-    it('should contain elements in the correct order', () => {
-      cy.get('@reminderSummary').contains(
-        'Approaching estimated land dates (1)Projects with no recent interaction (2)Outstanding propositions (5)Reminders and email notifications settings'
-      )
+    it('should contain a notification badge in the reminders heading', () => {
+      cy.get('@reminderSummaryHeading').should('contain.text', 'Reminders')
+      cy.get('@notificationBadge').should('have.text', '12')
     })
 
     it('should contain summary entries', () => {
@@ -63,6 +68,10 @@ describe('Dashboard reminder summary', () => {
       cy.get('[data-test="investment-outstanding-propositions"]').contains(
         'Outstanding propositions (5)'
       )
+
+      cy.get(
+        '[data-test="summary-item-export_no_recent_investment_interaction"]'
+      ).contains('Companies with no recent interactions (4)')
     })
 
     it('should be in a togglable section that starts open', () => {
@@ -81,16 +90,38 @@ describe('Dashboard reminder summary', () => {
             no_recent_interaction: 0,
             outstanding_propositions: 0,
           },
+          export: {
+            no_recent_interaction: 0,
+          },
         },
       }).as('apiRequest')
       cy.visit('/')
       cy.wait('@apiRequest')
     })
 
-    it('should contain a heading', () => {
-      cy.get('@reminderSummary').contains(
-        'Approaching estimated land dates (0)Projects with no recent interaction (0)Outstanding propositions (0)Reminders and email notifications settings'
+    it('should contain headers', () => {
+      cy.get('[data-test="investment-heading"]').should(
+        'have.text',
+        'Investment'
       )
+      cy.get('[data-test="export-heading"]').should('have.text', 'Export')
+    })
+
+    it('should contain summary entries', () => {
+      cy.get('[data-test="summary-item-estimated_land_date"]').contains(
+        'Approaching estimated land dates (0)'
+      )
+      cy.get(
+        '[data-test="summary-item-no_recent_investment_interaction"]'
+      ).contains('Projects with no recent interaction (0)')
+
+      cy.get('[data-test="summary-item-outstanding_propositions"]').contains(
+        'Outstanding propositions (0)'
+      )
+
+      cy.get(
+        '[data-test="summary-item-export_no_recent_investment_interaction"]'
+      ).contains('Companies with no recent interactions (0)')
     })
 
     it('should not contain a notification badge in the reminders heading', () => {

--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -70,7 +70,7 @@ describe('Dashboard reminder summary', () => {
       )
 
       cy.get(
-        '[data-test="summary-item-export_no_recent_investment_interaction"]'
+        '[data-test="export-companies-with-no-recent-interactions"]'
       ).contains('Companies with no recent interactions (4)')
     })
 
@@ -108,19 +108,19 @@ describe('Dashboard reminder summary', () => {
     })
 
     it('should contain summary entries', () => {
-      cy.get('[data-test="summary-item-estimated_land_date"]').contains(
-        'Approaching estimated land dates (0)'
-      )
       cy.get(
-        '[data-test="summary-item-no_recent_investment_interaction"]'
+        '[data-test="investment-approaching-estimated-land-dates"]'
+      ).contains('Approaching estimated land dates (0)')
+      cy.get(
+        '[data-test="investment-projects-with-no-recent-interaction"]'
       ).contains('Projects with no recent interaction (0)')
 
-      cy.get('[data-test="summary-item-outstanding_propositions"]').contains(
+      cy.get('[data-test="investment-outstanding-propositions"]').contains(
         'Outstanding propositions (0)'
       )
 
       cy.get(
-        '[data-test="summary-item-export_no_recent_investment_interaction"]'
+        '[data-test="export-companies-with-no-recent-interactions"]'
       ).contains('Companies with no recent interactions (0)')
     })
 


### PR DESCRIPTION
## Description of change

Add export links to summary reminder component

## Test instructions

Functional tests should continue passing

## Screenshots

<img width="368" alt="Screenshot 2022-11-17 at 08 42 59" src="https://user-images.githubusercontent.com/105509190/202398472-a70ec0c5-77cf-40e2-a220-2a8643c9ee4b.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
