### PR TITLE
Incorrect use of aria-labelledby changes to aria-label

### DIFF
--- a/src/client/components/Chip/index.jsx
+++ b/src/client/components/Chip/index.jsx
@@ -33,7 +33,7 @@ const Chip = ({ children, value, onClick = null }) => (
   <StyledButton
     onClick={onClick}
     data-value={value}
-    aria-labelledby={`remove filter ${children}`}
+    aria-label={`remove filter ${children}`}
   >
     {onClick && <span>✕</span>}
     <span>{children}</span>


### PR DESCRIPTION
## Description of change

Incorrect use of aria-labelledby in previos accissibility fix. Changed to aria-label

## Test instructions

Inspecting the chip shows the aria-label as: label="remove filter [chip name]" i.e. label="remove filter Type: Global HQ"

## Screenshots

No change

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
