### PR TITLE
Removes the /reminders redirect

### DIFF
--- a/src/client/components/NotificationAlert/index.jsx
+++ b/src/client/components/NotificationAlert/index.jsx
@@ -8,7 +8,6 @@ import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import { ID, TASK_GET_NOTIFICATION_ALERT_COUNT, state2props } from './state'
 import { NOTIFICATION_ALERT_COUNT__LOADED } from '../../actions'
 import Task from '../Task'
-import urls from '../../../lib/urls'
 import BellSVG from './bell-icon.svg'
 
 const StyledNotificationAlertNavLink = styled(NavLink)({})
@@ -35,7 +34,7 @@ const StyledImage = styled('img')({
   verticalAlign: 'sub',
 })
 
-const NotificationAlert = ({ count, hasFeatureGroup }) =>
+const NotificationAlert = ({ count, remindersURL, hasFeatureGroup }) =>
   hasFeatureGroup ? (
     <Task.Status
       name={TASK_GET_NOTIFICATION_ALERT_COUNT}
@@ -48,7 +47,7 @@ const NotificationAlert = ({ count, hasFeatureGroup }) =>
       {() => (
         <StyledNotificationAlertNavLink
           as="a"
-          href={urls.reminders.index()}
+          href={remindersURL}
           id="notification-bell-count"
         >
           <StyledImage

--- a/src/client/components/NotificationAlert/state.js
+++ b/src/client/components/NotificationAlert/state.js
@@ -1,13 +1,27 @@
+import urls from '../../../lib/urls'
+
 export const ID = 'notificationAlertCount'
 export const TASK_GET_NOTIFICATION_ALERT_COUNT =
   'TASK_GET_NOTIFICATION_ALERT_COUNT'
 
 export const state2props = (state) => {
-  const activeFeatureGroups = state?.activeFeatureGroups || []
+  const activeFeatureGroups = state.activeFeatureGroups
+  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+    'investment-notifications'
+  )
+  const hasExportFeatureGroup = activeFeatureGroups.includes(
+    'export-notifications'
+  )
+  const remindersURL =
+    hasInvestmentFeatureGroup && hasExportFeatureGroup
+      ? urls.reminders.investments.estimatedLandDate()
+      : hasInvestmentFeatureGroup
+      ? urls.reminders.investments.estimatedLandDate()
+      : urls.reminders.exports.noRecentInteractions()
+
   return {
     ...state[ID],
-    hasFeatureGroup:
-      activeFeatureGroups.includes('investment-notifications') ||
-      activeFeatureGroups.includes('export-notifications'),
+    remindersURL,
+    hasFeatureGroup: hasInvestmentFeatureGroup || hasExportFeatureGroup,
   }
 }

--- a/src/client/modules/Reminders/RemindersRoutes.jsx
+++ b/src/client/modules/Reminders/RemindersRoutes.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useRouteMatch, Redirect, Switch, Route } from 'react-router-dom'
+import { useRouteMatch, Switch, Route } from 'react-router-dom'
 import { RemindersLists, RemindersSettings, RemindersForms } from '.'
 
 const RemindersRoutes = () => {
@@ -12,11 +12,6 @@ const RemindersRoutes = () => {
       <Route path={`${path}/settings/:reminderType`}>
         <RemindersForms />
       </Route>
-      <Redirect
-        exact={true}
-        from={path}
-        to={`${path}/investments-estimated-land-dates`}
-      />
       <Route path={`${path}/:reminderType`}>
         <RemindersLists />
       </Route>

--- a/test/functional/cypress/specs/reminders/notification-bell-spec.js
+++ b/test/functional/cypress/specs/reminders/notification-bell-spec.js
@@ -38,4 +38,27 @@ describe('Notification bell', () => {
       assertNotificationBadgeNotExist()
     })
   })
+  context('Linking to a list of notifications', () => {
+    it('should link to "Estimated land date" when both feature groups are set', () => {
+      cy.setUserFeatureGroups([
+        'investment-notifications',
+        'export-notifications',
+      ])
+      cy.visit(urls.dashboard())
+      cy.get('[data-test="notification-alert-badge"]').click()
+      cy.url().should('include', urls.reminders.investments.estimatedLandDate())
+    })
+    it('should link to "Estimated land date" when only "investment-notifications" is set', () => {
+      cy.setUserFeatureGroups(['investment-notifications'])
+      cy.visit(urls.dashboard())
+      cy.get('[data-test="notification-alert-badge"]').click()
+      cy.url().should('include', urls.reminders.investments.estimatedLandDate())
+    })
+    it('should link to "Companies no recent interaction" when only "export-notifications" is set', () => {
+      cy.setUserFeatureGroups(['export-notifications'])
+      cy.visit(urls.dashboard())
+      cy.get('[data-test="notification-alert-badge"]').click()
+      cy.url().should('include', urls.reminders.exports.noRecentInteractions())
+    })
+  })
 })


### PR DESCRIPTION
## Description of change
Removes the redirect from `/reminders` to `/reminders/investments-estimated-land-dates`. The reminders URL is now determined by looking at the user group features and applying basic logic.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
