### PR TITLE
Aria labels added to pagination page links

### DIFF
--- a/src/client/components/Pagination/RoutedPagination.jsx
+++ b/src/client/components/Pagination/RoutedPagination.jsx
@@ -216,6 +216,7 @@ const Pagination = ({
                       data-page-number={page}
                       data-test={`${isActive && 'page-number-active'}`}
                       aria-label={`Page ${page}`}
+                      aria-current={isActive ? 'page' : 'false'}
                       ref={(el) => (linkRefs.current[index] = el)}
                       href="#"
                     >

--- a/src/client/components/Pagination/RoutedPagination.jsx
+++ b/src/client/components/Pagination/RoutedPagination.jsx
@@ -215,6 +215,7 @@ const Pagination = ({
                       onClick={(e) => handleOnClick(page, e)}
                       data-page-number={page}
                       data-test={`${isActive && 'page-number-active'}`}
+                      aria-label={`Page ${page}`}
                       ref={(el) => (linkRefs.current[index] = el)}
                       href="#"
                     >

--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -122,6 +122,7 @@ function Pagination({ totalPages, activePage, getPageUrl, onPageClick }) {
                   <PageNumberLink
                     data-test={isActive ? 'page-number-active' : 'page-number'}
                     data-page-number={pageNumber}
+                    aria-label={`Page ${pageNumber}`}
                     onClick={onClick}
                     href={getPageUrl(pageNumber)}
                   >

--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -123,6 +123,7 @@ function Pagination({ totalPages, activePage, getPageUrl, onPageClick }) {
                     data-test={isActive ? 'page-number-active' : 'page-number'}
                     data-page-number={pageNumber}
                     aria-label={`Page ${pageNumber}`}
+                    aria-current={isActive ? 'page' : 'false'}
                     onClick={onClick}
                     href={getPageUrl(pageNumber)}
                   >

--- a/src/templates/_macros/common/pagination.njk
+++ b/src/templates/_macros/common/pagination.njk
@@ -34,7 +34,7 @@
           {% for page in pagination.pages -%}
             <li class="c-pagination__list-item">
               {% if page.url -%}
-                <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}">
+                <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}" aria-label="Page {{ page.label }}">
                   {{- page.label -}}
                 </a>
               {% else -%}

--- a/src/templates/_macros/common/pagination.njk
+++ b/src/templates/_macros/common/pagination.njk
@@ -34,7 +34,7 @@
           {% for page in pagination.pages -%}
             <li class="c-pagination__list-item">
               {% if page.url -%}
-                <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}" aria-label="Page {{ page.label }}">
+                <a href="{{ page.url }}" class="c-pagination__label {{ 'is-current' if page.label == pagination.currentPage }}" aria-label="Page {{ page.label }}" {% if page.label == pagination.currentPage %} aria-current="page" {% else %} aria-current="false" {% endif %}>
                   {{- page.label -}}
                 </a>
               {% else -%}


### PR DESCRIPTION
## Description of change

Page links within pagination did not contain any meaning full text for screen readers. aria-labels added to the pages within the 3 separate pagination components on the site.

## Test instructions

n/a

## Screenshots

No change

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
