### PR TITLE
Added a condition if ESS title is missing

### DIFF
--- a/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
+++ b/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
@@ -36,6 +36,10 @@ export default class DirectoryFormsApi extends React.PureComponent {
     if (
       formType === 'dit:directoryFormsApi:SubmissionType:export-support-service'
     ) {
+      const natureOfEnquiry = formData.nature_of_enquiry
+        ? formData.nature_of_enquiry
+        : 'ESS Inbound Enquiry'
+
       const contacts = CardUtils.getContacts(activity)
       const formattedContacts = () =>
         contacts &&
@@ -64,7 +68,7 @@ export default class DirectoryFormsApi extends React.PureComponent {
             kind="Interaction"
           />
           <ActivityCardSubject dataTest="export-support-service-name">
-            {formData.nature_of_enquiry}
+            {natureOfEnquiry}
           </ActivityCardSubject>
           <ActivityCardMetadata metadata={metadata} />
         </ActivityCardWrapper>

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -26,6 +26,7 @@ module.exports = {
     canadianCompany: require('../../../../test/sandbox/fixtures/v4/company/company-canada-province.json'),
     allActivitiesCompany: require('../../../../test/sandbox/fixtures/v4/company/company-with-all-activities.json'),
     companyWithManyContacts: require('../../../../test/sandbox/fixtures/v4/company/company-with-many-contacts.json'),
+    essNoTitle: require('../../../../test/sandbox/fixtures/v4/company/company-with-ess-interactions.json'),
   },
   contact: {
     deanCox: require('./contact/dean-cox'),

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -282,3 +282,22 @@ describe('Company activity feed', () => {
     })
   })
 })
+
+context('Export Support Service No Title', () => {
+  before(() => {
+    cy.visit(urls.companies.activity.index(fixtures.company.essNoTitle.id))
+    cy.get('[data-test="activity-feed"] select').select(
+      'dataHubAndExternalActivity'
+    )
+  })
+
+  it('Displays the ESS Inbound Enquiry support title when no title provided', () => {
+    cy.get('[data-test="export-support-service"]').within(() =>
+      cy
+        .get('[data-test="export-support-service-name"]')
+        .contains('ESS Inbound Enquiry', {
+          matchCase: false,
+        })
+    )
+  })
+})

--- a/test/sandbox/fixtures/v4/activity-feed/ess-interaction-no-title.json
+++ b/test/sandbox/fixtures/v4/activity-feed/ess-interaction-no-title.json
@@ -1,0 +1,107 @@
+{
+    "took" : 1930,
+    "timed_out" : false,
+    "_shards" : {
+      "total" : 271,
+      "successful" : 271,
+      "skipped" : 135,
+      "failed" : 0
+    },
+    "hits" : {
+      "total" : {
+        "value" : 8,
+        "relation" : "eq"
+      },
+      "max_score" : 1.3122244,
+      "hits" : [
+        {
+          "_index": "activities__feed_id_forms-api__date_2022-12-05__timestamp_1670241189__batch_id_qhcuk8sa__",
+          "_type": "_doc",
+          "_id": "dit:directoryFormsApi:Submission:146133:Create",
+          "_score": 4.4319797,
+          "_source": {
+            "actor": {
+              "dit:blackListedReason": null,
+              "dit:emailAddress": "contact@bob.com",
+              "dit:isBlacklisted": false,
+              "dit:isWhitelisted": false,
+              "id": "dit:directoryFormsApi:Sender:1111",
+              "type": "dit:directoryFormsApi:Submission:Sender"
+            },
+            "id": "dit:directoryFormsApi:Submission:1111:Create",
+            "object": {
+              "attributedTo": [
+                {
+                  "id": "dit:directoryFormsApi:SubmissionType:export-support-service",
+                  "type": "dit:directoryFormsApi:SubmissionAction:zendesk"
+                }
+              ],
+              "dit:directoryFormsApi:Submission:Data": {
+                "_custom_fields": [
+                  {
+                    "360023876777": "Test Company"
+                  },
+                  {
+                    "360026747617": "TE57 7EST"
+                  },
+                  {
+                    "1900000266233": [
+                      "financial_and_professional_services__ess_sector_l1"
+                    ]
+                  },
+                  {
+                    "1900001969653": "-"
+                  },
+                  {
+                    "1900000265733": "-"
+                  }
+                ],
+                "aaa_question": "I have a very important question that I would like help with, regarding Exporting",
+                "company_name": "Best Ever Company",
+                "company_post_code": "GL11 4DH",
+                "company_registration_number": "123456",
+                "company_turnover": "",
+                "company_type": "-",
+                "company_type_category": "-",
+                "countries": "",
+                "email": "contact@bob.com",
+                "enquiry_subject": "Test",
+                "full_name": "Test Person",
+                "how_did_you_hear_about_this_service": "-",
+                "marketing_consent": false,
+                "nature_of_enquiry": "",
+                "number_of_employees": "",
+                "on_behalf_of": "-",
+                "other_sector": "",
+                "phone": "0123456789",
+                "sectors": "Financial and professional services"
+              },
+              "dit:directoryFormsApi:Submission:Meta": {
+                "action_name": "zendesk",
+                "email_address": "test.person@test.com",
+                "full_name": "Test Person",
+                "sender": {
+                  "country_code": "",
+                  "email_address": "test.person@test.com",
+                  "ip_address": null
+                },
+                "service_name": "export_support_service",
+                "spam_control": {
+                  "contents": "I have a very important question that I would like help with, regarding Exporting, Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum."
+                },
+                "subdomain": "dit",
+                "subject": "I have an enquiry"
+              },
+              "id": "dit:directoryFormsApi:Submission:1111",
+              "published": "2022-12-02T16:48:19.344421+00:00",
+              "type": "dit:directoryFormsApi:Submission",
+              "url": "https://www.get-help-selling-goods-services-abroad.service.gov.uk/"
+            },
+            "published": "2022-12-02T16:48:19.344421+00:00",
+            "type": "Create"
+          }
+        }
+      ]
+    }
+  }
+  

--- a/test/sandbox/fixtures/v4/company/company-with-ess-interactions.json
+++ b/test/sandbox/fixtures/v4/company/company-with-ess-interactions.json
@@ -1,0 +1,124 @@
+{  
+   "id":"c79ba298-106e-4629-aa12-61ec6e2e47be",
+   "reference_code":"",
+   "name":"Best Ever Company 2",
+   "trading_name":"",
+   "trading_names":[  
+   ],
+   "uk_based":true,
+   "company_number":"BCE100001",
+   "vat_number":"",
+   "duns_number":null,
+   "created_on":"2019-01-09T09:45:06.080938Z",
+   "modified_on":"2019-01-09T09:45:06.080969Z",
+   "archived":false,
+   "archived_documents_url_path":"",
+   "archived_on":null,
+   "archived_reason":null,
+   "archived_by":null,
+   "description":"Doloribus accusamus qui non nam et earum inventore.",
+   "transferred_by":null,
+   "transferred_on":null,
+   "transferred_to":null,
+   "transfer_reason":"",
+   "website":"http://best.biz",
+   "business_type":{  
+      "name":"UK branch of foreign company (BR)",
+      "id":"b0730fc6-fcce-4071-bdab-ba8de4f4fc98"
+   },
+   "one_list_group_tier":null,
+   "contacts":[
+      {  
+         "id":"67ecb4fc-2db9-4afb-9b7b-e4736b0a2d9d",
+         "title":null,
+         "first_name":"Super",
+         "last_name":"Glue",
+         "name":"Super Glue",
+         "job_title":"DIY Expert",
+         "company":{  
+            "name":"Best Company Ever",
+            "id":"c79ba298-106e-4629-aa12-61ec6e2e47be"
+         },
+         "adviser":{  
+            "name":"DIT Staff",
+            "first_name":"DIT",
+            "last_name":"Staff",
+            "id":"1af202f6-f864-4b66-9905-5303971018be"
+         },
+         "primary":true,
+         "telephone_countrycode":"222",
+         "telephone_number":"3453454",
+         "email":"superglue@gov.uk",
+         "address_same_as_company":true,
+         "address_1":null,
+         "address_2":null,
+         "address_town":null,
+         "address_county":null,
+         "address_country":null,
+         "address_postcode":null,
+         "telephone_alternative":null,
+         "email_alternative":null,
+         "notes":null,
+         "accepts_dit_email_marketing":false,
+         "archived":false,
+         "archived_documents_url_path":"",
+         "archived_on":null,
+         "archived_reason":null,
+         "archived_by":null,
+         "created_on":"2019-02-04T15:59:14.267412Z",
+         "modified_on":"2019-02-05T13:17:23.112153Z"
+      }
+   ],
+   "employee_range":{  
+      "name":"50 to 249",
+      "id":"3fafd8d0-5d95-e211-a939-e4115bead28a"
+   },
+   "number_of_employees":null,
+   "is_number_of_employees_estimated":null,
+   "export_to_countries":[  
+
+   ],
+   "future_interest_countries":[  
+
+   ],
+   "headquarter_type":null,
+   "one_list_group_global_account_manager":null,
+   "global_headquarters":null,
+   "sector":{  
+      "name":"Biotechnology and Pharmaceuticals : Bio and Pharma Marketing and Sales : Bio and Pharma Retail",
+      "id":"70f7ffde-5f95-e211-a939-e4115bead28a"
+   },
+   "turnover_range":{  
+      "name":"£1.34 to £6.7M",
+      "id":"784cd12a-6095-e211-a939-e4115bead28a"
+   },
+   "turnover":null,
+   "is_turnover_estimated":null,
+   "uk_region":{  
+      "name":"London",
+      "id":"874cd12a-6095-e211-a939-e4115bead28a"
+   },
+   "export_experience_category":null,
+   "address": {
+      "line_1":"3 Priory Court",
+      "line_2":"Kingshill Road",
+      "town":"Dursley",
+      "county":"Gloucestershire",
+      "postcode":"GL11 4DH",
+      "country":{
+         "name":"United Kingdom",
+         "id":"80756b9a-5d95-e211-a939-e4115bead28a"
+      }
+   },
+   "registered_address": {
+      "line_1":"3 Priory Court",
+      "line_2":"Kingshill Road",
+      "town":"Dursley",
+      "county":"Gloucestershire",
+      "postcode":"GL11 4DH",
+      "country":{
+         "name":"United Kingdom",
+         "id":"80756b9a-5d95-e211-a939-e4115bead28a"
+      }
+   }
+}

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -24,6 +24,9 @@ var dataHubEvents = require('../../../fixtures/v4/activity-feed/data-hub-events.
 var aventriAttendeesAToZOrder = require('../../../fixtures/v4/activity-feed/aventri-attendees-sort-a-z.json')
 var aventriRegistrationStatusWithAggregations = require('../../../fixtures/v4/activity-feed/aventri-registration-status-with-aggregation-counts.json')
 
+//ESS Interactions
+var essInteractionsNoTitle = require('../../../fixtures/v4/activity-feed/ess-interaction-no-title.json')
+
 ////This order is correct when sorted by: First Name Z-A, Last name Z-A and Company name Z-A
 var aventriAttendeesZToAOrder = require('../../../fixtures/v4/activity-feed/aventri-attendees-sort-z-a.json')
 //All Activitiy feed events
@@ -65,6 +68,9 @@ const ALL_ACTIVITIES_PER_PAGE = 10
 const VENUS_LTD = 'dit:DataHubCompany:0f5216e0-849f-11e6-ae22-56b6b6499611'
 const BEST_EVER_COMPANY =
   'dit:DataHubCompany:c79ba298-106e-4629-aa12-61ec6e2e47ce'
+
+const BEST_EVER_COMPANY_2 =
+  'dit:DataHubCompany:c79ba298-106e-4629-aa12-61ec6e2e47be'
 
 exports.activityFeed = function (req, res) {
   // Activities by contact
@@ -290,11 +296,16 @@ exports.activityFeed = function (req, res) {
       req.body,
       "query.bool.filter.bool.should[0].bool.must[1].terms['object.attributedTo.id'][0]"
     )
-    return res.json(
-      company === BEST_EVER_COMPANY
-        ? companyActivities
-        : dataHubAndExternalActivities
-    )
+    var activities
+    if (company === BEST_EVER_COMPANY) {
+      activities = companyActivities
+    } else if (company === BEST_EVER_COMPANY_2) {
+      activities = essInteractionsNoTitle
+    } else {
+      activities = dataHubAndExternalActivities
+    }
+
+    return res.json(activities)
   }
 
   // Maxemail campaigns

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -296,14 +296,12 @@ exports.activityFeed = function (req, res) {
       req.body,
       "query.bool.filter.bool.should[0].bool.must[1].terms['object.attributedTo.id'][0]"
     )
-    var activities
-    if (company === BEST_EVER_COMPANY) {
-      activities = companyActivities
-    } else if (company === BEST_EVER_COMPANY_2) {
-      activities = essInteractionsNoTitle
-    } else {
-      activities = dataHubAndExternalActivities
-    }
+    const activities =
+      company === BEST_EVER_COMPANY
+        ? companyActivities
+        : company === BEST_EVER_COMPANY_2
+        ? essInteractionsNoTitle
+        : dataHubAndExternalActivities
 
     return res.json(activities)
   }

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -31,7 +31,7 @@ var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-creat
 var companyWithNoGlobalAccountManager = require('../../../fixtures/v4/company/company-with-no-global-account-manager.json')
 var companyWithAllActivities = require('../../../fixtures/v4/company/company-with-all-activities.json')
 var companyWithManyContacts = require('../../../fixtures/v4/company/company-with-many-contacts.json')
-var companyWithEssInteractionnoTitle = require('../../../fixtures/v4/company/company-with-ess-interactions.json')
+var companyWithEssInteractionNoTitle = require('../../../fixtures/v4/company/company-with-ess-interactions.json')
 
 var largeCapitalProfileEmpty = require('../../../fixtures/v4/company/large-capital-profile-empty.json')
 var largeCapitalProfileNew = require('../../../fixtures/v4/company/large-capital-profile-new.json')
@@ -130,7 +130,7 @@ exports.company = function (req, res) {
     'b319d019-444a-4d2f-9e76-c70f84bb22f6': companyCanadianProvince,
     'c79ba298-106e-4629-aa12-61ec6e2e47ce': companyWithAllActivities,
     '57c41268-26be-4335-a873-557e8b0deb29': companyWithManyContacts,
-    'c79ba298-106e-4629-aa12-61ec6e2e47be': companyWithEssInteractionnoTitle,
+    'c79ba298-106e-4629-aa12-61ec6e2e47be': companyWithEssInteractionNoTitle,
     'not-managed': _.assign({}, company, {
       name: 'Not Managed Company',
       id: 'not-managed',

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -31,6 +31,7 @@ var companyCreateInvestigation = require('../../../fixtures/v4/dnb/company-creat
 var companyWithNoGlobalAccountManager = require('../../../fixtures/v4/company/company-with-no-global-account-manager.json')
 var companyWithAllActivities = require('../../../fixtures/v4/company/company-with-all-activities.json')
 var companyWithManyContacts = require('../../../fixtures/v4/company/company-with-many-contacts.json')
+var companyWithEssInteractionnoTitle = require('../../../fixtures/v4/company/company-with-ess-interactions.json')
 
 var largeCapitalProfileEmpty = require('../../../fixtures/v4/company/large-capital-profile-empty.json')
 var largeCapitalProfileNew = require('../../../fixtures/v4/company/large-capital-profile-new.json')
@@ -129,6 +130,7 @@ exports.company = function (req, res) {
     'b319d019-444a-4d2f-9e76-c70f84bb22f6': companyCanadianProvince,
     'c79ba298-106e-4629-aa12-61ec6e2e47ce': companyWithAllActivities,
     '57c41268-26be-4335-a873-557e8b0deb29': companyWithManyContacts,
+    'c79ba298-106e-4629-aa12-61ec6e2e47be': companyWithEssInteractionnoTitle,
     'not-managed': _.assign({}, company, {
       name: 'Not Managed Company',
       id: 'not-managed',


### PR DESCRIPTION
## Description of change

Some ESS Interactions don't have a title, have replaced these instances with 'ESS Inbound Enquiry' instead. 

## Test instructions

Navigate to One List Corp on Dev, and you will see a list of Export Support Service Interactions, with titles like 'test' or 'ESS Inbound Enquiry'

## Screenshots

### Before
![Screenshot 2022-12-20 at 13 07 10](https://user-images.githubusercontent.com/72502389/208679491-7c9a9e86-6f35-4b13-8472-acf5b362131d.png)


### After

![Screenshot 2022-12-20 at 13 06 28](https://user-images.githubusercontent.com/72502389/208679521-042ba078-2caf-4c0a-8489-978abfc10ea5.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
