### PR TITLE
Added new settings section for new interactions

### DIFF
--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -42,6 +42,7 @@ const RemindersSettings = ({
   const openESL = openSettings('investments_estimated_land_dates', qsParams)
   const openNRI = openSettings('investments_no_recent_interactions', qsParams)
   const openENRI = openSettings('companies_no_recent_interactions', qsParams)
+  const openENI = openSettings('companies_new_interactions', qsParams)
 
   return (
     <DefaultLayout
@@ -65,6 +66,7 @@ const RemindersSettings = ({
           estimatedLandDate,
           noRecentInteraction,
           exportNoRecentInteractions,
+          exportNewInteractions,
         }) => (
           <>
             {hasInvestmentFeatureGroup && (
@@ -114,6 +116,19 @@ const RemindersSettings = ({
                       dataName={'companies-no-recent-interactions'}
                       data={exportNoRecentInteractions}
                       to={urls.reminders.settings.exports.noRecentInteraction()}
+                    />
+                  </RemindersToggleSection>
+                  <RemindersToggleSection
+                    label="Companies with new interactions"
+                    id="companies-new-interactions-toggle"
+                    data-test="companies-new-interactions-toggle"
+                    isOpen={openENI}
+                    borderBottom={true}
+                  >
+                    <RemindersSettingsTable
+                      dataName={'companies-new-interactions'}
+                      data={exportNewInteractions}
+                      to={urls.reminders.settings.exports.newInteraction()}
                     />
                   </RemindersToggleSection>
                 </ToggleSectionContainer>

--- a/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
@@ -9,6 +9,7 @@ const summaryEndpoint = '/api-proxy/v4/reminder/subscription/summary'
 const eslDataTest = 'estimated-land-dates'
 const nriDataTest = 'no-recent-interactions'
 const enriDataTest = 'companies-no-recent-interactions'
+const eniDataTest = 'companies-new-interactions'
 
 const getToggle = (dataTest) => `[data-test="${dataTest}-toggle"]`
 const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
@@ -129,6 +130,7 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableNotVisible('ELD', eslDataTest)
     assertSettingsTableNotVisible('NRI', nriDataTest)
     assertSettingsTableNotVisible('ENRI', enriDataTest)
+    assertSettingsTableNotVisible('ENI', eniDataTest)
   })
 
   context(
@@ -144,6 +146,7 @@ describe('Settings: reminders and email notifications', () => {
       assertSettingsTableVisible('ELD', eslDataTest)
       assertSettingsTableNotVisible('NRI', nriDataTest)
       assertSettingsTableNotVisible('ENRI', enriDataTest)
+      assertSettingsTableNotVisible('ENI', eniDataTest)
 
       assertSettingsTableToggles({
         title: 'ELD',
@@ -188,12 +191,34 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableNotVisible('ELD', eslDataTest)
     assertSettingsTableNotVisible('NRI', nriDataTest)
     assertSettingsTableVisible('ENRI', enriDataTest)
+    assertSettingsTableNotVisible('ENI', eniDataTest)
 
     assertSettingsTableToggles({
       title: 'ENRI',
       dataTest: enriDataTest,
       reminderText: '10, 30 and 40 days after the last interaction',
       buttonText: 'Companies with no recent interaction',
+    })
+  })
+
+  context('When only new export interaction settings are visible', () => {
+    const queryParams = 'companies_new_interactions=true'
+    before(() => {
+      interceptAPICalls()
+      cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
+      waitForAPICalls()
+    })
+
+    assertSettingsTableNotVisible('ELD', eslDataTest)
+    assertSettingsTableNotVisible('NRI', nriDataTest)
+    assertSettingsTableNotVisible('ENRI', enriDataTest)
+    assertSettingsTableVisible('ENI', eniDataTest)
+
+    assertSettingsTableToggles({
+      title: 'ENI',
+      dataTest: eniDataTest,
+      reminderText: '2, 4 and 7 days after a new interaction was posted',
+      buttonText: 'Companies with new interactions',
     })
   })
 
@@ -209,6 +234,7 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableVisible('ELD', eslDataTest)
     assertSettingsTableVisible('NRI', nriDataTest)
     assertSettingsTableVisible('ENRI', enriDataTest)
+    assertSettingsTableVisible('ENI', eniDataTest)
   })
 
   context('When no settings have been set - the default', () => {
@@ -220,6 +246,8 @@ describe('Settings: reminders and email notifications', () => {
         nri_email_reminders_enabled: false,
         enri_reminder_days: [],
         enri_email_reminders_enabled: false,
+        eni_reminder_days: [],
+        eni_email_reminders_enabled: false,
       })
       cy.visit(urls.reminders.settings.index())
       waitForAPICalls()
@@ -241,6 +269,13 @@ describe('Settings: reminders and email notifications', () => {
 
     it('should render the ENRI settings table with Off', () => {
       assertKeyValueTable('companies-no-recent-interactions-table', {
+        Reminders: 'Off',
+        'Email notifications': 'Off',
+      })
+    })
+
+    it('should render the ENI settings table with Off', () => {
+      assertKeyValueTable('companies-new-interactions-table', {
         Reminders: 'Off',
         'Email notifications': 'Off',
       })


### PR DESCRIPTION
## Description of change

Added a new settings section for managing companies with new interactions notifications

## Test instructions

You need to login with a user that has the `export-notifications` user feature groups. Navigate to the http://localhost:3000/reminders/settings page and you should see the new settings section as the last option

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/213403320-974260ec-ce12-411c-ba0e-cd2e5db6efb8.png)

### After

![image](https://user-images.githubusercontent.com/102232401/213402917-6681f1b5-d60b-484e-9ef5-ad2aa06f19d7.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
