### PR TITLE
Add ID to the notification bell icon for GA purposes

### DIFF
--- a/src/client/components/NotificationAlert/index.jsx
+++ b/src/client/components/NotificationAlert/index.jsx
@@ -46,7 +46,11 @@ const NotificationAlert = ({ count, hasFeatureGroup }) =>
       }}
     >
       {() => (
-        <StyledNotificationAlertNavLink as="a" href={urls.reminders.index()}>
+        <StyledNotificationAlertNavLink
+          as="a"
+          href={urls.reminders.index()}
+          id="notification-bell-count"
+        >
           <StyledImage
             src={BellSVG}
             alt="An image of a bell with the notification count overlaid"


### PR DESCRIPTION
## Description of change
We need to track how many users are clicking the notification bell icon for reporting purposes.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
