### PR TITLE
Disable telemetry for Storybook

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,5 +15,6 @@ module.exports = {
   },
   core: {
     builder: 'webpack5',
+    disableTelemetry: true,
   },
 }


### PR DESCRIPTION
## Description of change

Storybook have added a new telemetry feature which sends them data from our local sessions. This PR disables this functionality.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
