### PR TITLE
Include a link to contacts for the Aventri events

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -1092,7 +1092,7 @@ describe('Activity feed controllers', () => {
     const generateEventResponse = (hits) => {
       return {
         hits: {
-          hits: hits,
+          hits,
         },
       }
     }

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -1,3 +1,4 @@
+const { faker } = require('@faker-js/faker')
 const activityFeedEsFixtures = require('../../../../../../test/unit/data/activity-feed/activity-feed-from-es.json')
 const activityFeedAventriAtendeeEsFixtures = require('../../../../../../test/unit/data/activity-feed/activity-feed-aventri-attendee-from-es.json')
 
@@ -1079,6 +1080,206 @@ describe('Activity feed controllers', () => {
       it('should call next with an error', async () => {
         expect(middlewareParameters.resMock.json).to.not.have.been.called
         expect(middlewareParameters.nextSpy).to.have.been.calledWith(error)
+      })
+    })
+  })
+
+  describe('#getAventriEventsAttendedByCompanyContacts', () => {
+    let fakeActivityFeed = () => {
+      return { hits: { hits: [] } }
+    }
+
+    const generateEventResponse = (hits) => {
+      return {
+        hits: {
+          hits: hits,
+        },
+      }
+    }
+
+    before(() => {
+      fetchActivityFeedStub = sinon.stub().callsFake(fakeActivityFeed)
+      controllers = proxyquire(
+        '../../src/apps/companies/apps/activity-feed/controllers',
+        {
+          './repos': {
+            fetchActivityFeed: fetchActivityFeedStub,
+          },
+        }
+      )
+      middlewareParameters = buildMiddlewareParameters()
+    })
+
+    it('when called with an empty list of contacts should return an empty event object', async () => {
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          []
+        )
+      expect(events).to.be.deep.equal({})
+    })
+
+    it('when called with a single contact that has no aventri events should return an empty event object', async () => {
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          [{ email: faker.internet.email }]
+        )
+      expect(events).to.be.deep.equal({})
+    })
+
+    it('when called with a single contact that has 1 aventri events should return an event object with 1 event and 1 contact email', async () => {
+      const email = faker.internet.email()
+
+      fetchActivityFeedStub.resolves(
+        generateEventResponse([
+          {
+            _source: {
+              object: {
+                attributedTo: { id: 1 },
+                'dit:emailAddress': email,
+              },
+            },
+          },
+        ])
+      )
+
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          [
+            {
+              email: email,
+              name: faker.name.fullName(),
+              id: faker.random.numeric(),
+            },
+          ]
+        )
+      expect(events['1:Create'].length).to.be.equal(1)
+      expect(events['1:Create'][0]['dit:emailAddress']).to.be.equal(email)
+    })
+
+    it('when called with a single contact that has 5 aventri events should return an event object with 5 events and 1 contact email', async () => {
+      const email = faker.internet.email()
+
+      fetchActivityFeedStub.resolves(
+        generateEventResponse(
+          [...Array(5).keys()].map((x) => {
+            return {
+              _source: {
+                object: {
+                  attributedTo: { id: x },
+                  'dit:emailAddress': email,
+                },
+              },
+            }
+          })
+        )
+      )
+
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          [
+            {
+              email: email,
+              name: faker.name.fullName(),
+              id: faker.random.numeric(),
+            },
+          ]
+        )
+      expect(Object.keys(events).length).to.be.equal(5)
+      Object.values(events).forEach((e) => {
+        expect(e.length).to.be.equal(1)
+        expect(e[0]['dit:emailAddress']).to.be.equal(email)
+      })
+    })
+
+    it('when called with 3 contacts that attended different events should return an event object with 3 event and 1 contact emails', async () => {
+      const emails = [
+        faker.internet.email(),
+        faker.internet.email(),
+        faker.internet.email(),
+      ]
+
+      fetchActivityFeedStub.resolves(
+        generateEventResponse(
+          [...emails].map((x, index) => {
+            return {
+              _source: {
+                object: {
+                  attributedTo: { id: index },
+                  'dit:emailAddress': x,
+                },
+              },
+            }
+          })
+        )
+      )
+
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          emails.map((x) => {
+            return {
+              email: x,
+              name: faker.name.fullName(),
+              id: faker.random.numeric(),
+            }
+          })
+        )
+      expect(Object.keys(events).length).to.be.equal(3)
+      Object.values(events).forEach((e, index) => {
+        expect(e.length).to.be.equal(1)
+        expect(e[0]['dit:emailAddress']).to.be.equal(emails[index])
+      })
+    })
+
+    it('when called with 3 contacts that attended the same event should return an event object with 1 event and 3 contact emails', async () => {
+      const emails = [
+        faker.internet.email(),
+        faker.internet.email(),
+        faker.internet.email(),
+      ]
+      const eventId = faker.random.numeric()
+
+      fetchActivityFeedStub.resolves(
+        generateEventResponse(
+          [...emails].map((x) => {
+            return {
+              _source: {
+                object: {
+                  attributedTo: { id: eventId },
+                  'dit:emailAddress': x,
+                },
+              },
+            }
+          })
+        )
+      )
+
+      const events =
+        await controllers.getAventriEventsAttendedByCompanyContacts(
+          middlewareParameters.reqMock,
+          middlewareParameters.nextSpy,
+          emails.map((x) => {
+            return {
+              email: x,
+              name: faker.name.fullName(),
+              id: faker.random.numeric(),
+            }
+          })
+        )
+      expect(Object.keys(events).length).to.be.equal(1)
+
+      Object.values(events).forEach((e, index) => {
+        expect(e.length).to.be.equal(3)
+        expect(e[0]['dit:emailAddress']).to.be.equal(emails[index])
       })
     })
   })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -177,6 +177,7 @@ async function getAventriEventsAttendedByCompanyContacts(req, next, contacts) {
       (obj, attendee) => {
         const eventId = `${attendee.object.attributedTo.id}:Create`
         const event = obj[eventId]
+
         const contact = contacts.find(
           (contact) => contact.email == attendee.object['dit:emailAddress']
         )
@@ -362,10 +363,9 @@ async function fetchActivityFeedHandler(req, res, next) {
       total += campaigns.length
     }
 
-    // console.log(activities)
     //loop over all the results, set the contact to be the matching contact from the contacts array
     activities = activities.map((activity) => {
-      if (activity.type == 'dit:aventri:Event') {
+      if (activity.type == 'dit:aventri:Event' && aventriEvents[activity.id]) {
         activity.object.attributedTo = [
           activity.object.attributedTo,
           ...aventriEvents[activity.id],

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -21,7 +21,7 @@ export default function AventriEvent({ activity: event }) {
   const contacts = CardUtils.getContacts(event)
 
   const formattedContacts = () =>
-    !!contacts.length &&
+    contacts &&
     contacts.map((contact, index) => (
       <span key={`contact-link-${index}`}>
         {index ? ', ' : ''}

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -18,7 +18,18 @@ export default function AventriEvent({ activity: event }) {
   const name = eventObject.name
   const aventriEventId = eventObject.id.split(':')[EVENT_ID_INDEX]
   const date = formatStartAndEndDate(eventObject.startTime, eventObject.endTime)
+  const contacts = CardUtils.getContacts(event)
 
+  const formattedContacts = () =>
+    !!contacts.length &&
+    contacts.map((contact, index) => (
+      <span key={`contact-link-${index}`}>
+        {index ? ', ' : ''}
+        <Link data-test={`contact-link-${index}`} href={contact.url}>
+          {contact.name}
+        </Link>
+      </span>
+    ))
   return (
     <ActivityCardWrapper dataTest="aventri-event">
       <ActivityCardLabels service="Event" kind="Aventri Service Delivery" />
@@ -34,6 +45,10 @@ export default function AventriEvent({ activity: event }) {
           {
             label: 'Aventri ID',
             value: aventriEventId,
+          },
+          {
+            label: 'Contact(s)',
+            value: formattedContacts(),
           },
         ]}
       />

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -171,6 +171,34 @@ describe('Company activity feed', () => {
     })
   })
 
+  context('Aventri', () => {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="aventri-event"]').within(() =>
+        cy
+          .get('[data-test="activity-kind-label"]')
+          .contains('Aventri Service Delivery', {
+            matchCase: false,
+          })
+      )
+    })
+
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="aventri-event"]').within(() =>
+        cy.get('[data-test="activity-service-label"]').contains('Event', {
+          matchCase: false,
+        })
+      )
+    })
+
+    it('displays the correct contact', () => {
+      cy.get('[data-test="aventri-event"]').within(() =>
+        cy.get('[data-test="contact-link-0"]').contains('Super Glue', {
+          matchCase: false,
+        })
+      )
+    })
+  })
+
   context('Email Campaign (Maxemail)', () => {
     before(() => {
       const companyId = fixtures.company.externalActivitiesLtd.id

--- a/test/sandbox/fixtures/v4/activity-feed/aventri-attendee-for-company.json
+++ b/test/sandbox/fixtures/v4/activity-feed/aventri-attendee-for-company.json
@@ -13,23 +13,37 @@
     "hits": [
       {
         "_source": {
-          "id": 1,
+          "id": "dit:aventri:Event:1111:Attendee:1111:Create",
           "object": {
             "attributedTo": {
-              "id": "dit:aventri:Event:1",
+              "id": "dit:aventri:Event:1111",
               "type": "dit:aventri:Event"
-            }
+            },
+            "dit:emailAddress":"contact@bob.com"
           }
         }
       },
       {
         "_source": {
-          "id": 2,
+          "id": "dit:aventri:Event:1111:Attendee:2222:Create",
           "object": {
             "attributedTo": {
-              "id": "dit:aventri:Event:2",
+              "id": "dit:aventri:Event:1111",
               "type": "dit:aventri:Event"
-            }
+            },
+            "dit:emailAddress":"superglue@gov.uk"
+          }
+        }
+      },
+      {
+        "_source": {
+          "id": "dit:aventri:Event:1112:Attendee:1111:Create",
+          "object": {
+            "attributedTo": {
+              "id": "dit:aventri:Event:1112",
+              "type": "dit:aventri:Event"
+            },
+            "dit:emailAddress":"contact@bob.com"
           }
         }
       }

--- a/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
@@ -9,7 +9,7 @@
   },
   "hits": {
     "total": {
-      "value": 5,
+      "value": 6,
       "relation": "eq"
     },
     "max_score": null,
@@ -334,7 +334,65 @@
            "published":"2020-05-21T17:43:47.957585Z",
            "type":"Announce"
         }
-     }
+     },
+     {
+      "_index" : "activities__feed_id_dummy-data-feed__date_2022-05-03__timestamp_1651585823__batch_id_jaedyooq__",
+      "_type" : "_doc",
+      "_id" : "dit:aventri:Event:1111:Create",
+      "_score" : 1.3122244,
+      "_source" : {
+        "dit:application" : "aventri",
+        "id" : "dit:aventri:Event:1111:Create",
+        "object" : {
+          "attributedTo" : {
+            "id" : "dit:aventri:Folder:EITA Event 2022",
+            "type" : "dit:aventri:Folder"
+          },
+          "content" : "<p>This is some content about event</p>",
+          "dit:aventri:approval_required" : "0",
+          "dit:aventri:approval_status" : "0",
+          "dit:aventri:city" : "Online",
+          "dit:aventri:clientcontact" : "",
+          "dit:aventri:closedate" : "2022-01-23T23:45:00",
+          "dit:aventri:code" : "EITA Code",
+          "dit:aventri:contactinfo" : "contact2@example.host",
+          "dit:aventri:country" : "",
+          "dit:aventri:createdby" : "1234",
+          "dit:aventri:defaultlanguage" : "eng",
+          "dit:aventri:folderid" : "1111",
+          "dit:aventri:live_date" : null,
+          "dit:aventri:location_address1" : "1 street avenue",
+          "dit:aventri:location_address2" : "Brockley",
+          "dit:aventri:location_address3" : "Lewisham",
+          "dit:aventri:location_city" : "London",
+          "dit:aventri:location_country" : "England",
+          "dit:aventri:location_name" : "",
+          "dit:aventri:location_postcode" : "ABC 123",
+          "dit:aventri:location_state" : "",
+          "dit:aventri:locationname" : "Name of Location",
+          "dit:aventri:max_reg" : "0",
+          "dit:aventri:modifiedby" : "firstname1.lastname1@example.host",
+          "dit:aventri:modifieddatetime" : "2022-01-23T20:53:38",
+          "dit:aventri:price_type" : "net",
+          "dit:aventri:standardcurrency" : "Sterling",
+          "dit:aventri:state" : "",
+          "dit:aventri:timezone" : "Europe/London",
+          "dit:public" : true,
+          "dit:status" : "Pre-Event",
+          "endTime" : "2022-05-04T20:09:14",
+          "id" : "dit:aventri:Event:1111",
+          "name" : "EITA Test Event 2022",
+          "published" : "2022-01-23T20:09:14",
+          "startTime" : "2021-03-02T20:09:14",
+          "type" : [
+            "dit:aventri:Event"
+          ],
+          "url" : ""
+        },
+        "published" : "2022-01-23T20:09:14",
+        "type" : "dit:aventri:Event"
+      }
+    }
     ]
   }
 }


### PR DESCRIPTION
## Description of change

- For the Aventri events shown in the activity feed, include a link to the contact record
- Updated the sandbox API to have matching events and attendees

## Test instructions

Using the One List Corp company, http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity, find any Aventri events and they should now have a link to the matched DIT contact 

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/205029646-6933730e-dbca-4362-8aeb-fb0cfab57837.png)

### After

![image](https://user-images.githubusercontent.com/102232401/205029827-184d66f5-7ede-4857-9f4f-0c3c10991b31.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
