### PR TITLE
Issue ID: DAC_Current_Page_Link_01

### DIFF
--- a/src/client/components/Pagination/RoutedPagination.jsx
+++ b/src/client/components/Pagination/RoutedPagination.jsx
@@ -216,7 +216,7 @@ const Pagination = ({
                       data-page-number={page}
                       data-test={`${isActive && 'page-number-active'}`}
                       aria-label={`Page ${page}`}
-                      aria-current={isActive ? 'page' : 'false'}
+                      aria-current={isActive ? 'page' : false}
                       ref={(el) => (linkRefs.current[index] = el)}
                       href="#"
                     >

--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -123,7 +123,7 @@ function Pagination({ totalPages, activePage, getPageUrl, onPageClick }) {
                     data-test={isActive ? 'page-number-active' : 'page-number'}
                     data-page-number={pageNumber}
                     aria-label={`Page ${pageNumber}`}
-                    aria-current={isActive ? 'page' : 'false'}
+                    aria-current={isActive ? 'page' : false}
                     onClick={onClick}
                     href={getPageUrl(pageNumber)}
                   >


### PR DESCRIPTION
## Description of change

On the ‘Companies’ page, there are pagination links with the current page being visually displayed without a background colour and the digit in a different colour to other pagination links. However, this information is not relayed programmatically to screen reader users; users are unaware that this is the current page and the link still works when selected. Screen reader users would expect pagination links to inform them of the page they are currently on.

Two types of pagination and they both have this problem.

This is linked to another accessibility ticket that introduced aria-current - https://github.com/uktrade/data-hub-frontend/pull/5283/files

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
