### PR TITLE
Implement edit opportunity details

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -19,6 +19,7 @@ import {
   FieldDate,
   FieldTypeahead,
   FieldAdvisersTypeahead,
+  FormLayout,
 } from '../../../../../client/components'
 import { FieldUKRegionTypeahead } from '../../../../../client/components/Form/elements/UKRegionOptions'
 import { FieldRequiredChecksRadios } from '../../../../../client/components/Form/elements/RequiredChecksOptions'
@@ -52,153 +53,155 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
 
   return (
     <Main>
-      <Form
-        id="opportunity-details"
-        submissionTaskName={TASK_SAVE_OPPORTUNITY_DETAILS}
-        analyticsFormName="opportunityDetailsForm"
-        transformPayload={(values) => ({ opportunityId, values })}
-        onSuccess={(opportunity) =>
-          dispatch({
-            type: INVESTMENT_OPPORTUNITY__UPDATED,
-            opportunity,
-          })
-        }
-        cancelRedirectTo={() =>
-          urls.investments.opportunities.details(opportunityId)
-        }
-      >
-        {(values) => (
-          <>
-            <FieldInput
-              label="Opportunity name"
-              initialValue={name}
-              name="name"
-              type="text"
-              required="Enter a name"
-            />
-            <FieldTextarea
-              label="Opportunity description"
-              initialValue={description}
-              name="description"
-              type="text"
-            />
-            <FieldUKRegionTypeahead
-              isMulti={true}
-              initialValue={ukRegions}
-              name="ukRegions"
-              aria-label="Select a uk location"
-            />
-            <FieldTypeahead
-              isMulti={true}
-              label="Promoters"
-              name="promoters"
-              placeholder="-- Select company --"
-              aria-label="Select a company"
-              initialValue={promoters}
-              loadOptions={throttle(
-                (searchString) =>
-                  apiProxyAxios
-                    .post('/v4/search/company', {
-                      name: searchString,
-                      archived: false,
-                    })
-                    .then(({ data: { results } }) =>
-                      idNamesToValueLabels(results)
-                    ),
-                500
-              )}
-            />
-            <FieldRequiredChecksRadios
-              name="requiredChecksConducted"
-              legend="Has this opportunity cleared the required checks?"
-              initialValue={requiredChecksConducted.value}
-            />
-            {[CLEARED_REFERENCE, ISSUES_IDENTIFIED_REFERENCE].includes(
-              values.values.requiredChecksConducted
-            ) && (
-              <>
-                <FieldDate
-                  name="requiredChecksConductedOn"
-                  label="Date of most recent checks"
-                  required="Enter a date"
-                  initialValue={transformDateStringToDateObject(
-                    requiredChecksConductedOn
-                  )}
-                />
-                <FieldAdvisersTypeahead
-                  name="requiredChecksConductedBy"
-                  label="Person responsible for most recent checks"
-                  placeholder="-- Search for an adviser --"
-                  required="Enter a name"
-                  initialValue={requiredChecksConductedBy}
-                />
-              </>
-            )}
-
-            <FieldConstructionRiskRadios
-              name="constructionRisks"
-              initialValue={constructionRisks[0]?.value}
-            />
-            <FieldAdvisersTypeahead
-              name="leadRelationshipManager"
-              label="Lead DIT relationship manager"
-              initialValue={leadRelationshipManager}
-              placeholder="-- Select adviser --"
-              isMulti={false}
-            />
-            {values.values.leadRelationshipManager && (
-              <FieldAdvisersTypeahead
-                name="otherDitContacts"
-                label="Other DIT contacts"
-                initialValue={otherDitContacts}
-                placeholder="-- Select adviser --"
-                aria-label="Select an adviser"
-                isMulti={true}
+      <FormLayout setWidth="three-quarters">
+        <Form
+          id="opportunity-details"
+          submissionTaskName={TASK_SAVE_OPPORTUNITY_DETAILS}
+          analyticsFormName="opportunityDetailsForm"
+          transformPayload={(values) => ({ opportunityId, values })}
+          onSuccess={(opportunity) =>
+            dispatch({
+              type: INVESTMENT_OPPORTUNITY__UPDATED,
+              opportunity,
+            })
+          }
+          cancelRedirectTo={() =>
+            urls.investments.opportunities.details(opportunityId)
+          }
+        >
+          {(values) => (
+            <>
+              <FieldInput
+                label="Opportunity name"
+                initialValue={name}
+                name="name"
+                type="text"
+                required="Enter a name"
               />
-            )}
-            <FieldOpportunityValueTypeRadios
-              name="valueType"
-              legend="Value"
-              initialValue={valueType.value}
-              interceptOption={(option) => ({
-                ...option,
-                hint: {
-                  'Capital expenditure':
-                    'For energy and infrastructure projects',
-                  'Gross development value (GDV)': 'For real estate projects',
-                }[option.label],
-                children: (
-                  <FieldInput
-                    label={option.label}
-                    hint="Enter the total amount in £"
-                    name="opportunityValue"
-                    initialValue={opportunityValue.value}
-                    type="text"
-                    validate={(value) =>
-                      !value || IS_NUMBER.test(value)
-                        ? null
-                        : 'Value must be a number'
-                    }
+              <FieldTextarea
+                label="Opportunity description"
+                initialValue={description}
+                name="description"
+                type="text"
+              />
+              <FieldUKRegionTypeahead
+                isMulti={true}
+                initialValue={ukRegions}
+                name="ukRegions"
+                aria-label="Select a uk location"
+              />
+              <FieldTypeahead
+                isMulti={true}
+                label="Promoters"
+                name="promoters"
+                placeholder="-- Select company --"
+                aria-label="Select a company"
+                initialValue={promoters}
+                loadOptions={throttle(
+                  (searchString) =>
+                    apiProxyAxios
+                      .post('/v4/search/company', {
+                        name: searchString,
+                        archived: false,
+                      })
+                      .then(({ data: { results } }) =>
+                        idNamesToValueLabels(results)
+                      ),
+                  500
+                )}
+              />
+              <FieldRequiredChecksRadios
+                name="requiredChecksConducted"
+                legend="Has this opportunity cleared the required checks?"
+                initialValue={requiredChecksConducted.value}
+              />
+              {[CLEARED_REFERENCE, ISSUES_IDENTIFIED_REFERENCE].includes(
+                values.values.requiredChecksConducted
+              ) && (
+                <>
+                  <FieldDate
+                    name="requiredChecksConductedOn"
+                    label="Date of most recent checks"
+                    required="Enter a date"
+                    initialValue={transformDateStringToDateObject(
+                      requiredChecksConductedOn
+                    )}
                   />
-                ),
-              })}
-            />
-            <FieldAssetClassTypeahead
-              isMulti={true}
-              name="assetClasses"
-              initialValue={assetClasses}
-            />
-            <p>
-              If the asset class you wish to select is not shown above, then
-              request it from&nbsp;
-              <a href={`mailto:capitalinvestment@trade.gov.uk`}>
-                capitalinvestment@trade.gov.uk
-              </a>
-              .
-            </p>
-          </>
-        )}
-      </Form>
+                  <FieldAdvisersTypeahead
+                    name="requiredChecksConductedBy"
+                    label="Person responsible for most recent checks"
+                    placeholder="-- Search for an adviser --"
+                    required="Enter a name"
+                    initialValue={requiredChecksConductedBy}
+                  />
+                </>
+              )}
+
+              <FieldConstructionRiskRadios
+                name="constructionRisks"
+                initialValue={constructionRisks[0]?.value}
+              />
+              <FieldAdvisersTypeahead
+                name="leadRelationshipManager"
+                label="Lead DIT relationship manager"
+                initialValue={leadRelationshipManager}
+                placeholder="-- Select adviser --"
+                isMulti={false}
+              />
+              {values.values.leadRelationshipManager && (
+                <FieldAdvisersTypeahead
+                  name="otherDitContacts"
+                  label="Other DIT contacts"
+                  initialValue={otherDitContacts}
+                  placeholder="-- Select adviser --"
+                  aria-label="Select an adviser"
+                  isMulti={true}
+                />
+              )}
+              <FieldOpportunityValueTypeRadios
+                name="valueType"
+                legend="Value"
+                initialValue={valueType.value}
+                interceptOption={(option) => ({
+                  ...option,
+                  hint: {
+                    'Capital expenditure':
+                      'For energy and infrastructure projects',
+                    'Gross development value (GDV)': 'For real estate projects',
+                  }[option.label],
+                  children: (
+                    <FieldInput
+                      label={option.label}
+                      hint="Enter the total amount in £"
+                      name="opportunityValue"
+                      initialValue={opportunityValue.value}
+                      type="text"
+                      validate={(value) =>
+                        !value || IS_NUMBER.test(value)
+                          ? null
+                          : 'Value must be a number'
+                      }
+                    />
+                  ),
+                })}
+              />
+              <FieldAssetClassTypeahead
+                isMulti={true}
+                name="assetClasses"
+                initialValue={assetClasses}
+              />
+              <p>
+                If the asset class you wish to select is not shown above, then
+                request it from&nbsp;
+                <a href={`mailto:capitalinvestment@trade.gov.uk`}>
+                  capitalinvestment@trade.gov.uk
+                </a>
+                .
+              </p>
+            </>
+          )}
+        </Form>
+      </FormLayout>
     </Main>
   )
 }


### PR DESCRIPTION
## Description of change

Navigate to Investments --> Click UK opportunities--> Click Any opportunity-->Click opportunity details -->Click Edit-->Then display the Opportunity details form- Opportunity details form- layout from full to two-thirds width.

## Test instructions

Full Form Width is reduced to three widths

## Screenshots

![image](https://user-images.githubusercontent.com/74972011/203556527-a42b6155-b42c-4391-84d2-de3bdcbc4f08.png)

_Add a screenshot_

### After

<img width="1335" alt="image" src="https://user-images.githubusercontent.com/74972011/203556468-99e691c4-8fac-400f-8578-30d46b8fb80b.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
