### PR TITLE
Use additional SSH key for publishing storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,6 +180,9 @@ jobs:
       - image: node:18.7.0-buster
     steps:
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "0b:88:e7:46:60:b5:25:b1:fb:10:49:1b:8d:7f:c7:b0"
       - run: npm install storybook
       - run:
           name: Release storybook
@@ -266,6 +269,7 @@ workflows:
             branches:
               only:
                 - main
+                - ssh-key-circleci
       - merge-and-publish-coverage:
           <<: *ignore_ghpages
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,6 @@ workflows:
             branches:
               only:
                 - main
-                - ssh-key-circleci
       - merge-and-publish-coverage:
           <<: *ignore_ghpages
           requires:


### PR DESCRIPTION
## Description of change

The datahub frontend was using a user key from github inside the circle ci deployment to publish storybook updates to the gh-branch. This change will instead use an additional SSH key as described https://circleci.com/docs/add-ssh-key/#adding-ssh-keys-to-a-job


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
