### PR TITLE
Add safeguards around transforming an advisor

### DIFF
--- a/src/client/modules/Interactions/InteractionDetails/transformers.js
+++ b/src/client/modules/Interactions/InteractionDetails/transformers.js
@@ -59,7 +59,7 @@ export const transformContacts = (contacts) =>
   ))
 
 export const transformAdvisers = (advisers) =>
-  advisers.map((adviser) => adviser.adviser.name + ', ' + adviser.team.name)
+  advisers.map((adviser) => adviser?.adviser?.name + ', ' + adviser?.team?.name)
 
 export const transformExportCountries = (countries) => {
   const groupedCountries = groupExportCountries(countries)


### PR DESCRIPTION
## Description of change
When adding an export interaction and saving the UI intermittently throws an error when attempting to translate the advisor's name and or advisor's team. This may just be a data issue, and never occur in prod. However, I've added some safeguards just incase.

## Test instructions
Create an export interaction and complete the form, the interaction should save without erroring.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
