### PR TITLE
Update form layout

### DIFF
--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { FieldInput, FormLayout } from '../../../client/components'
 import Form from '../../../client/components/Form'
-import FORM_LAYOUT from '../../../../../common/constants'
+import { FORM_LAYOUT } from '../../../common/constants'
 
 const CreateListForm = ({
   id,

--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { FieldInput } from '../../../client/components'
+import { FieldInput, FormLayout } from '../../../client/components'
 import Form from '../../../client/components/Form'
+import FORM_LAYOUT from '../../../../../common/constants'
 
 const CreateListForm = ({
   id,
@@ -12,35 +13,37 @@ const CreateListForm = ({
   maxLength,
   csrfToken,
 }) => (
-  <Form
-    id="create-list-form"
-    submissionTaskName="Create list"
-    analyticsFormName="create-list-form"
-    redirectTo={() => cancelUrl}
-    flashMessage={() => 'Company list created'}
-    submitButtonLabel="Create list"
-    cancelRedirectTo={() => cancelUrl}
-    transformPayload={(values) => ({
-      id,
-      values,
-      csrfToken,
-    })}
-  >
-    {() => (
-      <FieldInput
-        name={name}
-        type="text"
-        label={label}
-        required="Enter a name for your list"
-        hint={hint}
-        validate={(value) =>
-          value && value.length > maxLength
-            ? `Enter list name which is no longer than ${maxLength} characters`
-            : null
-        }
-      />
-    )}
-  </Form>
+  <FormLayout setWidth={FORM_LAYOUT.ONE_THIRD}>
+    <Form
+      id="create-list-form"
+      submissionTaskName="Create list"
+      analyticsFormName="create-list-form"
+      redirectTo={() => cancelUrl}
+      flashMessage={() => 'Company list created'}
+      submitButtonLabel="Create list"
+      cancelRedirectTo={() => cancelUrl}
+      transformPayload={(values) => ({
+        id,
+        values,
+        csrfToken,
+      })}
+    >
+      {() => (
+        <FieldInput
+          name={name}
+          type="text"
+          label={label}
+          required="Enter a name for your list"
+          hint={hint}
+          validate={(value) =>
+            value && value.length > maxLength
+              ? `Enter list name which is no longer than ${maxLength} characters`
+              : null
+          }
+        />
+      )}
+    </Form>
+  </FormLayout>
 )
 
 CreateListForm.propTypes = {

--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -13,7 +13,7 @@ const CreateListForm = ({
   maxLength,
   csrfToken,
 }) => (
-  <FormLayout setWidth={FORM_LAYOUT.ONE_THIRD}>
+  <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
     <Form
       id="create-list-form"
       submissionTaskName="Create list"


### PR DESCRIPTION
## Description of change

Navigate to Companies--> Select Any Company-->Click View Options--> Add or remove lists-->Create a list--> Create a list form from full to two-thirds width.

## Test instructions

Full Form Width is reduced to three widths

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/74972011/210059996-5c02ef37-a248-458d-935e-62246d5c1f41.png)

### After

![image](https://user-images.githubusercontent.com/74972011/210059973-f1f27d8a-3b36-4298-8629-86ffcd9d523e.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
