### PR TITLE
Reactify company list headings

### DIFF
--- a/src/apps/company-lists/client/EditCompanyList.jsx
+++ b/src/apps/company-lists/client/EditCompanyList.jsx
@@ -1,34 +1,48 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { FieldInput } from '../../../client/components'
-
+import { FieldInput, LocalHeader, Main } from '../../../client/components'
 import Form from '../../../client/components/Form'
 
+import urls from '../../../lib/urls'
+
 const EditCompanyList = ({ cancelUrl, listName, csrfToken, id, returnUrl }) => (
-  <Form
-    id="edit-company-list"
-    analyticsFormName="editCompanyList"
-    submissionTaskName="Edit company list"
-    flashMessage={() => 'List updated'}
-    initialValues={{ listName }}
-    cancelRedirectTo={() => cancelUrl}
-    transformPayload={(values) => ({ ...values, id, csrfToken })}
-    redirectTo={() => returnUrl}
-  >
-    <FieldInput
-      name="listName"
-      type="text"
-      label="List name"
-      required="Enter a name for your list"
-      hint="This is a name only you see, and can be up to 30 characters"
-      validate={(value) =>
-        value && value.length > 30
-          ? `Enter list name which is no longer than 30 characters`
-          : null
-      }
+  <>
+    <LocalHeader
+      heading="Edit list name"
+      breadcrumbs={[
+        { link: urls.dashboard(), text: 'Home' },
+        {
+          text: 'Edit list',
+        },
+      ]}
     />
-  </Form>
+    <Main>
+      <Form
+        id="edit-company-list"
+        analyticsFormName="editCompanyList"
+        submissionTaskName="Edit company list"
+        flashMessage={() => 'List updated'}
+        initialValues={{ listName }}
+        cancelRedirectTo={() => cancelUrl}
+        transformPayload={(values) => ({ ...values, id, csrfToken })}
+        redirectTo={() => returnUrl}
+      >
+        <FieldInput
+          name="listName"
+          type="text"
+          label="List name"
+          required="Enter a name for your list"
+          hint="This is a name only you see, and can be up to 30 characters"
+          validate={(value) =>
+            value && value.length > 30
+              ? `Enter list name which is no longer than 30 characters`
+              : null
+          }
+        />
+      </Form>
+    </Main>
+  </>
 )
 
 EditCompanyList.propTypes = {

--- a/src/apps/company-lists/views/delete-list.njk
+++ b/src/apps/company-lists/views/delete-list.njk
@@ -1,10 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block local_header %}
-  {% call LocalHeader({ heading: 'Delete list' }) %}{% endcall %}
-{% endblock %}
-
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'delete-company-list',
     props: props

--- a/src/apps/company-lists/views/edit-list.njk
+++ b/src/apps/company-lists/views/edit-list.njk
@@ -1,10 +1,6 @@
-{% extends "_layouts/template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block local_header %}
-  {% call LocalHeader({ heading: 'Edit list name' }) %}{% endcall %}
-{% endblock %}
-
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'edit-company-list',
     props: props

--- a/src/client/components/CompanyLists/DeleteCompanyListSection.jsx
+++ b/src/client/components/CompanyLists/DeleteCompanyListSection.jsx
@@ -10,7 +10,8 @@ import Paragraph from '@govuk-react/paragraph'
 import UnorderedList from '@govuk-react/unordered-list'
 import pluralize from 'pluralize'
 
-import { FormActions } from '../../../client/components'
+import { FormActions, LocalHeader, Main } from '../../../client/components'
+import urls from '../../../lib/urls'
 
 const DeleteCompanyListSection = ({
   companyList,
@@ -19,35 +20,47 @@ const DeleteCompanyListSection = ({
   returnUrl,
 }) => {
   const companyCountText = pluralize('company', companyList.item_count, true)
-
   return (
-    <div>
-      {errorMessage && (
-        <ErrorSummary
-          heading="There was an error deleting this list"
-          description={errorMessage}
-          errors={[]}
-        />
-      )}
-      <Paragraph>
-        Deleting this list will remove all companies from this list. These
-        companies will remain on any other lists.
-      </Paragraph>
-      <InsetText>
-        <UnorderedList listStyleType="none" mb={0}>
-          <ListItem>
-            <strong>{companyList.name}</strong>
-          </ListItem>
-          <ListItem>{companyCountText}</ListItem>
-        </UnorderedList>
-      </InsetText>
-      <FormActions>
-        <Button buttonColour={RED} onClick={onDelete}>
-          Delete list
-        </Button>
-        <Link href={returnUrl}>Return without deleting</Link>
-      </FormActions>
-    </div>
+    <>
+      <LocalHeader
+        heading="Delete list"
+        breadcrumbs={[
+          { link: urls.dashboard(), text: 'Home' },
+          {
+            text: 'Delete list',
+          },
+        ]}
+      />
+      <Main>
+        {errorMessage && (
+          <ErrorSummary
+            heading="There was an error deleting this list"
+            description={errorMessage}
+            errors={[]}
+          />
+        )}
+        <Paragraph>
+          Deleting this list will remove all companies from this list. These
+          companies will remain on any other lists.
+        </Paragraph>
+        <InsetText>
+          <UnorderedList listStyleType="none" mb={0}>
+            <ListItem data-test="list-name">
+              <strong>{companyList.name}</strong>
+            </ListItem>
+            <ListItem data-test="company-count">{companyCountText}</ListItem>
+          </UnorderedList>
+        </InsetText>
+        <FormActions>
+          <Button buttonColour={RED} onClick={onDelete}>
+            Delete list
+          </Button>
+          <Link href={returnUrl} data-test="return-link">
+            Return without deleting
+          </Link>
+        </FormActions>
+      </Main>
+    </>
   )
 }
 

--- a/test/functional/cypress/specs/company-lists/delete-spec.js
+++ b/test/functional/cypress/specs/company-lists/delete-spec.js
@@ -21,17 +21,14 @@ describe('Delete company list page', () => {
     })
 
     it('displays the list name', () => {
-      cy.get(selectors.companyList.delete.insetListItem.byIndex(1)).should(
+      cy.get('[data-test=list-name]').should(
         'have.text',
         'A list with multiple items'
       )
     })
 
     it('displays the number of companies on the list', () => {
-      cy.get(selectors.companyList.delete.insetListItem.byIndex(2)).should(
-        'have.text',
-        '13 companies'
-      )
+      cy.get('[data-test=company-count]').should('have.text', '13 companies')
     })
 
     it('displays the "Delete list" button', () => {
@@ -42,7 +39,7 @@ describe('Delete company list page', () => {
     })
 
     it('displays the "Return without deleting" link', () => {
-      cy.get(selectors.companyList.delete.returnAnchor).should(
+      cy.get('[data-test=return-link]').should(
         'have.text',
         'Return without deleting'
       )

--- a/test/functional/cypress/specs/company-lists/edit-spec.js
+++ b/test/functional/cypress/specs/company-lists/edit-spec.js
@@ -43,15 +43,9 @@ describe('Edit company list page', () => {
       cy.get(selectors.companyList.edit.saveButton).should('have.text', 'Save')
     })
     it('displays a cancel link', () => {
-      cy.get(selectors.companyList.edit.cancelLink).should(
-        'have.text',
-        'Cancel'
-      )
-      cy.get(selectors.companyList.edit.cancelLink).should(
-        'have.attr',
-        'href',
-        '/'
-      )
+      cy.get('[data-test=cancel-button]')
+        .should('have.text', 'Cancel')
+        .should('have.attr', 'href', '/')
     })
   })
 

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -97,7 +97,7 @@ const assertBreadcrumbs = (specs) => {
 }
 
 /**
- * @description Same as asserBreadcrumbs but already wrapped in an `it` block.
+ * @description Same as assertBreadcrumbs but already wrapped in an `it` block.
  * @param {Object} specs - A map of expected breadcrumb item labels to hrefs.
  */
 const testBreadcrumbs = (specs) =>

--- a/test/selectors/company-lists/delete.js
+++ b/test/selectors/company-lists/delete.js
@@ -1,8 +1,4 @@
 module.exports = {
   errorHeader: 'div h2',
-  insetListItem: {
-    byIndex: (index) => `#delete-company-list li:nth-child(${index})`,
-  },
   deleteButton: '#delete-company-list button',
-  returnAnchor: '#delete-company-list a',
 }

--- a/test/selectors/company-lists/edit.js
+++ b/test/selectors/company-lists/edit.js
@@ -6,5 +6,4 @@ module.exports = {
     input: '#edit-company-list form input[name="listName"]',
   },
   saveButton: '#edit-company-list button',
-  cancelLink: '#edit-company-list a',
 }


### PR DESCRIPTION
## Description of change

The pages for renaming and deleting a company list are currently set in the Nunjucks view. I have refactored these headings so they use the `LocalHeader` component. 

## Test instructions

It should be possible to rename and delete a company list as before.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
