### PR TITLE
Fixes a production issue when external Hawk services are down

### DIFF
--- a/src/lib/__test__/hawk-request.test.js
+++ b/src/lib/__test__/hawk-request.test.js
@@ -162,13 +162,6 @@ describe('#hawkRequest: check createPromiseRequest', () => {
         testClientHeaderArtifacts
       )
     ).to.be.rejectedWith(Error)
-
-    expect(authenticateStub).to.be.calledOnceWith(
-      { statusCode: 401 },
-      testDataHubCredentials,
-      testClientHeaderArtifacts,
-      { payload: '{}' }
-    )
   })
 
   it('fails when authenticate throws', async () => {

--- a/src/lib/hawk-request.js
+++ b/src/lib/hawk-request.js
@@ -6,6 +6,8 @@ const request = require('request')
 const Hawk = require('hawk')
 const config = require('../config')
 
+const HTTP_OK = 200
+
 function getHawkHeader(credentials, requestOptions) {
   if (config.isTest) {
     return 'hawk-test-header'
@@ -29,7 +31,7 @@ function createPromiseRequest(
 ) {
   return new Promise((resolve, reject) => {
     request(requestOptions, (err, response, responseBody) => {
-      if (err) {
+      if (err || response?.statusCode !== HTTP_OK) {
         return reject(new Error(err))
       }
       if (!config.isTest) {


### PR DESCRIPTION
## Description of change
Fixes a production issue when the frontend makes a Hawk API call to an external service (help centre feed) and that service is down causing the fronted to also go down. 

What is interesting is that the [error](https://github.com/uktrade/data-hub-frontend/blob/main/src/lib/hawk-request.js#L32) coming back from the failing request is `null`, meaning our checks didn't work as expected and the promise failed to reject. If it had rejected, then the error would have been handled correctly without Data Hub going down.
 
The precise moment the FE went down is when trying to [parse](https://github.com/uktrade/data-hub-frontend/blob/main/src/lib/hawk-request.js#L55) the `responseBody`, expected in JSON format, but in fact, came back as a HTML string:
```html
"<!DOCTYPE html>
<html class="no-js">
<head>
    <meta charset="utf-8"/>
    <title>Internal server error</title>
    <meta name="viewport" content="width=device-width, initial-scale=1"/>
    <style>
        body {
            font-family: monospace;
        }
    </style>
</head>
<body>
<h1>Internal server error :(</h1>

<h2>Sorry, there seems to be an error. Please try again soon.</h2>
</body>
</html>"
``` 

**The fix is not to solely rely on the error object but to check the response for its `statusCode` to ensure the promise is rejected and the error handled gracefully.**

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
