### PR TITLE
Wire up the reminders export link to the reminders list

### DIFF
--- a/src/client/components/ReminderSummary/tasks.js
+++ b/src/client/components/ReminderSummary/tasks.js
@@ -23,7 +23,7 @@ const transformSummaryData = ({ data }) => ({
   export: [
     {
       name: 'Companies with no recent interactions',
-      url: urls.reminders.investments.noRecentInteraction(),
+      url: urls.reminders.exports.noRecentInteractions(),
       count: data.export.no_recent_interaction,
     },
   ],

--- a/src/client/modules/Reminders/ExportsCollectionList.jsx
+++ b/src/client/modules/Reminders/ExportsCollectionList.jsx
@@ -129,8 +129,8 @@ const ExportsCollectionList = ({
                       </li>
                       <li>
                         <ItemHint>Name/Team</ItemHint>{' '}
-                        {interaction.created_by.name}
-                        {interaction.created_by.dit_team
+                        {interaction.created_by?.name || 'Name unknown'}
+                        {interaction.created_by?.dit_team
                           ? `/${interaction.created_by.dit_team.name}`
                           : ' - Team unknown'}
                       </li>

--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -58,20 +58,41 @@ describe('Dashboard reminder summary', () => {
     })
 
     it('should contain summary entries', () => {
-      cy.get(
-        '[data-test="investment-approaching-estimated-land-dates"]'
-      ).contains('Approaching estimated land dates (1)')
-      cy.get(
-        '[data-test="investment-projects-with-no-recent-interaction"]'
-      ).contains('Projects with no recent interaction (2)')
+      cy.get('[data-test="investment-approaching-estimated-land-dates"]')
+        .contains('Approaching estimated land dates (1)')
+        .find('a')
+        .should(
+          'have.attr',
+          'href',
+          '/reminders/investments-estimated-land-date'
+        )
 
-      cy.get('[data-test="investment-outstanding-propositions"]').contains(
-        'Outstanding propositions (5)'
-      )
+      cy.get('[data-test="investment-projects-with-no-recent-interaction"]')
+        .contains('Projects with no recent interaction (2)')
+        .find('a')
+        .should(
+          'have.attr',
+          'href',
+          '/reminders/investments-no-recent-interaction'
+        )
 
-      cy.get(
-        '[data-test="export-companies-with-no-recent-interactions"]'
-      ).contains('Companies with no recent interactions (4)')
+      cy.get('[data-test="investment-outstanding-propositions"]')
+        .contains('Outstanding propositions (5)')
+        .find('a')
+        .should(
+          'have.attr',
+          'href',
+          '/reminders/investments-outstanding-propositions'
+        )
+
+      cy.get('[data-test="export-companies-with-no-recent-interactions"]')
+        .contains('Companies with no recent interactions (4)')
+        .find('a')
+        .should(
+          'have.attr',
+          'href',
+          '/reminders/exports-no-recent-interactions'
+        )
     })
 
     it('should be in a togglable section that starts open', () => {


### PR DESCRIPTION
## Description of change
* Wires up the reminders export link on the dashboard to the corresponding reminders list
* Fixes an error when the reminders export interaction `created_by` field is `undefined`

## Test instructions
No visual changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
