### PR TITLE
Accessibility: remove incorrect use of aria-label and replace with visually hidden text

### DIFF
--- a/src/templates/_macros/form/entity-search-form.njk
+++ b/src/templates/_macros/form/entity-search-form.njk
@@ -55,10 +55,11 @@
           {% for item in props.aggregations %}
             {% set isCurrentPage = item.entity === props.entityType %}
             <li class="c-entity-search__aggregations-item {{ 'is-active' if isCurrentPage }}">
+              <span class="u-visually-hidden">Search results</span>
               {% if isCurrentPage %}
-                <span aria-label="{{item.text}} search results">{{ item.text }}</span>
+                <span>{{ item.text }}<span>
               {% else %}
-                <a class="c-entity-search__aggregations-link" href="{{ urls.search.type(item.path) }}?term={{ props.searchTerm }}"  aria-label="{{item.text}} search results">{{ item.text }}</a>
+                <a class="c-entity-search__aggregations-link" href="{{ urls.search.type(item.path) }}?term={{ props.searchTerm }}" >{{ item.text }}</a>
               {% endif %}
               <span class="c-entity-search__aggregations-count">({{ item.count | formatNumber }})</span>
             </li>


### PR DESCRIPTION
## Description of change
**Incorrect use of ARIA**
On the search results page, the currently selected filter has an `aria-label` attribute that is contained within a `<span>` with no valid role attribute, which is not supported. This is consistent for whichever filter is currently selected.

```html
<li class="c-entity-search__aggregations-item is-active">
 <span aria-label="Companies search results">Companies</span>
 <span class="c-entity-search__aggregations-count">(15)</span>
</li>
```
**Solution**
Using visually hidden text for each of the links instead of an aria-label will resolve this issue. 

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
