### PR TITLE
Feature/rr 808 add vertical line conditional revealed qus

### DIFF
--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -3,21 +3,20 @@ import PropTypes from 'prop-types'
 import Radio from '@govuk-react/radio'
 import MultiChoice from '@govuk-react/multi-choice'
 import styled from 'styled-components'
-import InsetText from '@govuk-react/inset-text'
 import { kebabCase } from 'lodash'
 
+import { BORDER_WIDTH } from '@govuk-react/constants'
 import { useField } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
 
-const StyledInsetText = styled(InsetText)`
-  border-left: 5px solid #bfc1c3;
-  padding-left: 0px;
+import { MID_GREY } from '../../../../utils/colors'
+
+const ChildContainer = styled('div')`
+  border-left: ${BORDER_WIDTH} solid ${MID_GREY};
   margin-left: 17px;
-  padding-inline: 1px;
 `
 const StyledChildField = styled('div')`
-  margin-left: 55px;
-  clear: both;
+  margin-left: 35px;
 `
 
 const StyledRadio = styled(Radio)`
@@ -79,9 +78,9 @@ const FieldRadios = ({
               </StyledRadio>
 
               {value === optionValue && optionChildren && (
-                <StyledInsetText>
+                <ChildContainer>
                   <StyledChildField>{optionChildren}</StyledChildField>
-                </StyledInsetText>
+                </ChildContainer>
               )}
             </React.Fragment>
           )

--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Radio from '@govuk-react/radio'
 import MultiChoice from '@govuk-react/multi-choice'
 import styled from 'styled-components'
-import InsetText from 'govuk-react/inset-text'
+import InsetText from 'govuk-react'
 import { kebabCase } from 'lodash'
 
 import { useField } from '../../hooks'

--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import Radio from '@govuk-react/radio'
 import MultiChoice from '@govuk-react/multi-choice'
 import styled from 'styled-components'
-import InsetText from 'govuk-react'
+import InsetText from '@govuk-react/inset-text'
 import { kebabCase } from 'lodash'
 
 import { useField } from '../../hooks'

--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -3,11 +3,18 @@ import PropTypes from 'prop-types'
 import Radio from '@govuk-react/radio'
 import MultiChoice from '@govuk-react/multi-choice'
 import styled from 'styled-components'
+import InsetText from 'govuk-react/inset-text'
 import { kebabCase } from 'lodash'
 
 import { useField } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
 
+const StyledInsetText = styled(InsetText)`
+  border-left: 5px solid #bfc1c3;
+  padding-left: 0px;
+  margin-left: 17px;
+  padding-inline: 1px;
+`
 const StyledChildField = styled('div')`
   margin-left: 55px;
   clear: both;
@@ -72,7 +79,9 @@ const FieldRadios = ({
               </StyledRadio>
 
               {value === optionValue && optionChildren && (
-                <StyledChildField>{optionChildren}</StyledChildField>
+                <StyledInsetText>
+                  <StyledChildField>{optionChildren}</StyledChildField>
+                </StyledInsetText>
               )}
             </React.Fragment>
           )


### PR DESCRIPTION
## Description of change

Adding an Vertical line in the Conditionally revealed questions

## Test instructions

In the conditional revealed questions for Estimate Land date and  No recent Interaction reminders should see Vertical line on the left side.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/74972011/209093547-2255096c-a332-4a43-9a8a-2deea378981e.png)
![image](https://user-images.githubusercontent.com/74972011/209093574-39e7b13d-4285-475c-9270-ad78828d5bde.png)


### After

![image](https://user-images.githubusercontent.com/74972011/209300699-841b46e9-63b4-48fd-94d1-ff7e65f57066.png)
![image](https://user-images.githubusercontent.com/74972011/209300725-b876ddbc-10c3-4987-b835-644873dc8fb2.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
