### PR TITLE
Fix flaky dashboard test

### DIFF
--- a/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminder-summary-spec.js
@@ -9,6 +9,7 @@ describe('Dashboard reminder summary', () => {
 
   after(() => {
     cy.resetUser()
+    cy.resetFeatureFlags()
   })
 
   beforeEach(() => {

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -25,6 +25,8 @@ describe('Dashboard reminders', () => {
   const myPropositions = [proposition1, ...propositionListFaker(2)]
 
   before(() => {
+    cy.resetUser()
+    cy.resetFeatureFlags()
     cy.setUserFeatures(['personalised-dashboard'])
   })
 

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -44,6 +44,9 @@ describe('Dashboard reminders', () => {
 
   context('View reminders', () => {
     before(() => {
+      cy.intercept('GET', '/api-proxy/help-centre/feed', {
+        body: [],
+      })
       cy.intercept('GET', '/api-proxy/v4/proposition*', {
         body: {
           count: myPropositions.length,
@@ -118,6 +121,9 @@ describe('Dashboard reminders', () => {
 
   context('View empty reminders', () => {
     before(() => {
+      cy.intercept('GET', '/api-proxy/help-centre/feed', {
+        body: [],
+      })
       cy.intercept('GET', '/api-proxy/v4/proposition*', {
         body: {
           count: 0,
@@ -150,6 +156,9 @@ describe('Dashboard reminders', () => {
 
   context('Toggle section', () => {
     before(() => {
+      cy.intercept('GET', '/api-proxy/help-centre/feed', {
+        body: [],
+      })
       cy.visit('/')
     })
 

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -25,8 +25,6 @@ describe('Dashboard reminders', () => {
   const myPropositions = [proposition1, ...propositionListFaker(2)]
 
   before(() => {
-    cy.resetUser()
-    cy.resetFeatureFlags()
     cy.setUserFeatures(['personalised-dashboard'])
   })
 

--- a/test/functional/cypress/specs/dashboard-new/reminders-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/reminders-spec.js
@@ -44,9 +44,6 @@ describe('Dashboard reminders', () => {
 
   context('View reminders', () => {
     before(() => {
-      cy.intercept('GET', '/api-proxy/help-centre/feed', {
-        body: [],
-      })
       cy.intercept('GET', '/api-proxy/v4/proposition*', {
         body: {
           count: myPropositions.length,
@@ -121,9 +118,6 @@ describe('Dashboard reminders', () => {
 
   context('View empty reminders', () => {
     before(() => {
-      cy.intercept('GET', '/api-proxy/help-centre/feed', {
-        body: [],
-      })
       cy.intercept('GET', '/api-proxy/v4/proposition*', {
         body: {
           count: 0,
@@ -156,9 +150,6 @@ describe('Dashboard reminders', () => {
 
   context('Toggle section', () => {
     before(() => {
-      cy.intercept('GET', '/api-proxy/help-centre/feed', {
-        body: [],
-      })
       cy.visit('/')
     })
 

--- a/test/sandbox/fixtures/help-centre/feed.js
+++ b/test/sandbox/fixtures/help-centre/feed.js
@@ -1,0 +1,16 @@
+exports.emptyFeed = { body: [] }
+
+exports.feeds = {
+  body: [
+    {
+      heading: 'Using Sectors in the Find Exporters Tool',
+      link: 'https://test-url',
+      date: 'a day ago',
+    },
+    {
+      heading: 'Adding more activity to company pages',
+      link: 'https://test-url2',
+      date: '2 hours ago',
+    },
+  ],
+}

--- a/test/sandbox/routes/helpCentre.js
+++ b/test/sandbox/routes/helpCentre.js
@@ -1,4 +1,5 @@
 var announcementArticles = require('../fixtures/help-centre/announcement.js')
+var feeds = require('../fixtures/help-centre/feed.js')
 
 exports.announcement = function (req, res) {
   if (req.query.test === 'help-centre-unavailable') {
@@ -8,4 +9,11 @@ exports.announcement = function (req, res) {
   } else {
     return res.json(announcementArticles.announcement)
   }
+}
+
+exports.feed = function (req, res) {
+  if (req.query.test == 'feed-empty') {
+    return res.json(feeds.emptyFeed)
+  }
+  return res.json(feeds.feeds)
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -601,6 +601,7 @@ app.post('/whoami', user.resetWhoami)
 
 // Help centre endpoint
 app.get('/help-centre/announcement', helpCentre.announcement)
+app.get('/help-centre/feed', helpCentre.feed)
 
 // Zendesk tickets endpoint
 app.post('/zendesk/tickets', zendesk.tickets)


### PR DESCRIPTION
## Description of change

- Add the help centre feed url into the sandbox to remove the 500 errors in the console
- Make sure `resetFeatureFlags ` is called in the `after` function when calling `setUserFeatureGroups` in the `before`

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
