### PR TITLE
bugfix/RR-872-reminders-menu-item

### DIFF
--- a/src/client/modules/Reminders/RemindersMenu.jsx
+++ b/src/client/modules/Reminders/RemindersMenu.jsx
@@ -58,6 +58,7 @@ export const RemindersMenu = ({
   reminderSummary,
   hasInvestmentFeatureGroup,
   hasExportFeatureGroup,
+  hasExportNewInteractionReminders,
 }) => {
   const location = useLocation()
   return (
@@ -94,12 +95,14 @@ export const RemindersMenu = ({
           >
             {`${COMPANIES_NO_RECENT_INTERACTIONS_LABEL} (${reminderSummary.export.no_recent_interaction})`}
           </MenuItem>
-          <MenuItem
-            to={urls.reminders.exports.newInteractions()}
-            pathname={location.pathname}
-          >
-            {`${COMPANIES_NEW_INTERACTIONS_LABEL} (${reminderSummary.export.new_interaction})`}
-          </MenuItem>
+          {hasExportNewInteractionReminders && (
+            <MenuItem
+              to={urls.reminders.exports.newInteractions()}
+              pathname={location.pathname}
+            >
+              {`${COMPANIES_NEW_INTERACTIONS_LABEL} (${reminderSummary.export.new_interaction})`}
+            </MenuItem>
+          )}
         </Menu>
       )}
     </>

--- a/src/client/modules/Reminders/state.js
+++ b/src/client/modules/Reminders/state.js
@@ -61,8 +61,8 @@ export const TASK_SAVE_EXPORT_NI_REMINDER_SUBSCRIPTIONS =
 
 export const state2props = (state) => {
   const reminderSummary = state[REMINDER_SUMMARY_ID]
-  const activeFeatureGroups = state?.activeFeatureGroups
-  const activeFeatures = state?.activeFeatures
+  const activeFeatureGroups = state.activeFeatureGroups
+  const activeFeatures = state.activeFeatures
 
   const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
     'investment-notifications'

--- a/src/client/modules/Reminders/state.js
+++ b/src/client/modules/Reminders/state.js
@@ -62,12 +62,17 @@ export const TASK_SAVE_EXPORT_NI_REMINDER_SUBSCRIPTIONS =
 export const state2props = (state) => {
   const reminderSummary = state[REMINDER_SUMMARY_ID]
   const activeFeatureGroups = state?.activeFeatureGroups || []
+  const activeFeatures = state?.activeFeatures || []
 
   const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
     'investment-notifications'
   )
   const hasExportFeatureGroup = activeFeatureGroups.includes(
     'export-notifications'
+  )
+
+  const hasExportNewInteractionReminders = activeFeatures.includes(
+    'export-new-interaction-reminders'
   )
 
   const defaultUrl =
@@ -81,6 +86,7 @@ export const state2props = (state) => {
     reminderSummary,
     hasInvestmentFeatureGroup,
     hasExportFeatureGroup,
+    hasExportNewInteractionReminders,
     defaultUrl,
   }
 }

--- a/src/client/modules/Reminders/state.js
+++ b/src/client/modules/Reminders/state.js
@@ -61,8 +61,8 @@ export const TASK_SAVE_EXPORT_NI_REMINDER_SUBSCRIPTIONS =
 
 export const state2props = (state) => {
   const reminderSummary = state[REMINDER_SUMMARY_ID]
-  const activeFeatureGroups = state?.activeFeatureGroups || []
-  const activeFeatures = state?.activeFeatures || []
+  const activeFeatureGroups = state?.activeFeatureGroups
+  const activeFeatures = state?.activeFeatures
 
   const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
     'investment-notifications'

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -17,7 +17,7 @@ module.exports = () => {
         ...res.locals.PERMITTED_APPLICATIONS.map(({ key }) => key),
       ]),
       currentAdviserId: req.session?.user?.id,
-      activeFeatures: req.session?.user?.active_features,
+      activeFeatures: req.session?.user?.active_features || [],
       activeFeatureGroups: req.session?.user?.active_feature_groups || [],
     }
     next()

--- a/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
+++ b/test/component/cypress/specs/Reminders/RemindersMenu.cy.jsx
@@ -82,6 +82,7 @@ describe('RemindersMenu', () => {
           <Component
             hasInvestmentFeatureGroup={false}
             hasExportFeatureGroup={true}
+            hasExportNewInteractionReminders={true}
           />
         </DataHubProvider>
       )
@@ -100,6 +101,32 @@ describe('RemindersMenu', () => {
           .should('have.attr', 'href', item.url)
       })
     })
+
+    context('and hasExportNewInteractionReminders is false', () => {
+      beforeEach(() => {
+        cy.mount(
+          <DataHubProvider>
+            <Component
+              hasInvestmentFeatureGroup={false}
+              hasExportFeatureGroup={true}
+              hasExportNewInteractionReminders={false}
+            />
+          </DataHubProvider>
+        )
+
+        cy.get('[data-test="link-list-item"]').as('listItems')
+      })
+
+      it('should not render Companies with new interactions', () => {
+        cy.get('@listItems').should('have.length', 1)
+
+        cy.get('@listItems')
+          .eq(0)
+          .find('a')
+          .should('have.text', exportLinks[0].title)
+          .should('have.attr', 'href', exportLinks[0].url)
+      })
+    })
   })
 
   context(
@@ -111,6 +138,7 @@ describe('RemindersMenu', () => {
             <Component
               hasInvestmentFeatureGroup={true}
               hasExportFeatureGroup={true}
+              hasExportNewInteractionReminders={true}
             />
           </DataHubProvider>
         )


### PR DESCRIPTION
## Description of change

Hide the "Companies with new interactions" menu item when feature flag is inactive. At the moment the check is only on the feature flag group and not the individual feature flag

## Test instructions

Toggling the `export-new-interaction-reminders` feature flag, the menu option for "Companies with new interactions" should show and hide

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/215131587-dc88fc01-f676-496d-9f2c-a670d3ef942f.png)
### After

![image](https://user-images.githubusercontent.com/102232401/215131456-06b3cdee-a49f-460d-a7f8-45597b4729a3.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
