### PR TITLE
Add new endpoint to get list of attendees by reg status

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -1558,9 +1558,7 @@ describe('Activity feed controllers', () => {
 
       it('should call fetchMatchingDataHubContacts with the correct ids', async () => {
         const attendeeEmails = allAttendees.hits.hits
-          .map((hit) => {
-            return hit._source.object['dit:aventri:email']
-          })
+          .map((hit) => hit._source.object['dit:aventri:email'])
           .filter((f) => f)
 
         attendeeEmails.forEach((email) =>

--- a/src/apps/companies/apps/activity-feed/constants.js
+++ b/src/apps/companies/apps/activity-feed/constants.js
@@ -78,11 +78,17 @@ const EVENT_ATTENDEES_SORT_OPTIONS = {
 }
 
 const EVENT_AVENTRI_ATTENDEES_STATUS = {
+  activated: 'Activated',
   attended: 'Attended',
   confirmed: 'Confirmed',
   cancelled: 'Cancelled',
-  registered: 'Registered',
+  noShow: 'No Show',
+  waitlist: 'Waitlist',
 }
+
+const EVENT_AVENTRI_ATTENDEES_STATUSES = Object.values(
+  EVENT_AVENTRI_ATTENDEES_STATUS
+)
 
 const EVENT_ACTIVITY_SORT_OPTIONS = {
   'modified_on:asc': {
@@ -151,6 +157,7 @@ module.exports = {
   EVENT_ATTENDEES_SORT_OPTIONS,
   EVENT_ACTIVITY_SORT_OPTIONS,
   EVENT_AVENTRI_ATTENDEES_STATUS,
+  EVENT_AVENTRI_ATTENDEES_STATUSES,
   EVENT_ALL_ACTIVITY,
   FILTER_KEYS,
   FILTER_ITEMS,

--- a/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/aventri-attendee-query.js
@@ -31,4 +31,4 @@ const aventriAttendeeQuery = ({
   sort,
 })
 
-module.exports = { aventriAttendeeQuery }
+module.exports = aventriAttendeeQuery

--- a/src/apps/companies/apps/activity-feed/es-queries/index.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/index.js
@@ -5,6 +5,7 @@ const dataHubActivityQuery = require('./data-hub-activity-query')
 const myActivityQuery = require('./my-activity-query')
 const aventriAttendeeForCompanyQuery = require('./aventri-attendee-for-company-query')
 const dataHubAndAventriActivityQuery = require('./data-hub-and-aventri-activity-query')
+const aventriAttendeeQuery = require('./aventri-attendee-query')
 
 module.exports = {
   myActivityQuery,
@@ -14,4 +15,5 @@ module.exports = {
   maxemailEmailSentQuery,
   aventriAttendeeForCompanyQuery,
   dataHubAndAventriActivityQuery,
+  aventriAttendeeQuery,
 }

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -12,6 +12,7 @@ const {
   fetchAventriEvent,
   fetchAventriEventAttended,
   fetchAllActivityFeedEvents,
+  fetchAventriEventRegistrationStatusAttendees,
 } = require('../companies/apps/activity-feed/controllers')
 
 router.get('/create', renderEventsView)
@@ -22,6 +23,10 @@ router.get('/aventri/:aventriEventId/details', renderEventsView)
 router.get(urls.events.aventri.detailsData.route, fetchAventriEvent)
 router.get('/aventri/:aventriEventId/attended', renderEventsView)
 router.get(urls.events.aventri.attendedData.route, fetchAventriEventAttended)
+router.get(
+  urls.events.aventri.registrationStatusData.route,
+  fetchAventriEventRegistrationStatusAttendees
+)
 
 router.use(
   '/:eventId',

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -256,6 +256,10 @@ module.exports = {
       detailsData: url('/events', '/aventri/:aventriEventId/details/data'),
       attended: url('/events', '/aventri/:aventriEventId/attended'),
       attendedData: url('/events', '/aventri/:aventriEventId/attended/data'),
+      registrationStatusData: url(
+        '/events',
+        '/aventri/:aventriEventId/registration/attendees/data'
+      ),
     },
   },
   search: {


### PR DESCRIPTION
## Description of change

- Add a new endpoint that will return a list of aventri attendees that match the list of registration status provided
- The new `fetchAventriEventRegistrationStatusAttendees` function is a duplicate of the `fetchAventriEventAttended` function. This function will be removed in a future PR but has been left to avoid breaking current functionality
## Test instructions

At the moment there is no UI screen for this change , to test use postman to query the url http://localhost:3000/events/aventri/3333/registration/attendees/data?sortBy=first_name:asc&page=1&size=10&registrationStatuses[]=Attended

The list of allowed registration status values are : 'Activated',  'Attended',  'Confirmed',  'Cancelled',  'No Show', 'Waitlist'.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
