### PR TITLE
Remove duplication from CollectionList tests

### DIFF
--- a/test/functional/cypress/specs/companies/collection-address-spec.js
+++ b/test/functional/cypress/specs/companies/collection-address-spec.js
@@ -1,4 +1,9 @@
-import { assertBreadcrumbs } from '../../support/assertions'
+import {
+  getCollectionList,
+  assertCollectionBreadcrumbs,
+  assertMetadataItem,
+} from '../../support/collection-list-assertions'
+import { collectionListRequest } from '../../support/actions'
 import { companies } from '../../../../../src/lib/urls'
 
 import { companyFaker, companyListFaker } from '../../fakers/companies'
@@ -26,34 +31,19 @@ describe('Company Collection Address', () => {
   const companyList = [usCompany, ...otherCompanies]
 
   before(() => {
-    cy.intercept('POST', '/api-proxy/v4/search/company', {
-      body: {
-        count: companyList.length,
-        results: companyList,
-      },
-    }).as('apiRequest')
-    cy.visit(companies.index())
-    cy.wait('@apiRequest')
+    collectionListRequest('v4/search/company', companyList, companies.index())
   })
 
   beforeEach(() => {
-    cy.get('[data-test="collection-item"]').as('collectionItems')
-    cy.get('@collectionItems').eq(0).as('firstListItem')
+    getCollectionList()
   })
 
-  it('should render home breadcumb', () => {
-    assertBreadcrumbs({
-      Home: '/',
-      Companies: null,
-    })
-  })
+  assertCollectionBreadcrumbs('Companies')
 
   it('should contain california displaying area for an US address', () => {
-    cy.get('@firstListItem')
-      .find('[data-test="metadata"]')
-      .should(
-        'contain',
-        '3525 Eastham Drive, Culver City, CA, 90232, California, United States'
-      )
+    assertMetadataItem(
+      '@firstListItem',
+      '3525 Eastham Drive, Culver City, CA, 90232, California, United States'
+    )
   })
 })

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -1,5 +1,13 @@
-import { assertBreadcrumbs } from '../../support/assertions'
-import urls from '../../../../../src/lib/urls'
+import {
+  getCollectionList,
+  assertCollectionBreadcrumbs,
+  assertAddItemButton,
+  assertBadge,
+  assertMetadataItem,
+  assertListLength,
+} from '../../support/collection-list-assertions'
+import { collectionListRequest } from '../../support/actions'
+import { companies } from '../../../../../src/lib/urls'
 
 import { companyFaker, companyListFaker } from '../../fakers/companies'
 
@@ -52,84 +60,51 @@ describe('Company Collections - React', () => {
   const companyList = [company1, company2, company3, ...otherCompanies]
 
   before(() => {
-    cy.intercept('POST', '/api-proxy/v4/search/company', {
-      body: {
-        count: companyList.length,
-        results: companyList,
-      },
-    }).as('apiRequest')
-    cy.visit(urls.companies.index())
-    cy.wait('@apiRequest')
+    collectionListRequest('v4/search/company', companyList, companies.index())
   })
 
   beforeEach(() => {
-    cy.get('[data-test="collection-list"]').as('collectionList')
-    cy.get('[data-test="collection-item"]').as('collectionItems')
-    cy.get('@collectionItems').eq(0).as('firstListItem')
+    getCollectionList()
     cy.get('@collectionItems').eq(1).as('secondListItem')
     cy.get('@collectionItems').eq(2).as('thirdListItem')
   })
 
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: '/',
-      Companies: null,
-    })
-  })
+  assertCollectionBreadcrumbs('Companies')
 
   it('should have a link to add company', () => {
-    cy.get('[data-test="add-collection-item-button"]')
-      .should('exist')
-      .should('contain', 'Add company')
-      .should('have.attr', 'href', '/companies/create')
+    assertAddItemButton('Add company', '/companies/create')
   })
 
   it('should display a list of companies', () => {
-    cy.get('@collectionList').should('have.length', 1)
-    cy.get('@collectionItems').should('have.length', companyList.length)
+    assertListLength(companyList)
   })
 
   it('should contain country badge', () => {
-    cy.get('@firstListItem')
-      .find('[data-test="badge"]')
-      .eq(0)
-      .should('contain', 'Malaysia')
+    assertBadge('@firstListItem', 'Malaysia')
   })
 
   it('should contain company sector and primary address', () => {
-    cy.get('@firstListItem')
-      .find('[data-test="metadata"]')
-      .should('contain', 'Energy')
-      .and(
-        'contain',
-        'Level 6, Avenue K Tower, 156 Jalan Ampang, Kuala Lumpur, 50450, Malaysia'
-      )
+    assertMetadataItem('@firstListItem', 'Energy')
+    assertMetadataItem(
+      '@firstListItem',
+      'Level 6, Avenue K Tower, 156 Jalan Ampang, Kuala Lumpur, 50450, Malaysia'
+    )
   })
 
   it('should contain trading names', () => {
-    cy.get('@secondListItem')
-      .find('[data-test="metadata"]')
-      .should('contain', 'Company Corp, Company Ltd')
+    assertMetadataItem('@secondListItem', 'Company Corp, Company Ltd')
   })
 
   it('should contain UK HQ Badge', () => {
-    cy.get('@secondListItem')
-      .find('[data-test="badge"]')
-      .should('contain', 'UK HQ')
+    assertBadge('@secondListItem', 'UK HQ')
   })
 
   it('should contain UK Region Badge', () => {
-    cy.get('@secondListItem')
-      .find('[data-test="badge"]')
-      .should('contain', 'London')
+    assertBadge('@secondListItem', 'London')
   })
 
   it('should contain Global HQ Badge', () => {
-    cy.get('@thirdListItem')
-      .find('[data-test="badge"]')
-      .should('contain', 'Global HQ')
-    cy.get('@thirdListItem')
-      .find('[data-test="metadata"]')
-      .should('contain', company3.global_headquarters.name)
+    assertBadge('@thirdListItem', 'Global HQ')
+    assertMetadataItem('@thirdListItem', company3.global_headquarters.name)
   })
 })

--- a/test/functional/cypress/specs/companies/contact-collection-spec.js
+++ b/test/functional/cypress/specs/companies/contact-collection-spec.js
@@ -1,8 +1,25 @@
 const qs = require('qs')
 
-const { assertBreadcrumbs } = require('../../support/assertions')
+const {
+  assertCompanyCollectionBreadcrumbs,
+  assertRemoveAllFiltersNotPresent,
+  assertAddItemButton,
+  assertAddItemButtonNotPresent,
+  assertListLength,
+  assertBadge,
+  assertBadgeNotPresent,
+  assertMetadataItem,
+  assertMetadataItemNotPresent,
+  assertItemLink,
+  assertArchiveMessage,
+  assertArchiveSummary,
+  assertUnarchiveLink,
+  assertUpdatedOn,
+  assertTitle,
+} = require('../../support/collection-list-assertions')
+const { collectionListRequest } = require('../../support/actions')
 const { contactFaker } = require('../../fakers/contacts')
-const urls = require('../../../../../src/lib/urls')
+const { companies } = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
 
 describe('Company Contacts Collections', () => {
@@ -54,6 +71,9 @@ describe('Company Contacts Collections', () => {
 
   const contacts = [ukContact, foreignContact]
 
+  const dnbFixture = fixtures.company.dnbCorp
+  const archivedFixture = fixtures.company.archivedLtd.id
+
   const buildQueryString = () =>
     qs.stringify({
       archived: ['false'],
@@ -69,16 +89,14 @@ describe('Company Contacts Collections', () => {
           results: [],
         },
       }).as('apiRequest')
-      cy.visit(
-        `${urls.companies.contacts(fixtures.company.dnbCorp.id)}?${queryString}`
-      )
+      cy.visit(`${companies.contacts(dnbFixture.id)}?${queryString}`)
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal({
           offset: 0,
           limit: 10,
           archived: false,
           sortby: 'modified_on:desc',
-          company: fixtures.company.dnbCorp.id,
+          company: dnbFixture.id,
         })
       })
     })
@@ -86,39 +104,21 @@ describe('Company Contacts Collections', () => {
 
   context('Viewing the companies contacts collection list page', () => {
     before(() => {
-      cy.intercept('POST', '/api-proxy/v3/search/contact', {
-        body: {
-          count: contacts.length,
-          results: contacts,
-        },
-      }).as('apiRequest')
-      cy.visit(urls.companies.contacts(fixtures.company.dnbCorp.id))
-      cy.wait('@apiRequest')
+      collectionListRequest(
+        'v3/search/contact',
+        contacts,
+        companies.contacts(dnbFixture.id)
+      )
     })
 
-    it('should render breadcrumbs', () => {
-      assertBreadcrumbs({
-        Home: urls.dashboard(),
-        Companies: urls.companies.index(),
-        [fixtures.company.dnbCorp.name]: urls.companies.detail(
-          fixtures.company.dnbCorp.id
-        ),
-        Contacts: null,
-      })
-    })
-
-    it('should render a title', () => {
-      cy.get('h2').should('have.text', '2 contacts')
-    })
-
-    it('should not render a "Remove all filters" button', () => {
-      cy.get('[data-test="clear-filters"]').should('not.exist')
-    })
+    assertCompanyCollectionBreadcrumbs(dnbFixture, 'Contacts')
+    assertTitle('2 contacts')
+    assertRemoveAllFiltersNotPresent()
 
     it('should render an "Add contact" button', () => {
-      cy.get('[data-test="add-collection-item-button"]').should(
-        'have.text',
-        'Add contact'
+      assertAddItemButton(
+        'Add contact',
+        `/contacts/create?company=${dnbFixture.id}`
       )
     })
 
@@ -141,24 +141,17 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should display a list of contacts', () => {
-      cy.get('[data-test="collection-list"]').should('have.length', 1)
-      cy.get('[data-test="collection-item"]').should(
-        'have.length',
-        contacts.length
-      )
+      assertListLength(contacts)
     })
   })
 
   context('UK contact', () => {
     before(() => {
-      cy.intercept('POST', '/api-proxy/v3/search/contact', {
-        body: {
-          count: contacts.length,
-          results: contacts,
-        },
-      }).as('apiRequest')
-      cy.visit(urls.companies.contacts(fixtures.company.dnbCorp.id))
-      cy.wait('@apiRequest')
+      collectionListRequest(
+        'v3/search/contact',
+        contacts,
+        companies.contacts(dnbFixture.id)
+      )
     })
 
     beforeEach(() => {
@@ -166,90 +159,63 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should have a link with the contact name', () => {
-      cy.get('@firstListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'Hanna Reinger')
-        .should('have.attr', 'href', '/contacts/1/details')
+      assertItemLink('@firstListItem', 'Hanna Reinger', '/contacts/1/details')
     })
 
     it('should contain a primary contact badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .should('contain', 'Primary')
+      assertBadge('@firstListItem', 'Primary')
     })
 
     it('should not contain an archived badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .should('not.contain', 'Archived')
+      assertBadgeNotPresent('@firstListItem', 'Archived')
     })
 
     it('should render the updated date and time', () => {
-      cy.get('@firstListItem')
-        .find('h4')
-        .should('have.text', 'Updated on 10 Aug 2020, 8:09pm')
+      assertUpdatedOn('@firstListItem', 'Updated on 10 Aug 2020, 8:09pm')
     })
 
     it('should not render the company name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.contain', 'Company Murray, Price and Hodkiewicz')
+      assertMetadataItemNotPresent(
+        '@firstListItem',
+        'Company Murray, Price and Hodkiewicz'
+      )
     })
 
     it('should render the job title', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(0)
-        .should('contain', 'Job title Dynamic Accountability Administrator')
+      assertMetadataItem(
+        '@firstListItem',
+        'Job title Dynamic Accountability Administrator'
+      )
     })
 
     it('should render the sector', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(1)
-        .should('contain', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
     })
 
     it('should render the country', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(2)
-        .should('contain', 'Country United Kingdom')
+      assertMetadataItem('@firstListItem', 'Country United Kingdom')
     })
 
     it('should render the UK region', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('contain', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region London')
     })
 
     it('should render the UK telephone number', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(4)
-        .should('contain', 'Phone number +44 02071234567')
+      assertMetadataItem('@firstListItem', 'Phone number +44 02071234567')
     })
 
     it('should render the email', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(5)
-        .should('contain', 'Email gloria33@gmail.com')
+      assertMetadataItem('@firstListItem', 'Email gloria33@gmail.com')
     })
   })
 
   context('Foreign contact', () => {
     before(() => {
-      cy.intercept('POST', '/api-proxy/v3/search/contact', {
-        body: {
-          count: contacts.length,
-          results: contacts,
-        },
-      }).as('apiRequest')
-      cy.visit(urls.companies.contacts(fixtures.company.dnbCorp.id))
-      cy.wait('@apiRequest')
+      collectionListRequest(
+        'v3/search/contact',
+        contacts,
+        companies.contacts(dnbFixture.id)
+      )
     })
 
     beforeEach(() => {
@@ -257,11 +223,7 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should have a link with the contact name', () => {
-      cy.get('@secondListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'Ted Woods')
-        .should('have.attr', 'href', '/contacts/2/details')
+      assertItemLink('@secondListItem', 'Ted Woods', '/contacts/2/details')
     })
 
     it('should not contain a primary contact badge', () => {
@@ -269,55 +231,40 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should render the updated date and time', () => {
-      cy.get('@secondListItem')
-        .find('h4')
-        .should('have.text', 'Updated on 25 Jan 2020, 7:09pm')
+      assertUpdatedOn('@secondListItem', 'Updated on 25 Jan 2020, 7:09pm')
     })
 
     it('should not render the company name', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.contain', 'Company Murray, Price and Hodkiewicz')
+      assertMetadataItemNotPresent(
+        '@secondListItem',
+        'Company Murray, Price and Hodkiewicz'
+      )
     })
 
     it('should render the job title', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(0)
-        .should('contain', 'Job title Legacy Branding Agent')
+      assertMetadataItem('@secondListItem', 'Job title Legacy Branding Agent')
     })
 
     it('should render the sector', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(1)
-        .should('contain', 'Sector Creative and Media')
+      assertMetadataItem('@secondListItem', 'Sector Creative and Media')
     })
 
     it('should render the foreign country', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(2)
-        .should('contain', 'Country United States')
+      assertMetadataItem('@secondListItem', 'Country United States')
     })
 
     it('should not render the UK region', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.contain', 'UK region')
+      assertMetadataItemNotPresent('@secondListItem', 'UK region')
     })
 
     it('should render the telephone number', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('contain', 'Phone number (0045) 48770000')
+      assertMetadataItem('@secondListItem', 'Phone number (0045) 48770000')
     })
   })
 
   context('when viewing contacts for an archived company', () => {
     before(() => {
-      cy.visit(urls.companies.contacts(fixtures.company.archivedLtd.id))
+      cy.visit(companies.contacts(archivedFixture))
     })
 
     it('should render a meta title', () => {
@@ -327,33 +274,12 @@ describe('Company Contacts Collections', () => {
       )
     })
 
-    it('should render the archived summary', () => {
-      cy.get('[data-test="archived-details"]').should(
-        'contain',
-        'Why can I not add a contact?'
-      )
-    })
-
-    it('should render an archived explanation', () => {
-      cy.get('[data-test="archived-details"]').should(
-        'contain',
-        'Contacts cannot be added to an archived company.'
-      )
-    })
-
-    it('should render "Click here to unarchive"', () => {
-      cy.get('[data-test="archived-details"]')
-        .find('a')
-        .should('have.text', 'Click here to unarchive')
-        .should(
-          'have.attr',
-          'href',
-          `/companies/${fixtures.company.archivedLtd.id}/unarchive`
-        )
-    })
+    assertArchiveSummary('contact')
+    assertArchiveMessage('Contacts')
+    assertUnarchiveLink(`/companies/${archivedFixture}/unarchive`)
 
     it('should not render an "Add contact" button', () => {
-      cy.get('[data-test="add-collection-item-button"]').should('not.exist')
+      assertAddItemButtonNotPresent()
     })
   })
 })

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -1,8 +1,25 @@
 const qs = require('qs')
 
 import { orderFaker } from '../../fakers/orders'
-import { assertBreadcrumbs, assertPayload } from '../../support/assertions'
+import { assertPayload } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
+import {
+  getCollectionList,
+  assertCompanyCollectionBreadcrumbs,
+  assertRemoveAllFiltersNotPresent,
+  assertAddItemButton,
+  assertAddItemButtonNotPresent,
+  assertListLength,
+  assertBadge,
+  assertMetadataItem,
+  assertMetadataItemNotPresent,
+  assertItemLink,
+  assertArchiveMessage,
+  assertArchiveSummary,
+  assertUnarchiveLink,
+  assertUpdatedOn,
+  assertOMISSumary,
+} from '../../support/collection-list-assertions'
 
 const fixtures = require('../../fixtures')
 
@@ -59,20 +76,11 @@ describe('Company Orders (OMIS) Collection Page', () => {
   })
 
   beforeEach(() => {
-    cy.get('[data-test="collection-list"]').as('collectionList')
-    cy.get('[data-test="collection-item"]').as('collectionItems')
-    cy.get('@collectionItems').eq(0).as('firstListItem')
+    getCollectionList()
     cy.get('@collectionItems').eq(1).as('secondListItem')
   })
 
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: urls.dashboard(),
-      Companies: urls.companies.index(),
-      [oneListCorp.name]: urls.companies.detail(oneListCorp.id),
-      'Orders (OMIS)': null,
-    })
-  })
+  assertCompanyCollectionBreadcrumbs(oneListCorp, 'Orders (OMIS)')
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'One List Corp')
@@ -82,19 +90,13 @@ describe('Company Orders (OMIS) Collection Page', () => {
     cy.title().should('eq', 'Orders - One List Corp - Companies - DIT Data Hub')
   })
 
-  it('should not render a "Remove all filters" button', () => {
-    cy.get('[data-test="clear-filters"]').should('not.exist')
-  })
+  assertRemoveAllFiltersNotPresent()
 
   it('should render an "Add order" button', () => {
-    cy.get('[data-test="add-collection-item-button"]')
-      .should('exist')
-      .should('contain', 'Add order')
-      .should(
-        'have.attr',
-        'href',
-        `/omis/create?company=${oneListCorp.id}&skip-company=true`
-      )
+    assertAddItemButton(
+      'Add order',
+      `/omis/create?company=${oneListCorp.id}&skip-company=true`
+    )
   })
 
   it('should render the sort options', () => {
@@ -114,15 +116,10 @@ describe('Company Orders (OMIS) Collection Page', () => {
     })
   })
 
-  it('should have the total value', () => {
-    cy.get('[data-test="summary"]')
-      .should('exist')
-      .should('contain', 'Total value: £232.18')
-  })
+  assertOMISSumary('Total value: £232.18')
 
   it('should display a list of orders', () => {
-    cy.get('@collectionList').should('have.length', 1)
-    cy.get('@collectionItems').should('have.length', ordersList.length)
+    assertListLength(ordersList)
   })
 
   context('API payload', () => {
@@ -146,81 +143,53 @@ describe('Company Orders (OMIS) Collection Page', () => {
 
   context('The first order', () => {
     it('should have a link with the reference', () => {
-      cy.get('@firstListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'TMY947/21 (Order reference)')
-        .should('have.attr', 'href', '/omis/111/work-order')
+      assertItemLink(
+        '@firstListItem',
+        'TMY947/21 (Order reference)',
+        '/omis/111/work-order'
+      )
     })
 
     it('should contain "Draft" badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .eq(0)
-        .should('have.text', 'Draft')
+      assertBadge('@firstListItem', 'Draft')
     })
 
     it('should contain "The Bahamas" badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .eq(1)
-        .should('have.text', 'The Bahamas')
+      assertBadge('@firstListItem', 'The Bahamas')
     })
 
     it('should render the updated date and time (modified_on)', () => {
-      cy.get('@firstListItem')
-        .find('h4')
-        .should('have.text', 'Updated on 11 Dec 2020, 1:28am')
+      assertUpdatedOn('@firstListItem', 'Updated on 11 Dec 2020, 1:28am')
     })
 
     it('should render the company name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(0)
-        .should('have.text', 'Company Williams-Rose')
+      assertMetadataItem('@firstListItem', 'Company Williams-Rose')
     })
 
     it('should render the created date (created_on)', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(1)
-        .should('have.text', 'Created 30 Nov 2020, 1:28am')
+      assertMetadataItem('@firstListItem', 'Created 30 Nov 2020, 1:28am')
     })
 
     it('should render the contact name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(2)
-        .should('have.text', 'Contact Melissa Compton')
+      assertMetadataItem('@firstListItem', 'Contact Melissa Compton')
     })
 
     it('should render the UK region', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('have.text', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region London')
     })
 
     it('should render the sector', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(4)
-        .should('have.text', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
     })
 
     it('should render the delivery date (delivery_date)', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(5)
-        .should('have.text', 'Delivery date 11 Dec 2022')
+      assertMetadataItem('@firstListItem', 'Delivery date 11 Dec 2022')
     })
   })
 
   context('The second order', () => {
     it('should not render the delivery date (delivery_date)', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.have.text', 'Delivery date')
+      assertMetadataItemNotPresent('@secondListItem', 'Delivery date')
     })
   })
 
@@ -243,29 +212,12 @@ describe('Company Orders (OMIS) Collection Page', () => {
       })
     })
 
-    it('should render the archived summary', () => {
-      cy.get('[data-test="archived-details"]').should(
-        'contain',
-        'Why can I not add an order?'
-      )
-    })
-
-    it('should render an archived explanation', () => {
-      cy.get('[data-test="archived-details"]').should(
-        'contain',
-        'Orders cannot be added to an archived company.'
-      )
-    })
-
-    it('should render "Click here to unarchive"', () => {
-      cy.get('[data-test="archived-details"]')
-        .find('a')
-        .should('have.text', 'Click here to unarchive')
-        .should('have.attr', 'href', `/companies/${archivedLtd.id}/unarchive`)
-    })
+    assertArchiveSummary('order')
+    assertArchiveMessage('Orders')
+    assertUnarchiveLink(`/companies/${archivedLtd.id}/unarchive`)
 
     it('should not render an "Add order" button', () => {
-      cy.get('[data-test="add-collection-item-button"]').should('not.exist')
+      assertAddItemButtonNotPresent()
     })
   })
 })

--- a/test/functional/cypress/specs/contacts/audit-spec.js
+++ b/test/functional/cypress/specs/contacts/audit-spec.js
@@ -1,5 +1,8 @@
 const urls = require('../../../../../src/lib/urls')
 const { assertBreadcrumbs } = require('../../support/assertions')
+const {
+  assertPaginationSummary,
+} = require('../../support/collection-list-assertions')
 
 describe('Contact audit history', () => {
   context('when viewing the audit history for a contact', () => {
@@ -38,9 +41,7 @@ describe('Contact audit history', () => {
     })
 
     it('should render the page counter', () => {
-      cy.get('[data-test=pagination-summary]')
-        .should('exist')
-        .should('have.text', 'Page 1 of 5')
+      assertPaginationSummary('Page 1 of 5')
     })
 
     it('should render the pagination component', () => {

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -1,4 +1,16 @@
-import { assertBreadcrumbs } from '../../support/assertions'
+import {
+  getCollectionList,
+  assertCollectionBreadcrumbs,
+  assertBadge,
+  assertBadgeNotPresent,
+  assertMetadataItem,
+  assertListLength,
+  assertItemLink,
+  assertUpdatedOn,
+  assertMetadataItemNotPresent,
+  assertBadgeShouldNotExist,
+} from '../../support/collection-list-assertions'
+import { collectionListRequest } from '../../support/actions'
 import { contacts } from '../../../../../src/lib/urls'
 import { contactsListFaker, contactFaker } from '../../fakers/contacts'
 
@@ -53,154 +65,100 @@ describe('Contacts Collections', () => {
   ]
 
   before(() => {
-    cy.intercept('POST', '/api-proxy/v3/search/contact', {
-      body: {
-        count: contactsList.length,
-        results: contactsList,
-      },
-    }).as('apiRequest')
-    cy.visit(contacts.index())
-    cy.wait('@apiRequest')
+    collectionListRequest('v3/search/contact', contactsList, contacts.index())
   })
 
   beforeEach(() => {
-    cy.get('[data-test="collection-list"]').as('collectionList')
-    cy.get('[data-test="collection-item"]').as('collectionItems')
-    cy.get('@collectionItems').eq(0).as('firstListItem')
+    getCollectionList()
     cy.get('@collectionItems').eq(1).as('secondListItem')
     cy.get('@collectionItems').eq(2).as('thirdListItem')
   })
 
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: '/',
-      Contacts: null,
-    })
-  })
+  assertCollectionBreadcrumbs('Contacts')
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Contacts')
   })
 
   it('should display a list of contacts', () => {
-    cy.get('@collectionList').should('have.length', 1)
-    cy.get('@collectionItems').should('have.length', contactsList.length)
+    assertListLength(contactsList)
   })
 
   context('UK contact', () => {
     it('should have a link with the contact name', () => {
-      cy.get('@firstListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'Hanna Reinger')
-        .should('have.attr', 'href', '/contacts/1/details')
+      assertItemLink('@firstListItem', 'Hanna Reinger', '/contacts/1/details')
     })
 
     it('should contain a primary contact badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .should('contain', 'Primary')
+      assertBadge('@firstListItem', 'Primary')
     })
 
     it('should not contain an archived badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .should('not.contain', 'Archived')
+      assertBadgeNotPresent('@firstListItem', 'Archived')
     })
 
     it('should render the updated date and time', () => {
-      cy.get('@firstListItem')
-        .find('h4')
-        .should('have.text', 'Updated on 10 Aug 2020, 8:09pm')
+      assertUpdatedOn('@firstListItem', 'Updated on 10 Aug 2020, 8:09pm')
     })
 
     it('should render the company name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(0)
-        .should('contain', 'Company Murray, Price and Hodkiewicz')
+      assertMetadataItem(
+        '@firstListItem',
+        'Company Murray, Price and Hodkiewicz'
+      )
     })
 
     it('should render the job title', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(1)
-        .should('contain', 'Job title Dynamic Accountability Administrator')
+      assertMetadataItem(
+        '@firstListItem',
+        'Job title Dynamic Accountability Administrator'
+      )
     })
 
     it('should render the sector', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(2)
-        .should('contain', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
     })
 
     it('should render the country', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('contain', 'Country United Kingdom')
+      assertMetadataItem('@firstListItem', 'Country United Kingdom')
     })
 
     it('should render the UK region', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(4)
-        .should('contain', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region London')
     })
 
     it('should render the UK telephone number', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(5)
-        .should('contain', 'Phone number +44 02071234567')
+      assertMetadataItem('@firstListItem', 'Phone number +44 02071234567')
     })
 
     it('should render the email', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(6)
-        .should('contain', 'Email gloria33@gmail.com')
+      assertMetadataItem('@firstListItem', 'Email gloria33@gmail.com')
     })
   })
 
   context('Foreign contact', () => {
     it('should have a link with the contact name', () => {
-      cy.get('@secondListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'Ted Woods')
-        .should('have.attr', 'href', '/contacts/2/details')
+      assertItemLink('@secondListItem', 'Ted Woods', '/contacts/2/details')
     })
 
     it('should not contain a primary contact badge', () => {
-      cy.get('@secondListItem').find('[data-test="badge"]').should('not.exist')
+      assertBadgeShouldNotExist('@secondListItem')
     })
 
     it('should render the foreign country', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('contain', 'Country United States')
+      assertMetadataItem('@secondListItem', 'Country United States')
     })
     it('should not render the UK region', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.contain', 'UK region')
+      assertMetadataItemNotPresent('@secondListItem', 'UK region')
     })
     it('should render the telephone number', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(4)
-        .should('contain', 'Phone number 0045 48770000')
+      assertMetadataItem('@secondListItem', 'Phone number 0045 48770000')
     })
   })
 
   context('Archived contact', () => {
     it('should contain an archived badge', () => {
-      cy.get('@thirdListItem')
-        .find('[data-test="badge"]')
-        .should('contain', 'Archived')
+      assertBadge('@thirdListItem', 'Archived')
     })
   })
 })

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -1,4 +1,9 @@
-import { assertBreadcrumbs, assertErrorDialog } from '../../support/assertions'
+import { assertErrorDialog } from '../../support/assertions'
+import {
+  assertCollectionBreadcrumbs,
+  assertAddItemButton,
+  assertPaginationSummary,
+} from '../../support/collection-list-assertions'
 import { events } from '../../../../../src/lib/urls'
 
 const urls = require('../../../../../src/lib/urls')
@@ -15,12 +20,7 @@ describe('Event Collection List Page - React', () => {
         cy.get('@aventriEvents').eq(0).as('firstAventriEvent')
       })
 
-      it('should render breadcrumbs', () => {
-        assertBreadcrumbs({
-          Home: '/',
-          Events: null,
-        })
-      })
+      assertCollectionBreadcrumbs('Events')
 
       it('should display the events result count header', () => {
         cy.get('[data-test="activity-feed-collection-header"]').contains(
@@ -29,14 +29,11 @@ describe('Event Collection List Page - React', () => {
       })
 
       it('should have a link to add event', () => {
-        cy.get('[data-test="add-collection-item-button"]')
-          .should('exist')
-          .should('contain', 'Add event')
-          .should('have.attr', 'href', '/events/create')
+        assertAddItemButton('Add event', '/events/create')
       })
 
       it('should display the expected number of pages', () => {
-        cy.get('[data-test=pagination-summary]').contains('Page 1 of 9')
+        assertPaginationSummary('Page 1 of 9')
       })
 
       it('should not display the data hub API collection list', () => {
@@ -114,7 +111,7 @@ describe('Event Collection List Page - React', () => {
       context('when there are more than 10 events', () => {
         it('should be possible to page through', () => {
           cy.get('[data-page-number="2"]').click()
-          cy.get('[data-test=pagination-summary]').contains('Page 2 of 9')
+          assertPaginationSummary('Page 2 of 9')
           cy.get('@firstDataHubEvent')
             .find('[data-test="data-hub-event-name"]')
             .should('exist')

--- a/test/functional/cypress/specs/interaction/collection-spec.js
+++ b/test/functional/cypress/specs/interaction/collection-spec.js
@@ -1,6 +1,10 @@
 import { omit } from 'lodash'
 
-import { assertBreadcrumbs } from '../../support/assertions'
+import {
+  assertCollectionBreadcrumbs,
+  assertListLength,
+} from '../../support/collection-list-assertions'
+import { collectionListRequest } from '../../support/actions'
 import { interactions } from '../../../../../src/lib/urls'
 import {
   interactionsListFaker,
@@ -158,14 +162,11 @@ const assertInteractionDetails = ({
 
 describe('Interactions Collections', () => {
   before(() => {
-    cy.intercept('POST', '/api-proxy/v3/search/interaction', {
-      body: {
-        count: interactionsList.length,
-        results: interactionsList,
-      },
-    }).as('apiRequest')
-    cy.visit(interactions.index())
-    cy.wait('@apiRequest')
+    collectionListRequest(
+      'v3/search/interaction',
+      interactionsList,
+      interactions.index()
+    )
   })
 
   beforeEach(() => {
@@ -173,20 +174,14 @@ describe('Interactions Collections', () => {
     cy.get('[data-test="collection-item"]').as('collectionItems')
   })
 
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: '/',
-      Interactions: null,
-    })
-  })
+  assertCollectionBreadcrumbs('Interactions')
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Interactions')
   })
 
   it('should display a list of interactions', () => {
-    cy.get('@collectionList').should('have.length', 1)
-    cy.get('@collectionItems').should('have.length', interactionsList.length)
+    assertListLength(interactionsList)
   })
 
   context('when an interaction has multiple contacts', () => {

--- a/test/functional/cypress/specs/omis/collection-spec.js
+++ b/test/functional/cypress/specs/omis/collection-spec.js
@@ -1,5 +1,17 @@
 import { ordersListFaker, orderFaker } from '../../fakers/orders'
-import { assertBreadcrumbs } from '../../support/assertions'
+import {
+  getCollectionList,
+  assertCollectionBreadcrumbs,
+  assertAddItemButton,
+  assertBadge,
+  assertMetadataItem,
+  assertMetadataItemNotPresent,
+  assertListLength,
+  assertOMISSumary,
+  assertItemLink,
+  assertUpdatedOn,
+} from '../../support/collection-list-assertions'
+import { omisCollectionListRequest } from '../../support/actions'
 import { omis } from '../../../../../src/lib/urls'
 
 describe('Orders (OMIS) Collection List Page', () => {
@@ -34,132 +46,79 @@ describe('Orders (OMIS) Collection List Page', () => {
   const ordersList = [order1, order2, ...ordersListFaker(8)]
 
   before(() => {
-    cy.intercept('POST', '/api-proxy/v3/search/order', {
-      body: {
-        count: ordersList.length,
-        results: ordersList,
-        summary: {
-          total_subtotal_cost: 23218.0,
-        },
-      },
-    }).as('apiRequest')
-    cy.visit(omis.index())
-    cy.wait('@apiRequest')
+    omisCollectionListRequest('v3/search/order', ordersList, omis.index())
   })
 
   beforeEach(() => {
-    cy.get('[data-test="collection-list"]').as('collectionList')
-    cy.get('[data-test="collection-item"]').as('collectionItems')
-    cy.get('@collectionItems').eq(0).as('firstListItem')
+    getCollectionList()
     cy.get('@collectionItems').eq(1).as('secondListItem')
   })
 
-  it('should render breadcrumbs', () => {
-    assertBreadcrumbs({
-      Home: '/',
-      'Orders (OMIS)': null,
-    })
-  })
+  assertCollectionBreadcrumbs('Orders (OMIS)')
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Orders (OMIS)')
   })
 
   it('should have a link to add order', () => {
-    cy.get('[data-test="add-collection-item-button"]')
-      .should('exist')
-      .should('contain', 'Add order')
-      .should('have.attr', 'href', '/omis/create')
+    assertAddItemButton('Add order', '/omis/create')
   })
 
-  it('should have the total value', () => {
-    cy.get('[data-test="summary"]')
-      .should('exist')
-      .should('contain', 'Total value: £232.18')
-  })
+  assertOMISSumary('Total value: £232.18')
 
-  it('should display a list of contacts', () => {
-    cy.get('@collectionList').should('have.length', 1)
-    cy.get('@collectionItems').should('have.length', ordersList.length)
+  it('should display a list of orders', () => {
+    assertListLength(ordersList)
   })
 
   context('The first order', () => {
     it('should have a link with the reference', () => {
-      cy.get('@firstListItem')
-        .find('h3')
-        .children()
-        .should('have.text', 'TMY947/21 (Order reference)')
-        .should('have.attr', 'href', '/omis/111/work-order')
+      assertItemLink(
+        '@firstListItem',
+        'TMY947/21 (Order reference)',
+        '/omis/111/work-order'
+      )
     })
 
     it('should contain "Draft" badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .eq(0)
-        .should('have.text', 'Draft')
+      assertBadge('@firstListItem', 'Draft')
     })
 
     it('should contain "The Bahamas" badge', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="badge"]')
-        .eq(1)
-        .should('have.text', 'The Bahamas')
+      assertBadge('@firstListItem', 'The Bahamas')
     })
 
     it('should render the updated date and time (modified_on)', () => {
-      cy.get('@firstListItem')
-        .find('h4')
-        .should('have.text', 'Updated on 11 Dec 2020, 1:28am')
+      assertUpdatedOn('@firstListItem', 'Updated on 11 Dec 2020, 1:28am')
     })
 
     it('should render the company name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(0)
-        .should('have.text', 'Company Williams-Rose')
+      assertMetadataItem('@firstListItem', 'Company Williams-Rose')
     })
 
     it('should render the created date (created_on)', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(1)
-        .should('have.text', 'Created 30 Nov 2020, 1:28am')
+      assertMetadataItem('@firstListItem', 'Created 30 Nov 2020, 1:28am')
     })
 
     it('should render the contact name', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(2)
-        .should('have.text', 'Contact Melissa Compton')
+      assertMetadataItem('@firstListItem', 'Contact Melissa Compton')
     })
 
     it('should render the UK region', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(3)
-        .should('have.text', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region London')
     })
 
     it('should render the sector', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(4)
-        .should('have.text', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
     })
 
     it('should render the delivery date (delivery_date)', () => {
-      cy.get('@firstListItem')
-        .find('[data-test="metadata-item"]')
-        .eq(5)
-        .should('have.text', 'Delivery date 11 Dec 2022')
+      assertMetadataItem('@firstListItem', 'Delivery date 11 Dec 2022')
     })
   })
 
   context('The second order', () => {
     it('should not render the delivery date (delivery_date)', () => {
-      cy.get('@secondListItem')
-        .find('[data-test="metadata-item"]')
-        .should('not.have.text', 'Delivery date')
+      assertMetadataItemNotPresent('@secondListItem', 'Delivery date')
     })
   })
 })

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -129,3 +129,41 @@ export const clickButton = (buttonText) => {
 export const clickCancelLink = () => {
   cy.get('[data-test="cancel-button"]').click()
 }
+
+/**
+ * Generic search request for a CollectionList
+ * @param {*} endpoint The search endpoint
+ * @param {*} fakeList The fake list of items to display
+ * @param {*} link The page to render
+ */
+export const collectionListRequest = (endpoint, fakeList, link) => {
+  const fullEndpoint = '/api-proxy/' + endpoint
+  cy.intercept('POST', fullEndpoint, {
+    body: {
+      count: fakeList.length,
+      results: fakeList,
+    },
+  }).as('apiRequest')
+  cy.visit(link)
+  cy.wait('@apiRequest')
+}
+
+export const omisCollectionListRequest = (
+  endpoint,
+  fakeList,
+  link,
+  subtotalCost = 23218.0
+) => {
+  const fullEndpoint = '/api-proxy/' + endpoint
+  cy.intercept('POST', fullEndpoint, {
+    body: {
+      count: fakeList.length,
+      results: fakeList,
+      summary: {
+        total_subtotal_cost: subtotalCost,
+      },
+    },
+  }).as('apiRequest')
+  cy.visit(link)
+  cy.wait('@apiRequest')
+}

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -1,0 +1,155 @@
+/**
+ * Assertions for the various CollectionList tests
+ */
+
+const { assertBreadcrumbs } = require('./assertions')
+const urls = require('../../../../src/lib/urls')
+
+const getCollectionList = () => {
+  cy.get('[data-test="collection-list"]').as('collectionList')
+  cy.get('[data-test="collection-item"]').as('collectionItems')
+  cy.get('@collectionItems').eq(0).as('firstListItem')
+}
+
+const assertCollectionBreadcrumbs = (pageName) => {
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      [pageName]: null,
+    })
+  })
+}
+
+const assertCompanyCollectionBreadcrumbs = (companyFixture, pageName) => {
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: urls.dashboard(),
+      Companies: urls.companies.index(),
+      [companyFixture.name]: urls.companies.detail(companyFixture.id),
+      [pageName]: null,
+    })
+  })
+}
+
+const assertAddItemButton = (buttonText, link) => {
+  cy.get('[data-test="add-collection-item-button"]')
+    .should('exist')
+    .should('contain', buttonText)
+    .should('have.attr', 'href', link)
+}
+
+const assertAddItemButtonNotPresent = () => {
+  cy.get('[data-test="add-collection-item-button"]').should('not.exist')
+}
+
+const assertBadge = (item, badgeText) => {
+  cy.get(item).find('[data-test="badge"]').should('contain', badgeText)
+}
+
+const assertBadgeNotPresent = (item, badgeText) => {
+  cy.get(item).find('[data-test="badge"]').should('not.contain', badgeText)
+}
+
+const assertBadgeShouldNotExist = (item) => {
+  cy.get(item).find('[data-test="badge"]').should('not.exist')
+}
+
+const assertMetadataItem = (item, metadataText) => {
+  cy.get(item).find('[data-test="metadata"]').should('contain', metadataText)
+}
+
+const assertMetadataItemNotPresent = (item, metadataText) => {
+  cy.get(item)
+    .find('[data-test="metadata"]')
+    .should('not.contain', metadataText)
+}
+
+const assertRemoveAllFiltersNotPresent = () => {
+  it('should not render a "Remove all filters" button', () => {
+    cy.get('[data-test="clear-filters"]').should('not.exist')
+  })
+}
+
+const assertListLength = (fakeList) => {
+  cy.get('[data-test="collection-list"]').should('have.length', 1)
+  cy.get('[data-test="collection-item"]').should('have.length', fakeList.length)
+}
+
+const assertItemLink = (item, linkText, link) => {
+  cy.get(item)
+    .find('h3')
+    .children()
+    .should('have.text', linkText)
+    .should('have.attr', 'href', link)
+}
+
+const assertArchiveSummary = (type) => {
+  const message =
+    type === 'contact'
+      ? 'Why can I not add a ' + type + '?'
+      : 'Why can I not add an ' + type + '?'
+  it('should render the archived summary', () => {
+    cy.get('[data-test="archived-details"]').should('contain', message)
+  })
+}
+
+const assertArchiveMessage = (type) => {
+  const message = type + ' cannot be added to an archived company.'
+  it('should render an archived explanation', () => {
+    cy.get('[data-test="archived-details"]').should('contain', message)
+  })
+}
+
+const assertUnarchiveLink = (url) => {
+  it('should render "Click here to unarchive"', () => {
+    cy.get('[data-test="archived-details"]')
+      .find('a')
+      .should('have.text', 'Click here to unarchive')
+      .should('have.attr', 'href', url)
+  })
+}
+
+const assertUpdatedOn = (item, text) => {
+  cy.get(item).find('h4').should('have.text', text)
+}
+
+const assertTitle = (headingText) => {
+  it('should render a title', () => {
+    cy.get('h2').should('have.text', headingText)
+  })
+}
+
+const assertPaginationSummary = (pageText) => {
+  cy.get('[data-test=pagination-summary]').contains(pageText)
+}
+
+const assertOMISSumary = (summaryText) => {
+  it('should have the total value', () => {
+    cy.get('[data-test="summary"]')
+      .should('exist')
+      .should('contain', summaryText)
+  })
+}
+
+module.exports = {
+  getCollectionList,
+  assertCollectionBreadcrumbs,
+  assertCompanyCollectionBreadcrumbs,
+  assertAddItemButton,
+  assertAddItemButtonNotPresent,
+  assertBadge,
+  assertBadgeNotPresent,
+  assertMetadataItem,
+  assertMetadataItemNotPresent,
+  assertRemoveAllFiltersNotPresent,
+  assertListLength,
+  assertItemLink,
+  assertArchiveSummary,
+  assertArchiveMessage,
+  assertUnarchiveLink,
+  assertUpdatedOn,
+  assertTitle,
+  assertBadgeShouldNotExist,
+  assertPaginationSummary,
+  assertOMISSumary,
+}


### PR DESCRIPTION
## Description of change

When writing the test for #5254 I noticed that there were a few assertions that had been duplicated across several test files. I have moved these into a new file so that these can be called from a central location.

## Test instructions

Changed tests should run as normal.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
