### PR TITLE
Add a prop to allow the CollectionHeader component to render without pluralising the title

### DIFF
--- a/src/client/components/CollectionList/CollectionHeader.jsx
+++ b/src/client/components/CollectionList/CollectionHeader.jsx
@@ -30,10 +30,13 @@ function CollectionHeader({
   totalItems,
   collectionName = 'result',
   addItemUrl,
+  shouldPluralize = true,
   ...rest
 }) {
   const formattedTotal = decimal(totalItems)
-  const counterSuffix = pluralize(collectionName, totalItems)
+  const counterSuffix = shouldPluralize
+    ? pluralize(collectionName, totalItems)
+    : collectionName
 
   const actions = addItemUrl && (
     <Button
@@ -49,7 +52,7 @@ function CollectionHeader({
 
   return (
     <CollectionHeaderRow primary={true} actions={actions} {...rest}>
-      <StyledHeaderText>
+      <StyledHeaderText data-test="collection-header-name">
         <StyledResultCount>{formattedTotal}</StyledResultCount>
         {` ${counterSuffix}`}
       </StyledHeaderText>

--- a/test/component/cypress/specs/CollectionList/CollectionHeader.cy.jsx
+++ b/test/component/cypress/specs/CollectionList/CollectionHeader.cy.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import CollectionHeader from '../../../../../src/client/components/CollectionList/CollectionHeader'
+
+describe('AventriAttendee', () => {
+  const Component = (props) => <CollectionHeader {...props} />
+
+  context('when the shouldPluralize prop is false', () => {
+    it('should render the collection name without modifications', () => {
+      cy.mount(
+        <Component
+          totalItems={5}
+          shouldPluralize={false}
+          collectionName="Waiting list"
+        />
+      )
+      cy.get('[data-test=collection-header-name]').contains('Waiting list')
+    })
+  })
+
+  context('when the shouldPluralize prop is true', () => {
+    it('the collection name should be rendered in a singular form when totalItems is 1', () => {
+      cy.mount(
+        <Component
+          totalItems={1}
+          shouldPluralize={true}
+          collectionName="Attendee"
+        />
+      )
+      cy.get('[data-test=collection-header-name]').contains('Attendee')
+    })
+
+    it('the collection name should be rendered in a pluralized form when totalItems is greater than 1', () => {
+      cy.mount(
+        <Component
+          totalItems={3}
+          shouldPluralize={true}
+          collectionName="Attendee"
+        />
+      )
+      cy.get('[data-test=collection-header-name]').contains('Attendees')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

The CollectionHeader component will always pluralise the title provided to it, however this component is being used for the new registration status page and the statuses should not be pluralised. 

The default for pluralising the title will be set to true to avoid breaking any current usages of this component

## Screenshots
No UI changes

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
