### PR TITLE
Fix flaky test

### DIFF
--- a/test/functional/cypress/specs/reminders/notification-bell-spec.js
+++ b/test/functional/cypress/specs/reminders/notification-bell-spec.js
@@ -10,6 +10,11 @@ const assertNotificationBadgeNotExist = () =>
   cy.get('[data-test="notification-alert-badge"]').should('not.exist')
 
 describe('Notification bell', () => {
+  after(() => {
+    cy.resetUser()
+    cy.resetFeatureFlags()
+  })
+
   context('Dashboard', () => {
     beforeEach(() => {
       cy.setUserFeatures(['personalised-dashboard'])


### PR DESCRIPTION
## Description of change

Remove the `personalised-dashboard` feature flag from a spec that has a missing `after` function call


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
