### PR TITLE
Issue ID: DAC_Unlabelled_Element_01 fixed

### DIFF
--- a/src/client/components/CompanyLists/Header.jsx
+++ b/src/client/components/CompanyLists/Header.jsx
@@ -48,7 +48,7 @@ export const Header = connect(state2props, (dispatch) => ({
           input={{
             onChange: (e) => onChange(e.target.value),
             initialValue: selectedId,
-            id: 'view-list,',
+            id: 'view-list',
           }}
         >
           {Object.entries(lists).map(([id, { name }]) => (


### PR DESCRIPTION
## Description of change

The accessibility audit raised the following issue:

“An element was found to be unlabelled due to the id and for attributes not matching.”

The drop-down for ‘View list’ on the home page has an id attribute which has a value that does not match the for attribute from the label. This is due to the value of the id being “view-list,” and the for value being “view-list”. The comma being placed within the id is causing the two to be unlinked.

The scope of this ticket is to ensure that the values for labels are correctly written in both the id and for attributes to keep the label correctly linked.


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
