### PR TITLE
Issue ID: DAC_List_Not_Marked_Up_01

### DIFF
--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -31,15 +31,18 @@ const StyledInactiveLink = styled('a')({
   },
 })
 
-export const LocalNav = ({ children, dataTest = 'local-nav' }) => (
-  <nav data-test={dataTest}>
-    <ul>
-      {children.map((link) => (
-        <li> {link} </li>
-      ))}
-    </ul>
-  </nav>
-)
+export const LocalNav = ({ children, dataTest = 'local-nav' }) => {
+  children = children.filter((child) => child !== false)
+  return (
+    <nav data-test={dataTest}>
+      <ul>
+        {children.map((link) => (
+          <li> {link} </li>
+        ))}
+      </ul>
+    </nav>
+  )
+}
 
 export const LocalNavLink = ({
   children,

--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -32,7 +32,13 @@ const StyledInactiveLink = styled('a')({
 })
 
 export const LocalNav = ({ children, dataTest = 'local-nav' }) => (
-  <nav data-test={dataTest}>{children}</nav>
+  <nav data-test={dataTest}>
+    <ul>
+      {children.map((link) => (
+        <li> {link} </li>
+      ))}
+    </ul>
+  </nav>
 )
 
 export const LocalNavLink = ({

--- a/src/templates/_macros/common/local-nav.njk
+++ b/src/templates/_macros/common/local-nav.njk
@@ -9,14 +9,20 @@
 {% macro LocalNav(props) %}
   {% if props %}
     <nav class="{{ 'c-local-nav' | applyClassModifiers(props.modifier) }}" aria-label="local navigation">
-      {% for item in props.items %}
-        <a class="{{ 'c-local-nav__link' | applyClassModifiers(props.modifier) }} {{ 'is-active' if item.isActive }}" href="{{item.url}}" 
-          {% if item.ariaDescription %} aria-label="{{ item.ariaDescription }}" {% endif %}
-          {% for key, value in item.data %}
-            data-{{ key }}="{{ value | escape }}-link"
-          {% endfor %}
-        >{{ item.label }}</a>
-      {% endfor %}
+      <ul>
+        {% for item in props.items %}
+        <li>
+          <a class="{{ 'c-local-nav__link' | applyClassModifiers(props.modifier) }} {{ 'is-active' if item.isActive }}" href="{{item.url}}"
+            {% if item.ariaDescription %} aria-label="{{ item.ariaDescription }}" {% endif %}
+            {% for key, value in item.data %}
+              data-{{ key }}="{{ value | escape }}-link"
+            {% endfor %}
+            >{{ item.label }}
+          </a>
+        </li>
+
+        {% endfor %}
+      </ul>
     </nav>
   {% endif %}
 {% endmacro %}

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -61,7 +61,10 @@ describe('DA Permission', () => {
     })
 
     it('should display DA only tabs', () => {
-      assertLocalReactNav('[data-test=local-nav]', ['Details', 'Audit history'])
+      assertLocalReactNav('[data-test=local-nav] > ul', [
+        'Details',
+        'Audit history',
+      ])
     })
   })
 

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -102,7 +102,7 @@ describe('DIT Permission', () => {
     })
 
     it('should display DIT only side navs', () => {
-      const navSelector = '[data-test="eventDetails"] > div > nav > a'
+      const navSelector = '[data-test="event-details-nav-link"]'
       assertLocalNav(navSelector, ['Details', 'Attendee'])
     })
   })

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -65,7 +65,7 @@ describe('DIT Permission', () => {
     })
 
     it('should display DIT only side navs', () => {
-      assertLocalReactNav('[data-test=local-nav]', [
+      assertLocalReactNav('[data-test=local-nav] > ul', [
         'Details',
         'Activity',
         'Audit history',

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -58,7 +58,10 @@ describe('LEP Permission', () => {
     })
 
     it('should display LEP only tabs', () => {
-      assertLocalReactNav('[data-test=local-nav]', ['Details', 'Audit history'])
+      assertLocalReactNav('[data-test=local-nav] > ul', [
+        'Details',
+        'Audit history',
+      ])
     })
   })
 


### PR DESCRIPTION
## Description of change

On the ‘Project 0612 (CU)’ page, there is a list of links from ‘Project details’ to ‘Evidence’ that has not been programmatically marked up as a list. Due to this, screen readers are not given the same context as sighted users are.

Ensure that all visual lists are also marked up programmatically as lists to give the same context to screen reader users that sighted users get from visual cues.


[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
