### PR TITLE
RR-737 - Handle reminders for companies with no interactions

### DIFF
--- a/src/client/modules/Reminders/ExportsCollectionList.jsx
+++ b/src/client/modules/Reminders/ExportsCollectionList.jsx
@@ -93,86 +93,114 @@ const ExportsCollectionList = ({
 }) => {
   return (
     <List data-test="reminders-list">
-      {results.map(({ id, created_on, company, interaction, deleted }) => (
-        <ListItem key={id} data-test="reminders-list-item">
-          <GridRow>
-            {deleted ? (
-              <GridCol>
-                <ItemHeader data-test="item-header">
-                  Reminder deleted
-                </ItemHeader>
-                <ItemContent colour={DARK_GREY} data-test="item-content">
-                  Reminder received {formatLongDate(created_on)} for{' '}
-                  {company.name}
-                </ItemContent>
-              </GridCol>
-            ) : (
-              <>
+      {results.map(
+        ({
+          id,
+          created_on,
+          last_interaction_date,
+          company,
+          interaction,
+          deleted,
+        }) => (
+          <ListItem key={id} data-test="reminders-list-item">
+            <GridRow>
+              {deleted ? (
                 <GridCol>
                   <ItemHeader data-test="item-header">
-                    <ul>
-                      <li>Reminder received {formatLongDate(created_on)}</li>
-                      <li>
-                        <ItemHeaderLink
-                          href={`${urls.companies.detail(company.id)}`}
-                        >
-                          No interaction recorded for {company.name}
-                        </ItemHeaderLink>
-                      </li>
-                    </ul>
+                    Reminder deleted
                   </ItemHeader>
-                  <ItemContent colour={BLACK} data-test="item-content">
-                    <ul>
-                      <li>
-                        <ItemHint>Date of last interaction</ItemHint>{' '}
-                        {formatLongDate(interaction.date)}
-                      </li>
-                      <li>
-                        <ItemHint>Name/Team</ItemHint>{' '}
-                        {interaction.created_by?.name || 'Name unknown'}
-                        {interaction.created_by?.dit_team
-                          ? `/${interaction.created_by.dit_team.name}`
-                          : ' - Team unknown'}
-                      </li>
-                      <li>
-                        <ItemHint>Type of interaction</ItemHint>{' '}
-                        {INTERACTION_NAMES[interaction.kind]}
-                      </li>
-                      <li>
-                        <ItemHint>Interaction title</ItemHint>{' '}
-                        {interaction.subject}
-                      </li>
-                    </ul>
+                  <ItemContent colour={DARK_GREY} data-test="item-content">
+                    Reminder received {formatLongDate(created_on)} for{' '}
+                    {company.name}
                   </ItemContent>
-                  {/* Display on mobile only */}
-                  {onDeleteReminder && !disableDelete && (
-                    <DeleteButton
-                      isMobile={true}
-                      data-test="delete-button"
-                      onClick={() => onDeleteReminder(id)}
-                    >
-                      Delete reminder
-                    </DeleteButton>
-                  )}
                 </GridCol>
-                {/* Display on Tablet and Desktop only */}
-                {onDeleteReminder && (
-                  <RightCol setWidth="one-quarter">
-                    {!disableDelete && (
+              ) : (
+                <>
+                  <GridCol>
+                    <ItemHeader data-test="item-header">
+                      <ul>
+                        <li>Reminder received {formatLongDate(created_on)}</li>
+                        <li>
+                          <ItemHeaderLink
+                            href={`${urls.companies.detail(company.id)}`}
+                          >
+                            No interaction recorded for {company.name}
+                          </ItemHeaderLink>
+                        </li>
+                      </ul>
+                    </ItemHeader>
+                    <ItemContent colour={BLACK} data-test="item-content">
+                      <ul>
+                        <li>
+                          <ItemHint>Date of last interaction</ItemHint>{' '}
+                          {formatLongDate(last_interaction_date)}
+                        </li>
+                        {interaction ? (
+                          <>
+                            <li>
+                              <ItemHint>Name/Team</ItemHint>{' '}
+                              {interaction.created_by?.name || 'Name unknown'}
+                              {interaction.created_by?.dit_team
+                                ? `/${interaction.created_by.dit_team.name}`
+                                : ' - Team unknown'}
+                            </li>
+                            <li>
+                              <ItemHint>Type of interaction</ItemHint>{' '}
+                              {INTERACTION_NAMES[interaction.kind]}
+                            </li>
+                            <li>
+                              <ItemHint>Interaction title</ItemHint>{' '}
+                              {interaction.subject}
+                            </li>
+                          </>
+                        ) : (
+                          <>
+                            <li>
+                              <ItemHint>Name/Team</ItemHint>
+                              {' N/A'}
+                            </li>
+                            <li>
+                              <ItemHint>Type of interaction</ItemHint>
+                              {' N/A'}
+                            </li>
+                            <li>
+                              <ItemHint>Interaction title</ItemHint>
+                              {' N/A'}
+                            </li>
+                          </>
+                        )}
+                      </ul>
+                    </ItemContent>
+                    {/* Display on mobile only */}
+                    {onDeleteReminder && !disableDelete && (
                       <DeleteButton
+                        isMobile={true}
                         data-test="delete-button"
                         onClick={() => onDeleteReminder(id)}
                       >
                         Delete reminder
                       </DeleteButton>
                     )}
-                  </RightCol>
-                )}
-              </>
-            )}
-          </GridRow>
-        </ListItem>
-      ))}
+                  </GridCol>
+                  {/* Display on Tablet and Desktop only */}
+                  {onDeleteReminder && (
+                    <RightCol setWidth="one-quarter">
+                      {!disableDelete && (
+                        <DeleteButton
+                          data-test="delete-button"
+                          onClick={() => onDeleteReminder(id)}
+                        >
+                          Delete reminder
+                        </DeleteButton>
+                      )}
+                    </RightCol>
+                  )}
+                </>
+              )}
+            </GridRow>
+          </ListItem>
+        )
+      )}
     </List>
   )
 }

--- a/test/functional/cypress/fakers/reminders.js
+++ b/test/functional/cypress/fakers/reminders.js
@@ -4,6 +4,14 @@ import { relativeDateFaker } from './dates'
 import { investmentProjectCodeFaker } from './investment-projects'
 import { listFaker } from './utils'
 
+export const nestedAdviserFaker = (overrides = {}) => ({
+  name: faker.name.fullName(),
+  dit_team: {
+    name: `${faker.address.country()} Team`,
+  },
+  ...overrides,
+})
+
 export const nestedProjectFaker = (overrides = {}) => ({
   id: faker.datatype.uuid(),
   name: faker.lorem.words(),
@@ -18,12 +26,7 @@ export const nestedCompanyFaker = (overrides = {}) => ({
 })
 
 export const nestedInteractionFaker = (overrides = {}) => ({
-  created_by: {
-    name: faker.name.fullName(),
-    dit_team: {
-      name: `${faker.address.country()} Team`,
-    },
-  },
+  created_by: nestedAdviserFaker(),
   date: relativeDateFaker({ minDays: -365, maxDays: 0 }),
   kind: faker.helpers.arrayElement(['interaction', 'service_delivery']),
   subject: faker.datatype.string(),
@@ -47,6 +50,7 @@ export const reminderListFaker = (
 export const exportReminderFaker = (overrides = {}) => ({
   id: faker.datatype.uuid(),
   created_on: relativeDateFaker({ minDays: -365, maxDays: 0 }),
+  last_interaction_date: relativeDateFaker({ minDays: -365, maxDays: 0 }),
   event: faker.lorem.words(),
   company: nestedCompanyFaker(),
   interaction: nestedInteractionFaker(),

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -86,6 +86,7 @@ exports.getNoRecentExportInteractionReminders = function (req, res) {
       {
         id: '4af1527e-ed3e-4af4-84fc-dc8bb19078bb',
         created_on: '2022-06-06T13:56:45.068248Z',
+        last_interaction_date: '2021-08-14T08:49:23Z',
         event: '30 days since last interaction',
         company: {
           id: 'c79ba298-106e-4629-aa12-61ec6e2e47ce',
@@ -110,6 +111,7 @@ exports.getNoRecentExportInteractionReminders = function (req, res) {
       {
         id: '4342c516-9898-e211-a939-e4115bead28a',
         created_on: '2022-10-06T13:56:45.068248Z',
+        last_interaction_date: '2021-02-09T08:49:23Z',
         event: '30 days since last interaction',
         company: {
           id: 'c79ba298-106e-4629-aa12-61ec6e2e47ce',
@@ -127,6 +129,17 @@ exports.getNoRecentExportInteractionReminders = function (req, res) {
           kind: 'service_delivery',
           subject: 'Ran export event',
         },
+      },
+      {
+        id: '4342c516-9898-e211-a939-e4115bead28a',
+        created_on: '2022-10-06T13:56:45.068248Z',
+        last_interaction_date: '2019-03-11T08:49:23Z',
+        event: '30 days since last interaction',
+        company: {
+          id: 'b2c34b41-1d5a-4b4b-9249-7c53ff2868dd',
+          name: 'Mars Exports Ltd',
+        },
+        interaction: null,
       },
     ],
   })


### PR DESCRIPTION
## Description of change
The previous designs and implementation for the export 'no recent interactions' reminders did not account for companies with no interactions at all. This PR builds on the API change merged here: https://github.com/uktrade/data-hub-api/pull/4390/files , to handle these cases. _This has now been deployed_

## Test instructions

Run locally with the sandbox API and visit `http://localhost:3000/reminders/exports-no-recent-interactions` ; view the example of a company with no prior interaction at the end of the list. Copy was agreed with Darren - it can be reviewed with the whole of the `export-reminders` feature branch if we deploy to UAT.

## Screenshot
<img width="814" alt="Screenshot 2022-11-28 at 13 20 39" src="https://user-images.githubusercontent.com/23265724/204265588-d5cc17b4-d115-4500-8d82-2ed54d973c98.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
