### PR TITLE
Fix: RR-772 add export-email-reminders feature flag

### DIFF
--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -7,6 +7,7 @@ import { H3 } from 'govuk-react'
 import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
+import CheckUserFeatureFlag from '../../components/CheckUserFeatureFlags'
 
 const LinkList = styled('ul')({
   listStyleType: 'none',
@@ -70,15 +71,21 @@ const RemindersMenu = () => {
           Reminders for outstanding propositions
         </MenuItem>
       </Menu>
-      <Menu>
-        <H3 as="h2">Export</H3>
-        <MenuItem
-          to={urls.reminders.exports.noRecentInteractions()}
-          pathname={location.pathname}
-        >
-          Reminders for companies with no recent interactions
-        </MenuItem>
-      </Menu>
+      <CheckUserFeatureFlag userFeatureFlagName="export-email-reminders">
+        {(isFeatureFlagOn) =>
+          isFeatureFlagOn && (
+            <Menu>
+              <H3 as="h2">Export</H3>
+              <MenuItem
+                to={urls.reminders.exports.noRecentInteractions()}
+                pathname={location.pathname}
+              >
+                Reminders for companies with no recent interactions
+              </MenuItem>
+            </Menu>
+          )
+        }
+      </CheckUserFeatureFlag>
     </>
   )
 }

--- a/test/functional/cypress/fakers/users.js
+++ b/test/functional/cypress/fakers/users.js
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-const userFaker = () => {
+const userFaker = (overrides) => {
   const first_name = faker.name.firstName()
   const last_name = faker.name.lastName()
   return {
@@ -8,6 +8,7 @@ const userFaker = () => {
     first_name,
     last_name,
     name: `${first_name} ${last_name}`,
+    ...overrides,
   }
 }
 

--- a/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/reminders/estimated-land-date-spec.js
@@ -1,10 +1,13 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { reminderFaker, reminderListFaker } from '../../fakers/reminders'
+import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/estimated-land-date'
+const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('Estimated Land Date Reminders', () => {
+  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     reminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -15,6 +18,15 @@ describe('Estimated Land Date Reminders', () => {
   const totalCount = 25
 
   const interceptApiCalls = () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: whoAmIEndpoint,
+      },
+      {
+        body: user,
+      }
+    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -73,6 +85,7 @@ describe('Estimated Land Date Reminders', () => {
     before(() => {
       interceptApiCalls()
       cy.visit(urls.reminders.investments.estimatedLandDate())
+      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/exports-no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/exports-no-recent-interaction-spec.js
@@ -7,10 +7,13 @@ import {
   reminderListFaker,
 } from '../../fakers/reminders'
 import { formatMediumDate } from '../../../../../src/client/utils/date'
+import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/no-recent-export-interaction'
+const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('Exports no recent Interaction Reminders', () => {
+  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     exportReminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -23,6 +26,15 @@ describe('Exports no recent Interaction Reminders', () => {
   const nextReminder = exportReminderFaker()
 
   const interceptApiCalls = () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: whoAmIEndpoint,
+      },
+      {
+        body: user,
+      }
+    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -80,6 +92,7 @@ describe('Exports no recent Interaction Reminders', () => {
     before(() => {
       interceptApiCalls()
       cy.visit(urls.reminders.exports.noRecentInteractions())
+      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
+++ b/test/functional/cypress/specs/reminders/no-recent-interaction-spec.js
@@ -1,11 +1,14 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { reminderFaker, reminderListFaker } from '../../fakers/reminders'
+import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint =
   '/api-proxy/v4/reminder/no-recent-investment-interaction'
+const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('No Recent Interaction Reminders', () => {
+  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     reminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -16,6 +19,15 @@ describe('No Recent Interaction Reminders', () => {
   const nextReminder = reminderFaker()
 
   const interceptApiCalls = () => {
+    cy.intercept(
+      {
+        method: 'GET',
+        pathname: whoAmIEndpoint,
+      },
+      {
+        body: user,
+      }
+    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -74,6 +86,7 @@ describe('No Recent Interaction Reminders', () => {
     before(() => {
       interceptApiCalls()
       cy.visit(urls.reminders.investments.noRecentInteraction())
+      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
+++ b/test/functional/cypress/specs/reminders/outstanding-reminders-spec.js
@@ -10,7 +10,7 @@ const propositionsEndpoint = '/api-proxy/v4/proposition'
 const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('Outstanding Proposition Reminders', () => {
-  const user = userFaker()
+  const user = userFaker({ active_features: ['export-email-reminders'] })
   const totalCount = 11
   const propositions = [
     propositionFaker({

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -109,7 +109,7 @@ exports.getNoRecentExportInteractionReminders = function (req, res) {
         },
       },
       {
-        id: '4342c516-9898-e211-a939-e4115bead28a',
+        id: 'c79ba298-9898-e211-a939-e4115bead28a',
         created_on: '2022-10-06T13:56:45.068248Z',
         last_interaction_date: '2021-02-09T08:49:23Z',
         event: '30 days since last interaction',


### PR DESCRIPTION
## Description of change
Hides the Export reminders link behind a feature flag on the Investment reminders pages.

## Test instructions
- Run locally and visit `/reminders` to view the Investment reminders list without the navigation link for the export company reminders
- Set up a feature flag called `export-email-reminders` either in your local API admin, or by editing `whoami.js` in the Sandbox directory

## Screenshots

### Before
<img width="814" alt="Screenshot 2022-11-28 at 13 20 39" src="https://user-images.githubusercontent.com/23265724/204546417-d87a112b-9b2d-4596-881c-677f0ac46ce3.png">

### After
<img width="861" alt="Screenshot 2022-11-29 at 15 50 02" src="https://user-images.githubusercontent.com/23265724/204546461-ead502a5-858f-4f0d-a839-234cabf2c21d.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
