### PR TITLE
bugfix/RR-720-include-qs-params-in-redirect

### DIFF
--- a/src/apps/__test__/middleware.test.js
+++ b/src/apps/__test__/middleware.test.js
@@ -458,4 +458,44 @@ describe('Apps middleware', () => {
       })
     })
   })
+
+  describe('redirectWithQueryString()', () => {
+    context('when query string params are included', () => {
+      it('should permanently redirect with query string params', () => {
+        const resMock = { redirect: sinon.spy() }
+        this.middleware.redirectWithQueryString(
+          { protocol: 'http', get: () => 'localhost', query: { a: 1, b: 2 } },
+          resMock,
+          '/somepath'
+        )
+
+        expect(resMock.redirect).to.have.been.calledWith(
+          301,
+          sinon.match({
+            pathname: '/somepath',
+            search: '?a=1&b=2',
+          })
+        )
+      })
+    })
+
+    context('when query string params are missing', () => {
+      it('should permanently redirect without query string params', () => {
+        const resMock = { redirect: sinon.spy() }
+        this.middleware.redirectWithQueryString(
+          { protocol: 'http', get: () => 'localhost' },
+          resMock,
+          '/somepath'
+        )
+
+        expect(resMock.redirect).to.have.been.calledWith(
+          301,
+          sinon.match({
+            pathname: '/somepath',
+            search: '',
+          })
+        )
+      })
+    })
+  })
 })

--- a/src/apps/companies/controllers/__test__/details.test.js
+++ b/src/apps/companies/controllers/__test__/details.test.js
@@ -1,28 +1,70 @@
 const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
-
+const companyMock = require('../../../../../test/unit/data/companies/company-v4.json')
+const urls = require('../../../../lib/urls')
 const { renderDetails } = require('../details')
 
 describe('Companies details controller', () => {
   describe('#renderDetails', () => {
-    beforeEach(async () => {
-      this.middlewareParameters = buildMiddlewareParameters({})
+    context('when query string params are included', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          reqMock: { protocol: 'http', get: () => 'localhost' },
+          requestQuery: { param1: 'a', param2: 'b' },
+          company: companyMock,
+        })
 
-      await renderDetails(
-        this.middlewareParameters.reqMock,
-        this.middlewareParameters.resMock,
-        this.middlewareParameters.nextSpy
-      )
+        await renderDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy
+        )
+      })
+      it('should permanently redirect to interactions with query string params', () => {
+        expect(
+          this.middlewareParameters.resMock.redirect
+        ).to.have.been.calledWith(
+          301,
+          sinon.match({
+            pathname: urls.companies.interactions.index(companyMock.id),
+            search: '?param1=a&param2=b',
+          })
+        )
+        expect(this.middlewareParameters.resMock.redirect).to.have.been
+          .calledOnce
+      })
     })
 
-    it('should permanently redirect to interactions', () => {
-      expect(
-        this.middlewareParameters.resMock.redirect
-      ).to.have.been.calledWith(301, 'interactions')
-      expect(this.middlewareParameters.resMock.redirect).to.have.been.calledOnce
-    })
+    context('when query string params do not exist', () => {
+      beforeEach(async () => {
+        this.middlewareParameters = buildMiddlewareParameters({
+          reqMock: { protocol: 'http', get: () => 'localhost' },
+          company: companyMock,
+        })
 
-    it('should not render a template', () => {
-      expect(this.middlewareParameters.resMock.render).to.not.be.called
+        await renderDetails(
+          this.middlewareParameters.reqMock,
+          this.middlewareParameters.resMock,
+          this.middlewareParameters.nextSpy
+        )
+      })
+
+      it('should permanently redirect to interactions without query string params', () => {
+        expect(
+          this.middlewareParameters.resMock.redirect
+        ).to.have.been.calledWith(
+          301,
+          sinon.match({
+            pathname: urls.companies.interactions.index(companyMock.id),
+            search: '',
+          })
+        )
+        expect(this.middlewareParameters.resMock.redirect).to.have.been
+          .calledOnce
+      })
+
+      it('should not render a template', () => {
+        expect(this.middlewareParameters.resMock.render).to.not.be.called
+      })
     })
   })
 })

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,10 +1,17 @@
+const urls = require('../../../lib/urls')
 const queryString = require('qs')
+const { URL } = require('url')
 
 async function renderDetails(req, res) {
-  return res.redirect(
-    301,
-    `interactions${req.query ? '?' + queryString.stringify(req.query) : ''}`
+  const { company } = res.locals
+
+  const url = new URL(
+    urls.companies.interactions.index(company.id),
+    `${req.protocol}://${req.get('host')}`
   )
+
+  url.search = new URLSearchParams(queryString.stringify(req.query))
+  return res.redirect(301, url)
 }
 
 module.exports = {

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,5 +1,10 @@
+const queryString = require('qs')
+
 async function renderDetails(req, res) {
-  return res.redirect(301, 'interactions')
+  return res.redirect(
+    301,
+    `interactions${req.query ? '?' + queryString.stringify(req.query) : ''}`
+  )
 }
 
 module.exports = {

--- a/src/apps/companies/controllers/details.js
+++ b/src/apps/companies/controllers/details.js
@@ -1,17 +1,14 @@
 const urls = require('../../../lib/urls')
-const queryString = require('qs')
-const { URL } = require('url')
+const { redirectWithQueryString } = require('../../middleware')
 
 async function renderDetails(req, res) {
   const { company } = res.locals
 
-  const url = new URL(
-    urls.companies.interactions.index(company.id),
-    `${req.protocol}://${req.get('host')}`
+  return redirectWithQueryString(
+    req,
+    res,
+    urls.companies.interactions.index(company.id)
   )
-
-  url.search = new URLSearchParams(queryString.stringify(req.query))
-  return res.redirect(301, url)
 }
 
 module.exports = {

--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -1,14 +1,17 @@
 const urls = require('../../../lib/urls')
 const queryString = require('qs')
+const { URL } = require('url')
 
 function setInteractionsDetails(req, res, next) {
   const { company } = res.locals
 
   if (req.path === '/') {
-    return res.redirect(
-      301,
-      `activity${req.query ? '?' + queryString.stringify(req.query) : ''}`
+    const url = new URL(
+      urls.companies.activity.index(company.id),
+      `${req.protocol}://${req.get('host')}`
     )
+    url.search = new URLSearchParams(queryString.stringify(req.query))
+    return res.redirect(301, url)
   }
 
   res.locals.interactions = {

--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -1,17 +1,15 @@
 const urls = require('../../../lib/urls')
-const queryString = require('qs')
-const { URL } = require('url')
+const { redirectWithQueryString } = require('../../middleware')
 
 function setInteractionsDetails(req, res, next) {
   const { company } = res.locals
 
   if (req.path === '/') {
-    const url = new URL(
-      urls.companies.activity.index(company.id),
-      `${req.protocol}://${req.get('host')}`
+    return redirectWithQueryString(
+      req,
+      res,
+      urls.companies.activity.index(company.id)
     )
-    url.search = new URLSearchParams(queryString.stringify(req.query))
-    return res.redirect(301, url)
   }
 
   res.locals.interactions = {

--- a/src/apps/companies/middleware/interactions.js
+++ b/src/apps/companies/middleware/interactions.js
@@ -1,10 +1,14 @@
 const urls = require('../../../lib/urls')
+const queryString = require('qs')
 
 function setInteractionsDetails(req, res, next) {
   const { company } = res.locals
 
   if (req.path === '/') {
-    return res.redirect(301, 'activity')
+    return res.redirect(
+      301,
+      `activity${req.query ? '?' + queryString.stringify(req.query) : ''}`
+    )
   }
 
   res.locals.interactions = {

--- a/src/apps/middleware.js
+++ b/src/apps/middleware.js
@@ -2,6 +2,7 @@ const { get, isEmpty, assign, intersection, isUndefined } = require('lodash')
 const queryString = require('qs')
 const { parse } = require('url')
 const path = require('path')
+const { URL } = require('url')
 
 const { filterNonPermittedItem } = require('../modules/permissions/filters')
 
@@ -89,6 +90,13 @@ function redirectToFirstNavItem(req, res) {
   return res.redirect(res.locals.localNavItems[0].url)
 }
 
+function redirectWithQueryString(req, res, relativeUrl) {
+  const url = new URL(relativeUrl, `${req.protocol}://${req.get('host')}`)
+
+  url.search = new URLSearchParams(queryString.stringify(req.query))
+  return res.redirect(301, url)
+}
+
 module.exports = {
   setHomeBreadcrumb,
   removeBreadcrumb,
@@ -97,4 +105,5 @@ module.exports = {
   setDefaultQuery,
   handleRoutePermissions,
   isPermittedRoute,
+  redirectWithQueryString,
 }


### PR DESCRIPTION
## Description of change

Include the query string params in the forwarded requests as we include GTM params in emails

## Test instructions

Checkout this branch locally, run the site and open chrome dev tools. On the network tab filter to just Doc requests, and turn on the Preserve log option. Browse the url http://localhost:3000/companies/eea020f8-0d7c-416d-ac4c-38f4c888c2f0/details?1=1&2=2 and you will see the 301 redirects being handled including the query string params.

On the dev site, perform the same test using the url http://datahub.dev.uktrade.io/companies/eea020f8-0d7c-416d-ac4c-38f4c888c2f0/details?1=1&2=2 and the query string params are not included in the 301 redirect



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
