### PR TITLE
Create a business details tab on Company page

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -61,6 +61,7 @@ async function renderActivityFeed(req, res, next) {
           company,
           breadcrumbs,
           flashMessages: res.locals.getMessages(),
+          localNavItems: res.locals.localNavItems,
         }
       : {
           company,

--- a/src/apps/companies/apps/business-details/__test__/controllers.test.js
+++ b/src/apps/companies/apps/business-details/__test__/controllers.test.js
@@ -29,6 +29,10 @@ describe('Company business details', () => {
           )
           .reply(200, { count: 999 })
 
+        const getMessages = () => {
+          return []
+        }
+
         middlewareParams = buildMiddlewareParameters({
           company: companyMock,
           locals: {
@@ -42,6 +46,21 @@ describe('Company business details', () => {
             user: {
               permissions: [],
             },
+            localNavItems: [
+              {
+                path: 'business-details',
+                label: 'Business details',
+                url: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/business-details',
+                isActive: true,
+              },
+              {
+                path: 'advisers',
+                label: 'Core team',
+                url: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/advisers',
+                isActive: false,
+              },
+            ],
+            getMessages,
           },
         })
 
@@ -60,13 +79,25 @@ describe('Company business details', () => {
         expect(middlewareParams.resMock.render).to.be.calledOnceWithExactly(
           'companies/apps/business-details/views/client-container',
           {
-            heading: 'Business details',
             props: {
+              breadcrumbs: [
+                { link: urls.dashboard(), text: 'Home' },
+                {
+                  link: urls.companies.index(),
+                  text: 'Companies',
+                },
+                {
+                  link: urls.companies.detail(companyMock.id),
+                  text: companyMock.name,
+                },
+                { text: 'Business details' },
+              ],
               businessDetails: {
                 id: '1',
                 name: 'Test company',
                 company_number: '222',
               },
+              company: companyMock,
               globalUltimate: {
                 name: 'Test Global Ultimate',
                 url: '/test/222',
@@ -110,16 +141,24 @@ describe('Company business details', () => {
                 dnbHierarchy: urls.companies.dnbHierarchy.index(companyMock.id),
                 editOneList: urls.companies.editOneList(companyMock.id),
               },
+              localNavItems: [
+                {
+                  path: 'business-details',
+                  label: 'Business details',
+                  url: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/business-details',
+                  isActive: true,
+                },
+                {
+                  path: 'advisers',
+                  label: 'Core team',
+                  url: '/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/advisers',
+                  isActive: false,
+                },
+              ],
+              flashMessages: [],
             },
           }
         )
-      })
-
-      it('should add a breadcrumb', () => {
-        expect(middlewareParams.resMock.breadcrumb.args).to.deep.equal([
-          ['Test company', urls.companies.detail(companyMock.id)],
-          ['Business details'],
-        ])
       })
 
       it('should not call "next" with an error', () => {

--- a/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
+++ b/src/apps/companies/apps/business-details/client/CompanyBusinessDetails.jsx
@@ -190,7 +190,7 @@ CompanyBusinessDetails.propTypes = {
   urls: PropTypes.object.isRequired,
   subsidiariesCount: PropTypes.number,
   dnbRelatedCompaniesCount: PropTypes.number,
-  globalUltimate: PropTypes.object.isRequired,
+  globalUltimate: PropTypes.object,
   canEditOneList: PropTypes.bool,
 }
 

--- a/src/apps/companies/apps/business-details/client/SectionHierarchy.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionHierarchy.jsx
@@ -69,7 +69,7 @@ SubsectionDnBHierarchy.propTypes = {
   isDnbCompany: PropTypes.bool.isRequired,
   isGlobalUltimate: PropTypes.bool.isRequired,
   dnbRelatedCompaniesCount: PropTypes.number.isRequired,
-  globalUltimate: PropTypes.object.isRequired,
+  globalUltimate: PropTypes.object,
   urls: PropTypes.object.isRequired,
 }
 
@@ -243,7 +243,7 @@ SectionHierarchy.propTypes = {
   isGlobalUltimate: PropTypes.bool.isRequired,
   subsidiariesCount: PropTypes.number.isRequired,
   dnbRelatedCompaniesCount: PropTypes.number.isRequired,
-  globalUltimate: PropTypes.object.isRequired,
+  globalUltimate: PropTypes.object,
   urls: PropTypes.object.isRequired,
 }
 

--- a/src/apps/companies/apps/business-details/controllers.js
+++ b/src/apps/companies/apps/business-details/controllers.js
@@ -67,6 +67,7 @@ async function renderBusinessDetails(req, res) {
           editOneList: urls.companies.editOneList(company.id),
         },
         canEditOneList: canEditOneList(userPermissions),
+        localNavItems: res.locals.localNavItems,
       },
     })
 }

--- a/src/apps/companies/apps/business-details/controllers.js
+++ b/src/apps/companies/apps/business-details/controllers.js
@@ -74,6 +74,7 @@ async function renderBusinessDetails(req, res) {
       canEditOneList: canEditOneList(userPermissions),
       company,
       localNavItems: res.locals.localNavItems,
+      flashMessages: res.locals.getMessages(),
     },
   })
 }

--- a/src/apps/companies/apps/business-details/controllers.js
+++ b/src/apps/companies/apps/business-details/controllers.js
@@ -28,48 +28,54 @@ async function renderBusinessDetails(req, res) {
   const userPermissions = res.locals.user.permissions
   const subsidiaries = await getCompanySubsidiaries(req, company.id)
 
-  res
-    .breadcrumb(company.name, urls.companies.detail(company.id))
-    .breadcrumb('Business details')
-    .render('companies/apps/business-details/views/client-container', {
-      heading: 'Business details',
-      props: {
-        businessDetails: transformCompanyToBusinessDetails(company),
-        subsidiariesCount: subsidiaries.count,
-        dnbRelatedCompaniesCount,
-        globalUltimate: globalUltimate
-          ? pick(globalUltimate, ['name', 'url'])
-          : undefined,
-        urls: {
-          companiesHouse: urls.external.companiesHouse(company.company_number),
-          companyBusinessDetails: urls.companies.businessDetails(company.id),
-          companyEdit: urls.companies.edit(company.id),
-          companyArchive: `${urls.companies.archive(
-            company.id
-          )}?_csrf=${csrfToken}`,
-          companyUnarchive: `${urls.companies.unarchive(
-            company.id
-          )}?_csrf=${csrfToken}`,
-          companyAdvisers: urls.companies.advisers.index(company.id),
-          companyEditHistory: urls.companies.editHistory.index(company.id),
-          support: urls.support(),
-          subsidiaries: urls.companies.subsidiaries.index(company.id),
-          linkSubsidiary: urls.companies.subsidiaries.link(company.id),
-          dnbHierarchy: urls.companies.dnbHierarchy.index(company.id),
-          linkGlobalHQ: urls.companies.hierarchies.ghq.link(company.id),
-          globalHQ: company.global_headquarters
-            ? urls.companies.detail(company.global_headquarters.id)
-            : undefined,
-          removeGlobalHQ: urls.companies.hierarchies.ghq.remove(company.id),
-          archivedDocument: company.archived_documents_url_path
-            ? ARCHIVED_DOCUMENT_BASE_URL + company.archived_documents_url_path
-            : undefined,
-          editOneList: urls.companies.editOneList(company.id),
+  res.render('companies/apps/business-details/views/client-container', {
+    props: {
+      breadcrumbs: [
+        { link: urls.dashboard(), text: 'Home' },
+        {
+          link: urls.companies.index(),
+          text: 'Companies',
         },
-        canEditOneList: canEditOneList(userPermissions),
-        localNavItems: res.locals.localNavItems,
+        { link: urls.companies.detail(company.id), text: company.name },
+        { text: 'Business details' },
+      ],
+      businessDetails: transformCompanyToBusinessDetails(company),
+      subsidiariesCount: subsidiaries.count,
+      dnbRelatedCompaniesCount,
+      globalUltimate: globalUltimate
+        ? pick(globalUltimate, ['name', 'url'])
+        : undefined,
+      urls: {
+        companiesHouse: urls.external.companiesHouse(company.company_number),
+        companyBusinessDetails: urls.companies.businessDetails(company.id),
+        companyEdit: urls.companies.edit(company.id),
+        companyArchive: `${urls.companies.archive(
+          company.id
+        )}?_csrf=${csrfToken}`,
+        companyUnarchive: `${urls.companies.unarchive(
+          company.id
+        )}?_csrf=${csrfToken}`,
+        companyAdvisers: urls.companies.advisers.index(company.id),
+        companyEditHistory: urls.companies.editHistory.index(company.id),
+        support: urls.support(),
+        subsidiaries: urls.companies.subsidiaries.index(company.id),
+        linkSubsidiary: urls.companies.subsidiaries.link(company.id),
+        dnbHierarchy: urls.companies.dnbHierarchy.index(company.id),
+        linkGlobalHQ: urls.companies.hierarchies.ghq.link(company.id),
+        globalHQ: company.global_headquarters
+          ? urls.companies.detail(company.global_headquarters.id)
+          : undefined,
+        removeGlobalHQ: urls.companies.hierarchies.ghq.remove(company.id),
+        archivedDocument: company.archived_documents_url_path
+          ? ARCHIVED_DOCUMENT_BASE_URL + company.archived_documents_url_path
+          : undefined,
+        editOneList: urls.companies.editOneList(company.id),
       },
-    })
+      canEditOneList: canEditOneList(userPermissions),
+      company,
+      localNavItems: res.locals.localNavItems,
+    },
+  })
 }
 
 module.exports = {

--- a/src/apps/companies/apps/business-details/views/client-container.njk
+++ b/src/apps/companies/apps/business-details/views/client-container.njk
@@ -1,5 +1,22 @@
 {% extends "_layouts/template.njk" %}
 
+{% block local_header %}
+
+  {% component 'react-slot', {
+    id: 'company-local-header',
+    props: props
+  } %}
+
+{% endblock %}
+
+{% block local_nav %}
+  {% component 'react-slot', {
+    id: 'company-tabbed-local-navigation',
+    props: props
+  } %}
+
+{% endblock %}
+
 {% block body_main_content %}
   {% component 'react-slot', {
     id: 'company-business-details',

--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -32,6 +32,10 @@ const LOCAL_NAV = [
     permissions: ['interaction.view_all_interaction'],
   },
   {
+    path: 'business-details',
+    label: 'Business details',
+  },
+  {
     path: 'contacts',
     label: 'Company contacts',
     permissions: ['company.view_contact'],

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -193,11 +193,6 @@ const CompanyLocalHeader = ({
             )}
           </StyledDescription>
         )}
-        <p>
-          <a href={urls.companies.businessDetails(company.id)}>
-            View full business details
-          </a>
-        </p>
       </LocalHeader>
 
       {company.archived && (

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -112,163 +112,166 @@ const CompanyLocalHeader = ({
 }) => {
   const queryString = returnUrl ? `${returnUrl}` : `/companies/${company.id}`
   return (
-    <>
-      <LocalHeader breadcrumbs={breadcrumbs} flashMessages={flashMessages}>
-        <GridRow>
-          <GridCol setWidth="two-thirds">
-            <LocalHeaderHeading data-test="heading">
-              {company.name}
-            </LocalHeaderHeading>
-            <StyledAddress data-test="address">
-              {addressToString(company.address)}
-            </StyledAddress>
-          </GridCol>
-          <GridCol setWith="one-third">
-            <ConnectedDropdownMenu
-              label="View options"
-              closedLabel="Hide options"
-              id="local_header"
-            >
-              <DropdownButton
-                href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
+    company && (
+      <>
+        <LocalHeader breadcrumbs={breadcrumbs} flashMessages={flashMessages}>
+          <GridRow>
+            <GridCol setWidth="two-thirds">
+              <LocalHeaderHeading data-test="heading">
+                {company.name}
+              </LocalHeaderHeading>
+              <StyledAddress data-test="address">
+                {addressToString(company.address)}
+              </StyledAddress>
+            </GridCol>
+            <GridCol setWith="one-third">
+              <ConnectedDropdownMenu
+                label="View options"
+                closedLabel="Hide options"
+                id="local_header"
               >
-                Add to or remove from lists
-              </DropdownButton>
-              <DropdownButton href={urls.companies.pipelineAdd(company.id)}>
-                Add to my pipeline
-              </DropdownButton>
-            </ConnectedDropdownMenu>
-          </GridCol>
-        </GridRow>
-        {(company.isUltimate || company.isGlobalHQ) && (
-          <TypeWrapper>
-            <BadgeWrapper>
-              <Badge>
-                <BadgeText data-test="badge">
-                  {company.isUltimate ? 'Ultimate HQ' : 'Global HQ'}
-                </BadgeText>
-              </Badge>
-            </BadgeWrapper>
-            {company.isUltimate && (
-              <StyledDetails
-                summary="What does Ultimate HQ mean?"
-                data-test="metaList"
-              >
-                This HQ is in control of all related company records for{' '}
-                {company.name}.
-              </StyledDetails>
-            )}
-          </TypeWrapper>
-        )}
-        {(dnbRelatedCompaniesCount > 0 || company.hasManagedAccountDetails) && (
-          <StyledDescription data-test="description">
-            {dnbRelatedCompaniesCount > 0 && (
-              <p>
-                Data Hub contains{' '}
-                <a href={urls.companies.dnbHierarchy.index(company.id)}>
-                  {dnbRelatedCompaniesCount} other company{' '}
-                  {pluralize('record', dnbRelatedCompaniesCount)}
-                </a>{' '}
-                related to this company
-              </p>
-            )}
-            {company.hasManagedAccountDetails && (
-              <>
+                <DropdownButton
+                  href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}
+                >
+                  Add to or remove from lists
+                </DropdownButton>
+                <DropdownButton href={urls.companies.pipelineAdd(company.id)}>
+                  Add to my pipeline
+                </DropdownButton>
+              </ConnectedDropdownMenu>
+            </GridCol>
+          </GridRow>
+          {(company.isUltimate || company.isGlobalHQ) && (
+            <TypeWrapper>
+              <BadgeWrapper>
+                <Badge>
+                  <BadgeText data-test="badge">
+                    {company.isUltimate ? 'Ultimate HQ' : 'Global HQ'}
+                  </BadgeText>
+                </Badge>
+              </BadgeWrapper>
+              {company.isUltimate && (
+                <StyledDetails
+                  summary="What does Ultimate HQ mean?"
+                  data-test="metaList"
+                >
+                  This HQ is in control of all related company records for{' '}
+                  {company.name}.
+                </StyledDetails>
+              )}
+            </TypeWrapper>
+          )}
+          {(dnbRelatedCompaniesCount > 0 ||
+            company.hasManagedAccountDetails) && (
+            <StyledDescription data-test="description">
+              {dnbRelatedCompaniesCount > 0 && (
                 <p>
-                  This is an account managed company (One List{' '}
-                  {company.one_list_group_tier.name})
+                  Data Hub contains{' '}
+                  <a href={urls.companies.dnbHierarchy.index(company.id)}>
+                    {dnbRelatedCompaniesCount} other company{' '}
+                    {pluralize('record', dnbRelatedCompaniesCount)}
+                  </a>{' '}
+                  related to this company
                 </p>
-                <p>
-                  {company.isItaTierDAccount
-                    ? 'Lead ITA'
-                    : 'Global Account Manager'}
-                  : {company.one_list_group_global_account_manager.name}{' '}
-                  <a href={urls.companies.advisers.index(company.id)}>
-                    {company.isItaTierDAccount
-                      ? 'View Lead adviser'
-                      : 'View core team'}
-                  </a>
-                </p>
-              </>
-            )}
-          </StyledDescription>
-        )}
-      </LocalHeader>
-
-      {company.archived && (
-        <ArchivePanel
-          archivedBy={company.archived_by}
-          archivedOn={company.archived_on}
-          archiveReason={company.archived_reason}
-          unarchiveUrl={urls.companies.unarchive(company.id)}
-          type="company"
-        />
-      )}
-
-      {company.pending_dnb_investigation && (
-        <StyledMain data-test="investigationMessage">
-          <StatusMessage>
-            This company record is based on information that has not yet been
-            validated. This information is currently being checked by the Data
-            Hub support team.
-          </StatusMessage>
-        </StyledMain>
-      )}
-
-      {company.account_plan_url && (
-        <StyledMainMuted data-test="accountPlanMessage">
-          <StatusMessage>
-            <a
-              href={company.account_plan_url}
-              target="_blank"
-              aria-label="Opens in a new window or tab"
-              rel="noopener noreferrer"
-            >
-              Go to Sharepoint to view the account plan
-            </a>{' '}
-            for {company.name} (opens in a new window or tab). You might have to
-            request access to this file.
-            {company.one_list_group_global_account_manager &&
-              company.one_list_group_global_account_manager.contact_email && (
+              )}
+              {company.hasManagedAccountDetails && (
                 <>
-                  &nbsp;To do so, contact the Global Account Manager at&nbsp;
-                  <a
-                    href={
-                      'mailto:' +
-                      company.one_list_group_global_account_manager
-                        .contact_email
-                    }
-                  >
-                    {
-                      company.one_list_group_global_account_manager
-                        .contact_email
-                    }
-                  </a>
-                  .
+                  <p>
+                    This is an account managed company (One List{' '}
+                    {company.one_list_group_tier.name})
+                  </p>
+                  <p>
+                    {company.isItaTierDAccount
+                      ? 'Lead ITA'
+                      : 'Global Account Manager'}
+                    : {company.one_list_group_global_account_manager.name}{' '}
+                    <a href={urls.companies.advisers.index(company.id)}>
+                      {company.isItaTierDAccount
+                        ? 'View Lead adviser'
+                        : 'View core team'}
+                    </a>
+                  </p>
                 </>
               )}
-            <StyledDetailsMuted
-              summary="What is an account plan?"
-              data-test="metaList"
-            >
-              All businesses on the One List are expected to have an account
-              plan, to ensure that the wider virtual team understands the
-              company and its key priorities. The Global Account Manager is
-              responsible for adding and updating the account plan. For further
-              information{' '}
-              <NewWindowLink
-                href={
-                  urls.external.digitalWorkspace.accountManagementStrategyTeam
-                }
-                aria-label="view the Account Management Framework"
+            </StyledDescription>
+          )}
+        </LocalHeader>
+
+        {company.archived && (
+          <ArchivePanel
+            archivedBy={company.archived_by}
+            archivedOn={company.archived_on}
+            archiveReason={company.archived_reason}
+            unarchiveUrl={urls.companies.unarchive(company.id)}
+            type="company"
+          />
+        )}
+
+        {company.pending_dnb_investigation && (
+          <StyledMain data-test="investigationMessage">
+            <StatusMessage>
+              This company record is based on information that has not yet been
+              validated. This information is currently being checked by the Data
+              Hub support team.
+            </StatusMessage>
+          </StyledMain>
+        )}
+
+        {company.account_plan_url && (
+          <StyledMainMuted data-test="accountPlanMessage">
+            <StatusMessage>
+              <a
+                href={company.account_plan_url}
+                target="_blank"
+                aria-label="Opens in a new window or tab"
+                rel="noopener noreferrer"
               >
-                view the Account Management Framework
-              </NewWindowLink>
-            </StyledDetailsMuted>
-          </StatusMessage>
-        </StyledMainMuted>
-      )}
-    </>
+                Go to Sharepoint to view the account plan
+              </a>{' '}
+              for {company.name} (opens in a new window or tab). You might have
+              to request access to this file.
+              {company.one_list_group_global_account_manager &&
+                company.one_list_group_global_account_manager.contact_email && (
+                  <>
+                    &nbsp;To do so, contact the Global Account Manager at&nbsp;
+                    <a
+                      href={
+                        'mailto:' +
+                        company.one_list_group_global_account_manager
+                          .contact_email
+                      }
+                    >
+                      {
+                        company.one_list_group_global_account_manager
+                          .contact_email
+                      }
+                    </a>
+                    .
+                  </>
+                )}
+              <StyledDetailsMuted
+                summary="What is an account plan?"
+                data-test="metaList"
+              >
+                All businesses on the One List are expected to have an account
+                plan, to ensure that the wider virtual team understands the
+                company and its key priorities. The Global Account Manager is
+                responsible for adding and updating the account plan. For
+                further information{' '}
+                <NewWindowLink
+                  href={
+                    urls.external.digitalWorkspace.accountManagementStrategyTeam
+                  }
+                  aria-label="view the Account Management Framework"
+                >
+                  view the Account Management Framework
+                </NewWindowLink>
+              </StyledDetailsMuted>
+            </StatusMessage>
+          </StyledMainMuted>
+        )}
+      </>
+    )
   )
 }
 

--- a/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
@@ -82,8 +82,8 @@ const CompanyLocalTab = (props) => {
       <StyledAnchorTag
         selected={navItem.isActive}
         href={navItem.url}
-        id={`tab-${index}`}
-        key={`tab-link-${index}`}
+        id={`tab-${navItem.path}`}
+        key={`tab-link-${navItem.path}`}
         aria-label={navItem.ariaDescription}
       >
         {navItem.label}

--- a/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
@@ -9,68 +9,58 @@ const StyledListItem = styled.li`
     box-sizing: border-box;
   }
   border-left-width: 1px;
-  flex-grow: 1;
   text-align: center;
-  white-space: nowrap;
-  @media (min-width: 40.0625em) {
-    margin-left: 0;
+  border-bottom: 1px solid #bfc1c3;
+
+  @media (min-width: 1020px) {
+    white-space: nowrap;
   }
-  a {
-    display: block;
-    width: calc(100% - 5px);
+  @media (max-width: 839px) {
+    text-align: left;
+    margin-left: 25px;
+    line-height: 2.5em;
+    border-bottom: none;
+    &::before {
+      content: '—';
+      margin-left: -25px;
+      padding-right: 5px;
+    }
+    a {
+      width: calc(100% - 5px);
+    }
   }
 `
 
 const StyledAnchorTag = styled.a`
-  font-family: Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-family: Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
-  padding: 10px 20px;
-  margin-right: 5px;
-  display: block;
-  flex: 1;
-  padding-right: -4px;
-  padding-left: -4px;
-  &:link,
-  &:visited,
-  &:hover,
-  &:active {
-    color: black;
-  }
-  @media (min-width: 40.0625em) {
-    margin-right: 5px;
-    padding-right: 20px;
-    padding-left: 20px;
-    float: left;
-    color: #0b0c0c;
+  display: inline-block;
+
+  @media (min-width: 840px) {
+    padding: 10px 20px;
+    margin: 0 5px 0 0;
+    &:link,
+    &:visited,
+    &:hover,
+    &:active {
+      color: black;
+    }
     background-color: #f8f8f8;
     text-align: center;
     text-decoration: none;
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
+    height: 90%;
 
     ${(props) =>
       props.selected &&
       css`
-        margin: -5px, 1px, -1px, 0px;
-        margin-top: -5px;
-        margin-bottom: -1px;
+        margin: -5px 5px -1px 0px;
         padding-top: 14px;
         padding-right: 19px;
         padding-bottom: 16px;
         padding-left: 19px;
         border: 1px solid #bfc1c3;
-        border-bottom: 0;
+        border-bottom: 0px;
         color: #0b0c0c;
         background-color: #fff;
+        height: auto;
       `}
   }
 `

--- a/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
@@ -11,7 +11,7 @@ const StyledListItem = styled.li`
   border-left-width: 1px;
   flex-grow: 1;
   text-align: center;
-
+  white-space: nowrap;
   @media (min-width: 40.0625em) {
     margin-left: 0;
   }

--- a/src/client/components/CompanyTabbedLocalNavigation/index.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/index.jsx
@@ -13,28 +13,18 @@ const StyledGridColumn = styled.div`
   box-sizing: border-box;
   width: 100%;
   padding: 0 15px;
-  @media (min-width: 40.0625em) {
+  @media (min-width: 840px) {
     width: 100%;
     float: left;
   }
 `
 const StyledNav = styled.nav`
   margin-bottom: 15px;
-  font-family: Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
   color: #0b0c0c;
   margin-top: 5px;
-  @media (min-width: 40.0625em) {
+  @media (min-width: 840px) {
     margin-bottom: 30px;
     margin-top: 5px;
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
   }
 `
 
@@ -43,9 +33,11 @@ const StyledUnorderedList = styled.ul`
   padding: 0;
   list-style: none;
   display: flex;
-
-  @media (min-width: 40.0625em) {
-    border-bottom: 1px solid #bfc1c3;
+  border-bottom: none;
+  @media (max-width: 839px) {
+    display: block;
+    padding-bottom: 20px;
+    border-bottom: 0;
   }
 `
 

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -25,6 +25,7 @@ describe('DA Permission', () => {
     it('should display DA only tabs', () => {
       assertLocalReactNav('[data-test="tabbedLocalNavList"]', [
         'Company contacts',
+        'Business details',
         'Core team',
         'Investment',
         'Orders',

--- a/test/end-to-end/cypress/specs/DIT/business-hierarchy-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/business-hierarchy-spec.js
@@ -27,10 +27,11 @@ describe('Business hierarchy', () => {
           .next()
           .click()
         cy.get('.c-entity-list li a').first().click()
-        cy.get('.c-message--success').should(
+        cy.get('[data-test="status-message"]').should(
           'contain',
           'You’ve linked the Global Headquarters'
         )
+
         cy.get(selectors.companyBusinessDetails().hierarchy).should(
           'contain',
           'Global HQOne List CorpRemove link'
@@ -42,7 +43,7 @@ describe('Business hierarchy', () => {
         cy.get(
           `${selectors.companyBusinessDetails().hierarchy} td a:nth-child(2)`
         ).click()
-        cy.get('.c-message--success').should(
+        cy.get('[data-test="status-message"]').should(
           'contain',
           'You’ve removed the link to Global Headquarters'
         )
@@ -94,7 +95,7 @@ describe('Business hierarchy', () => {
       cy.get(selectors.companySubsidiaries().oneLinkedSubsidiary).click()
       cy.get(selectors.companySubsidiariesLink().removeSubsidiary).click()
 
-      cy.get(selectors.message.successful).should(
+      cy.get('[data-test="status-message"]').should(
         'contain',
         'You’ve removed the link to Global Headquarters'
       )

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -44,6 +44,7 @@ describe('DIT Permission', () => {
     it('should display DIT only tabs', () => {
       assertLocalReactNav('[data-test="tabbedLocalNavList"]', [
         'Activity',
+        'Business details',
         'Company contacts',
         'Core team',
         'Investment',

--- a/test/end-to-end/cypress/specs/DIT/manage-adviser-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/manage-adviser-spec.js
@@ -12,7 +12,7 @@ const addOrReplaceTestCase = ({
 }) => {
   it(`should be able to ${replace ? 'replace' : 'add'} an adviser`, () => {
     cy.visit(urls.companies.detail(company.pk))
-    cy.get(selectors.tabbedLocalNav().item(3)).click()
+    cy.get('#tab-advisers').click()
     cy.get('#lead-advisers a')
       .contains(`${replace ? 'Replace Lead ITA' : 'Add a Lead ITA'}`)
       .click()
@@ -53,13 +53,13 @@ describe('Manage Lead ITA', () => {
   })
   it('should not be able to add an advisor who is no longer active', () => {
     cy.visit(urls.companies.detail(company.pk))
-    cy.get(selectors.tabbedLocalNav().item(3)).click()
+    cy.get('#tab-advisers').click()
     cy.get('#lead-advisers a').contains('Replace Lead ITA').click()
     cy.get('form label').next().next().checkNoTypeaheadOptionsDisplayed('Ava')
   })
   it('should be able to remove an adviser', () => {
     cy.visit(urls.companies.detail(company.pk))
-    cy.get(selectors.tabbedLocalNav().item(3)).click()
+    cy.get('#tab-advisers').click()
     cy.get('#lead-advisers a + a').click()
     cy.get('form button').click()
     cy.get(selectors.companyLocalHeader().flashMessageList).contains(

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -25,6 +25,7 @@ describe('LEP Permission', () => {
     it('should display LEP only tabs', () => {
       assertLocalReactNav('[data-test="tabbedLocalNavList"]', [
         'Company contacts',
+        'Business details',
         'Core team',
         'Investment',
       ])

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -54,12 +54,6 @@ const assertBusinessDetailsBreadcrumbs = (company) => {
   })
 }
 
-const assertBusinessDetailsHeading = (company) => {
-  it('should display the "Business details" heading', () => {
-    cy.get(selectors.localHeader().heading).should('have.text', company.name)
-  })
-}
-
 const assertLastUpdatedParagraph = (date) => {
   const paragraphText = 'Last updated on: ' + date
   it('should display the "Last updated" paragraph', () => {
@@ -196,7 +190,6 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.oneListCorp)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading(fixtures.company.oneListCorp)
       assertLastUpdatedParagraph('26 Nov 2017')
 
       it('should not display the "Pending Change Request" box', () => {
@@ -335,7 +328,6 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.venusLtd)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading(fixtures.company.venusLtd)
       assertLastUpdatedParagraph('15 Jul 2016')
       assertAreDetailsRightNotVisible()
       assertUnarchiveLinkNotVisible()
@@ -407,7 +399,6 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.dnbCorp)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading(fixtures.company.dnbCorp)
       assertLastUpdatedParagraph('26 Oct 2018')
       assertAreDetailsRight()
       assertUnarchiveLinkNotVisible()
@@ -493,7 +484,6 @@ describe('Companies business details', () => {
       })
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.archivedLtd)
-      assertBusinessDetailsHeading(fixtures.company.archivedLtd)
       assertLastUpdatedParagraph('16 Jul 2017')
       assertAreDetailsRightNotVisible()
 
@@ -565,7 +555,6 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.minimallyMinimalLtd)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading(fixtures.company.minimallyMinimalLtd)
       assertLastUpdatedParagraph('11 Dec 2015')
       assertAreDetailsRightNotVisible()
       assertUnarchiveLinkNotVisible()

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -54,12 +54,9 @@ const assertBusinessDetailsBreadcrumbs = (company) => {
   })
 }
 
-const assertBusinessDetailsHeading = () => {
+const assertBusinessDetailsHeading = (company) => {
   it('should display the "Business details" heading', () => {
-    cy.get(selectors.localHeader().heading).should(
-      'have.text',
-      'Business details'
-    )
+    cy.get(selectors.localHeader().heading).should('have.text', company.name)
   })
 }
 
@@ -199,7 +196,7 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.oneListCorp)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading()
+      assertBusinessDetailsHeading(fixtures.company.oneListCorp)
       assertLastUpdatedParagraph('26 Nov 2017')
 
       it('should not display the "Pending Change Request" box', () => {
@@ -338,7 +335,7 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.venusLtd)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading()
+      assertBusinessDetailsHeading(fixtures.company.venusLtd)
       assertLastUpdatedParagraph('15 Jul 2016')
       assertAreDetailsRightNotVisible()
       assertUnarchiveLinkNotVisible()
@@ -410,7 +407,7 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.dnbCorp)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading()
+      assertBusinessDetailsHeading(fixtures.company.dnbCorp)
       assertLastUpdatedParagraph('26 Oct 2018')
       assertAreDetailsRight()
       assertUnarchiveLinkNotVisible()
@@ -496,7 +493,7 @@ describe('Companies business details', () => {
       })
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.archivedLtd)
-      assertBusinessDetailsHeading()
+      assertBusinessDetailsHeading(fixtures.company.archivedLtd)
       assertLastUpdatedParagraph('16 Jul 2017')
       assertAreDetailsRightNotVisible()
 
@@ -568,7 +565,7 @@ describe('Companies business details', () => {
 
       assertBusinessDetailsBreadcrumbs(fixtures.company.minimallyMinimalLtd)
       assertArchivePanelNotVisible()
-      assertBusinessDetailsHeading()
+      assertBusinessDetailsHeading(fixtures.company.minimallyMinimalLtd)
       assertLastUpdatedParagraph('11 Dec 2015')
       assertAreDetailsRightNotVisible()
       assertUnarchiveLinkNotVisible()

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -6,7 +6,7 @@ describe('Lead advisers', () => {
   context('when viewing a non One List tier company', () => {
     before(() => {
       cy.visit(urls.companies.detail(fixtures.company.marsExportsLtd.id))
-      cy.get(selectors.tabbedLocalNav().item(3)).click()
+      cy.get('#tab-advisers').click()
     })
 
     it('should render a meta title', () => {
@@ -17,10 +17,7 @@ describe('Lead advisers', () => {
     })
 
     it('should display the "Lead Adviser" tab in the navigation', () => {
-      cy.get(selectors.tabbedLocalNav().item(3)).should(
-        'contain',
-        'Lead adviser'
-      )
+      cy.get('#tab-advisers').should('contain', 'Lead adviser')
     })
     it('should display a header with the company name', () => {
       cy.get(selectors.companyLeadAdviser.header).should(
@@ -51,7 +48,7 @@ describe('Lead advisers', () => {
     })
 
     it('should display the "Core team" tab in the navigation', () => {
-      cy.get(selectors.tabbedLocalNav().item(3)).should('contain', 'Core team')
+      cy.get('#tab-advisers').should('contain', 'Core team')
     })
   })
   context(
@@ -59,7 +56,7 @@ describe('Lead advisers', () => {
     () => {
       before(() => {
         cy.visit(urls.companies.detail(fixtures.company.oneListTierDita.id))
-        cy.get(selectors.tabbedLocalNav().item(3)).click()
+        cy.get('#tab-advisers').click()
       })
 
       it('should have a link to the Lead adviser tab', () => {
@@ -71,10 +68,7 @@ describe('Lead advisers', () => {
           )
       })
       it('should display the "Lead Adviser" tab in the navigation', () => {
-        cy.get(selectors.tabbedLocalNav().item(3)).should(
-          'contain',
-          'Lead adviser'
-        )
+        cy.get('#tab-advisers').should('contain', 'Lead adviser')
       })
       it('should display a header with the company name', () => {
         cy.get(selectors.companyLeadAdviser.header).should(

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -8,7 +8,6 @@ const {
   assertButtons,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
-  assertViewFullBusinessDetails,
   assertOneListTierA,
   assertCoreTeam,
 } = require('../../../support/company-local-header-assertions')
@@ -22,7 +21,6 @@ const company = fixtures.company.archivedLtd
 
 const advisersUrl = urls.companies.advisers.index(company.id)
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
-const businessDetailsUrl = urls.companies.businessDetails(company.id)
 const detailsUrl = urls.companies.detail(company.id)
 const unarchiveUrl = urls.companies.unarchive(company.id)
 
@@ -53,10 +51,6 @@ describe('Local header for archived company', () => {
     it('should display the correct description', () => {
       assertOneListTierA(1)
       assertCoreTeam(2, advisersUrl)
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the archived message', () => {
@@ -91,10 +85,6 @@ describe('Local header for archived company', () => {
       assertCoreTeam(2, advisersUrl)
     })
 
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
-    })
-
     it('should display the archived message', () => {
       assertArchiveMessage()
     })
@@ -123,10 +113,6 @@ describe('Local header for archived company', () => {
     it('should display the correct description', () => {
       assertOneListTierA(1)
       assertCoreTeam(2, advisersUrl)
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the archived message', () => {
@@ -161,10 +147,6 @@ describe('Local header for archived company', () => {
     it('should display the correct description', () => {
       assertOneListTierA(1)
       assertCoreTeam(2, advisersUrl)
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the archived message', () => {
@@ -206,10 +188,6 @@ describe('Local header for archived company', () => {
         assertCoreTeam(2, advisersUrl)
       })
 
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
-
       it('should display the archived message', () => {
         assertArchiveMessage()
       })
@@ -241,10 +219,6 @@ describe('Local header for archived company', () => {
     it('should display the correct description', () => {
       assertOneListTierA(1)
       assertCoreTeam(2, advisersUrl)
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the archived message', () => {
@@ -281,10 +255,6 @@ describe('Local header for archived company', () => {
       assertCoreTeam(2, advisersUrl)
     })
 
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
-    })
-
     it('should display the archived message', () => {
       assertArchiveMessage()
     })
@@ -315,10 +285,6 @@ describe('Local header for archived company', () => {
     it('should display the correct description', () => {
       assertOneListTierA(1)
       assertCoreTeam(2, advisersUrl)
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the archived message', () => {

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -8,7 +8,6 @@ const {
   assertButtons,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
-  assertViewFullBusinessDetails,
   assertOneListTierA,
   assertCoreTeam,
   assertArchivePanelNotVisible,
@@ -22,7 +21,6 @@ const address =
 
 const advisersUrl = urls.companies.advisers.index(company.id)
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
-const businessDetailsUrl = urls.companies.businessDetails(company.id)
 const detailsUrl = urls.companies.detail(company.id)
 const dnbHierarchyUrl = urls.companies.dnbHierarchy.index(company.id)
 
@@ -61,9 +59,40 @@ describe('Local header for global ultimate company', () => {
     it('should display the correct description', () => {
       assertDescription()
     })
+  })
+  context('when visting a global ultimate company activity page', () => {
+    before(() => {
+      cy.visit(urls.companies.businessDetails(company.id))
+    })
 
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
+    assertBreadcrumbs(company.name, detailsUrl, 'Business details')
+
+    it('should not display the archive panel', () => {
+      assertArchivePanelNotVisible()
+    })
+
+    it('should display the company name', () => {
+      assertCompanyName(company.name)
+    })
+
+    it('should display the company address', () => {
+      assertCompanyAddress(address)
+    })
+
+    it('should display the correct buttons', () => {
+      assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}`)
+    })
+
+    it('should display an "Ultimate HQ" badge', () => {
+      assertBadgeText('Ultimate HQ')
+    })
+
+    it('should display "What does Ultimate HQ mean?" details', () => {
+      assertMetaList()
+    })
+
+    it('should display the correct description', () => {
+      assertDescription()
     })
   })
   context('when visting a global ultimate company contacts page', () => {
@@ -95,10 +124,6 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the correct description', () => {
       assertDescription()
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
   })
   context('when visting a global ultimate company core team page', () => {
@@ -134,10 +159,6 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the correct description', () => {
       assertDescription()
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
   })
   context(
@@ -177,10 +198,6 @@ describe('Local header for global ultimate company', () => {
 
       it('should display the correct description', () => {
         assertDescription()
-      })
-
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
       })
     }
   )
@@ -222,10 +239,6 @@ describe('Local header for global ultimate company', () => {
       it('should display the correct description', () => {
         assertDescription()
       })
-
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
     }
   )
   context('when visting a global ultimate company export page', () => {
@@ -261,10 +274,6 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the correct description', () => {
       assertDescription()
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
   })
   context('when visting a global ultimate company export history page', () => {
@@ -303,10 +312,6 @@ describe('Local header for global ultimate company', () => {
     it('should display the correct description', () => {
       assertDescription()
     })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
-    })
   })
   context('when visting a global ultimate company orders page', () => {
     before(() => {
@@ -341,10 +346,6 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the correct description', () => {
       assertDescription()
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
   })
 })

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -7,7 +7,6 @@ const {
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
   assertButtons,
-  assertViewFullBusinessDetails,
   assertArchivePanelNotVisible,
 } = require('../../../support/company-local-header-assertions')
 
@@ -17,7 +16,6 @@ const address = 'Unit 10, Ockham Drive, GREENFORD, UB6 0F2, United Kingdom'
 const company = fixtures.company.investigationLimited
 
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
-const businessDetailsUrl = urls.companies.businessDetails(company.id)
 const detailsUrl = urls.companies.detail(company.id)
 
 describe('Local header for company under dnb investigation', () => {
@@ -52,10 +50,6 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the correct description', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
-      })
-
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
       })
 
       it('should display the investigation message', () => {
@@ -102,10 +96,6 @@ describe('Local header for company under dnb investigation', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
       })
 
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
-
       it('should display the investigation message', () => {
         assertInvestigationMessage()
       })
@@ -150,10 +140,6 @@ describe('Local header for company under dnb investigation', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
       })
 
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
-
       it('should display the investigation message', () => {
         assertInvestigationMessage()
       })
@@ -192,10 +178,6 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the correct description', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
-      })
-
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
       })
 
       it('should display the investigation message', () => {
@@ -242,10 +224,6 @@ describe('Local header for company under dnb investigation', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
       })
 
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
-
       it('should display the investigation message', () => {
         assertInvestigationMessage()
       })
@@ -284,10 +262,6 @@ describe('Local header for company under dnb investigation', () => {
 
     it('should display the correct description', () => {
       cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the investigation message', () => {
@@ -333,10 +307,6 @@ describe('Local header for company under dnb investigation', () => {
         cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
       })
 
-      it('should display the link to the full business details', () => {
-        assertViewFullBusinessDetails(businessDetailsUrl)
-      })
-
       it('should display the investigation message', () => {
         assertInvestigationMessage()
       })
@@ -371,10 +341,6 @@ describe('Local header for company under dnb investigation', () => {
 
     it('should display the correct description', () => {
       cy.get(companyLocalHeader.description.paragraph(1)).should('not.exist')
-    })
-
-    it('should display the link to the full business details', () => {
-      assertViewFullBusinessDetails(businessDetailsUrl)
     })
 
     it('should display the investigation message', () => {

--- a/test/functional/cypress/specs/companies/tab-history-spec.js
+++ b/test/functional/cypress/specs/companies/tab-history-spec.js
@@ -4,14 +4,24 @@ const {
   companyAddRemoveFromLists: { cancelLink },
 } = require('../../../../selectors')
 
-const testTab = (tabText, index) => {
+const testTab = (tabText) => {
+  const lookUp = {
+    Activity: 'tab-activity',
+    'Business details': 'tab-business-details',
+    'Company contacts': 'tab-contacts',
+    'Lead adviser': 'tab-advisers',
+    Investment: 'tab-investments',
+    Export: 'tab-exports',
+    Orders: 'tab-orders',
+  }
+  const tab = lookUp[tabText]
   it(`should return to the tab ${tabText}`, () => {
-    cy.get(`#tab-${index}`).contains(tabText).click()
+    cy.get(`#${tab}`).contains(tabText).click()
     cy.contains('View options').click()
     cy.contains('Add to or remove from lists').click()
     cy.get(cancelLink).click()
 
-    cy.get(`#tab-${index}`).contains(tabText)
+    cy.get(`#${tab}`).contains(tabText)
   })
 }
 
@@ -21,6 +31,7 @@ describe('Company tab history', () => {
   })
   ;[
     'Activity',
+    'Business details',
     'Company contacts',
     'Lead adviser',
     'Investment',

--- a/test/functional/cypress/support/company-local-header-assertions.js
+++ b/test/functional/cypress/support/company-local-header-assertions.js
@@ -60,17 +60,6 @@ const assertExportCountryHistoryBreadcrumbs = (company, detailsUrl) => {
   })
 }
 
-/**
- * Asserts that the business details URL appears and is correct
- */
-const assertViewFullBusinessDetails = (businessDetailsUrl) => {
-  cy.contains('View full business details').should(
-    'have.attr',
-    'href',
-    businessDetailsUrl
-  )
-}
-
 const assertOneListTierA = (paragraphNumber) => {
   cy.get(companyLocalHeader.description.paragraph(paragraphNumber)).contains(
     'This is an account managed company (One List Tier A - Strategic Account)'
@@ -95,7 +84,6 @@ module.exports = {
   assertButtons,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
-  assertViewFullBusinessDetails,
   assertOneListTierA,
   assertCoreTeam,
   assertArchivePanelNotVisible,


### PR DESCRIPTION
## Description of change

On the companies tab page we created the Business Details tab and added the content from the Business Details page (example: https://www.datahub.trade.gov.uk/companies/689f42c1-a098-e211-a939-e4115bead28a/business-details). 

The ‘View full business details’ link in the header has also need to be removed.

This will ensure consistency in how the information is displayed as tabs.

## Test instructions

-Visit a company e.g. http://localhost:3000/companies/0eb9e12e-2591-483d-a677-3e54ea721f3b/activity
-You should see a Business details tab instead of a link to View business details 

## Screenshots

### Before

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/83657534/220667403-7f73310b-7871-4764-9fd4-5282866fccfd.png">


### After
![image](https://user-images.githubusercontent.com/83657534/220875064-15cd2033-16da-4b75-a93b-56b799802ec0.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
