### PR TITLE
Refactor to remove duplicate tests

### DIFF
--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -47,7 +47,7 @@ const MenuItem = ({ to, pathname, children }) => (
   </LinkListItem>
 )
 
-const RemindersMenu = ({
+export const RemindersMenu = ({
   hasInvestmentFeatureGroup,
   hasExportFeatureGroup,
 }) => {

--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -35,8 +35,8 @@ const LinkListLink = styled(Link)(({ $isActive }) => ({
     : {}),
 }))
 
-const Menu = ({ children }) => (
-  <LinkList data-test="link-list">{children}</LinkList>
+const Menu = ({ children, dataTest }) => (
+  <LinkList data-test={`${dataTest} link-list`}>{children}</LinkList>
 )
 
 const MenuItem = ({ to, pathname, children }) => (
@@ -55,7 +55,7 @@ export const RemindersMenu = ({
   return (
     <>
       {hasInvestmentFeatureGroup && (
-        <Menu>
+        <Menu dataTest="investment-menu-group">
           <H3 as="h2">Investment</H3>
           <MenuItem
             to={urls.reminders.investments.estimatedLandDate()}
@@ -78,7 +78,7 @@ export const RemindersMenu = ({
         </Menu>
       )}
       {hasExportFeatureGroup && (
-        <Menu>
+        <Menu dataTest="export-menu-group">
           <H3 as="h2">Export</H3>
           <MenuItem
             to={urls.reminders.exports.noRecentInteractions()}

--- a/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
+++ b/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
@@ -1,0 +1,114 @@
+import React from 'react'
+import { RemindersMenu } from '../../../../../src/client/modules/Reminders/RemindersMenu.jsx'
+import urls from '../../../../../src/lib/urls'
+
+import DataHubProvider from '../provider'
+
+describe('ContactLocalHeader', () => {
+  const Component = (props) => <RemindersMenu {...props} />
+  const investmentLinks = [
+    {
+      title: 'Approaching estimated land dates',
+      url: urls.reminders.investments.estimatedLandDate(),
+    },
+    {
+      title: 'Projects with no recent interaction',
+      url: urls.reminders.investments.noRecentInteraction(),
+    },
+    {
+      title: 'Outstanding propositions',
+      url: urls.reminders.investments.outstandingPropositions(),
+    },
+  ]
+
+  const exportLinks = [
+    {
+      title: 'Companies with no recent interaction',
+      url: urls.reminders.exports.noRecentInteractions(),
+    },
+  ]
+
+  context('When hasInvestmentFeatureGroup is true', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasInvestmentFeatureGroup={true}
+            hasExportFeatureGroup={false}
+          />
+        </DataHubProvider>
+      )
+
+      cy.get('[data-test="link-list-item"]').as('listItems')
+    })
+
+    it('should render all investment menu items', () => {
+      cy.get('@listItems').should('have.length', 3)
+
+      investmentLinks.forEach((item, index) => {
+        cy.get('@listItems')
+          .eq(index)
+          .find('a')
+          .should('contain', item.title)
+          .should('have.attr', 'href', item.url)
+      })
+    })
+  })
+
+  context('When hasExportFeatureGroup is true', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasInvestmentFeatureGroup={false}
+            hasExportFeatureGroup={true}
+          />
+        </DataHubProvider>
+      )
+
+      cy.get('[data-test="link-list-item"]').as('listItems')
+    })
+
+    it('should render all export menu items', () => {
+      cy.get('@listItems').should('have.length', 2)
+
+      exportLinks.forEach((item, index) => {
+        cy.get('@listItems')
+          .eq(index)
+          .find('a')
+          .should('contain', item.title)
+          .should('have.attr', 'href', item.url)
+      })
+    })
+  })
+
+  context(
+    'When hasInvestmentFeatureGroup and hasExportFeatureGroup is true',
+    () => {
+      beforeEach(() => {
+        cy.mount(
+          <DataHubProvider>
+            <Component
+              hasInvestmentFeatureGroup={true}
+              hasExportFeatureGroup={true}
+            />
+          </DataHubProvider>
+        )
+
+        cy.get('[data-test="link-list-item"]').as('listItems')
+      })
+
+      it('should render all investment menu items', () => {
+        cy.get('@listItems').should('have.length', 5)
+
+        investmentLinks.concat(exportLinks).forEach((item, index) => {
+          cy.get('@listItems')
+            .eq(index)
+            .find('a')
+            .should('contain', item.title)
+            .should('have.attr', 'href', item.url)
+        })
+      })
+    }
+  )
+})

--- a/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
+++ b/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
@@ -70,7 +70,7 @@ describe('ContactLocalHeader', () => {
     })
 
     it('should render all export menu items', () => {
-      cy.get('@listItems').should('have.length', 2)
+      cy.get('@listItems').should('have.length', 1)
 
       exportLinks.forEach((item, index) => {
         cy.get('@listItems')
@@ -99,7 +99,7 @@ describe('ContactLocalHeader', () => {
       })
 
       it('should render all investment menu items', () => {
-        cy.get('@listItems').should('have.length', 5)
+        cy.get('@listItems').should('have.length', 4)
 
         investmentLinks.concat(exportLinks).forEach((item, index) => {
           cy.get('@listItems')

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -78,10 +78,7 @@ describe('Exports no recent Interaction Reminders', () => {
 
   context('Reminders List', () => {
     before(() => {
-      cy.setUserFeatureGroups([
-        'export-notifications',
-        'investment-notifications',
-      ])
+      cy.setUserFeatureGroups(['export-notifications'])
       interceptApiCalls()
       cy.visit(urls.reminders.exports.noRecentInteractions())
       cy.wait('@remindersApiRequest')
@@ -100,6 +97,10 @@ describe('Exports no recent Interaction Reminders', () => {
         'have.text',
         'Companies with no recent interactions'
       )
+    })
+
+    it('should include export menu section', () => {
+      cy.get('[data-test="export-menu-group"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -102,51 +102,6 @@ describe('Exports no recent Interaction Reminders', () => {
       )
     })
 
-    it('should include a list of links to other reminders', () => {
-      cy.get('[data-test="link-list-item"]')
-        .should('have.length', 4)
-        .as('listItems')
-      cy.get('@listItems')
-        .eq(0)
-        .find('a')
-        .should('contain', 'Approaching estimated land dates')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.estimatedLandDate()
-        )
-
-      cy.get('@listItems')
-        .eq(1)
-        .find('a')
-        .should('contain', 'Projects with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.noRecentInteraction()
-        )
-
-      cy.get('@listItems')
-        .eq(2)
-        .find('a')
-        .should('contain', 'Outstanding propositions')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.outstandingPropositions()
-        )
-
-      cy.get('@listItems')
-        .eq(3)
-        .find('a')
-        .should('contain', 'Companies with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.exports.noRecentInteractions()
-        )
-    })
-
     it('should render the list heading with the total number of reminders', () => {
       cy.get('[data-test="reminder-list-header"').should(
         'contain',

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -100,7 +100,7 @@ describe('Exports no recent Interaction Reminders', () => {
     })
 
     it('should include export menu section', () => {
-      cy.get('[data-test="export-menu-group"]').should('exist')
+      cy.get('[data-test="export-menu-group link-list"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
@@ -95,51 +95,6 @@ describe('Estimated Land Date Reminders', () => {
       )
     })
 
-    it('should include a list of links to other reminders', () => {
-      cy.get('[data-test="link-list-item"]')
-        .should('have.length', 4)
-        .as('listItems')
-      cy.get('@listItems')
-        .eq(0)
-        .find('a')
-        .should('contain', 'Approaching estimated land dates')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.estimatedLandDate()
-        )
-
-      cy.get('@listItems')
-        .eq(1)
-        .find('a')
-        .should('contain', 'Projects with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.noRecentInteraction()
-        )
-
-      cy.get('@listItems')
-        .eq(2)
-        .find('a')
-        .should('contain', 'Outstanding propositions')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.outstandingPropositions()
-        )
-
-      cy.get('@listItems')
-        .eq(3)
-        .find('a')
-        .should('contain', 'Companies with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.exports.noRecentInteractions()
-        )
-    })
-
     it('should render the list heading with the total number of reminders', () => {
       cy.get('[data-test="reminder-list-header"]').should(
         'contain',

--- a/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
@@ -72,10 +72,7 @@ describe('Estimated Land Date Reminders', () => {
   context('Reminders List', () => {
     before(() => {
       interceptApiCalls()
-      cy.setUserFeatureGroups([
-        'export-notifications',
-        'investment-notifications',
-      ])
+      cy.setUserFeatureGroups(['investment-notifications'])
       cy.visit(urls.reminders.investments.estimatedLandDate())
       cy.wait('@remindersApiRequest')
     })
@@ -93,6 +90,10 @@ describe('Estimated Land Date Reminders', () => {
         'have.text',
         'Approaching estimated land dates'
       )
+    })
+
+    it('should include investment menu section', () => {
+      cy.get('[data-test="investment-menu-group"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
@@ -93,7 +93,7 @@ describe('Estimated Land Date Reminders', () => {
     })
 
     it('should include investment menu section', () => {
-      cy.get('[data-test="investment-menu-group"]').should('exist')
+      cy.get('[data-test="investment-menu-group link-list"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
@@ -73,10 +73,7 @@ describe('No Recent Interaction Reminders', () => {
   context('Reminders List', () => {
     before(() => {
       interceptApiCalls()
-      cy.setUserFeatureGroups([
-        'export-notifications',
-        'investment-notifications',
-      ])
+      cy.setUserFeatureGroups(['investment-notifications'])
       cy.visit(urls.reminders.investments.noRecentInteraction())
       cy.wait('@remindersApiRequest')
     })
@@ -94,6 +91,10 @@ describe('No Recent Interaction Reminders', () => {
         'have.text',
         'Projects with no recent interactions'
       )
+    })
+
+    it('should include investment menu section', () => {
+      cy.get('[data-test="investment-menu-group"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
@@ -96,51 +96,6 @@ describe('No Recent Interaction Reminders', () => {
       )
     })
 
-    it('should include a list of links to other reminders', () => {
-      cy.get('[data-test="link-list-item"]')
-        .should('have.length', 4)
-        .as('listItems')
-      cy.get('@listItems')
-        .eq(0)
-        .find('a')
-        .should('contain', 'Approaching estimated land dates')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.estimatedLandDate()
-        )
-
-      cy.get('@listItems')
-        .eq(1)
-        .find('a')
-        .should('contain', 'Projects with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.noRecentInteraction()
-        )
-
-      cy.get('@listItems')
-        .eq(2)
-        .find('a')
-        .should('contain', 'Outstanding propositions')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.outstandingPropositions()
-        )
-
-      cy.get('@listItems')
-        .eq(3)
-        .find('a')
-        .should('contain', 'Companies with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.exports.noRecentInteractions()
-        )
-    })
-
     it('should render the list heading with the total number of reminders', () => {
       cy.get('[data-test="reminder-list-header"]').should(
         'contain',

--- a/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
@@ -94,7 +94,7 @@ describe('No Recent Interaction Reminders', () => {
     })
 
     it('should include investment menu section', () => {
-      cy.get('[data-test="investment-menu-group"]').should('exist')
+      cy.get('[data-test="investment-menu-group link-list"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
@@ -70,10 +70,7 @@ describe('Outstanding Proposition Reminders', () => {
 
   context('Reminders List', () => {
     before(() => {
-      cy.setUserFeatureGroups([
-        'export-notifications',
-        'investment-notifications',
-      ])
+      cy.setUserFeatureGroups(['investment-notifications'])
       interceptApiCalls()
       cy.visit(urls.reminders.investments.outstandingPropositions())
       waitForAPICalls()
@@ -92,6 +89,10 @@ describe('Outstanding Proposition Reminders', () => {
         'have.text',
         'Outstanding propositions'
       )
+    })
+
+    it('should include investment menu section', () => {
+      cy.get('[data-test="investment-menu-group"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
@@ -92,7 +92,7 @@ describe('Outstanding Proposition Reminders', () => {
     })
 
     it('should include investment menu section', () => {
-      cy.get('[data-test="investment-menu-group"]').should('exist')
+      cy.get('[data-test="investment-menu-group link-list"]').should('exist')
     })
 
     it('should render the list heading with the total number of reminders', () => {

--- a/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
@@ -94,51 +94,6 @@ describe('Outstanding Proposition Reminders', () => {
       )
     })
 
-    it('should include a list of links to other reminders', () => {
-      cy.get('[data-test="link-list-item"]')
-        .should('have.length', 4)
-        .as('listItems')
-      cy.get('@listItems')
-        .eq(0)
-        .find('a')
-        .should('contain', 'Approaching estimated land dates')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.estimatedLandDate()
-        )
-
-      cy.get('@listItems')
-        .eq(1)
-        .find('a')
-        .should('contain', 'Projects with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.noRecentInteraction()
-        )
-
-      cy.get('@listItems')
-        .eq(2)
-        .find('a')
-        .should('contain', 'Outstanding propositions')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.investments.outstandingPropositions()
-        )
-
-      cy.get('@listItems')
-        .eq(3)
-        .find('a')
-        .should('contain', 'Companies with no recent interaction')
-        .should(
-          'have.attr',
-          'href',
-          urls.reminders.exports.noRecentInteractions()
-        )
-    })
-
     it('should render the list heading with the total number of reminders', () => {
       cy.get('[data-test="reminder-list-header"]').should(
         'contain',


### PR DESCRIPTION
## Description of change

There are duplicate tests for checking the reminder menu list items that can be moved into a single component test. The functional tests can then be updated to just check the presence of the menu section

## Test instructions

No visible changes

## Screenshots

NA

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
