### PR TITLE
Fix invalid DOM attribute

### DIFF
--- a/src/client/components/SearchLocalHeader/index.jsx
+++ b/src/client/components/SearchLocalHeader/index.jsx
@@ -51,7 +51,7 @@ const SearchLocalHeader = ({ csrfToken, flashMessages }) => (
     >
       <FlashMessages flashMessages={flashMessages} />
       <StyledMain>
-        <StyledLabel for="search-input">
+        <StyledLabel htmlFor="search-input">
           Search for company, contact, event, investment project or OMIS order
         </StyledLabel>
         <StyledSearchContainer role="search">


### PR DESCRIPTION
## Description of change
Fixes an invalid DOM attribute on the home page. In JavaScript, `for` is a reserved word, React/JSX elements use `htmlFor` instead. 

<img width="692" alt="Screenshot 2023-02-23 at 08 19 47" src="https://user-images.githubusercontent.com/964268/220856099-f4c037e2-7966-46c9-81a8-c6114b89c3bf.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
