### PR TITLE
RR-831-remove-duplicate-reminder-labels

### DIFF
--- a/src/client/components/ReminderSummary/state.js
+++ b/src/client/components/ReminderSummary/state.js
@@ -1,33 +1,40 @@
 import { ID } from '../NotificationAlert/state'
 import urls from '../../../lib/urls'
+import {
+  COMPANIES_NEW_INTERACTIONS_LABEL,
+  COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+  INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+  INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+  INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL,
+} from '../../modules/Reminders/constants'
 
 const transformReminderSummary = (data) => ({
   count: data.count,
   investment: [
     {
-      name: 'Approaching estimated land dates',
+      name: INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
       url: urls.reminders.investments.estimatedLandDate(),
       count: data.investment.estimated_land_date,
     },
     {
-      name: 'Projects with no recent interactions',
+      name: INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
       url: urls.reminders.investments.noRecentInteraction(),
       count: data.investment.no_recent_interaction,
     },
     {
-      name: 'Outstanding propositions',
+      name: INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL,
       url: urls.reminders.investments.outstandingPropositions(),
       count: data.investment.outstanding_propositions,
     },
   ],
   export: [
     {
-      name: 'Companies with no recent interactions',
+      name: COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
       url: urls.reminders.exports.noRecentInteractions(),
       count: data.export.no_recent_interaction,
     },
     {
-      name: 'Companies with new interactions',
+      name: COMPANIES_NEW_INTERACTIONS_LABEL,
       url: urls.reminders.exports.newInteractions(),
       count: data.export.new_interaction,
     },

--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -9,6 +9,13 @@ import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../lib/urls'
 import { state2props } from './state'
+import {
+  COMPANIES_NEW_INTERACTIONS_LABEL,
+  COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+  INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+  INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+  INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL,
+} from './constants'
 
 const LinkList = styled('ul')({
   listStyleType: 'none',
@@ -62,22 +69,19 @@ export const RemindersMenu = ({
             to={urls.reminders.investments.estimatedLandDate()}
             pathname={location.pathname}
           >
-            Approaching estimated land dates (
-            {reminderSummary.investment.estimated_land_date})
+            {`${INVESTMENTS_ESTIMATED_LAND_DATES_LABEL} (${reminderSummary.investment.estimated_land_date})`}
           </MenuItem>
           <MenuItem
             to={urls.reminders.investments.noRecentInteraction()}
             pathname={location.pathname}
           >
-            Projects with no recent interactions (
-            {reminderSummary.investment.no_recent_interaction})
+            {`${INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL} (${reminderSummary.investment.no_recent_interaction})`}
           </MenuItem>
           <MenuItem
             to={urls.reminders.investments.outstandingPropositions()}
             pathname={location.pathname}
           >
-            Outstanding propositions (
-            {reminderSummary.investment.outstanding_propositions})
+            {`${INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL} (${reminderSummary.investment.outstanding_propositions})`}
           </MenuItem>
         </Menu>
       )}
@@ -88,15 +92,13 @@ export const RemindersMenu = ({
             to={urls.reminders.exports.noRecentInteractions()}
             pathname={location.pathname}
           >
-            Companies with no recent interactions (
-            {reminderSummary.export.no_recent_interaction})
+            {`${COMPANIES_NO_RECENT_INTERACTIONS_LABEL} (${reminderSummary.export.no_recent_interaction})`}
           </MenuItem>
           <MenuItem
             to={urls.reminders.exports.newInteractions()}
             pathname={location.pathname}
           >
-            Companies with new interactions (
-            {reminderSummary.export.new_interaction})
+            {`${COMPANIES_NEW_INTERACTIONS_LABEL} (${reminderSummary.export.new_interaction})`}
           </MenuItem>
         </Menu>
       )}

--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -15,6 +15,12 @@ import urls from '../../../../lib/urls'
 import { state2props } from '../state'
 
 import { TASK_GET_SUBSCRIPTION_SUMMARY } from '../state'
+import {
+  INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+  INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+  COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+  COMPANIES_NEW_INTERACTIONS_LABEL,
+} from '../constants'
 
 const ToggleSectionContainer = styled('div')({
   marginTop: SPACING.SCALE_3,
@@ -74,7 +80,7 @@ const RemindersSettings = ({
                 <H2 size={LEVEL_SIZE[3]}>Investment</H2>
                 <ToggleSectionContainer>
                   <RemindersToggleSection
-                    label="Approaching estimated land dates"
+                    label={INVESTMENTS_ESTIMATED_LAND_DATES_LABEL}
                     id="estimated-land-dates-toggle"
                     data-test="estimated-land-dates-toggle"
                     isOpen={openESL}
@@ -86,7 +92,7 @@ const RemindersSettings = ({
                     />
                   </RemindersToggleSection>
                   <RemindersToggleSection
-                    label="Projects with no recent interactions"
+                    label={INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL}
                     id="no-recent-interactions-toggle"
                     data-test="no-recent-interactions-toggle"
                     isOpen={openNRI}
@@ -106,7 +112,7 @@ const RemindersSettings = ({
                 <H2 size={LEVEL_SIZE[3]}>Export</H2>
                 <ToggleSectionContainer>
                   <RemindersToggleSection
-                    label="Companies with no recent interactions"
+                    label={COMPANIES_NO_RECENT_INTERACTIONS_LABEL}
                     id="companies-no-recent-interactions-toggle"
                     data-test="companies-no-recent-interactions-toggle"
                     isOpen={openENRI}
@@ -119,7 +125,7 @@ const RemindersSettings = ({
                     />
                   </RemindersToggleSection>
                   <RemindersToggleSection
-                    label="Companies with new interactions"
+                    label={COMPANIES_NEW_INTERACTIONS_LABEL}
                     id="companies-new-interactions-toggle"
                     data-test="companies-new-interactions-toggle"
                     isOpen={openENI}

--- a/src/client/modules/Reminders/constants.js
+++ b/src/client/modules/Reminders/constants.js
@@ -27,12 +27,29 @@ export const COMPANIES_NO_RECENT_INTERACTIONS =
   'companies-no-recent-interactions'
 export const COMPANIES_NEW_INTERACTIONS = 'companies-new-interactions'
 
+export const INVESTMENTS_ESTIMATED_LAND_DATES_LABEL =
+  'Approaching estimated land dates'
+
+export const INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL =
+  'Projects with no recent interactions'
+
+export const INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL =
+  'Outstanding propositions'
+
+export const COMPANIES_NO_RECENT_INTERACTIONS_LABEL =
+  'Companies with no recent interactions'
+
+export const COMPANIES_NEW_INTERACTIONS_LABEL =
+  'Companies with new interactions'
+
 export const reminderTypeToLabel = {
-  [INVESTMENTS_ESTIMATED_LAND_DATES]: 'Approaching estimated land dates',
-  [INVESTMENTS_NO_RECENT_INTERACTIONS]: 'Projects with no recent interactions',
-  [INVESTMENTS_OUTSTANDING_PROPOSITIONS]: 'Outstanding propositions',
-  [COMPANIES_NO_RECENT_INTERACTIONS]: 'Companies with no recent interactions',
-  [COMPANIES_NEW_INTERACTIONS]: 'Companies with new interactions',
+  [INVESTMENTS_ESTIMATED_LAND_DATES]: INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+  [INVESTMENTS_NO_RECENT_INTERACTIONS]:
+    INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+  [INVESTMENTS_OUTSTANDING_PROPOSITIONS]:
+    INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL,
+  [COMPANIES_NO_RECENT_INTERACTIONS]: COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+  [COMPANIES_NEW_INTERACTIONS]: COMPANIES_NEW_INTERACTIONS_LABEL,
 }
 
 export const INTERACTION_NAMES = {


### PR DESCRIPTION
## Description of change

Move duplicate labels into constants file

## Test instructions

No visible changes to screens

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
