### PR TITLE
Bugfix/ccit 229 aventri events not in right order

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -376,7 +376,7 @@ async function fetchActivityFeedHandler(req, res, next) {
       return activity
     })
 
-    //Sort activities by published date
+    // Sort activities by startTime
     activities.sort(
       (a, b) => Date.parse(b.object.startTime) - Date.parse(a.object.startTime)
     )

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -370,10 +370,16 @@ async function fetchActivityFeedHandler(req, res, next) {
             activity.object.attributedTo,
             mapEssContacts(essContact),
           ]
+          activity.object.startTime = activity.published
         }
       }
       return activity
     })
+
+    //Sort activities by published date
+    activities.sort(
+      (a, b) => Date.parse(b.object.startTime) - Date.parse(a.object.startTime)
+    )
 
     res.json({
       total,

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -242,7 +242,7 @@ describe('Company activity feed', () => {
 
         it('correctly displays contacts for a future event', () => {
           cy.get('[data-test="aventri-event"]')
-            .eq(3)
+            .eq(1)
             .within(() => {
               cy.get('[data-test="cancelled-label"]').should('exist')
               cy.get('[data-test="attended-label"]').should('exist')


### PR DESCRIPTION
## Description of change

The activity feed for companies makes multiple calls to activity stream and the api to get activities back. 

Although these are sorted in the individual calls, they are concatenated in the activity list in the order the calls are made (e.g Aventri Events and ESS at the start of the list, then serviced deliveries, etc.)

This PR sorts the activities by StartTime (which is usually the published date, except for Events where it is the Event Date) to ensure that activities in the activity feed are actually in Date Order, and not grouped by type. 


## Test instructions

On Dev go to One List Corp, and the activities there will now be ordered by date. 
e.g. http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity

## Screenshots

### Before
![Screenshot 2023-01-26 at 11 42 15](https://user-images.githubusercontent.com/72502389/214827069-9e7f833a-6400-495a-8d71-8f33bcc39b0f.png)


### After 
![Screenshot 2023-01-26 at 11 39 55](https://user-images.githubusercontent.com/72502389/214826917-1abf160c-b472-47f3-b334-fd1978deec7c.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
