### PR TITLE
Only show aventri events to pilot group users

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -53,7 +53,7 @@ describe('Activity feed controllers', () => {
     })
 
     context(
-      'when filtering on "Data Hub & External activity" for a company',
+      'when filtering on "Data Hub & External activity" for a company with the aventri feature flag on',
       () => {
         before(async () => {
           middlewareParameters = buildMiddlewareParameters({
@@ -278,220 +278,227 @@ describe('Activity feed controllers', () => {
       })
     })
 
-    context('when filtering on "Data Hub activity" for a company', () => {
-      before(async () => {
-        middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
-          requestQuery: {
-            activityTypeFilter: 'dataHubActivity',
-            showDnbHierarchy: false,
-          },
-          user: {
-            id: 123,
-          },
-          locals: {
-            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
-          },
+    context(
+      'when filtering on "Data Hub activity" for a company with the aventri feature flag on',
+      () => {
+        before(async () => {
+          middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            requestQuery: {
+              activityTypeFilter: 'dataHubActivity',
+              showDnbHierarchy: false,
+            },
+            user: {
+              id: 123,
+            },
+            locals: {
+              userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
+            },
+          })
+
+          await controllers.fetchActivityFeedHandler(
+            middlewareParameters.reqMock,
+            middlewareParameters.resMock,
+            middlewareParameters.nextSpy
+          )
         })
 
-        await controllers.fetchActivityFeedHandler(
-          middlewareParameters.reqMock,
-          middlewareParameters.resMock,
-          middlewareParameters.nextSpy
-        )
-      })
-
-      it('should call fetchActivityFeed with the right params', async () => {
-        const expectedEsQuery = {
-          from: 0,
-          size: 20,
-          sort: [
-            {
-              'object.startTime': {
-                order: 'desc',
+        it('should call fetchActivityFeed with the right params', async () => {
+          const expectedEsQuery = {
+            from: 0,
+            size: 20,
+            sort: [
+              {
+                'object.startTime': {
+                  order: 'desc',
+                },
               },
-            },
-          ],
-          query: {
-            bool: {
-              filter: {
-                bool: {
-                  should: [
-                    {
-                      bool: {
-                        must: [
-                          {
-                            terms: {
-                              'object.type': DATA_HUB_AND_AVENTRI_ACTIVITY,
+            ],
+            query: {
+              bool: {
+                filter: {
+                  bool: {
+                    should: [
+                      {
+                        bool: {
+                          must: [
+                            {
+                              terms: {
+                                'object.type': DATA_HUB_AND_AVENTRI_ACTIVITY,
+                              },
                             },
-                          },
-                          {
-                            terms: {
-                              'object.attributedTo.id': [
-                                'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                              ],
+                            {
+                              terms: {
+                                'object.attributedTo.id': [
+                                  'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
+                                ],
+                              },
                             },
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                    {
-                      bool: {
-                        must: [
-                          {
-                            term: {
-                              'object.type': 'dit:aventri:Event',
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                'object.type': 'dit:aventri:Event',
+                              },
                             },
-                          },
-                          {
-                            terms: {
-                              id: [
-                                'dit:aventri:Event:1:Create',
-                                'dit:aventri:Event:2:Create',
-                              ],
+                            {
+                              terms: {
+                                id: [
+                                  'dit:aventri:Event:1:Create',
+                                  'dit:aventri:Event:2:Create',
+                                ],
+                              },
                             },
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
               },
             },
-          },
-        }
+          }
 
-        expect(fetchActivityFeedStub).to.be.calledWith(
-          middlewareParameters.reqMock,
-          expectedEsQuery
-        )
-      })
-    })
-
-    context('when filtering on "External activity"', () => {
-      before(async () => {
-        middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
-          requestQuery: {
-            activityTypeFilter: 'externalActivity',
-            showDnbHierarchy: false,
-          },
-          user: {
-            id: 123,
-          },
-          locals: {
-            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
-          },
+          expect(fetchActivityFeedStub).to.be.calledWith(
+            middlewareParameters.reqMock,
+            expectedEsQuery
+          )
         })
-
-        await controllers.fetchActivityFeedHandler(
-          middlewareParameters.reqMock,
-          middlewareParameters.resMock,
-          middlewareParameters.nextSpy
-        )
-      })
-
-      it('should call fetchActivityFeed with the right params', async () => {
-        const expectedEsQuery = {
-          from: 0,
-          size: 20,
-          sort: [
-            {
-              'object.startTime': {
-                order: 'desc',
-              },
-            },
-          ],
-          query: {
-            bool: {
-              filter: {
-                bool: {
-                  should: [
-                    {
-                      bool: {
-                        must: [
-                          {
-                            terms: {
-                              'object.type': EXTERNAL_ACTIVITY,
-                            },
-                          },
-                          {
-                            terms: {
-                              'object.attributedTo.id': [
-                                'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        must: [
-                          {
-                            term: {
-                              'object.type': 'dit:directoryFormsApi:Submission',
-                            },
-                          },
-                          {
-                            term: {
-                              'object.attributedTo.type':
-                                'dit:directoryFormsApi:SubmissionAction:gov-notify-email',
-                            },
-                          },
-                          {
-                            term: {
-                              'object.url': '/contact/export-advice/comment/',
-                            },
-                          },
-                          {
-                            terms: {
-                              'actor.dit:emailAddress': [
-                                'fred@acme.org',
-                                'fred@acme.org',
-                                'fred@acme.org',
-                                'byvanuwenu@yahoo.com',
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    },
-                    {
-                      bool: {
-                        must: [
-                          {
-                            term: {
-                              'object.type': 'dit:aventri:Event',
-                            },
-                          },
-                          {
-                            terms: {
-                              id: [
-                                'dit:aventri:Event:1:Create',
-                                'dit:aventri:Event:2:Create',
-                              ],
-                            },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
-              },
-            },
-          },
-        }
-
-        expect(fetchActivityFeedStub).to.be.calledWith(
-          middlewareParameters.reqMock,
-          expectedEsQuery
-        )
-      })
-    })
+      }
+    )
 
     context(
-      'when applying both Data Hub activity and DnB hierarchical filters',
+      'when filtering on "External activity" with the aventri feature flag on',
+      () => {
+        before(async () => {
+          middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            requestQuery: {
+              activityTypeFilter: 'externalActivity',
+              showDnbHierarchy: false,
+            },
+            user: {
+              id: 123,
+            },
+            locals: {
+              userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
+            },
+          })
+
+          await controllers.fetchActivityFeedHandler(
+            middlewareParameters.reqMock,
+            middlewareParameters.resMock,
+            middlewareParameters.nextSpy
+          )
+        })
+
+        it('should call fetchActivityFeed with the right params', async () => {
+          const expectedEsQuery = {
+            from: 0,
+            size: 20,
+            sort: [
+              {
+                'object.startTime': {
+                  order: 'desc',
+                },
+              },
+            ],
+            query: {
+              bool: {
+                filter: {
+                  bool: {
+                    should: [
+                      {
+                        bool: {
+                          must: [
+                            {
+                              terms: {
+                                'object.type': EXTERNAL_ACTIVITY,
+                              },
+                            },
+                            {
+                              terms: {
+                                'object.attributedTo.id': [
+                                  'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                'object.type':
+                                  'dit:directoryFormsApi:Submission',
+                              },
+                            },
+                            {
+                              term: {
+                                'object.attributedTo.type':
+                                  'dit:directoryFormsApi:SubmissionAction:gov-notify-email',
+                              },
+                            },
+                            {
+                              term: {
+                                'object.url': '/contact/export-advice/comment/',
+                              },
+                            },
+                            {
+                              terms: {
+                                'actor.dit:emailAddress': [
+                                  'fred@acme.org',
+                                  'fred@acme.org',
+                                  'fred@acme.org',
+                                  'byvanuwenu@yahoo.com',
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                'object.type': 'dit:aventri:Event',
+                              },
+                            },
+                            {
+                              terms: {
+                                id: [
+                                  'dit:aventri:Event:1:Create',
+                                  'dit:aventri:Event:2:Create',
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          }
+
+          expect(fetchActivityFeedStub).to.be.calledWith(
+            middlewareParameters.reqMock,
+            expectedEsQuery
+          )
+        })
+      }
+    )
+
+    context(
+      'when applying both Data Hub activity and DnB hierarchical filters with the aventri feature flag on',
       () => {
         before(async () => {
           middlewareParameters = buildMiddlewareParameters({
@@ -588,95 +595,98 @@ describe('Activity feed controllers', () => {
       }
     )
 
-    context('when filtering param is invalid', () => {
-      before(async () => {
-        middlewareParameters = buildMiddlewareParameters({
-          company: companyMock,
-          requestQuery: {
-            activityTypeFilter: 'foobar',
-            showDnbHierarchy: false,
-          },
-          user: {
-            id: 123,
-          },
-          locals: {
-            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
-          },
+    context(
+      'when filtering param is invalid with the aventri feature flag on',
+      () => {
+        before(async () => {
+          middlewareParameters = buildMiddlewareParameters({
+            company: companyMock,
+            requestQuery: {
+              activityTypeFilter: 'foobar',
+              showDnbHierarchy: false,
+            },
+            user: {
+              id: 123,
+            },
+            locals: {
+              userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
+            },
+          })
+
+          await controllers.fetchActivityFeedHandler(
+            middlewareParameters.reqMock,
+            middlewareParameters.resMock,
+            middlewareParameters.nextSpy
+          )
         })
 
-        await controllers.fetchActivityFeedHandler(
-          middlewareParameters.reqMock,
-          middlewareParameters.resMock,
-          middlewareParameters.nextSpy
-        )
-      })
-
-      it('should default to dataHubActivity', async () => {
-        const expectedEsQuery = {
-          from: 0,
-          size: 20,
-          sort: [
-            {
-              'object.startTime': {
-                order: 'desc',
+        it('should default to dataHubActivity', async () => {
+          const expectedEsQuery = {
+            from: 0,
+            size: 20,
+            sort: [
+              {
+                'object.startTime': {
+                  order: 'desc',
+                },
               },
-            },
-          ],
-          query: {
-            bool: {
-              filter: {
-                bool: {
-                  should: [
-                    {
-                      bool: {
-                        must: [
-                          {
-                            terms: {
-                              'object.type': DATA_HUB_AND_AVENTRI_ACTIVITY,
+            ],
+            query: {
+              bool: {
+                filter: {
+                  bool: {
+                    should: [
+                      {
+                        bool: {
+                          must: [
+                            {
+                              terms: {
+                                'object.type': DATA_HUB_AND_AVENTRI_ACTIVITY,
+                              },
                             },
-                          },
-                          {
-                            terms: {
-                              'object.attributedTo.id': [
-                                'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
-                              ],
+                            {
+                              terms: {
+                                'object.attributedTo.id': [
+                                  'dit:DataHubCompany:dcdabbc9-1781-e411-8955-e4115bead28a',
+                                ],
+                              },
                             },
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                    {
-                      bool: {
-                        must: [
-                          {
-                            term: {
-                              'object.type': 'dit:aventri:Event',
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                'object.type': 'dit:aventri:Event',
+                              },
                             },
-                          },
-                          {
-                            terms: {
-                              id: [
-                                'dit:aventri:Event:1:Create',
-                                'dit:aventri:Event:2:Create',
-                              ],
+                            {
+                              terms: {
+                                id: [
+                                  'dit:aventri:Event:1:Create',
+                                  'dit:aventri:Event:2:Create',
+                                ],
+                              },
                             },
-                          },
-                        ],
+                          ],
+                        },
                       },
-                    },
-                  ],
+                    ],
+                  },
                 },
               },
             },
-          },
-        }
+          }
 
-        expect(fetchActivityFeedStub).to.be.calledWith(
-          middlewareParameters.reqMock,
-          expectedEsQuery
-        )
-      })
-    })
+          expect(fetchActivityFeedStub).to.be.calledWith(
+            middlewareParameters.reqMock,
+            expectedEsQuery
+          )
+        })
+      }
+    )
 
     context('when the endpoint returns error', () => {
       const error = {

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -10,6 +10,7 @@ const {
   EXTERNAL_ACTIVITY,
   DATA_HUB_AND_EXTERNAL_ACTIVITY,
   DATA_HUB_AND_AVENTRI_ACTIVITY,
+  ACTIVITY_STREAM_FEATURE_FLAG,
 } = require('../constants')
 const { eventsColListQueryBuilder } = require('../controllers')
 const { has } = require('lodash')
@@ -63,6 +64,9 @@ describe('Activity feed controllers', () => {
             },
             user: {
               id: 123,
+            },
+            locals: {
+              userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
             },
           })
 
@@ -285,6 +289,9 @@ describe('Activity feed controllers', () => {
           user: {
             id: 123,
           },
+          locals: {
+            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
+          },
         })
 
         await controllers.fetchActivityFeedHandler(
@@ -371,6 +378,9 @@ describe('Activity feed controllers', () => {
           },
           user: {
             id: 123,
+          },
+          locals: {
+            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
           },
         })
 
@@ -496,6 +506,9 @@ describe('Activity feed controllers', () => {
             user: {
               id: 123,
             },
+            locals: {
+              userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
+            },
           })
 
           await controllers.fetchActivityFeedHandler(
@@ -585,6 +598,9 @@ describe('Activity feed controllers', () => {
           },
           user: {
             id: 123,
+          },
+          locals: {
+            userFeatures: [ACTIVITY_STREAM_FEATURE_FLAG],
           },
         })
 

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -332,14 +332,6 @@ async function fetchActivityFeedHandler(req, res, next) {
         .map((company) => company.id)
     }
 
-    res.locals.userFeatures = await fetchUserFeatureFlags(req).catch(
-      // istanbul ignore next: Covered by functional tests
-      (error) => {
-        next(error)
-      }
-    )
-
-    // istanbul ignore next: Covered by functional tests
     let isActivityStreamFeatureFlagEnabled = res.locals?.userFeatures?.includes(
       ACTIVITY_STREAM_FEATURE_FLAG
     )

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -332,13 +332,29 @@ async function fetchActivityFeedHandler(req, res, next) {
         .map((company) => company.id)
     }
 
-    const aventriEvents = await getAventriEventsAttendedByCompanyContacts(
-      req,
-      next,
-      company.contacts
+    res.locals.userFeatures = await fetchUserFeatureFlags(req).catch(
+      // istanbul ignore next: Covered by functional tests
+      (error) => {
+        next(error)
+      }
     )
 
-    const aventriEventIds = Object.keys(aventriEvents)
+    // istanbul ignore next: Covered by functional tests
+    let isActivityStreamFeatureFlagEnabled = res.locals?.userFeatures?.includes(
+      ACTIVITY_STREAM_FEATURE_FLAG
+    )
+
+    let aventriEventIds = []
+    let aventriEvents = []
+    if (isActivityStreamFeatureFlagEnabled) {
+      aventriEvents = await getAventriEventsAttendedByCompanyContacts(
+        req,
+        next,
+        company.contacts
+      )
+
+      aventriEventIds = Object.keys(aventriEvents)
+    }
 
     const queries = getQueries({
       from,

--- a/src/apps/companies/apps/activity-feed/router.js
+++ b/src/apps/companies/apps/activity-feed/router.js
@@ -6,11 +6,14 @@ const {
   renderActivityFeed,
   fetchActivityFeedHandler,
 } = require('./controllers')
+const { ACTIVITY_STREAM_FEATURE_FLAG } = require('./constants')
+const userFeatures = require('../../../../middleware/user-features')
 
 router.get(urls.companies.activity.index.route, renderActivityFeed)
 router.get(
   urls.companies.activity.data.route,
   convertQueryTypes,
+  userFeatures(ACTIVITY_STREAM_FEATURE_FLAG),
   fetchActivityFeedHandler
 )
 

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -195,14 +195,6 @@ describe('Company activity feed', () => {
           })
         )
       })
-
-      it('displays the correct contact', () => {
-        cy.get('[data-test="aventri-event"]').within(() =>
-          cy.get('[data-test="contact-link-0"]').contains('Super Glue', {
-            matchCase: false,
-          })
-        )
-      })
     })
   })
 

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -1,6 +1,8 @@
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
+import { ACTIVITY_STREAM_FEATURE_FLAG } from '../../../../../src/apps/companies/apps/activity-feed/constants'
+
 describe('Company activity feed', () => {
   before(() => {
     cy.visit(
@@ -172,30 +174,35 @@ describe('Company activity feed', () => {
   })
 
   context('Aventri', () => {
-    it('displays the correct activity type label', () => {
-      cy.get('[data-test="aventri-event"]').within(() =>
-        cy
-          .get('[data-test="activity-kind-label"]')
-          .contains('Aventri Service Delivery', {
+    context('when the activity stream flag is on', () => {
+      before(() => {
+        cy.setUserFeatures([ACTIVITY_STREAM_FEATURE_FLAG])
+      })
+      it('displays the correct activity type label', () => {
+        cy.get('[data-test="aventri-event"]').within(() =>
+          cy
+            .get('[data-test="activity-kind-label"]')
+            .contains('Aventri Service Delivery', {
+              matchCase: false,
+            })
+        )
+      })
+
+      it('displays the correct sub-topic label', () => {
+        cy.get('[data-test="aventri-event"]').within(() =>
+          cy.get('[data-test="activity-service-label"]').contains('Event', {
             matchCase: false,
           })
-      )
-    })
+        )
+      })
 
-    it('displays the correct sub-topic label', () => {
-      cy.get('[data-test="aventri-event"]').within(() =>
-        cy.get('[data-test="activity-service-label"]').contains('Event', {
-          matchCase: false,
-        })
-      )
-    })
-
-    it('displays the correct contact', () => {
-      cy.get('[data-test="aventri-event"]').within(() =>
-        cy.get('[data-test="contact-link-0"]').contains('Super Glue', {
-          matchCase: false,
-        })
-      )
+      it('displays the correct contact', () => {
+        cy.get('[data-test="aventri-event"]').within(() =>
+          cy.get('[data-test="contact-link-0"]').contains('Super Glue', {
+            matchCase: false,
+          })
+        )
+      })
     })
   })
 

--- a/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
+++ b/test/sandbox/fixtures/v4/activity-feed/company-activity-feed-activities.json
@@ -15,6 +15,64 @@
     "max_score": null,
     "hits": [
       {
+        "_index" : "activities__feed_id_dummy-data-feed__date_2022-05-03__timestamp_1651585823__batch_id_jaedyooq__",
+        "_type" : "_doc",
+        "_id" : "dit:aventri:Event:1111:Create",
+        "_score" : 1.3122244,
+        "_source" : {
+          "dit:application" : "aventri",
+          "id" : "dit:aventri:Event:1111:Create",
+          "object" : {
+            "attributedTo" : {
+              "id" : "dit:aventri:Folder:EITA Event 2022",
+              "type" : "dit:aventri:Folder"
+            },
+            "content" : "<p>This is some content about event</p>",
+            "dit:aventri:approval_required" : "0",
+            "dit:aventri:approval_status" : "0",
+            "dit:aventri:city" : "Online",
+            "dit:aventri:clientcontact" : "",
+            "dit:aventri:closedate" : "2022-01-23T23:45:00",
+            "dit:aventri:code" : "EITA Code",
+            "dit:aventri:contactinfo" : "contact2@example.host",
+            "dit:aventri:country" : "",
+            "dit:aventri:createdby" : "1234",
+            "dit:aventri:defaultlanguage" : "eng",
+            "dit:aventri:folderid" : "1111",
+            "dit:aventri:live_date" : null,
+            "dit:aventri:location_address1" : "1 street avenue",
+            "dit:aventri:location_address2" : "Brockley",
+            "dit:aventri:location_address3" : "Lewisham",
+            "dit:aventri:location_city" : "London",
+            "dit:aventri:location_country" : "England",
+            "dit:aventri:location_name" : "",
+            "dit:aventri:location_postcode" : "ABC 123",
+            "dit:aventri:location_state" : "",
+            "dit:aventri:locationname" : "Name of Location",
+            "dit:aventri:max_reg" : "0",
+            "dit:aventri:modifiedby" : "firstname1.lastname1@example.host",
+            "dit:aventri:modifieddatetime" : "2022-01-23T20:53:38",
+            "dit:aventri:price_type" : "net",
+            "dit:aventri:standardcurrency" : "Sterling",
+            "dit:aventri:state" : "",
+            "dit:aventri:timezone" : "Europe/London",
+            "dit:public" : true,
+            "dit:status" : "Pre-Event",
+            "endTime" : "2022-05-04T20:09:14",
+            "id" : "dit:aventri:Event:1111",
+            "name" : "EITA Test Event 2022",
+            "published" : "2022-01-23T20:09:14",
+            "startTime" : "2021-03-02T20:09:14",
+            "type" : [
+              "dit:aventri:Event"
+            ],
+            "url" : ""
+          },
+          "published" : "2022-01-23T20:09:14",
+          "type" : "dit:aventri:Event"
+        }
+      },
+      {
         "_index": "activities__feed_id_datascience-lab-external-sources-1",
         "_type": "_doc",
         "_id": "dit:DataScienceExport:397780733:Announce",
@@ -334,65 +392,7 @@
            "published":"2020-05-21T17:43:47.957585Z",
            "type":"Announce"
         }
-     },
-     {
-      "_index" : "activities__feed_id_dummy-data-feed__date_2022-05-03__timestamp_1651585823__batch_id_jaedyooq__",
-      "_type" : "_doc",
-      "_id" : "dit:aventri:Event:1111:Create",
-      "_score" : 1.3122244,
-      "_source" : {
-        "dit:application" : "aventri",
-        "id" : "dit:aventri:Event:1111:Create",
-        "object" : {
-          "attributedTo" : {
-            "id" : "dit:aventri:Folder:EITA Event 2022",
-            "type" : "dit:aventri:Folder"
-          },
-          "content" : "<p>This is some content about event</p>",
-          "dit:aventri:approval_required" : "0",
-          "dit:aventri:approval_status" : "0",
-          "dit:aventri:city" : "Online",
-          "dit:aventri:clientcontact" : "",
-          "dit:aventri:closedate" : "2022-01-23T23:45:00",
-          "dit:aventri:code" : "EITA Code",
-          "dit:aventri:contactinfo" : "contact2@example.host",
-          "dit:aventri:country" : "",
-          "dit:aventri:createdby" : "1234",
-          "dit:aventri:defaultlanguage" : "eng",
-          "dit:aventri:folderid" : "1111",
-          "dit:aventri:live_date" : null,
-          "dit:aventri:location_address1" : "1 street avenue",
-          "dit:aventri:location_address2" : "Brockley",
-          "dit:aventri:location_address3" : "Lewisham",
-          "dit:aventri:location_city" : "London",
-          "dit:aventri:location_country" : "England",
-          "dit:aventri:location_name" : "",
-          "dit:aventri:location_postcode" : "ABC 123",
-          "dit:aventri:location_state" : "",
-          "dit:aventri:locationname" : "Name of Location",
-          "dit:aventri:max_reg" : "0",
-          "dit:aventri:modifiedby" : "firstname1.lastname1@example.host",
-          "dit:aventri:modifieddatetime" : "2022-01-23T20:53:38",
-          "dit:aventri:price_type" : "net",
-          "dit:aventri:standardcurrency" : "Sterling",
-          "dit:aventri:state" : "",
-          "dit:aventri:timezone" : "Europe/London",
-          "dit:public" : true,
-          "dit:status" : "Pre-Event",
-          "endTime" : "2022-05-04T20:09:14",
-          "id" : "dit:aventri:Event:1111",
-          "name" : "EITA Test Event 2022",
-          "published" : "2022-01-23T20:09:14",
-          "startTime" : "2021-03-02T20:09:14",
-          "type" : [
-            "dit:aventri:Event"
-          ],
-          "url" : ""
-        },
-        "published" : "2022-01-23T20:09:14",
-        "type" : "dit:aventri:Event"
-      }
-    }
+     }
     ]
   }
 }


### PR DESCRIPTION
## Description of change

Only get run the query to get aventri ids if the feature flag is enabled for the logged in user

## Test instructions

- In the Admin site, set the `user-activity-stream-aventri` feature flag to be OFF for your user
- Go to the URL http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity, you should not see any aventri events
- In the Admin site, set the `user-activity-stream-aventri` feature flag to be ON for your user
- Go to the URL http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity, you should see aventri events

## Screenshots

### With feature flag

![image](https://user-images.githubusercontent.com/102232401/205385139-50a1713c-8872-4355-8093-d186d28a583d.png)

### Without feature flag

![image](https://user-images.githubusercontent.com/102232401/205385281-cbcae015-8e04-4c2b-b103-cd89dc747c69.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
