### PR TITLE
Ensure update contact with US address uses the correct state field

### DIFF
--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -104,7 +104,7 @@ const _ContactForm = ({
 
   const getAreaValue = (values) => {
     if (values.country === UNITED_STATES_ID) {
-      return values.areaUS
+      return values.area
     } else if (values.country === CANADA_ID) {
       return values.areaCanada
     } else {
@@ -146,6 +146,7 @@ const _ContactForm = ({
                     'new-contact-name': name,
                     'new-contact-id': id,
                   })
+
                   return origin_url
                     ? `${origin_url}?${encoded}`
                     : urls.contacts.details(id)


### PR DESCRIPTION
## Description of change

When updating contacts, we would reference the `area_address` field for US addresses with the wrong state value, causing the backend to fail.

With this fix the user should be able to edit US based addresses contacts

## Test instructions

Functional tests should pass

## Screenshots
N/A

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
