### PR TITLE
Moved reminder export component into shared component

### DIFF
--- a/src/client/modules/Reminders/ExportsList.jsx
+++ b/src/client/modules/Reminders/ExportsList.jsx
@@ -1,0 +1,102 @@
+import React from 'react'
+import { useLocation } from 'react-router-dom'
+import { BLACK } from 'govuk-colours'
+import { SPACING, FONT_SIZE } from '@govuk-react/constants'
+import styled from 'styled-components'
+import qs from 'qs'
+
+import { ID } from './state'
+
+import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
+
+import { CollectionSort, RoutedPagination } from '../../components'
+import ExportItemRenderer from './ItemRenderers/ExportItemRenderer'
+import CollectionHeader from './CollectionHeader'
+import CollectionList from './CollectionList'
+import Effect from '../../components/Effect'
+import Task from '../../components/Task'
+
+const Summary = styled('p')({
+  color: BLACK,
+  paddingTop: SPACING.SCALE_2,
+  fontSize: FONT_SIZE.SIZE_19,
+})
+
+const ExportsList = ({
+  reminders,
+  pageOrigin,
+  summaryDataTest,
+  taskStatusName,
+  taskStatusSuccessFunction,
+  deleteTaskName,
+  getNextTaskName,
+  effectSuccessFunction,
+  deleteTaskSuccessFunction,
+}) => {
+  const { results, count, nextPending } = reminders
+  const location = useLocation()
+  const qsParams = qs.parse(location.search.slice(1))
+  const page = parseInt(qsParams.page, 10) || 1
+  const totalPages = Math.ceil(
+    Math.min(count, maxItemsToPaginate) / itemsPerPage
+  )
+
+  return (
+    <>
+      <CollectionHeader totalItems={count} pageOrigin={pageOrigin} />
+      {results.length === 0 ? (
+        <Summary data-test={summaryDataTest}>You have no reminders.</Summary>
+      ) : (
+        <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
+      )}
+      <Task.Status
+        name={taskStatusName}
+        id={ID}
+        startOnRender={{
+          payload: { page, sortby: qsParams.sortby },
+          onSuccessDispatch: taskStatusSuccessFunction,
+        }}
+      >
+        {() => (
+          <Task>
+            {(getTask) => {
+              const deleteTask = getTask(deleteTaskName, ID)
+              const getNextTask = getTask(getNextTaskName, ID)
+              return (
+                <>
+                  <Effect
+                    dependencyList={[nextPending]}
+                    effect={() =>
+                      nextPending &&
+                      getNextTask.start({
+                        payload: {
+                          page,
+                          sortby: qsParams.sortby,
+                        },
+                        onSuccessDispatch: effectSuccessFunction,
+                      })
+                    }
+                  />
+                  <CollectionList
+                    results={results}
+                    itemRenderer={ExportItemRenderer}
+                    disableDelete={deleteTask.status || nextPending}
+                    onDeleteReminder={(reminderId) => {
+                      deleteTask.start({
+                        payload: { id: reminderId },
+                        onSuccessDispatch: deleteTaskSuccessFunction,
+                      })
+                    }}
+                  />
+                  <RoutedPagination initialPage={page} items={count || 0} />
+                </>
+              )
+            }}
+          </Task>
+        )}
+      </Task.Status>
+    </>
+  )
+}
+
+export default ExportsList

--- a/src/client/modules/Reminders/ExportsNoRecentInteractionsList.jsx
+++ b/src/client/modules/Reminders/ExportsNoRecentInteractionsList.jsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import { useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { BLACK } from 'govuk-colours'
-import { SPACING, FONT_SIZE } from '@govuk-react/constants'
-import styled from 'styled-components'
-import qs from 'qs'
 
 import {
   REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_LOADED,
@@ -19,101 +14,27 @@ import {
   TASK_DELETE_EXPORTS_NO_RECENT_INTERACTION_REMINDER,
 } from './state'
 
-import { sortOptions, maxItemsToPaginate, itemsPerPage } from './constants'
-
-import { CollectionSort, RoutedPagination } from '../../components'
-import ExportItemRenderer from './ItemRenderers/ExportItemRenderer'
-import CollectionHeader from './CollectionHeader'
-import CollectionList from './CollectionList'
-import Effect from '../../components/Effect'
-import Task from '../../components/Task'
-
-const Summary = styled('p')({
-  color: BLACK,
-  paddingTop: SPACING.SCALE_2,
-  fontSize: FONT_SIZE.SIZE_19,
-})
-
 const ExportsNoRecentInteractionsList = ({
   exportsNoRecentInteractionReminders,
 }) => {
-  const { results, count, nextPending } = exportsNoRecentInteractionReminders
-  const location = useLocation()
-  const qsParams = qs.parse(location.search.slice(1))
-  const page = parseInt(qsParams.page, 10) || 1
-  const totalPages = Math.ceil(
-    Math.min(count, maxItemsToPaginate) / itemsPerPage
-  )
-
   return (
-    <>
-      <CollectionHeader
-        totalItems={count}
-        pageOrigin="companies_no_recent_interactions"
-      />
-      {results.length === 0 ? (
-        <Summary data-test="investments-no-reminders">
-          You have no reminders.
-        </Summary>
-      ) : (
-        <CollectionSort sortOptions={sortOptions} totalPages={totalPages} />
-      )}
-      <Task.Status
-        name={TASK_GET_EXPORTS_NO_RECENT_INTERACTION_REMINDERS}
-        id={ID}
-        startOnRender={{
-          payload: { page, sortby: qsParams.sortby },
-          onSuccessDispatch:
-            REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_LOADED,
-        }}
-      >
-        {() => (
-          <Task>
-            {(getTask) => {
-              const deleteTask = getTask(
-                TASK_DELETE_EXPORTS_NO_RECENT_INTERACTION_REMINDER,
-                ID
-              )
-              const getNextTask = getTask(
-                TASK_GET_NEXT_EXPORTS_NO_RECENT_INTERACTION_REMINDERS,
-                ID
-              )
-              return (
-                <>
-                  <Effect
-                    dependencyList={[nextPending]}
-                    effect={() =>
-                      nextPending &&
-                      getNextTask.start({
-                        payload: {
-                          page,
-                          sortby: qsParams.sortby,
-                        },
-                        onSuccessDispatch:
-                          REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_GOT_NEXT,
-                      })
-                    }
-                  />
-                  <CollectionList
-                    results={results}
-                    itemRenderer={ExportItemRenderer}
-                    disableDelete={deleteTask.status || nextPending}
-                    onDeleteReminder={(reminderId) => {
-                      deleteTask.start({
-                        payload: { id: reminderId },
-                        onSuccessDispatch:
-                          REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_DELETED,
-                      })
-                    }}
-                  />
-                  <RoutedPagination initialPage={page} items={count || 0} />
-                </>
-              )
-            }}
-          </Task>
-        )}
-      </Task.Status>
-    </>
+    <ExportsList
+      reminders={exportsNoRecentInteractionReminders}
+      pageOrigin="companies_no_recent_interactions"
+      summaryDataTest="investments-no-reminders"
+      taskStatusName={TASK_GET_EXPORTS_NO_RECENT_INTERACTION_REMINDERS}
+      taskStatusSuccessFunction={
+        REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_LOADED
+      }
+      deleteTaskName={TASK_DELETE_EXPORTS_NO_RECENT_INTERACTION_REMINDER}
+      getNextTaskName={TASK_GET_NEXT_EXPORTS_NO_RECENT_INTERACTION_REMINDERS}
+      effectSuccessFunction={
+        REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_GOT_NEXT
+      }
+      deleteTaskSuccessFunction={
+        REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_DELETED
+      }
+    />
   )
 }
 

--- a/src/client/modules/Reminders/ExportsNoRecentInteractionsList.jsx
+++ b/src/client/modules/Reminders/ExportsNoRecentInteractionsList.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-
+import ExportsList from './ExportsList'
 import {
   REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_LOADED,
   REMINDERS__EXPORTS_NO_RECENT_INTERACTION_REMINDERS_DELETED,


### PR DESCRIPTION
## Description of change

The logic inside ExportsNoRecentInteractionsList.jsx can be extracted into it's own component ready for reuse in an upcoming ticket


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
