### PR TITLE
Refactor reminders summary to accomodate changes to the endpoint

### DIFF
--- a/src/client/components/ReminderSummary/Summary.jsx
+++ b/src/client/components/ReminderSummary/Summary.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { kebabCase } from 'lodash'
 
 import { LINK_COLOUR } from 'govuk-colours'
 import { FONT_SIZE, SPACING } from '@govuk-react/constants'
@@ -23,44 +24,39 @@ const StyledListItem = styled('li')(() => ({
   margin: `${SPACING.SCALE_2} 0`,
 }))
 
-const typeToReminderName = {
-  estimated_land_date: 'Approaching estimated land dates',
-  no_recent_investment_interaction: 'Projects with no recent interaction',
-  outstanding_propositions: 'Outstanding propositions',
-}
-
-const typeToURL = {
-  estimated_land_date: urls.reminders.estimatedLandDate(),
-  no_recent_investment_interaction: urls.reminders.noRecentInteraction(),
-  outstanding_propositions: urls.reminders.outstandingPropositions(),
-}
-
-const Summary = ({ summary }) => {
-  return (
-    <>
-      <StyledList>
-        {Object.entries(summary).map(([type, number]) => (
-          <StyledListItem key={type} data-test={`summary-item-${type}`}>
-            <StyledReminderLink href={typeToURL[type]}>
-              {typeToReminderName[type]}
+const Summary = ({ summary }) => (
+  <>
+    <StyledList>
+      {summary &&
+        summary.investment.map((reminder) => (
+          <StyledListItem
+            key={reminder.name}
+            data-test={`investment-${kebabCase(reminder.name)}`}
+          >
+            <StyledReminderLink href={reminder.url}>
+              {reminder.name}
             </StyledReminderLink>
-            &nbsp;({number})
+            &nbsp;({reminder.count})
           </StyledListItem>
         ))}
-      </StyledList>
-      <StyledReminderLink href={urls.reminders.settings.index()}>
-        Reminders and email notifications settings
-      </StyledReminderLink>
-    </>
-  )
-}
+    </StyledList>
+    <StyledReminderLink href={urls.reminders.settings.index()}>
+      Reminders and email notifications settings
+    </StyledReminderLink>
+  </>
+)
+
+const reminderType = PropTypes.arrayOf(
+  PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+    count: PropTypes.number.isRequired,
+  })
+)
 
 Summary.propTypes = {
-  summary: PropTypes.shape({
-    estimated_land_date: PropTypes.number.isRequired,
-    no_recent_investment_interaction: PropTypes.number.isRequired,
-    outstanding_propositions: PropTypes.number.isRequired,
-  }),
+  count: PropTypes.number,
+  investment: reminderType,
 }
 
 export default Summary

--- a/src/client/components/ReminderSummary/index.jsx
+++ b/src/client/components/ReminderSummary/index.jsx
@@ -8,7 +8,7 @@ import { REMINDER_SUMMARY__LOADED } from '../../actions'
 import Summary from './Summary'
 import Task from '../Task'
 
-const ReminderSummary = ({ summary }) => (
+const ReminderSummary = (data) => (
   <div data-test="reminder-summary">
     <Task.Status
       name={TASK_GET_REMINDER_SUMMARY}
@@ -18,17 +18,22 @@ const ReminderSummary = ({ summary }) => (
         onSuccessDispatch: REMINDER_SUMMARY__LOADED,
       }}
     >
-      {() => <Summary summary={summary} />}
+      {() => <Summary summary={data} />}
     </Task.Status>
   </div>
 )
 
+const reminderType = PropTypes.arrayOf(
+  PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired,
+    count: PropTypes.number.isRequired,
+  })
+)
+
 ReminderSummary.propTypes = {
-  summary: PropTypes.shape({
-    estimated_land_date: PropTypes.number.isRequired,
-    no_recent_investment_interaction: PropTypes.number.isRequired,
-    outstanding_propositions: PropTypes.number.isRequired,
-  }),
+  count: PropTypes.number,
+  investment: reminderType,
 }
 
 export default connect(state2props)(ReminderSummary)

--- a/src/client/components/ReminderSummary/reducer.js
+++ b/src/client/components/ReminderSummary/reducer.js
@@ -2,23 +2,14 @@ import { REMINDER_SUMMARY__LOADED } from '../../actions'
 
 const initialState = {
   count: 0,
-  summary: {
-    estimated_land_date: 0,
-    no_recent_investment_interaction: 0,
-    outstanding_propositions: 0,
-  },
+  investment: [],
 }
 
 export default (state = initialState, { type, result }) => {
   switch (type) {
     case REMINDER_SUMMARY__LOADED:
-      const count = Object.entries(result)
-        .map(([, value]) => value)
-        .reduce((total, value) => (total += value))
-
       return {
-        count,
-        summary: result,
+        ...result,
       }
     default:
       return state

--- a/src/client/components/ReminderSummary/tasks.js
+++ b/src/client/components/ReminderSummary/tasks.js
@@ -1,4 +1,26 @@
 import { apiProxyAxios } from '../Task/utils'
+import urls from '../../../lib/urls'
+
+const transformSummaryData = ({ data }) => ({
+  count: data.count,
+  investment: [
+    {
+      name: 'Approaching estimated land dates',
+      url: urls.reminders.estimatedLandDate(),
+      count: data.investment.estimated_land_date,
+    },
+    {
+      name: 'Projects with no recent interaction',
+      url: urls.reminders.noRecentInteraction(),
+      count: data.investment.no_recent_interaction,
+    },
+    {
+      name: 'Outstanding propositions',
+      url: urls.reminders.outstandingPropositions(),
+      count: data.investment.outstanding_propositions,
+    },
+  ],
+})
 
 export const fetchReminderSummary = () =>
-  apiProxyAxios.get('/v4/reminder/summary').then(({ data }) => data)
+  apiProxyAxios.get('/v4/reminder/summary').then(transformSummaryData)

--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -21,9 +21,12 @@ describe('Dashboard reminder summary', () => {
     before(() => {
       cy.intercept('GET', '/api-proxy/v4/reminder/summary', {
         body: {
-          estimated_land_date: 1,
-          no_recent_investment_interaction: 2,
-          outstanding_propositions: 5,
+          count: 8,
+          investment: {
+            estimated_land_date: 1,
+            no_recent_interaction: 2,
+            outstanding_propositions: 5,
+          },
         },
       }).as('apiRequest')
       cy.visit('/')
@@ -31,7 +34,7 @@ describe('Dashboard reminder summary', () => {
     })
 
     beforeEach(() => {
-      cy.get('[data-test="summary-item-estimated_land_date"]').as(
+      cy.get('[data-test="investment-approaching-estimated-land-dates"]').as(
         'estimatedLandDate'
       )
 
@@ -50,14 +53,14 @@ describe('Dashboard reminder summary', () => {
     })
 
     it('should contain summary entries', () => {
-      cy.get('[data-test="summary-item-estimated_land_date"]').contains(
-        'Approaching estimated land dates (1)'
-      )
       cy.get(
-        '[data-test="summary-item-no_recent_investment_interaction"]'
+        '[data-test="investment-approaching-estimated-land-dates"]'
+      ).contains('Approaching estimated land dates (1)')
+      cy.get(
+        '[data-test="investment-projects-with-no-recent-interaction"]'
       ).contains('Projects with no recent interaction (2)')
 
-      cy.get('[data-test="summary-item-outstanding_propositions"]').contains(
+      cy.get('[data-test="investment-outstanding-propositions"]').contains(
         'Outstanding propositions (5)'
       )
     })
@@ -72,9 +75,12 @@ describe('Dashboard reminder summary', () => {
     before(() => {
       cy.intercept('GET', '/api-proxy/v4/reminder/summary', {
         body: {
-          estimated_land_date: 0,
-          no_recent_investment_interaction: 0,
-          outstanding_propositions: 0,
+          count: 0,
+          investment: {
+            estimated_land_date: 0,
+            no_recent_interaction: 0,
+            outstanding_propositions: 0,
+          },
         },
       }).as('apiRequest')
       cy.visit('/')

--- a/test/sandbox/fixtures/v4/reminder/summary.json
+++ b/test/sandbox/fixtures/v4/reminder/summary.json
@@ -1,5 +1,11 @@
 {
-  "estimated_land_date": 230,
-  "no_recent_investment_interaction": 10,
-  "outstanding_propositions": 5
+  "count": 289,
+  "investment": {
+    "estimated_land_date": 230,
+    "no_recent_interaction": 10,
+    "outstanding_propositions": 5
+  },
+  "export": {
+    "no_recent_interaction": 44
+  }
 }


### PR DESCRIPTION
## Description of change

In order to accommodate export reminders we need to restructure the JSON response coming from the `/v4/reminder/summary` endpoint. This PR has a dependency on this [API PR](https://github.com/uktrade/data-hub-api/pull/4384).

Before:
```json
{
  "estimated_land_date": 1,
  "no_recent_investment_interaction": 2,
  "outstanding_propositions": 3
}
```
After:
```json
  "count": 10,
  "investment": {
    "estimated_land_date": 1,
    "no_recent_interaction": 2,
    "outstanding_propositions": 3
  },
  "export": {
    "no_recent_interaction": 4
  }
```

## Test instructions
As this PR has a dependency on an API change we can only test against sandbox for now.

Add the following feature flags to the `active_features` of `test/sandbox/fixtures/whoami.json`

```json
"export-email-reminders",
"personalised-dashboard",
"reminder-summary"
```

**There are no visual changes.**

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
