### PR TITLE
RR-771: add content fixes for the export no recent interaction list

### DIFF
--- a/src/client/modules/Reminders/ExportsCollectionList.jsx
+++ b/src/client/modules/Reminders/ExportsCollectionList.jsx
@@ -14,7 +14,7 @@ import {
 } from '@govuk-react/constants'
 
 import { DARK_GREY } from '../../utils/colors'
-import { formatLongDate } from '../../utils/date'
+import { formatMediumDate } from '../../utils/date'
 import { INTERACTION_NAMES } from '../../../apps/interactions/constants'
 import urls from '../../../lib/urls'
 
@@ -110,8 +110,7 @@ const ExportsCollectionList = ({
                     Reminder deleted
                   </ItemHeader>
                   <ItemContent colour={DARK_GREY} data-test="item-content">
-                    Reminder received {formatLongDate(created_on)} for{' '}
-                    {company.name}
+                    Received {formatMediumDate(created_on)} for {company.name}
                   </ItemContent>
                 </GridCol>
               ) : (
@@ -119,7 +118,7 @@ const ExportsCollectionList = ({
                   <GridCol>
                     <ItemHeader data-test="item-header">
                       <ul>
-                        <li>Reminder received {formatLongDate(created_on)}</li>
+                        <li>Received {formatMediumDate(created_on)}</li>
                         <li>
                           <ItemHeaderLink
                             href={`${urls.companies.detail(company.id)}`}
@@ -132,40 +131,40 @@ const ExportsCollectionList = ({
                     <ItemContent colour={BLACK} data-test="item-content">
                       <ul>
                         <li>
-                          <ItemHint>Date of last interaction</ItemHint>{' '}
-                          {formatLongDate(last_interaction_date)}
+                          <ItemHint>Date of last interaction:</ItemHint>{' '}
+                          {formatMediumDate(last_interaction_date)}
                         </li>
                         {interaction ? (
                           <>
                             <li>
-                              <ItemHint>Name/Team</ItemHint>{' '}
+                              <ItemHint>Recorded by:</ItemHint>{' '}
                               {interaction.created_by?.name || 'Name unknown'}
                               {interaction.created_by?.dit_team
-                                ? `/${interaction.created_by.dit_team.name}`
-                                : ' - Team unknown'}
+                                ? ` in ${interaction.created_by.dit_team.name}`
+                                : ' - team unknown'}
                             </li>
                             <li>
-                              <ItemHint>Type of interaction</ItemHint>{' '}
+                              <ItemHint>Interaction type:</ItemHint>{' '}
                               {INTERACTION_NAMES[interaction.kind]}
                             </li>
                             <li>
-                              <ItemHint>Interaction title</ItemHint>{' '}
+                              <ItemHint>Subject:</ItemHint>{' '}
                               {interaction.subject}
                             </li>
                           </>
                         ) : (
                           <>
                             <li>
-                              <ItemHint>Name/Team</ItemHint>
-                              {' N/A'}
+                              <ItemHint>Recorded by:</ItemHint>
+                              {' no information'}
                             </li>
                             <li>
-                              <ItemHint>Type of interaction</ItemHint>
-                              {' N/A'}
+                              <ItemHint>Interaction type:</ItemHint>
+                              {' no information'}
                             </li>
                             <li>
-                              <ItemHint>Interaction title</ItemHint>
-                              {' N/A'}
+                              <ItemHint>Subject:</ItemHint>
+                              {' no information'}
                             </li>
                           </>
                         )}

--- a/src/client/modules/Reminders/ExportsNoRecentInteractionList.jsx
+++ b/src/client/modules/Reminders/ExportsNoRecentInteractionList.jsx
@@ -1,6 +1,9 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import { BLACK } from 'govuk-colours'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
+import styled from 'styled-components'
 import qs from 'qs'
 
 import {
@@ -24,6 +27,12 @@ import Task from '../../components/Task'
 import ExportsCollectionList from './ExportsCollectionList'
 import { CollectionSort, RoutedPagination } from '../../components'
 
+const Summary = styled('p')({
+  color: BLACK,
+  paddingTop: SPACING.SCALE_2,
+  fontSize: FONT_SIZE.SIZE_19,
+})
+
 const ExportsNoRecentInteractionList = ({
   exportsNoRecentInteractionReminders,
 }) => {
@@ -42,7 +51,9 @@ const ExportsNoRecentInteractionList = ({
         pageOrigin="exports_no_recent_interactions"
       />
       {results.length === 0 ? (
-        <p data-test="investments-no-reminders">You have no reminders.</p>
+        <Summary data-test="investments-no-reminders">
+          You have no reminders.
+        </Summary>
       ) : (
         <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
       )}

--- a/test/functional/cypress/specs/reminders/exports-no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/exports-no-recent-interaction-spec.js
@@ -6,7 +6,7 @@ import {
   nestedInteractionFaker,
   reminderListFaker,
 } from '../../fakers/reminders'
-import { formatLongDate } from '../../../../../src/client/utils/date'
+import { formatMediumDate } from '../../../../../src/client/utils/date'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/no-recent-export-interaction'
 
@@ -172,7 +172,7 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${formatLongDate(reminders[0].last_interaction_date)}`
+          `${formatMediumDate(reminders[0].last_interaction_date)}`
         )
     })
   })
@@ -210,7 +210,7 @@ describe('Exports no recent Interaction Reminders', () => {
       cy.get('[data-test="reminders-list-item"]').eq(0).as('reminder')
       cy.get('@reminder')
         .find('[data-test="item-content"]')
-        .should('contain', 'Team unknown')
+        .should('contain', 'team unknown')
     })
   })
 
@@ -245,7 +245,7 @@ describe('Exports no recent Interaction Reminders', () => {
       cy.get('[data-test="reminders-list-item"]').eq(0).as('reminder')
       cy.get('@reminder')
         .find('[data-test="item-content"]')
-        .should('contain', ' N/A')
+        .should('contain', ' no information')
     })
   })
 
@@ -377,7 +377,7 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Reminder received ${formatLongDate(
+          `Received ${formatMediumDate(
             deleted_reminder_date.toISOString()
           )} for ${reminders[4].company.name}`
         )


### PR DESCRIPTION
## Description of change
Makes requested updates to the copy of the new 'no recent export interactions' list. 

## Test instructions

- Run the branch using the mock data in 
- Navigate to `/reminders/exports-no-recent-interactions` 
- Compare with the UAT environment.

## Screenshots

### Before
<img width="814" alt="Screenshot 2022-11-28 at 13 20 39" src="https://user-images.githubusercontent.com/23265724/204531967-808ac0e3-b3c6-4b39-ab75-875aa0a9f500.png">

### After
<img width="865" alt="Screenshot 2022-11-29 at 14 41 42" src="https://user-images.githubusercontent.com/23265724/204531998-422dcb56-d4b6-43bf-8d0b-29e002c552bc.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
