### PR TITLE
change to wording of the aventri label

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -58,9 +58,7 @@ export default function AventriAttendee({ activity: attendee }) {
       <ActivityCardLabels
         service="event"
         kind={
-          registrationStatus === 'Attended'
-            ? 'aventri service delivery'
-            : 'interaction'
+          registrationStatus === 'Attended' ? 'aventri event' : 'interaction'
         }
       />
       <ActivityCardSubject>

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -32,7 +32,7 @@ export default function AventriEvent({ activity: event }) {
     ))
   return (
     <ActivityCardWrapper dataTest="aventri-event">
-      <ActivityCardLabels service="Event" kind="Aventri Service Delivery" />
+      <ActivityCardLabels service="Event" kind="Aventri Event" />
       <ActivityCardSubject dataTest="aventri-event-name">
         <Link href={`/events/aventri/${aventriEventId}/details`}>{name}</Link>
       </ActivityCardSubject>

--- a/test/component/cypress/specs/ActivityFeed/AventriAttendee.cy.jsx
+++ b/test/component/cypress/specs/ActivityFeed/AventriAttendee.cy.jsx
@@ -78,10 +78,10 @@ describe('AventriAttendee', () => {
         cy.mount(<Component activity={activity} />)
       })
 
-      it('should display the Aventri Service Delivery label when registration status is Attended', () => {
+      it('should display the Aventri Event label when registration status is Attended', () => {
         cy.get('[data-test="aventri-activity"]').within(() => {
           cy.get('[data-test="activity-kind-label"]').contains(
-            'aventri service delivery',
+            'Aventri Event',
             {
               matchCase: false,
             }

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -182,7 +182,7 @@ describe('Company activity feed', () => {
         cy.get('[data-test="aventri-event"]').within(() =>
           cy
             .get('[data-test="activity-kind-label"]')
-            .contains('Aventri Service Delivery', {
+            .contains('Aventri Event', {
               matchCase: false,
             })
         )


### PR DESCRIPTION
## Description of change

change to wording of the aventri label from Aventri Service Delivery to Aventri Event

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

![image](https://user-images.githubusercontent.com/102232401/206423637-e5bbe8c6-0425-4730-b4e5-fe692db1afb3.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
