### PR TITLE
Add user feature groups to notifications

### DIFF
--- a/src/client/components/NotificationAlert/index.jsx
+++ b/src/client/components/NotificationAlert/index.jsx
@@ -35,8 +35,8 @@ const StyledImage = styled('img')({
   verticalAlign: 'sub',
 })
 
-const NotificationAlert = ({ count, hasFeatureFlag }) =>
-  hasFeatureFlag ? (
+const NotificationAlert = ({ count, hasFeatureGroup }) =>
+  hasFeatureGroup ? (
     <Task.Status
       name={TASK_GET_NOTIFICATION_ALERT_COUNT}
       id={ID}

--- a/src/client/components/NotificationAlert/state.js
+++ b/src/client/components/NotificationAlert/state.js
@@ -3,10 +3,11 @@ export const TASK_GET_NOTIFICATION_ALERT_COUNT =
   'TASK_GET_NOTIFICATION_ALERT_COUNT'
 
 export const state2props = (state) => {
-  const activeFeatures = state?.adviser?.active_features || []
-  const hasFeatureFlag = activeFeatures.includes('reminder-summary')
+  const activeFeatureGroups = state?.activeFeatureGroups || []
   return {
     ...state[ID],
-    hasFeatureFlag,
+    hasFeatureGroup:
+      activeFeatureGroups.includes('investment-notifications') ||
+      activeFeatureGroups.includes('export-notifications'),
   }
 }

--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -8,7 +8,6 @@ import { BLUE } from 'govuk-colours'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
 import Banner from '../LocalHeader/Banner'
-import CheckUserFeatureFlag from '../CheckUserFeatureFlags'
 import { ID as INVESTMENT_REMINDERS_ID } from '../InvestmentReminders/state'
 import { ID as REMINDER_SUMMARY_ID } from '../ReminderSummary/state'
 import {
@@ -61,11 +60,22 @@ const state2props = (state) => {
   const { count: reminderSummaryCount } = state[REMINDER_SUMMARY_ID]
   const { hasInvestmentProjects } = state[CHECK_FOR_INVESTMENTS_ID]
   const { dataHubFeed } = state[DATA_HUB_FEED_ID]
+
+  const activeFeatureGroups = state.activeFeatureGroups || []
+  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+    'investment-notifications'
+  )
+  const hasExportFeatureGroup = activeFeatureGroups.includes(
+    'export-notifications'
+  )
+
   return {
     hasInvestmentProjects,
     dataHubFeed,
     remindersCount,
     reminderSummaryCount,
+    hasInvestmentFeatureGroup,
+    hasExportFeatureGroup,
   }
 }
 
@@ -77,6 +87,8 @@ const PersonalisedDashboard = ({
   reminderSummaryCount,
   hasInvestmentProjects,
   dataHubFeed,
+  hasInvestmentFeatureGroup,
+  hasExportFeatureGroup,
 }) => (
   <ThemeProvider theme={blueTheme}>
     <Banner items={dataHubFeed} />
@@ -101,44 +113,40 @@ const PersonalisedDashboard = ({
             {hasInvestmentProjects && (
               <GridCol setWidth="one-third">
                 <Aside>
-                  <CheckUserFeatureFlag userFeatureFlagName="reminder-summary">
-                    {(isFeatureFlagOn) =>
-                      isFeatureFlagOn ? (
-                        <DashboardToggleSection
-                          label="Reminders"
-                          id="reminder-summary-section"
-                          badge={
-                            !!reminderSummaryCount && (
-                              <NotificationBadge
-                                label={`${reminderSummaryCount}`}
-                              />
-                            )
-                          }
-                          major={true}
-                          isOpen={reminderSummaryCount > 0}
-                          data-test="reminder-summary-section"
-                        >
-                          <ReminderSummary />
-                        </DashboardToggleSection>
-                      ) : (
-                        <DashboardToggleSection
-                          label="Reminders"
-                          id="investment-reminders-section"
-                          badge={
-                            !!remindersCount && (
-                              <NotificationBadge label={`${remindersCount}`} />
-                            )
-                          }
-                          major={true}
-                          isOpen={false}
-                          data-test="investment-reminders-section"
-                        >
-                          <InvestmentReminders adviser={adviser} />
-                        </DashboardToggleSection>
-                      )
-                    }
-                  </CheckUserFeatureFlag>
-
+                  {hasInvestmentFeatureGroup || hasExportFeatureGroup ? (
+                    <DashboardToggleSection
+                      label="Reminders"
+                      id="reminder-summary-section"
+                      badge={
+                        !!reminderSummaryCount && (
+                          <NotificationBadge
+                            label={`${reminderSummaryCount}`}
+                          />
+                        )
+                      }
+                      major={true}
+                      isOpen={reminderSummaryCount > 0}
+                      data-test="reminder-summary-section"
+                    >
+                      <ReminderSummary />
+                    </DashboardToggleSection>
+                  ) : (
+                    // Outstanding propositions
+                    <DashboardToggleSection
+                      label="Reminders"
+                      id="investment-reminders-section"
+                      badge={
+                        !!remindersCount && (
+                          <NotificationBadge label={`${remindersCount}`} />
+                        )
+                      }
+                      major={true}
+                      isOpen={false}
+                      data-test="investment-reminders-section"
+                    >
+                      <InvestmentReminders adviser={adviser} />
+                    </DashboardToggleSection>
+                  )}
                   <DashboardToggleSection
                     label="Investment projects summary"
                     id="investment-project-summary-section"

--- a/src/client/components/ReminderSummary/Summary.jsx
+++ b/src/client/components/ReminderSummary/Summary.jsx
@@ -32,45 +32,59 @@ const StyledListItem = styled('li')(() => ({
   margin: `${SPACING.SCALE_2} 0`,
 }))
 
-const Summary = ({ summary }) => (
-  <>
-    <StyledSubHeading data-test="investment-heading">
-      Investment
-    </StyledSubHeading>
-    <StyledList>
-      {summary &&
-        summary.investment.map((reminder) => (
-          <StyledListItem
-            key={reminder.name}
-            data-test={`investment-${kebabCase(reminder.name)}`}
-          >
-            <StyledReminderLink href={reminder.url}>
-              {reminder.name}
-            </StyledReminderLink>
-            &nbsp;({reminder.count})
-          </StyledListItem>
-        ))}
-    </StyledList>
-    <StyledSubHeading data-test="export-heading">Export</StyledSubHeading>
-    <StyledList>
-      {summary &&
-        summary.export.map((reminder) => (
-          <StyledListItem
-            key={reminder.name}
-            data-test={`export-${kebabCase(reminder.name)}`}
-          >
-            <StyledReminderLink href={reminder.url}>
-              {reminder.name}
-            </StyledReminderLink>
-            &nbsp;({reminder.count})
-          </StyledListItem>
-        ))}
-    </StyledList>
-    <StyledReminderLink href={urls.reminders.settings.index()}>
-      Settings: reminders and email notifications
-    </StyledReminderLink>
-  </>
-)
+const Summary = ({
+  summary,
+  hasInvestmentFeatureGroup,
+  hasExportFeatureGroup,
+}) => {
+  const showInvestment = hasInvestmentFeatureGroup && summary
+  const showExport = hasExportFeatureGroup && summary
+  return (
+    <>
+      {showInvestment && (
+        <>
+          <StyledSubHeading data-test="investment-heading">
+            Investment
+          </StyledSubHeading>
+          <StyledList>
+            {summary.investment.map((reminder) => (
+              <StyledListItem
+                key={reminder.name}
+                data-test={`investment-${kebabCase(reminder.name)}`}
+              >
+                <StyledReminderLink href={reminder.url}>
+                  {reminder.name}
+                </StyledReminderLink>
+                &nbsp;({reminder.count})
+              </StyledListItem>
+            ))}
+          </StyledList>
+        </>
+      )}
+      {showExport && (
+        <>
+          <StyledSubHeading data-test="export-heading">Export</StyledSubHeading>
+          <StyledList>
+            {summary.export.map((reminder) => (
+              <StyledListItem
+                key={reminder.name}
+                data-test={`export-${kebabCase(reminder.name)}`}
+              >
+                <StyledReminderLink href={reminder.url}>
+                  {reminder.name}
+                </StyledReminderLink>
+                &nbsp;({reminder.count})
+              </StyledListItem>
+            ))}
+          </StyledList>
+        </>
+      )}
+      <StyledReminderLink href={urls.reminders.settings.index()}>
+        Settings: reminders and email notifications
+      </StyledReminderLink>
+    </>
+  )
+}
 
 const reminderType = PropTypes.arrayOf(
   PropTypes.shape({
@@ -81,9 +95,13 @@ const reminderType = PropTypes.arrayOf(
 )
 
 Summary.propTypes = {
-  count: PropTypes.number,
-  investment: reminderType,
-  export: reminderType,
+  summary: PropTypes.shape({
+    count: PropTypes.number,
+    investment: reminderType,
+    export: reminderType,
+  }),
+  hasExportFeatureGroup: PropTypes.bool.isRequired,
+  hasInvestmentFeatureGroup: PropTypes.bool.isRequired,
 }
 
 export default Summary

--- a/src/client/components/ReminderSummary/index.jsx
+++ b/src/client/components/ReminderSummary/index.jsx
@@ -18,7 +18,7 @@ const ReminderSummary = (data) => (
         onSuccessDispatch: REMINDER_SUMMARY__LOADED,
       }}
     >
-      {() => <Summary summary={data} />}
+      {() => <Summary {...data} />}
     </Task.Status>
   </div>
 )

--- a/src/client/components/ReminderSummary/state.js
+++ b/src/client/components/ReminderSummary/state.js
@@ -1,3 +1,16 @@
 export const ID = 'reminderSummary'
 export const TASK_GET_REMINDER_SUMMARY = 'TASK_GET_REMINDER_SUMMARY'
-export const state2props = (state) => state[ID]
+export const state2props = (state) => {
+  const activeFeatureGroups = state?.activeFeatureGroups || []
+  const hasExportFeatureGroup = activeFeatureGroups.includes(
+    'export-notifications'
+  )
+  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+    'investment-notifications'
+  )
+  return {
+    summary: state[ID],
+    hasExportFeatureGroup,
+    hasInvestmentFeatureGroup,
+  }
+}

--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Link, useLocation } from 'react-router-dom'
+import { connect } from 'react-redux'
 
 import { BLUE, BORDER_COLOUR } from 'govuk-colours'
 import { H3 } from 'govuk-react'
 import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
-import CheckUserFeatureFlag from '../../components/CheckUserFeatureFlags'
+import { state2props } from './state'
 
 const LinkList = styled('ul')({
   listStyleType: 'none',
@@ -46,48 +47,49 @@ const MenuItem = ({ to, pathname, children }) => (
   </LinkListItem>
 )
 
-const RemindersMenu = () => {
+const RemindersMenu = ({
+  hasInvestmentFeatureGroup,
+  hasExportFeatureGroup,
+}) => {
   const location = useLocation()
   return (
     <>
-      <Menu>
-        <H3 as="h2">Investment</H3>
-        <MenuItem
-          to={urls.reminders.investments.estimatedLandDate()}
-          pathname={location.pathname}
-        >
-          Approaching estimated land dates
-        </MenuItem>
-        <MenuItem
-          to={urls.reminders.investments.noRecentInteraction()}
-          pathname={location.pathname}
-        >
-          Projects with no recent interactions
-        </MenuItem>
-        <MenuItem
-          to={urls.reminders.investments.outstandingPropositions()}
-          pathname={location.pathname}
-        >
-          Outstanding propositions
-        </MenuItem>
-      </Menu>
-      <CheckUserFeatureFlag userFeatureFlagName="export-email-reminders">
-        {(isFeatureFlagOn) =>
-          isFeatureFlagOn && (
-            <Menu>
-              <H3 as="h2">Export</H3>
-              <MenuItem
-                to={urls.reminders.exports.noRecentInteractions()}
-                pathname={location.pathname}
-              >
-                Companies with no recent interactions
-              </MenuItem>
-            </Menu>
-          )
-        }
-      </CheckUserFeatureFlag>
+      {hasInvestmentFeatureGroup && (
+        <Menu>
+          <H3 as="h2">Investment</H3>
+          <MenuItem
+            to={urls.reminders.investments.estimatedLandDate()}
+            pathname={location.pathname}
+          >
+            Approaching estimated land dates
+          </MenuItem>
+          <MenuItem
+            to={urls.reminders.investments.noRecentInteraction()}
+            pathname={location.pathname}
+          >
+            Projects with no recent interactions
+          </MenuItem>
+          <MenuItem
+            to={urls.reminders.investments.outstandingPropositions()}
+            pathname={location.pathname}
+          >
+            Outstanding propositions
+          </MenuItem>
+        </Menu>
+      )}
+      {hasExportFeatureGroup && (
+        <Menu>
+          <H3 as="h2">Export</H3>
+          <MenuItem
+            to={urls.reminders.exports.noRecentInteractions()}
+            pathname={location.pathname}
+          >
+            Companies with no recent interactions
+          </MenuItem>
+        </Menu>
+      )}
     </>
   )
 }
 
-export default RemindersMenu
+export default connect(state2props)(RemindersMenu)

--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -6,12 +6,13 @@ import { H2 } from '@govuk-react/heading'
 import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
 import { get } from 'lodash'
 import qs from 'qs'
+import { connect } from 'react-redux'
 
 import { DefaultLayout, RemindersToggleSection } from '../../../components'
 import RemindersSettingsTable from './RemindersSettingsTable'
-import CheckUserFeatureFlag from '../../../components/CheckUserFeatureFlags'
 import Resource from '../../../components/Resource'
 import urls from '../../../../lib/urls'
+import { state2props } from '../state'
 
 import { TASK_GET_SUBSCRIPTION_SUMMARY } from '../state'
 
@@ -32,7 +33,10 @@ const openSettings = (queryParamType, qsParams) => {
   return !!settingsExpand
 }
 
-const RemindersSettings = () => {
+const RemindersSettings = ({
+  hasInvestmentFeatureGroup,
+  hasExportFeatureGroup,
+}) => {
   const location = useLocation()
   const qsParams = qs.parse(location.search.slice(1))
   const openESL = openSettings('investments_estimated_land_dates', qsParams)
@@ -63,58 +67,58 @@ const RemindersSettings = () => {
           exportNoRecentInteractions,
         }) => (
           <>
-            <H2 size={LEVEL_SIZE[3]}>Investment</H2>
-            <ToggleSectionContainer>
-              <RemindersToggleSection
-                label="Approaching estimated land dates"
-                id="estimated-land-dates-toggle"
-                data-test="estimated-land-dates-toggle"
-                isOpen={openESL}
-              >
-                <RemindersSettingsTable
-                  dataName={'estimated-land-dates'}
-                  data={estimatedLandDate}
-                  to={urls.reminders.settings.investments.estimatedLandDate()}
-                />
-              </RemindersToggleSection>
-              <RemindersToggleSection
-                label="Projects with no recent interactions"
-                id="no-recent-interactions-toggle"
-                data-test="no-recent-interactions-toggle"
-                isOpen={openNRI}
-                borderBottom={true}
-              >
-                <RemindersSettingsTable
-                  dataName={'no-recent-interactions'}
-                  data={noRecentInteraction}
-                  to={urls.reminders.settings.investments.noRecentInteraction()}
-                />
-              </RemindersToggleSection>
-            </ToggleSectionContainer>
-            <CheckUserFeatureFlag userFeatureFlagName="export-email-reminders">
-              {(isFeatureFlagEnabled) =>
-                isFeatureFlagEnabled && (
-                  <>
-                    <H2 size={LEVEL_SIZE[3]}>Export</H2>
-                    <ToggleSectionContainer>
-                      <RemindersToggleSection
-                        label="Companies with no recent interactions"
-                        id="companies-no-recent-interactions-toggle"
-                        data-test="companies-no-recent-interactions-toggle"
-                        isOpen={openENRI}
-                        borderBottom={true}
-                      >
-                        <RemindersSettingsTable
-                          dataName={'companies-no-recent-interactions'}
-                          data={exportNoRecentInteractions}
-                          to={urls.reminders.settings.exports.noRecentInteraction()}
-                        />
-                      </RemindersToggleSection>
-                    </ToggleSectionContainer>
-                  </>
-                )
-              }
-            </CheckUserFeatureFlag>
+            {hasInvestmentFeatureGroup && (
+              <>
+                <H2 size={LEVEL_SIZE[3]}>Investment</H2>
+                <ToggleSectionContainer>
+                  <RemindersToggleSection
+                    label="Approaching estimated land dates"
+                    id="estimated-land-dates-toggle"
+                    data-test="estimated-land-dates-toggle"
+                    isOpen={openESL}
+                  >
+                    <RemindersSettingsTable
+                      dataName={'estimated-land-dates'}
+                      data={estimatedLandDate}
+                      to={urls.reminders.settings.investments.estimatedLandDate()}
+                    />
+                  </RemindersToggleSection>
+                  <RemindersToggleSection
+                    label="Projects with no recent interactions"
+                    id="no-recent-interactions-toggle"
+                    data-test="no-recent-interactions-toggle"
+                    isOpen={openNRI}
+                    borderBottom={true}
+                  >
+                    <RemindersSettingsTable
+                      dataName={'no-recent-interactions'}
+                      data={noRecentInteraction}
+                      to={urls.reminders.settings.investments.noRecentInteraction()}
+                    />
+                  </RemindersToggleSection>
+                </ToggleSectionContainer>
+              </>
+            )}
+            {hasExportFeatureGroup && (
+              <>
+                <H2 size={LEVEL_SIZE[3]}>Export</H2>
+                <ToggleSectionContainer>
+                  <RemindersToggleSection
+                    label="Companies with no recent interactions"
+                    id="companies-no-recent-interactions-toggle"
+                    data-test="companies-no-recent-interactions-toggle"
+                    isOpen={openENRI}
+                    borderBottom={true}
+                  >
+                    <RemindersSettingsTable
+                      dataName={'companies-no-recent-interactions'}
+                      data={exportNoRecentInteractions}
+                      to={urls.reminders.settings.exports.noRecentInteraction()}
+                    />
+                  </RemindersToggleSection>
+                </ToggleSectionContainer>
+              </>
+            )}
             <StyledHomeLink href={urls.dashboard()} aria-label="Home">
               Home
             </StyledHomeLink>
@@ -125,4 +129,4 @@ const RemindersSettings = () => {
   )
 }
 
-export default RemindersSettings
+export default connect(state2props)(RemindersSettings)

--- a/src/client/modules/Reminders/state.js
+++ b/src/client/modules/Reminders/state.js
@@ -44,3 +44,17 @@ export const TASK_GET_EXPORT_NRI_REMINDER_SUBSCRIPTIONS =
   'TASK_GET_EXPORT_NRI_REMINDER_SUBSCRIPTIONS'
 export const TASK_SAVE_EXPORT_NRI_REMINDER_SUBSCRIPTIONS =
   'TASK_SAVE_EXPORT_NRI_REMINDER_SUBSCRIPTIONS'
+
+export const state2props = (state) => {
+  const activeFeatureGroups = state?.activeFeatureGroups || []
+  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+    'investment-notifications'
+  )
+  const hasExportFeatureGroup = activeFeatureGroups.includes(
+    'export-notifications'
+  )
+  return {
+    hasInvestmentFeatureGroup,
+    hasExportFeatureGroup,
+  }
+}

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -148,7 +148,8 @@ const parseProps = (domNode) => {
     return {
       modulePermissions: [],
       currentAdviserId: '',
-      adviser: null,
+      activeFeatures: null,
+      activeFeatureGroups: null,
     }
   }
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
@@ -156,11 +157,17 @@ const parseProps = (domNode) => {
 
 const appWrapper = document.getElementById('react-app')
 
-const { modulePermissions, currentAdviserId, adviser } = parseProps(appWrapper)
+const {
+  modulePermissions,
+  currentAdviserId,
+  activeFeatures,
+  activeFeatureGroups,
+} = parseProps(appWrapper)
 
 const reducer = {
   currentAdviserId: () => currentAdviserId,
-  adviser: () => adviser,
+  activeFeatures: () => activeFeatures,
+  activeFeatureGroups: () => activeFeatureGroups,
   modulePermissions: () => modulePermissions,
   router: connectRouter(history),
   tasks,

--- a/src/middleware/__test__/user.test.js
+++ b/src/middleware/__test__/user.test.js
@@ -24,33 +24,6 @@ describe('user middleware', () => {
     })
   })
 
-  context('if user already exists on session', () => {
-    beforeEach(() => {
-      this.reqMock = {
-        session: {
-          token,
-          user,
-        },
-      }
-      this.resMock = {
-        locals: {},
-      }
-      this.userMiddleware(this.reqMock, this.resMock, this.nextSpy)
-    })
-
-    it('should add user property on locals', () => {
-      expect(this.resMock.locals).to.have.property('user')
-    })
-
-    it('should set user to session value', () => {
-      expect(this.resMock.locals.user).to.deep.equal(user)
-    })
-
-    it('should call next with no arguments', () => {
-      expect(this.nextSpy).to.be.calledWith()
-    })
-  })
-
   context('if not token is set', () => {
     beforeEach(() => {
       this.reqMock = {

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -17,7 +17,8 @@ module.exports = () => {
         ...res.locals.PERMITTED_APPLICATIONS.map(({ key }) => key),
       ]),
       currentAdviserId: req.session?.user?.id,
-      adviser: req.session?.user,
+      activeFeatures: req.session?.user?.active_features,
+      activeFeatureGroups: req.session?.user?.active_feature_groups || [],
     }
     next()
   }

--- a/src/middleware/user.js
+++ b/src/middleware/user.js
@@ -1,17 +1,8 @@
-const { get } = require('lodash')
-
 const config = require('../config')
 const { authorisedRequest } = require('../lib/authorised-request')
 
 async function userMiddleware(req, res, next) {
   const token = req.session.token
-  const userSession = req.session.user
-
-  if (userSession) {
-    res.locals.user = userSession
-    return next()
-  }
-
   if (!token) {
     return next()
   }
@@ -22,15 +13,7 @@ async function userMiddleware(req, res, next) {
       `${config.apiRoot}/whoami/`
     )
 
-    const userId = get(req.session, 'userProfile.user_id')
-
-    const user = {
-      ...userResponse,
-      userId,
-    }
-
-    req.session.user = res.locals.user = user
-
+    req.session.user = res.locals.user = userResponse
     next()
   } catch (error) {
     next(error)

--- a/src/templates/_includes/google-tag-manager-snippet.njk
+++ b/src/templates/_includes/google-tag-manager-snippet.njk
@@ -3,7 +3,7 @@
 window.dataLayer = window.dataLayer || []
 window.dataLayer.push({
   userId: '{{user.id}}',
-  userUserId: '{{user.userId}}',
+  userUserId: '{{user.sso_user_id}}',
 })
 if ('{{userFeatureGTMEvent}}') {
   window.dataLayer.push({

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -257,6 +257,12 @@ Cypress.Commands.add('setUserFeatures', (features) => {
   })
 })
 
+Cypress.Commands.add('setUserFeatureGroups', (groups) => {
+  return cy.request('PUT', `${Cypress.env('sandbox_url')}/whoami`, {
+    active_feature_groups: groups,
+  })
+})
+
 Cypress.Commands.add('setAdviserId', (id) => {
   return cy.request('PUT', `${Cypress.env('sandbox_url')}/whoami`, { id })
 })

--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -1,6 +1,10 @@
 describe('Dashboard reminder summary', () => {
   before(() => {
-    cy.setUserFeatures(['personalised-dashboard', 'reminder-summary'])
+    cy.setUserFeatures(['personalised-dashboard'])
+    cy.setUserFeatureGroups([
+      'investment-notifications',
+      'export-notifications',
+    ])
   })
 
   after(() => {

--- a/test/functional/cypress/specs/layout-spec.js
+++ b/test/functional/cypress/specs/layout-spec.js
@@ -53,24 +53,3 @@ describe('Layout', () => {
     })
   })
 })
-
-describe('When reminders feature flag notification is on', () => {
-  beforeEach(() => {
-    cy.setUserFeatures(['reminder-summary'])
-    cy.visit('/reminders')
-  })
-
-  it('should display notification alert badge', () => {
-    cy.get('[data-test="notification-alert-badge"]').should('contain', '289')
-  })
-})
-
-describe('When reminders feature flag notification is off', () => {
-  beforeEach(() => {
-    cy.visit('/')
-  })
-
-  it('should display empty notification alert badge', () => {
-    cy.get(selectors.nav.headerNav).should('not.contain', 'Notification alert')
-  })
-})

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -7,13 +7,10 @@ import {
   reminderListFaker,
 } from '../../fakers/reminders'
 import { formatMediumDate } from '../../../../../src/client/utils/date'
-import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/no-recent-export-interaction'
-const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('Exports no recent Interaction Reminders', () => {
-  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     exportReminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -26,15 +23,6 @@ describe('Exports no recent Interaction Reminders', () => {
   const nextReminder = exportReminderFaker()
 
   const interceptApiCalls = () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        pathname: whoAmIEndpoint,
-      },
-      {
-        body: user,
-      }
-    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -90,9 +78,12 @@ describe('Exports no recent Interaction Reminders', () => {
 
   context('Reminders List', () => {
     before(() => {
+      cy.setUserFeatureGroups([
+        'export-notifications',
+        'investment-notifications',
+      ])
       interceptApiCalls()
       cy.visit(urls.reminders.exports.noRecentInteractions())
-      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
@@ -1,13 +1,10 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { reminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/estimated-land-date'
-const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('Estimated Land Date Reminders', () => {
-  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     reminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -18,15 +15,6 @@ describe('Estimated Land Date Reminders', () => {
   const totalCount = 25
 
   const interceptApiCalls = () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        pathname: whoAmIEndpoint,
-      },
-      {
-        body: user,
-      }
-    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -84,8 +72,11 @@ describe('Estimated Land Date Reminders', () => {
   context('Reminders List', () => {
     before(() => {
       interceptApiCalls()
+      cy.setUserFeatureGroups([
+        'export-notifications',
+        'investment-notifications',
+      ])
       cy.visit(urls.reminders.investments.estimatedLandDate())
-      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
@@ -1,14 +1,11 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { reminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { userFaker } from '../../fakers/users'
 
 const remindersEndpoint =
   '/api-proxy/v4/reminder/no-recent-investment-interaction'
-const whoAmIEndpoint = '/api-proxy/whoami/'
 
 describe('No Recent Interaction Reminders', () => {
-  const user = userFaker({ active_features: ['export-email-reminders'] })
   const reminders = [
     reminderFaker({
       created_on: '2022-01-01T10:00:00.000000Z',
@@ -19,15 +16,6 @@ describe('No Recent Interaction Reminders', () => {
   const nextReminder = reminderFaker()
 
   const interceptApiCalls = () => {
-    cy.intercept(
-      {
-        method: 'GET',
-        pathname: whoAmIEndpoint,
-      },
-      {
-        body: user,
-      }
-    ).as('whoAmIApiRequest')
     cy.intercept(
       {
         method: 'GET',
@@ -85,8 +73,11 @@ describe('No Recent Interaction Reminders', () => {
   context('Reminders List', () => {
     before(() => {
       interceptApiCalls()
+      cy.setUserFeatureGroups([
+        'export-notifications',
+        'investment-notifications',
+      ])
       cy.visit(urls.reminders.investments.noRecentInteraction())
-      cy.wait('@whoAmIApiRequest')
       cy.wait('@remindersApiRequest')
     })
 

--- a/test/functional/cypress/specs/reminders/notification-bell-spec.js
+++ b/test/functional/cypress/specs/reminders/notification-bell-spec.js
@@ -1,0 +1,41 @@
+import urls from '../../../../../src/lib/urls'
+
+const assertNotificationBadgeExists = () => {
+  cy.get('[data-test="notification-alert-badge"]')
+    .should('exist')
+    .should('contain', '289')
+}
+
+const assertNotificationBadgeNotExist = () =>
+  cy.get('[data-test="notification-alert-badge"]').should('not.exist')
+
+describe('Notification bell', () => {
+  context('Dashboard', () => {
+    beforeEach(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
+    })
+    it('should display a notification bell when investments are enabled', () => {
+      cy.setUserFeatureGroups(['investment-notifications'])
+      cy.visit(urls.dashboard())
+      assertNotificationBadgeExists()
+    })
+    it('should display a notification bell when exports are enabled', () => {
+      cy.setUserFeatureGroups(['export-notifications'])
+      cy.visit(urls.dashboard())
+      assertNotificationBadgeExists()
+    })
+    it('should display a notification bell when both investments and exports are enabled', () => {
+      cy.setUserFeatureGroups([
+        'investment-notifications',
+        'export-notifications',
+      ])
+      cy.visit(urls.dashboard())
+      assertNotificationBadgeExists()
+    })
+    it('should not display a notification bell when either investments or exports are disabled', () => {
+      cy.setUserFeatureGroups([])
+      cy.visit(urls.dashboard())
+      assertNotificationBadgeNotExist()
+    })
+  })
+})

--- a/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
@@ -14,6 +14,7 @@ const selectors = {
 describe('Notification settings', () => {
   context('when in estimated land date page', () => {
     before(() => {
+      cy.setUserFeatureGroups(['investment-notifications'])
       cy.visit(urls.reminders.investments.estimatedLandDate())
       cy.get(selectors.collectionItem).should('be.visible')
       cy.get(selectors.remindersSettings).eq(1).should('be.visible').click()

--- a/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
@@ -4,7 +4,6 @@ import {
 } from '../../../support/assertions'
 import urls from '../../../../../../src/lib/urls'
 
-const userEndpoint = '/api-proxy/whoami'
 const summaryEndpoint = '/api-proxy/v4/reminder/subscription/summary'
 
 const eslDataTest = 'estimated-land-dates'
@@ -23,9 +22,6 @@ const interceptAPICalls = ({
   enri_reminder_days = [10, 40, 30],
   enri_email_reminders_enabled = true,
 } = {}) => {
-  cy.intercept('GET', userEndpoint, {
-    active_features: 'export-email-reminders',
-  }).as('userRequest')
   cy.intercept('GET', summaryEndpoint, {
     body: {
       estimated_land_date: {
@@ -45,7 +41,6 @@ const interceptAPICalls = ({
 }
 
 const waitForAPICalls = () => {
-  cy.wait('@userRequest')
   cy.wait('@summaryRequest')
 }
 
@@ -90,6 +85,10 @@ const assertSettingsTableToggles = ({
 describe('Settings: reminders and email notifications', () => {
   context('Breadcrumbs and title', () => {
     before(() => {
+      cy.setUserFeatureGroups([
+        'export-notifications',
+        'investment-notifications',
+      ])
       interceptAPICalls()
       cy.visit(urls.reminders.settings.index())
       waitForAPICalls()

--- a/test/sandbox/fixtures/whoami.json
+++ b/test/sandbox/fixtures/whoami.json
@@ -96,5 +96,6 @@
     "company.change_one_list_core_team_member"
   ],
   "features": [],
-  "active_features": []
+  "active_features": [],
+  "active_feature_groups": []
 }

--- a/test/sandbox/routes/whoami.js
+++ b/test/sandbox/routes/whoami.js
@@ -18,6 +18,9 @@ exports.setWhoami = function (req, res) {
   if (req.body.active_features) {
     whoami.active_features = req.body.active_features
   }
+  if (req.body.active_feature_groups) {
+    whoami.active_feature_groups = req.body.active_feature_groups
+  }
   if (req.body.permissions) {
     whoami.permissions = req.body.permissions
   }
@@ -28,6 +31,7 @@ exports.resetWhoami = function (req, res) {
   whoami.id = defaultAdviserId
   whoami.dit_team.id = defaultTeamId
   whoami.active_features = []
+  whoami.active_feature_groups = []
   whoami.permissions = defaultPermissions
   res.json(whoami)
 }


### PR DESCRIPTION
## Description of change
* This PR allows us enable/disable individual features (investments/exports) of notifications. Giving users features they only care about.
* No need to make an API call to the `/whoami` endpoint from the browser to extract the active feature. Instead we pass the adviser feature flags (`active_features`  and `active_feature_groups `) from Express to the Redux store (just once per page load) making the adviser available to all connected components. At present we are making too many calls to the `/whoami` endpoint, this PR will fix that. 

Please ignore the count within the screenshots, this has been fixed with this API [PR](https://github.com/uktrade/data-hub-api/pull/4412).

## Test
Point your local FE to the UAT API on PaaS.

Or to view this in Sandbox you will need the following user feature groups, they should be added to the bottom of the `whoami.json` file:
```json
  "active_feature_groups": [
    "investment-notifications",
    "export-notifications"
  ]
```

When applying the user feature groups to your functional tests use the Cypress command:
```js
cy.setUserFeatureGroups([
  'export-notifications',
  'investment-notifications',
])
```

**The personalised dashboard with Outstanding Propositions (no reminders)**
<img width="1727" alt="personalised-dashboard" src="https://user-images.githubusercontent.com/964268/208680299-5343a61b-c8c6-4cea-aaf4-a7e31dfb7fde.png">

**The personalised dashboard with Investment notifications**
<img width="1645" alt="investments" src="https://user-images.githubusercontent.com/964268/208680500-58418993-2761-47a4-b20e-2d7fc1d1f376.png">

**The personalised dashboard with export notifications**
<img width="1827" alt="exports" src="https://user-images.githubusercontent.com/964268/208680773-6ec32df0-2f3d-40da-b452-ec1c6968998f.png">

**The personalised dashboard with both investment and export notifications**
<img width="1638" alt="investment+exports" src="https://user-images.githubusercontent.com/964268/208680914-4ed6abfc-3024-4927-8cfc-71afc9ed88be.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
