### PR TITLE
role added to alert to resolve accessibility issue

### DIFF
--- a/src/client/components/StatusMessage/index.jsx
+++ b/src/client/components/StatusMessage/index.jsx
@@ -21,8 +21,8 @@ StatusMessage.propTypes = {
 
 StatusMessage.defaultProps = {
   colour: BLUE,
+  role: 'alert',
   'data-test': 'status-message',
-  'aria-live': 'polite',
 }
 
 export default StatusMessage

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -290,7 +290,7 @@ describe('Add company form', () => {
       cy.get('[data-test="status-message"]')
         .should('exist')
         .should('contain.text', 'Error occurred while searching for company.')
-        .should('have.attr', 'aria-live', 'polite')
+        .should('have.attr', 'role', 'alert')
     })
   })
 


### PR DESCRIPTION
## Description of change

Status messages do not get read out for screen reader users upon first loading the page. This is due to not having a role="alert" attribute placed upon the element and instead having aria-live="polite". This change removes aria-live="polite" and replaces it with ole="alert" for all alerts.

## Test instructions

N/A

## Screenshots
No change
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
