### PR TITLE
Bump Cypress to v11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,6 +25,9 @@ updates:
   - dependency-name: axios # TET-354
     versions:
     - "> 0.27.2"
+  - dependency-name: cypress # TET-372
+    versions:
+    - "> 11.2.0"
 
   # These are part of dependency groups and should be updated via the relevant script.
   - dependency-name: "@storybook/addon-a11y"

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,7 +120,7 @@
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
-        "cypress": "^10.11.0",
+        "cypress": "^11.2.0",
         "cypress-image-diff-js": "^1.22.0",
         "eslint": "^8.31.0",
         "eslint-config-prettier": "^8.6.0",
@@ -16986,9 +16986,9 @@
       "dev": true
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^2.88.10",
@@ -51971,9 +51971,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-11.2.0.tgz",
+      "integrity": "sha512-u61UGwtu7lpsNWLUma/FKNOsrjcI6wleNmda/TyKHe0dOBcVjbCPlp1N6uwFZ0doXev7f/91YDpU9bqDCFeBLA==",
       "requires": {
         "@cypress/request": "^2.88.10",
         "@cypress/xvfb": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -180,7 +180,7 @@
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "chai-subset": "^1.6.0",
-    "cypress": "^10.11.0",
+    "cypress": "^11.2.0",
     "cypress-image-diff-js": "^1.22.0",
     "eslint": "^8.31.0",
     "eslint-config-prettier": "^8.6.0",


### PR DESCRIPTION
## Description of change

Cypress have added some breaking changes into v12 that will require a significant amount of work to resolve.

Until we are able to do this work I've upgraded Cypress to v11 and added it to the Dependabot ignore list.

## Test instructions

Tests should run as before

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
