### PR TITLE
Modify Investment - Edit Large Capital Profile form layout

### DIFF
--- a/src/apps/companies/apps/investments/large-capital-profile/client/EditLargeCapitalInvestorDetails.jsx
+++ b/src/apps/companies/apps/investments/large-capital-profile/client/EditLargeCapitalInvestorDetails.jsx
@@ -8,6 +8,7 @@ import {
   FieldInput,
   FieldTextarea,
   FieldRadios,
+  FormLayout,
 } from '../../../../../../client/components'
 import {
   transformIdNameToValueLabel,
@@ -17,6 +18,7 @@ import {
 
 import { InvestorCheckDetails } from './InvestorCheckDetails'
 import { TASK_SAVE_LARGE_CAPITAL_INVESTOR_DETAILS } from './state'
+import { FORM_LAYOUT } from '../../../../../../common/constants'
 
 const InvestorDescriptionHint = () => (
   <>
@@ -47,71 +49,75 @@ const EditLargeCapitalInvestorDetails = ({
   )?.value
 
   return (
-    <Form
-      id="edit-large-capital-investor-details"
-      analyticsFormName="editLargeCapitalInvestorDetails"
-      cancelButtonLabel="Return without saving"
-      cancelRedirectTo={() =>
-        urls.companies.investments.largeCapitalProfile(companyId)
-      }
-      flashMessage={() => 'Investor details changes saved'}
-      submitButtonLabel="Save and return"
-      submissionTaskName={TASK_SAVE_LARGE_CAPITAL_INVESTOR_DETAILS}
-      redirectTo={() =>
-        urls.companies.investments.largeCapitalProfile(companyId)
-      }
-      transformPayload={(values) =>
-        transformInvestorDetailsToApi({ profileId, companyId, values })
-      }
-    >
-      {() => (
-        <>
-          <FieldTypeahead
-            name="investor_type"
-            label="Investor type"
-            initialValue={transformObjectToValueLabel(investorType)}
-            options={transformIdNameToValueLabel(investorType?.items)}
-            placeholder="Please select an investor type"
-            arial-label="Select an investor type"
-          />
-          <FieldInput
-            name="global_assets_under_management"
-            label="Global assets under management"
-            initialValue={globalAssetsUnderManagement?.value?.toString()}
-            type="text"
-            hint="Enter value in US dollars"
-          />
-          <FieldInput
-            name="investable_capital"
-            label="Investable capital"
-            initialValue={investableCapital?.value?.toString()}
-            type="text"
-            hint="Enter value in US dollars"
-          />
-          <FieldTextarea
-            name="investor_notes"
-            label="Investor description"
-            initialValue={investorDescription?.value}
-            type="text"
-            hint={<InvestorDescriptionHint />}
-          />
-          <FieldRadios
-            legend="Has this investor cleared the required checks within the last 12 months?"
-            name="required_checks"
-            initialValue={requiredChecksCheckedValue}
-            options={Object.values(requiredChecks).map((option) => ({
-              label: option.text,
-              value: option.value,
-              ...((option.text === OPTION_CLEARED ||
-                option.text === OPTION_ISSUES_IDENTIFIED) && {
-                children: <InvestorCheckDetails {...option} />,
-              }),
-            }))}
-            inline={false}
-          />
-        </>
-      )}
-    </Form>
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+      <Form
+        id="edit-large-capital-investor-details"
+        analyticsFormName="editLargeCapitalInvestorDetails"
+        cancelButtonLabel="Return without saving"
+        cancelRedirectTo={() =>
+          urls.companies.investments.largeCapitalProfile(companyId)
+        }
+        flashMessage={() => 'Investor details changes saved'}
+        submitButtonLabel="Save and return"
+        submissionTaskName={TASK_SAVE_LARGE_CAPITAL_INVESTOR_DETAILS}
+        redirectTo={() =>
+          urls.companies.investments.largeCapitalProfile(companyId)
+        }
+        transformPayload={(values) =>
+          transformInvestorDetailsToApi({ profileId, companyId, values })
+        }
+      >
+        {() => (
+          <>
+            <FieldTypeahead
+              name="investor_type"
+              label="Investor type"
+              initialValue={transformObjectToValueLabel(investorType)}
+              options={transformIdNameToValueLabel(investorType?.items)}
+              placeholder="Please select an investor type"
+              arial-label="Select an investor type"
+            />
+            <FormLayout setWidth={FORM_LAYOUT.TWO_THIRDS}>
+              <FieldInput
+                name="global_assets_under_management"
+                label="Global assets under management"
+                initialValue={globalAssetsUnderManagement?.value?.toString()}
+                type="text"
+                hint="Enter value in US dollars"
+              />
+              <FieldInput
+                name="investable_capital"
+                label="Investable capital"
+                initialValue={investableCapital?.value?.toString()}
+                type="text"
+                hint="Enter value in US dollars"
+              />
+            </FormLayout>
+            <FieldTextarea
+              name="investor_notes"
+              label="Investor description"
+              initialValue={investorDescription?.value}
+              type="text"
+              hint={<InvestorDescriptionHint />}
+            />
+            <FieldRadios
+              legend="Has this investor cleared the required checks within the last 12 months?"
+              name="required_checks"
+              initialValue={requiredChecksCheckedValue}
+              options={Object.values(requiredChecks).map((option) => ({
+                label: option.text,
+                value: option.value,
+                ...((option.text === OPTION_CLEARED ||
+                  option.text === OPTION_ISSUES_IDENTIFIED) && {
+                  children: <InvestorCheckDetails {...option} />,
+                }),
+              }))}
+              inline={false}
+            />
+          </>
+        )}
+      </Form>
+    </FormLayout>
   )
 }
 

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -29,7 +29,11 @@ const OPTIONS_YES_NO = [
   { label: 'No', value: OPTION_NO },
 ]
 
-const FORM_LAYOUT = { THREE_QUARTERS: 'three-quarters', ONE_THIRD: 'one-third' }
+const FORM_LAYOUT = {
+  THREE_QUARTERS: 'three-quarters',
+  ONE_THIRD: 'one-third',
+  TWO_THIRDS: 'two-thirds',
+}
 
 const METHOD_PATCH = 'PATCH'
 const METHOD_POST = 'POST'


### PR DESCRIPTION
## Description of change

Changing `Edit Investment Large Capital Profile form from full width into one-third/two-thirds of screen layout. To make it the form to be shorter and easily read what was entered.

## Test instructions

- Navigate into `Companies` from DH navigation header
- Select one Company from collection list
- From Company details, click `Investment` tab then `Large capital profile`
- Select `Investors details` accordion then click `Edit` button


## Screenshots

### Before

![image](https://user-images.githubusercontent.com/28296624/209953572-2f2b3b66-c068-4d46-81c3-c8748d7fdf74.png)

### After

![image](https://user-images.githubusercontent.com/28296624/209966107-acda01e1-0d48-4c0a-9c57-dab6750f3f12.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
