### PR TITLE
bugfix/RR-819 delete reminders flicker

### DIFF
--- a/src/client/modules/Reminders/InvestmentsEstimatedLandDatesList.jsx
+++ b/src/client/modules/Reminders/InvestmentsEstimatedLandDatesList.jsx
@@ -91,7 +91,7 @@ const InvestmentsEstimatedLandDatesList = ({ estimatedLandDateReminders }) => {
                   <CollectionList
                     results={results}
                     itemRenderer={InvestmentItemRenderer}
-                    disableDelete={nextPending}
+                    disableDelete={deleteTask.status || nextPending}
                     onDeleteReminder={(reminderId) => {
                       deleteTask.start({
                         payload: { id: reminderId },

--- a/src/client/modules/Reminders/ItemRenderers/ExportItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/ExportItemRenderer.jsx
@@ -3,73 +3,23 @@ import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
-import { BLACK, GREY_1, GREY_2 } from 'govuk-colours'
-import { H3 } from '@govuk-react/heading'
 import {
-  SPACING,
-  FONT_SIZE,
-  FONT_WEIGHTS,
-  HEADING_SIZES,
-  MEDIA_QUERIES,
-} from '@govuk-react/constants'
+  DeleteButton,
+  RightCol,
+  ListItem,
+  ItemHeader,
+  ItemContent,
+} from './styled'
+import { BLACK, GREY_1 } from 'govuk-colours'
+import { FONT_WEIGHTS } from '@govuk-react/constants'
 
 import { formatMediumDate } from '../../../utils/date'
 import { DARK_GREY } from '../../../utils/colors'
 import { INTERACTION_NAMES } from '../constants'
 import urls from '../../../../lib/urls'
 
-const Button = styled('button')({
-  padding: 0,
-  background: 'transparent',
-  border: 'none',
-  fontSize: FONT_SIZE.SIZE_16,
-  fontFamily: 'inherit',
-  color: DARK_GREY,
-  cursor: 'pointer',
-  textDecoration: 'underline',
-})
-
-const DeleteButton = styled(Button)({
-  display: ({ isMobile }) => (isMobile ? 'inline' : 'none'),
-  marginBottom: SPACING.SCALE_4,
-  [MEDIA_QUERIES.TABLET]: {
-    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
-    margin: `${SPACING.SCALE_3} 0`,
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
-    margin: `${SPACING.SCALE_3} 0`,
-  },
-})
-
-const RightCol = styled(GridCol)({
-  display: 'none',
-  textAlign: 'right',
-  [MEDIA_QUERIES.TABLET]: {
-    display: 'block',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'block',
-  },
-})
-
-const ListItem = styled('li')({
-  borderBottom: `solid 1px ${GREY_2}`,
-})
-
-const ItemHeader = styled(H3)({
-  fontSize: HEADING_SIZES.SMALL,
-  marginTop: SPACING.SCALE_3,
-  marginBottom: SPACING.SCALE_4,
-})
-
 const ItemHeaderLink = styled(Link)({
   fontWeight: FONT_WEIGHTS.regular,
-})
-
-const ItemContent = styled('div')({
-  color: ({ colour }) => colour,
-  marginBottom: SPACING.SCALE_3,
 })
 
 const ItemHint = styled('span')({
@@ -143,11 +93,12 @@ const ExportItemRenderer = (item, onDeleteReminder, disableDelete) => (
               </ul>
             </ItemContent>
             {/* Display on mobile only */}
-            {onDeleteReminder && !disableDelete && (
+            {onDeleteReminder && (
               <DeleteButton
                 isMobile={true}
                 data-test="delete-button"
                 onClick={() => onDeleteReminder(item.id)}
+                disabled={disableDelete}
               >
                 Delete reminder
               </DeleteButton>
@@ -156,14 +107,13 @@ const ExportItemRenderer = (item, onDeleteReminder, disableDelete) => (
           {/* Display on Tablet and Desktop only */}
           {onDeleteReminder && (
             <RightCol setWidth="one-quarter">
-              {!disableDelete && (
-                <DeleteButton
-                  data-test="delete-button"
-                  onClick={() => onDeleteReminder(item.id)}
-                >
-                  Delete reminder
-                </DeleteButton>
-              )}
+              <DeleteButton
+                data-test="delete-button"
+                onClick={() => onDeleteReminder(item.id)}
+                disabled={disableDelete}
+              >
+                Delete reminder
+              </DeleteButton>
             </RightCol>
           )}
         </>

--- a/src/client/modules/Reminders/ItemRenderers/InvestmentItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/InvestmentItemRenderer.jsx
@@ -2,75 +2,19 @@ import React from 'react'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import { Link } from 'govuk-react'
-import styled from 'styled-components'
-import { BLACK, GREY_2 } from 'govuk-colours'
-import { H3 } from '@govuk-react/heading'
 import {
-  SPACING,
-  FONT_SIZE,
-  HEADING_SIZES,
-  MEDIA_QUERIES,
-} from '@govuk-react/constants'
+  DeleteButton,
+  RightCol,
+  ListItem,
+  ItemHeader,
+  ItemContent,
+  ItemFooter,
+} from './styled'
+import { BLACK } from 'govuk-colours'
 
 import { formatMediumDate } from '../../../utils/date'
 import { DARK_GREY } from '../../../utils/colors'
 import urls from '../../../../lib/urls'
-
-const Button = styled('button')({
-  padding: 0,
-  background: 'transparent',
-  border: 'none',
-  fontSize: FONT_SIZE.SIZE_16,
-  fontFamily: 'inherit',
-  color: DARK_GREY,
-  cursor: 'pointer',
-  textDecoration: 'underline',
-})
-
-const DeleteButton = styled(Button)({
-  display: ({ isMobile }) => (isMobile ? 'inline' : 'none'),
-  marginBottom: SPACING.SCALE_4,
-  [MEDIA_QUERIES.TABLET]: {
-    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
-    margin: `${SPACING.SCALE_3} 0`,
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
-    margin: `${SPACING.SCALE_3} 0`,
-  },
-})
-
-const RightCol = styled(GridCol)({
-  display: 'none',
-  textAlign: 'right',
-  [MEDIA_QUERIES.TABLET]: {
-    display: 'block',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'block',
-  },
-})
-
-const ListItem = styled('li')({
-  borderBottom: `solid 1px ${GREY_2}`,
-})
-
-const ItemHeader = styled(H3)({
-  fontSize: HEADING_SIZES.SMALL,
-  marginTop: SPACING.SCALE_3,
-  marginBottom: SPACING.SCALE_4,
-})
-
-const ItemContent = styled('div')({
-  color: ({ colour }) => colour,
-  marginBottom: SPACING.SCALE_3,
-})
-
-const ItemFooter = styled('div')({
-  color: DARK_GREY,
-  fontSize: FONT_SIZE.SIZE_16,
-  marginBottom: SPACING.SCALE_4,
-})
 
 const InvestmentItemRenderer = (item, onDeleteReminder, disableDelete) => (
   <ListItem key={item.id} data-test="reminders-list-item">
@@ -101,11 +45,12 @@ const InvestmentItemRenderer = (item, onDeleteReminder, disableDelete) => (
               Project code {item.project.project_code}
             </ItemFooter>
             {/* Display on mobile only */}
-            {onDeleteReminder && !disableDelete && (
+            {onDeleteReminder && (
               <DeleteButton
                 isMobile={true}
                 data-test="delete-button"
                 onClick={() => onDeleteReminder(item.id)}
+                disabled={disableDelete}
               >
                 Delete reminder
               </DeleteButton>
@@ -114,14 +59,13 @@ const InvestmentItemRenderer = (item, onDeleteReminder, disableDelete) => (
           {/* Display on Tablet and Desktop only */}
           {onDeleteReminder && (
             <RightCol setWidth="one-quarter">
-              {!disableDelete && (
-                <DeleteButton
-                  data-test="delete-button"
-                  onClick={() => onDeleteReminder(item.id)}
-                >
-                  Delete reminder
-                </DeleteButton>
-              )}
+              <DeleteButton
+                data-test="delete-button"
+                onClick={() => onDeleteReminder(item.id)}
+                disabled={disableDelete}
+              >
+                Delete reminder
+              </DeleteButton>
             </RightCol>
           )}
         </>

--- a/src/client/modules/Reminders/ItemRenderers/InvestmentOPListItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/InvestmentOPListItemRenderer.jsx
@@ -1,44 +1,27 @@
 import React from 'react'
-import { SPACING, FONT_SIZE, HEADING_SIZES } from '@govuk-react/constants'
-import { GREY_2 } from 'govuk-colours'
+import { SPACING } from '@govuk-react/constants'
 import GridRow from '@govuk-react/grid-row'
 import GridCol from '@govuk-react/grid-col'
 import styled from 'styled-components'
+import { ListItem, ItemHeader, ItemFooter } from './styled'
 import { Link } from 'govuk-react'
 
 import { DATE_DAY_LONG_FORMAT } from '../../../../common/constants'
-import { DARK_GREY } from '../../../utils/colors'
 import { format } from '../../../utils/date'
 import urls from '../../../../lib/urls'
-
-const ListItem = styled('li')({
-  borderBottom: `solid 1px ${GREY_2}`,
-})
-
-const ListItemHeader = styled('div')({
-  fontSize: HEADING_SIZES.SMALL,
-  marginTop: SPACING.SCALE_3,
-  marginBottom: SPACING.SCALE_4,
-})
 
 const ListItemContent = styled('div')({
   marginBottom: SPACING.SCALE_2,
   marginTop: SPACING.SCALE_2,
 })
 
-const ListItemFooter = styled('div')({
-  color: DARK_GREY,
-  fontSize: FONT_SIZE.SIZE_16,
-  marginBottom: SPACING.SCALE_4,
-})
-
 const InvestmentOPListItemRenderer = (item) => (
   <ListItem key={item.id} data-test="reminders-list-item">
     <GridRow>
       <GridCol>
-        <ListItemHeader data-test="item-header">
+        <ItemHeader data-test="item-header">
           Due {format(item.deadline, DATE_DAY_LONG_FORMAT)}
-        </ListItemHeader>
+        </ItemHeader>
         <ListItemContent data-test="item-content">
           <Link
             href={`${urls.investments.projects.propositions(
@@ -48,9 +31,9 @@ const InvestmentOPListItemRenderer = (item) => (
             {item.name}
           </Link>
         </ListItemContent>
-        <ListItemFooter data-test="item-footer">
+        <ItemFooter data-test="item-footer">
           Project code {item.investment_project.project_code}
-        </ListItemFooter>
+        </ItemFooter>
       </GridCol>
     </GridRow>
   </ListItem>

--- a/src/client/modules/Reminders/ItemRenderers/styled.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/styled.jsx
@@ -1,0 +1,64 @@
+import styled from 'styled-components'
+import GridCol from '@govuk-react/grid-col'
+import { GREY_2 } from 'govuk-colours'
+import { H3 } from '@govuk-react/heading'
+import {
+  SPACING,
+  FONT_SIZE,
+  HEADING_SIZES,
+  MEDIA_QUERIES,
+} from '@govuk-react/constants'
+import { DARK_GREY } from '../../../utils/colors'
+
+export const DeleteButton = styled('button')({
+  padding: 0,
+  background: 'transparent',
+  border: 'none',
+  fontSize: FONT_SIZE.SIZE_16,
+  fontFamily: 'inherit',
+  color: DARK_GREY,
+  cursor: 'pointer',
+  textDecoration: 'underline',
+  display: ({ isMobile }) => (isMobile ? 'inline' : 'none'),
+  marginBottom: SPACING.SCALE_4,
+  [MEDIA_QUERIES.TABLET]: {
+    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
+    margin: `${SPACING.SCALE_3} 0`,
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: ({ isMobile }) => (isMobile ? 'none' : 'inline'),
+    margin: `${SPACING.SCALE_3} 0`,
+  },
+})
+
+export const RightCol = styled(GridCol)({
+  display: 'none',
+  textAlign: 'right',
+  [MEDIA_QUERIES.TABLET]: {
+    display: 'block',
+  },
+  [MEDIA_QUERIES.DESKTOP]: {
+    display: 'block',
+  },
+})
+
+export const ListItem = styled('li')({
+  borderBottom: `solid 1px ${GREY_2}`,
+})
+
+export const ItemHeader = styled(H3)({
+  fontSize: HEADING_SIZES.SMALL,
+  marginTop: SPACING.SCALE_3,
+  marginBottom: SPACING.SCALE_4,
+})
+
+export const ItemContent = styled('div')({
+  color: ({ colour }) => colour,
+  marginBottom: SPACING.SCALE_3,
+})
+
+export const ItemFooter = styled('div')({
+  color: DARK_GREY,
+  fontSize: FONT_SIZE.SIZE_16,
+  marginBottom: SPACING.SCALE_4,
+})


### PR DESCRIPTION

## Description of change

- Disable the delete button instead of not rendering it while the DELETE request is sent to the server. This removes the flicker of the delete buttons all disappearing then reappearing.
- Move shared components into their own file to remove duplication.

## Test instructions

Make sure you have at least 2 notifications, delete one of them and the delete button for any others should remain visible

## Screenshots

### Before

![chrome_gMSWdVVzuF](https://user-images.githubusercontent.com/102232401/212300759-8af1d436-fd55-4787-a8c1-f570c5864edc.gif)


### After

![chrome_hmNk363CWa](https://user-images.githubusercontent.com/102232401/212300859-40e3c117-cbd2-4211-99be-46270feb9634.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
