### PR TITLE
Change form layout props value into constant variable

### DIFF
--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -18,6 +18,7 @@ import {
   GENERIC_PHONE_NUMBER_REGEX,
 } from './constants'
 import nameValidator from './nameValidator'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const websiteValidator = (
   value,
@@ -51,7 +52,7 @@ const telephoneValidator = (
 
 function CompanyNotFoundStep({ organisationTypes, country, features }) {
   return (
-    <FormLayout setWidth="three-quarters">
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
       <Step name="unhappy">
         <Details summary="Why am I seeing this?">
           The company you want to add to Data Hub cannot be found in the

--- a/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
+++ b/src/apps/companies/apps/edit-company/client/EditCompanyForm.jsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types'
 import CompanyMatched from './CompanyMatched'
 import CompanyUnmatched from './CompanyUnmatched'
 import Form from '../../../../../client/components/Form'
-import { UNITED_STATES_ID, CANADA_ID } from '../../../../../common/constants'
+import {
+  UNITED_STATES_ID,
+  CANADA_ID,
+  FORM_LAYOUT,
+} from '../../../../../common/constants'
 import urls from '../../../../../lib/urls'
 import { FormLayout } from '../../../../../client/components'
 
@@ -36,7 +40,7 @@ function EditCompanyForm({
 
   // TODO: Support nested form values to avoid transformation
   return (
-    <FormLayout setWidth="three-quarters">
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
       <Form
         id="edit-company-form"
         submissionTaskName="Edit company"

--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -19,6 +19,7 @@ import {
   ONE_LIST_TEAM_FIELD_NAME,
   TIER_FIELD_NAME,
 } from '../constants'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 function EditOneListForm({
   companyId,
@@ -62,7 +63,7 @@ function EditOneListForm({
             </Step>
 
             {values.one_list_tier !== NONE && (
-              <FormLayout setWidth="three-quarters">
+              <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
                 <Step name="oneListAdvisers">
                   <FieldAdvisersTypeahead
                     name={ACCOUNT_MANAGER_FIELD_NAME}

--- a/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
+++ b/src/apps/companies/apps/exports/client/ExportCountriesEdit/index.jsx
@@ -11,6 +11,7 @@ import {
   FieldTypeahead,
   FormLayout,
 } from '../../../../../../client/components/'
+import { FORM_LAYOUT } from '../../../../../../common/constants'
 
 const StyledH2 = styled.h2`
   font-weight: bold;
@@ -72,7 +73,7 @@ export default ({ companyId, countryOptions, fields }) => {
               return acc
             }, {})}
         >
-          <FormLayout setWidth="three-quarters">
+          <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
             {fields.map(({ label, name }) => (
               <FieldTypeahead
                 key={name}

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -17,6 +17,7 @@ import {
 } from './state'
 import urls from '../../../../../lib/urls'
 import { FormLayout } from '../../../../../client/components'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const getReturnLink = (
   companyId,
@@ -75,7 +76,7 @@ const InteractionDetailsForm = ({
         const openContactFormTask = getTask(TASK_OPEN_CONTACT_FORM, STATE_ID)
         const companyIds = [companyId]
         return (
-          <FormLayout setWidth="three-quarters">
+          <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
             <Route>
               {({ location }) => {
                 const contactCreated =

--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -31,6 +31,7 @@ import { idNamesToValueLabels } from '../../../../../client/utils'
 
 import { FieldOpportunityValueTypeRadios } from '../../../../../client/components/Form/elements/FieldOpportunityValueType'
 import { apiProxyAxios } from '../../../../../client/components/Task/utils'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
   const {
@@ -53,7 +54,7 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
 
   return (
     <Main>
-      <FormLayout setWidth="three-quarters">
+      <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
         <Form
           id="opportunity-details"
           submissionTaskName={TASK_SAVE_OPPORTUNITY_DETAILS}

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -24,6 +24,7 @@ import {
   FieldInput,
   FieldCheckboxes,
   FieldRadios,
+  FormLayout,
 } from '../../../../../client/components'
 import {
   TOTAL_INVESTMENT_SOUGHT_FIELD_NAME,
@@ -86,30 +87,32 @@ const OpportunityRequirementsForm = (state) => {
                   urls.investments.opportunities.details(opportunityId)
                 }
               >
-                <FieldInput
-                  label="Total investment sought"
-                  hint="Enter value in £"
-                  name={TOTAL_INVESTMENT_SOUGHT_FIELD_NAME}
-                  initialValue={totalInvestmentSought}
-                  type="text"
-                  validate={(value) =>
-                    !value || IS_NUMBER.test(value)
-                      ? null
-                      : 'Total investment sought value must be a number'
-                  }
-                />
-                <FieldInput
-                  label="Investment secured so far"
-                  hint="Enter value in £"
-                  name={CURRENT_INVESTMENT_SECURED_FIELD_NAME}
-                  initialValue={currentInvestmentSecured}
-                  type="text"
-                  validate={(value) =>
-                    !value || IS_NUMBER.test(value)
-                      ? null
-                      : 'Investment secured so far value must be a number'
-                  }
-                />
+                <FormLayout setWidth="one-third">
+                  <FieldInput
+                    label="Total investment sought"
+                    hint="Enter value in £"
+                    name={TOTAL_INVESTMENT_SOUGHT_FIELD_NAME}
+                    initialValue={totalInvestmentSought}
+                    type="text"
+                    validate={(value) =>
+                      !value || IS_NUMBER.test(value)
+                        ? null
+                        : 'Total investment sought value must be a number'
+                    }
+                  />
+                  <FieldInput
+                    label="Investment secured so far"
+                    hint="Enter value in £"
+                    name={CURRENT_INVESTMENT_SECURED_FIELD_NAME}
+                    initialValue={currentInvestmentSecured}
+                    type="text"
+                    validate={(value) =>
+                      !value || IS_NUMBER.test(value)
+                        ? null
+                        : 'Investment secured so far value must be a number'
+                    }
+                  />
+                </FormLayout>
                 <StyledFieldCheckboxes
                   legend="Types of investment"
                   name={INVESTMENT_TYPES_FIELD_NAME}

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -33,6 +33,7 @@ import {
   ESTIMATED_RETURN_RATE_FIELD_NAME,
   TIME_HORIZONS_FIELD_NAME,
 } from '../Details/constants'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const StyledFieldCheckboxes = styled(FieldCheckboxes)`
   margin-bottom: 0;
@@ -87,7 +88,7 @@ const OpportunityRequirementsForm = (state) => {
                   urls.investments.opportunities.details(opportunityId)
                 }
               >
-                <FormLayout setWidth="one-third">
+                <FormLayout setWidth={FORM_LAYOUT.ONE_THIRD}>
                   <FieldInput
                     label="Total investment sought"
                     hint="Enter value in £"

--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -23,6 +23,7 @@ import {
   CREATE_INVESTMENT_OPEN_CONTACT_FORM_ID,
   TASK_CREATE_INVESTMENT_OPEN_CONTACT_FORM,
 } from './state'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const StyledContainer = styled.div(({ error }) => ({
   paddingLeft: SPACING.SCALE_4,
@@ -115,7 +116,7 @@ const InvestmentDetailsStep = ({ values, errors, company }) => {
   )
   const fdiType = findSelectedItem(values.fdiTypes, values.fdi_type)
   return (
-    <FormLayout setWidth="three-quarters">
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
       <Step name="details">
         <SummaryTable
           caption="Investment type"

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -27,6 +27,7 @@ import {
   UNITED_STATES_ID,
   CANADA_ID,
   GENERIC_PHONE_NUMBER_REGEX,
+  FORM_LAYOUT,
 } from '../../../common/constants'
 
 import useAdministrativeAreaLookup from '../AdministrativeAreaSearch/useAdministrativeAreaLookup'
@@ -152,7 +153,7 @@ const _ContactForm = ({
                     : urls.contacts.details(id)
                 }
                 return (
-                  <FormLayout setWidth="three-quarters">
+                  <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
                     <Form
                       id="add-contact-form"
                       analyticsFormName={update ? 'editContact' : 'addContact'}

--- a/src/client/components/Form/elements/FieldDnbCompany/index.jsx
+++ b/src/client/components/Form/elements/FieldDnbCompany/index.jsx
@@ -23,6 +23,7 @@ import useDnbSearch from '../../../EntityList/useDnbSearch'
 import FormActions from '../FormActions'
 import EntityList from '../../../EntityList'
 import FormLayout from '../../../Layout/FormLayout'
+import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const COMPANY_NAME_MIN_LENGTH = 2
 const COMPANY_NAME_MAX_LENGTH = 30
@@ -81,7 +82,7 @@ const FieldDnbCompany = ({
   useEffect(() => setIsLoading(searching), [searching])
 
   return (
-    <FormLayout setWidth="three-quarters">
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
       <FieldWrapper {...{ name, label, legend, hint }}>
         {country && (
           <FieldUneditable

--- a/src/client/modules/Events/EventForm/index.jsx
+++ b/src/client/modules/Events/EventForm/index.jsx
@@ -9,6 +9,7 @@ import { TASK_GET_EVENTS_FORM_AND_METADATA, TASK_SAVE_EVENT } from './state'
 import { EventFormFields } from './EventFormFields'
 import { transformEventFormForAPIRequest } from './transformers'
 import { FormLayout } from '../../../../client/components'
+import { FORM_LAYOUT } from '../../../../common/constants'
 
 const DISPLAY_EDIT_EVENT = 'Edit event'
 const DISPLAY_ADD_EVENT = 'Add event'
@@ -47,7 +48,7 @@ const EventForm = () => {
       breadcrumbs={breadcrumbs}
       useReactRouter={true}
     >
-      <FormLayout setWidth="three-quarters">
+      <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
         <Form
           id="event-form"
           submissionTaskName={TASK_SAVE_EVENT}

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -29,6 +29,8 @@ const OPTIONS_YES_NO = [
   { label: 'No', value: OPTION_NO },
 ]
 
+const FORM_LAYOUT = { THREE_QUARTERS: 'three-quaters', ONE_THIRD: 'one-third' }
+
 const METHOD_PATCH = 'PATCH'
 const METHOD_POST = 'POST'
 
@@ -51,6 +53,7 @@ module.exports = {
   OPTIONS_YES_NO,
   OPTION_YES,
   OPTION_NO,
+  FORM_LAYOUT,
   METHOD_PATCH,
   METHOD_POST,
 }

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -29,7 +29,7 @@ const OPTIONS_YES_NO = [
   { label: 'No', value: OPTION_NO },
 ]
 
-const FORM_LAYOUT = { THREE_QUARTERS: 'three-quaters', ONE_THIRD: 'one-third' }
+const FORM_LAYOUT = { THREE_QUARTERS: 'three-quarters', ONE_THIRD: 'one-third' }
 
 const METHOD_PATCH = 'PATCH'
 const METHOD_POST = 'POST'


### PR DESCRIPTION
## Description of change

Implements a constant values of `setWidth` e.g. three-quarters and one-third from `FormLayout`, to improved the used of constant parameters and minimised typo errors to form layout.


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
