### PR TITLE
Edit investment opportunity requirements form layout

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -24,6 +24,7 @@ import {
   FieldInput,
   FieldCheckboxes,
   FieldRadios,
+  FormLayout,
 } from '../../../../../client/components'
 import {
   TOTAL_INVESTMENT_SOUGHT_FIELD_NAME,
@@ -86,30 +87,32 @@ const OpportunityRequirementsForm = (state) => {
                   urls.investments.opportunities.details(opportunityId)
                 }
               >
-                <FieldInput
-                  label="Total investment sought"
-                  hint="Enter value in £"
-                  name={TOTAL_INVESTMENT_SOUGHT_FIELD_NAME}
-                  initialValue={totalInvestmentSought}
-                  type="text"
-                  validate={(value) =>
-                    !value || IS_NUMBER.test(value)
-                      ? null
-                      : 'Total investment sought value must be a number'
-                  }
-                />
-                <FieldInput
-                  label="Investment secured so far"
-                  hint="Enter value in £"
-                  name={CURRENT_INVESTMENT_SECURED_FIELD_NAME}
-                  initialValue={currentInvestmentSecured}
-                  type="text"
-                  validate={(value) =>
-                    !value || IS_NUMBER.test(value)
-                      ? null
-                      : 'Investment secured so far value must be a number'
-                  }
-                />
+                <FormLayout setWidth="one-third">
+                  <FieldInput
+                    label="Total investment sought"
+                    hint="Enter value in £"
+                    name={TOTAL_INVESTMENT_SOUGHT_FIELD_NAME}
+                    initialValue={totalInvestmentSought}
+                    type="text"
+                    validate={(value) =>
+                      !value || IS_NUMBER.test(value)
+                        ? null
+                        : 'Total investment sought value must be a number'
+                    }
+                  />
+                  <FieldInput
+                    label="Investment secured so far"
+                    hint="Enter value in £"
+                    name={CURRENT_INVESTMENT_SECURED_FIELD_NAME}
+                    initialValue={currentInvestmentSecured}
+                    type="text"
+                    validate={(value) =>
+                      !value || IS_NUMBER.test(value)
+                        ? null
+                        : 'Investment secured so far value must be a number'
+                    }
+                  />
+                </FormLayout>
                 <StyledFieldCheckboxes
                   legend="Types of investment"
                   name={INVESTMENT_TYPES_FIELD_NAME}

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -33,6 +33,7 @@ import {
   ESTIMATED_RETURN_RATE_FIELD_NAME,
   TIME_HORIZONS_FIELD_NAME,
 } from '../Details/constants'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const StyledFieldCheckboxes = styled(FieldCheckboxes)`
   margin-bottom: 0;
@@ -87,7 +88,7 @@ const OpportunityRequirementsForm = (state) => {
                   urls.investments.opportunities.details(opportunityId)
                 }
               >
-                <FormLayout setWidth="one-third">
+                <FormLayout setWidth={FORM_LAYOUT.ONE_THIRD}>
                   <FieldInput
                     label="Total investment sought"
                     hint="Enter value in £"

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -29,6 +29,8 @@ const OPTIONS_YES_NO = [
   { label: 'No', value: OPTION_NO },
 ]
 
+const FORM_LAYOUT = { THREE_QUARTERS: 'three-quarters', ONE_THIRD: 'one-third' }
+
 const METHOD_PATCH = 'PATCH'
 const METHOD_POST = 'POST'
 
@@ -51,6 +53,7 @@ module.exports = {
   OPTIONS_YES_NO,
   OPTION_YES,
   OPTION_NO,
+  FORM_LAYOUT,
   METHOD_PATCH,
   METHOD_POST,
 }


### PR DESCRIPTION
## Description of change

Changing `Edit Investment Opportunity`  form from full width into one-third/two-thirds of screen layout. To make it the form to be shorter and easily read what was entered.

## Test instructions

- Navigate into Investments ->  UK opportunities
- Select one UK opportunities from collection list
- From UK opportunities details, click Opportunity requirements accordion then select Edit button

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/28296624/208648996-4c95ca49-150d-4381-84db-b48d1201a62a.png)

### After

![image](https://user-images.githubusercontent.com/28296624/208648634-2d27091d-a31e-4579-95a3-8d320dc93cb2.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
