### PR TITLE
Add export segment and export subsegment filters to Company Collectio…

### DIFF
--- a/src/apps/companies/apps/edit-company/client/constants.js
+++ b/src/apps/companies/apps/edit-company/client/constants.js
@@ -2,6 +2,7 @@ export const export_segments = [
   { value: 'hep', label: 'High export potential' },
   { value: 'non-hep', label: 'Not high export potential' },
 ]
+
 export const export_sub_segments = [
   { value: 'sustain_nurture_and_grow', label: 'Sustain: nurture & grow' },
   {

--- a/src/client/modules/Companies/CollectionList/constants.js
+++ b/src/client/modules/Companies/CollectionList/constants.js
@@ -10,6 +10,8 @@ export const LABELS = {
   companyStatus: 'Status',
   currentlyExportingTo: 'Currently exporting to',
   futureCountriesOfInterest: 'Future countries of interest',
+  exportSegment: 'Export Segment',
+  exportSubsegment: 'Export Subsegment',
   lastInteractionAfter: 'Last interaction from',
   lastInteractionBefore: 'Last interaction to',
   leadItaOrGlobalAccountManager: 'Lead ITA or global account manager',

--- a/src/client/modules/Companies/CollectionList/filters.js
+++ b/src/client/modules/Companies/CollectionList/filters.js
@@ -1,4 +1,8 @@
 import {
+  export_segments,
+  export_sub_segments,
+} from '../../../../apps/companies/apps/edit-company/client/constants'
+import {
   buildDatesFilter,
   buildOptionsFilter,
   buildInputFieldFilter,
@@ -118,5 +122,21 @@ export const buildSelectedFilters = (
       value: advisers.id,
       categoryLabel: LABELS.leadItaOrGlobalAccountManager,
     })),
+  },
+  exportSegment: {
+    queryParam: 'export_segment',
+    options: buildOptionsFilter({
+      options: export_segments,
+      value: queryParams.export_segment,
+      categoryLabel: LABELS.exportSegment,
+    }),
+  },
+  exportSubsegment: {
+    queryParam: 'export_sub_segment',
+    options: buildOptionsFilter({
+      options: export_sub_segments,
+      value: queryParams.export_sub_segment,
+      categoryLabel: LABELS.exportSubsegment,
+    }),
   },
 })

--- a/src/client/modules/Companies/CollectionList/index.jsx
+++ b/src/client/modules/Companies/CollectionList/index.jsx
@@ -33,6 +33,10 @@ import {
 } from './state'
 
 import { sanitizeFilter } from '../../../../client/filters'
+import {
+  export_segments,
+  export_sub_segments,
+} from '../../../../apps/companies/apps/edit-company/client/constants'
 
 const CompaniesCollection = ({
   payload,
@@ -252,6 +256,26 @@ const CompaniesCollection = ({
                 selectedFilters.futureCountriesOfInterest.options
               }
               data-test="future-countries-of-interest-filter"
+            />
+            <Filters.Typeahead
+              isMulti={true}
+              label={LABELS.exportSegment}
+              name="export_segment"
+              qsParam="export_segment"
+              placeholder="Search export segment"
+              options={export_segments}
+              selectedOptions={selectedFilters.exportSegment.options}
+              data-test="export-segment-filter"
+            />
+            <Filters.Typeahead
+              isMulti={true}
+              label={LABELS.exportSubsegment}
+              name="export_sub_segment"
+              qsParam="export_sub_segment"
+              placeholder="Search export subsegment"
+              options={export_sub_segments}
+              selectedOptions={selectedFilters.exportSubsegment.options}
+              data-test="export-sub-segment-filter"
             />
           </FilterToggleSection>
         </CollectionFilters>

--- a/src/client/modules/Companies/CollectionList/tasks.js
+++ b/src/client/modules/Companies/CollectionList/tasks.js
@@ -30,6 +30,8 @@ const getCompanies = ({
   latest_interaction_date_before,
   latest_interaction_date_after,
   one_list_group_global_account_manager,
+  export_segment,
+  export_sub_segment,
   sortby = 'modified_on:desc',
 }) => {
   const administrativeAreas = [...us_state, ...canadian_province]
@@ -50,6 +52,8 @@ const getCompanies = ({
       latest_interaction_date_before,
       latest_interaction_date_after,
       one_list_group_global_account_manager,
+      export_segment,
+      export_sub_segment,
       sortby,
     })
     .then(({ data }) => transformResponseToCompanyCollection(data))

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -631,6 +631,108 @@ describe('Companies Collections Filter', () => {
       assertFieldEmpty(element)
     })
   })
+  context('Export segment', () => {
+    const element = '[data-test="export-segment-filter"]'
+    const segmentValue = 'hep'
+    const expectedPayload = {
+      offset: 0,
+      limit: 10,
+      archived: false,
+      sortby: 'modified_on:desc',
+      export_segment: [segmentValue],
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        export_segment: [segmentValue],
+      })
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`/companies?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      cy.get(element).should('contain', 'High export potential')
+      assertChipExists({ label: 'Active', position: 1 })
+      assertChipExists({ label: 'High export potential', position: 2 })
+    })
+
+    it('should filter from user input and remove chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`/companies?${queryString}`)
+      cy.wait('@apiRequest')
+
+      cy.get('[data-test="toggle-section-button"]')
+        .contains('Company activity details')
+        .click()
+      testTypeahead({
+        element,
+        label: 'Export Segment',
+        placeholder: 'Search export segment',
+        input: 'high',
+        expectedOption: 'High export potential',
+      })
+      assertPayload('@apiRequest', expectedPayload)
+      assertQueryParams('export_segment', [segmentValue])
+      assertChipExists({ label: 'Active', position: 1 })
+      assertChipExists({ label: 'High export potential', position: 2 })
+      removeChip(segmentValue)
+      cy.wait('@apiRequest')
+      removeChip(activeStatusFlag)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+      assertFieldEmpty(element)
+    })
+  })
+  context('Export subsegment', () => {
+    const element = '[data-test="export-sub-segment-filter"]'
+    const subSegmentValue = 'sustain_nurture_and_grow'
+    const expectedPayload = {
+      offset: 0,
+      limit: 10,
+      archived: false,
+      sortby: 'modified_on:desc',
+      export_sub_segment: [subSegmentValue],
+    }
+
+    it('should filter from the url', () => {
+      const queryString = buildQueryString({
+        export_sub_segment: [subSegmentValue],
+      })
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`/companies?${queryString}`)
+      assertPayload('@apiRequest', expectedPayload)
+      cy.get(element).should('contain', 'Sustain: nurture & grow')
+      assertChipExists({ label: 'Active', position: 1 })
+      assertChipExists({ label: 'Sustain: nurture & grow', position: 2 })
+    })
+
+    it('should filter from user input and remove chips', () => {
+      const queryString = buildQueryString()
+      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.visit(`/companies?${queryString}`)
+      cy.wait('@apiRequest')
+
+      cy.get('[data-test="toggle-section-button"]')
+        .contains('Company activity details')
+        .click()
+      testTypeahead({
+        element,
+        label: 'Export Subsegment',
+        placeholder: 'Search export subsegment',
+        input: 'sust',
+        expectedOption: 'Sustain: nurture & grow',
+      })
+      assertPayload('@apiRequest', expectedPayload)
+      assertQueryParams('export_sub_segment', [subSegmentValue])
+      assertChipExists({ label: 'Active', position: 1 })
+      assertChipExists({ label: 'Sustain: nurture & grow', position: 2 })
+      removeChip(subSegmentValue)
+      cy.wait('@apiRequest')
+      removeChip(activeStatusFlag)
+      assertPayload('@apiRequest', minimumPayload)
+      assertChipsEmpty()
+      assertFieldEmpty(element)
+    })
+  })
 
   context('Last interaction dates', () => {
     const fromElement = '[data-test="last-interaction-after-filter"]'


### PR DESCRIPTION
## Description of change

We have added two new filters to the Company Collection List. Users will now be able to filter on export segment and export subsegment.
This is linked to an API PR: https://github.com/uktrade/data-hub-api/pull/4434

## Test instructions
- Get this branch up locally
- Visit the[ Company Collection List]( http://localhost:3000/companies )
- Open the Company activity details filter tab
- Filter by export segment and/or export subsegment 

## Screenshots

### Before

<img width="393" alt="image" src="https://user-images.githubusercontent.com/83657534/212090999-2151641b-ec77-474e-a79b-f7d2c06eb2a9.png">


### After

<img width="336" alt="image" src="https://user-images.githubusercontent.com/83657534/212091088-592d3d27-b06c-434d-8997-30cd4eb02558.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
