### PR TITLE
aria-labelledby added to filter chips

### DIFF
--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -30,7 +30,11 @@ const StyledButton = styled('button')`
  * A Chip could be used to display a list of selected filters in a collection list.
  */
 const Chip = ({ children, value, onClick = null }) => (
-  <StyledButton onClick={onClick} data-value={value}>
+  <StyledButton
+    onClick={onClick}
+    data-value={value}
+    aria-labelledby={`remove filter ${children}`}
+  >
     {onClick && <span>✕</span>}
     <span>{children}</span>
   </StyledButton>


### PR DESCRIPTION
This resolves accessibility issue Issue ID: DAC_Non-descriptive_Button_01

## Description of change

Currently when using the website with a screen reader the filter chips at the top of the collection are reading, for example, “X Status: Active” as "multiplication sign X active status". This change adds the aria-labelledby "remove filter [chip name]" i.e. "remove filter active status".

## Test instructions

N/A

## Screenshots

No change visible screen changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
