### PR TITLE
Ccit 105 accessibility dac label in name

### DIFF
--- a/src/client/components/SearchButton/index.jsx
+++ b/src/client/components/SearchButton/index.jsx
@@ -9,7 +9,7 @@ const StyledButton = styled('button')`
   top: 0;
   right: 0;
   border: 0;
-  margin: 0;
+  margin: 10px 0 0 10px;
   border-radius: 0;
   cursor: pointer;
   padding: 12px;

--- a/src/client/components/SearchLocalHeader/index.jsx
+++ b/src/client/components/SearchLocalHeader/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import VisuallyHidden from '@govuk-react/visually-hidden'
 import { SPACING } from '@govuk-react/constants'
 import Input from '@govuk-react/input'
 import styled from 'styled-components'
@@ -21,14 +20,13 @@ const StyledSearchInput = styled(Input)`
   border: 2px solid #0b0c0c;
   width: 100%;
   padding-left: ${SPACING.SCALE_3};
+  margin-top: 10px;
 `
 const StyledMain = styled(Main)`
   padding-top: 0;
 `
 
-const StyledDiv = styled('div')({
-  marginTop: 2 * 20.5,
-  marginBottom: 10,
+const StyledLabel = styled('label')({
   fontSize: 19,
   color: DARK_GREY,
 })
@@ -52,13 +50,10 @@ const SearchLocalHeader = ({ csrfToken, flashMessages }) => (
     >
       <FlashMessages flashMessages={flashMessages} />
       <StyledMain>
-        <StyledDiv>
+        <StyledLabel for="search-input">
           Search for company, contact, event, investment project or OMIS order
-        </StyledDiv>
+        </StyledLabel>
         <StyledSearchContainer role="search">
-          <label htmlFor="search-input">
-            <VisuallyHidden>Input your search term</VisuallyHidden>
-          </label>
           <StyledSearchInput
             name="term"
             type="text"

--- a/src/client/components/SearchLocalHeader/index.jsx
+++ b/src/client/components/SearchLocalHeader/index.jsx
@@ -23,10 +23,11 @@ const StyledSearchInput = styled(Input)`
   margin-top: 10px;
 `
 const StyledMain = styled(Main)`
-  padding-top: 0;
+  padding-top: 40px;
 `
 
 const StyledLabel = styled('label')({
+  marginTop: 2 * 20.5,
   fontSize: 19,
   color: DARK_GREY,
 })

--- a/src/templates/_macros/form/form-group.njk
+++ b/src/templates/_macros/form/form-group.njk
@@ -53,9 +53,7 @@
         "
         {% if labelElement == 'label' %}for="{{ props.fieldId }}"{% endif %}
       >
-        <span class="{{ labelClassName + '-text' }}">
-          {{ props.label }} {{ '(optional)' if props.optional }}
-        </span>
+        {{ props.label }} {{ '(optional)' if props.optional }}
         {% if props.error and labelElement == 'label' %}
           <span class="c-form-group__error-message" data-test="field-error">{{ props.error }}</span>
         {% endif %}


### PR DESCRIPTION
## Description of change

Amended affected hidden search input label elements to no longer contain a span containing the text. Fixes accessibility issue DAC_Label_In_Name_01

## Test instructions

n/a

## Screenshots

No change

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
