### PR TITLE
Change styling of the aventri event to look similar to other entries

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -74,7 +74,6 @@ describe('Activity feed controllers', () => {
 
         it('should call fetchActivityFeed with correct params when retrieving aventri attendees', async () => {
           const expectedEsQuery = {
-            size: 20,
             query: {
               bool: {
                 must: [

--- a/src/apps/companies/apps/activity-feed/__test__/query.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/query.test.js
@@ -166,7 +166,6 @@ describe('#activityFeedEventsQuery', () => {
   context('query applies correct filtering', () => {
     context('should return the filtered aventri attendee data', () => {
       const expectedEsQuery = (emails) => ({
-        size: 20,
         query: {
           bool: {
             must: [

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -173,9 +173,9 @@ async function getAventriEventIds(req, next, contacts) {
     const aventriResults = await fetchActivityFeed(req, aventriQuery)
     const aventriAttendees = aventriResults.hits.hits.map((hit) => hit._source)
     // Fetch aventri event ids for aventri attendees
-    const aventriEventIds = aventriAttendees
-      .map((attendee) => attendee.object.attributedTo.id)
-      .map((id) => `${id}:Create`)
+    const aventriEventIds = aventriAttendees.map(
+      (attendee) => `${attendee.object.attributedTo.id}:Create`
+    )
     return aventriEventIds
   } catch (error) {
     next(error)

--- a/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-for-company-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-for-company-query.js
@@ -1,5 +1,4 @@
 const aventriAttendeeForCompanyQuery = (contacts) => ({
-  size: 20,
   query: {
     bool: {
       must: [

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -19,7 +19,6 @@ export default function AventriEvent({ activity: event }) {
   const name = eventObject.name
   const aventriEventId = eventObject.id.split(':')[EVENT_ID_INDEX]
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
-  const country = eventObject['dit:aventri:country'] || 'Not set'
 
   return (
     <ActivityCardWrapper dataTest="aventri-event">
@@ -36,8 +35,8 @@ export default function AventriEvent({ activity: event }) {
             value: date,
           },
           {
-            label: 'Country',
-            value: country,
+            label: 'Aventri ID',
+            value: aventriEventId,
           },
         ]}
       />

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -9,6 +9,7 @@ import { ACTIVITY_TYPE } from '../constants'
 import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
+import ActivityCardLabels from './card/ActivityCardLabels'
 
 // Event index to extract id from Aventri Event string feed by activity-stream
 // e.g. dit:aventri:Event:1113:Create
@@ -18,9 +19,11 @@ export default function AventriEvent({ activity: event }) {
   const name = eventObject.name
   const aventriEventId = eventObject.id.split(':')[EVENT_ID_INDEX]
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
+  const country = eventObject['dit:aventri:country'] || 'Not set'
 
   return (
     <ActivityCardWrapper dataTest="aventri-event">
+      <ActivityCardLabels service="Event" />
       <ActivityCardSubject dataTest="aventri-event-name">
         <Link as={RouterLink} to={`/events/aventri/${aventriEventId}/details`}>
           {name}
@@ -31,6 +34,10 @@ export default function AventriEvent({ activity: event }) {
           {
             label: 'Event date',
             value: date,
+          },
+          {
+            label: 'Country',
+            value: country,
           },
         ]}
       />

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -22,7 +22,7 @@ export default function AventriEvent({ activity: event }) {
 
   return (
     <ActivityCardWrapper dataTest="aventri-event">
-      <ActivityCardLabels service="Event" />
+      <ActivityCardLabels service="Event" kind="Aventri Service Delivery" />
       <ActivityCardSubject dataTest="aventri-event-name">
         <Link as={RouterLink} to={`/events/aventri/${aventriEventId}/details`}>
           {name}

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import CardUtils from './card/CardUtils'
-import { Link as RouterLink } from 'react-router-dom'
 import Link from '@govuk-react/link'
 
 import { formatStartAndEndDate } from '../../../utils/date'
@@ -24,9 +23,7 @@ export default function AventriEvent({ activity: event }) {
     <ActivityCardWrapper dataTest="aventri-event">
       <ActivityCardLabels service="Event" kind="Aventri Service Delivery" />
       <ActivityCardSubject dataTest="aventri-event-name">
-        <Link as={RouterLink} to={`/events/aventri/${aventriEventId}/details`}>
-          {name}
-        </Link>
+        <Link href={`/events/aventri/${aventriEventId}/details`}>{name}</Link>
       </ActivityCardSubject>
       <ActivityCardMetadata
         metadata={[

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
@@ -40,11 +40,13 @@ const ActivityCardLabels = ({ isExternalActivity, theme, service, kind }) => (
         </Tag>
       )}
     </TagColumn>
-    <TagColumn>
-      <Tag data-test="activity-kind-label" colour="grey">
-        {kind}
-      </Tag>
-    </TagColumn>
+    {kind && (
+      <TagColumn>
+        <Tag data-test="activity-kind-label" colour="grey">
+          {kind}
+        </Tag>
+      </TagColumn>
+    )}
   </TagRow>
 )
 

--- a/test/component/cypress/specs/ActivityFeed/ActivityCard/ActivityCardLabels.cy.jsx
+++ b/test/component/cypress/specs/ActivityFeed/ActivityCard/ActivityCardLabels.cy.jsx
@@ -41,6 +41,16 @@ describe('ActivityCardLabels', () => {
       })
     })
 
+    context('When there is NOT a kind property value', () => {
+      beforeEach(() => {
+        cy.mount(<Component kind={undefined} />)
+      })
+
+      it('should not render the label', () => {
+        cy.get('[data-test="activity-kind-label"]').should('not.exist')
+      })
+    })
+
     context('When there is an topic/theme label', () => {
       beforeEach(() => {
         cy.mount(<Component theme="Topic Label" />)


### PR DESCRIPTION
## Description of change

- Add additional meta data for an Aventri event to the component
- Add an EVENT label to the Aventri events
- Update the ActivityCardLabels.jsx component so kind does not render when the value is missing
- Use a href instead of react router for the aventri event link to remove bug of 2 matching routes
- Remove limit of 20, as there is no pagination on this page

## Test instructions

View a company that has a contact who has attended an Aventri event. The Aventri event this displays should have a similar styling to datahub events. An example is https://www.datahub.dev.uktrade.io/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/202731043-b32882df-4b1a-4fbc-ab93-8bd8b5d21e0b.png)

### After

![image](https://user-images.githubusercontent.com/102232401/203573760-1d369fd7-6e5d-4666-94ab-c3ed37e5b49e.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
