### PR TITLE
Use correct company URL for company interactions

### DIFF
--- a/src/client/components/ActivityFeed/activities/Interaction.jsx
+++ b/src/client/components/ActivityFeed/activities/Interaction.jsx
@@ -100,7 +100,10 @@ export default class Interaction extends React.PureComponent {
       <ActivityCardWrapper dataTest="interaction-activity">
         <ActivityCardLabels theme={theme} service={service} kind={kind} />
         <ActivityCardSubject>
-          <Link data-test="interaction-subject" href={transformed.url}>
+          <Link
+            data-test="interaction-subject"
+            href={transformed.interactionUrl}
+          >
             {transformed.subject}
           </Link>
         </ActivityCardSubject>
@@ -112,7 +115,10 @@ export default class Interaction extends React.PureComponent {
         <Row>
           <LeftCol>
             <ActivityCardSubject>
-              <Link data-test="interaction-subject" href={transformed.url}>
+              <Link
+                data-test="interaction-subject"
+                href={transformed.interactionUrl}
+              >
                 {transformed.subject}
               </Link>
             </ActivityCardSubject>

--- a/src/client/components/ActivityFeed/activities/InteractionUtils.js
+++ b/src/client/components/ActivityFeed/activities/InteractionUtils.js
@@ -1,5 +1,6 @@
 import { get, includes } from 'lodash'
 import { STATUS, BADGES, INTERACTION_SERVICES } from '../constants'
+import urls from '../../../../lib/urls'
 
 const getStatus = (activity) => {
   const apiStatus = get(activity, 'object.dit:status')
@@ -20,6 +21,12 @@ const getStatus = (activity) => {
 const isServiceDelivery = (activity) => {
   const activityTypes = get(activity, 'object.type')
   return includes(activityTypes, 'dit:ServiceDelivery')
+}
+
+const getCompanyInteractionUrl = (activity) => {
+  const companyId = activity.object.attributedTo[0].id.split(':').pop()
+  const interactionId = activity.id.split(':')[2]
+  return urls.companies.interactions.detail(companyId, interactionId)
 }
 
 export const getServiceText = (service) => {
@@ -74,6 +81,7 @@ export default class InteractionUtils {
       activity,
       'object.dit:communicationChannel.name'
     )
+    const interactionUrl = getCompanyInteractionUrl(activity)
 
     return {
       badge,
@@ -82,6 +90,7 @@ export default class InteractionUtils {
       serviceText,
       themeText,
       communicationChannel,
+      interactionUrl,
     }
   }
 }

--- a/test/component/cypress/specs/ActivityFeed/InteractionActivity.cy.jsx
+++ b/test/component/cypress/specs/ActivityFeed/InteractionActivity.cy.jsx
@@ -11,7 +11,8 @@ import { getServiceText } from '../../../../../src/client/components/ActivityFee
 const subject = 'An interaction with a company'
 const typeInteraction = 'dit:Interaction'
 const typeServiceDelivery = 'dit:ServiceDelivery'
-const interactionUrl = urls.interactions.detail(
+const interactionUrl = urls.companies.interactions.detail(
+  'bbab3b56-d2bb-4d5e-bb2f-dd159e5439dc',
   'accf9d98-93c5-48ad-adf5-d71757cdeb44'
 )
 const shortNotes = 'Labore\nculpa\nquas\ncupiditate\nvoluptatibus\nmagni.'


### PR DESCRIPTION
## Description of change

The URL for interactions in a company activity feed is currently the direct URL for the interaction (which was being taken directly from ActivityStream), whereas it should be the using the URL from the interaction sub-app within companies.

## Test instructions

Go to a company with interactions and click one from the activity feed. The breadcrumbs on the interaction page should display `Companies > Interaction` rather than `Interactions > Interaction`.

## Screenshots

### Before

<img width="547" alt="Screenshot 2022-12-05 at 14 45 12" src="https://user-images.githubusercontent.com/36161814/206185558-576b110d-bc4a-46cb-a5d2-7c5467b31f8d.png">


### After

<img width="552" alt="Screenshot 2022-12-05 at 14 45 05" src="https://user-images.githubusercontent.com/36161814/206185594-ea7f2b8f-522e-48e5-94d8-933b8db94934.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
