### PR TITLE
Added a function to remove contacts from aventri and ess queries when…

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -25,6 +25,7 @@ const {
   eventsColListQueryBuilder,
   isEssActivity,
   augmentEssActivity,
+  filterContactList,
 } = require('../controllers')
 const { has, get } = require('lodash')
 
@@ -1391,6 +1392,35 @@ describe('Activity feed controllers', () => {
         expect(e.length).to.be.equal(3)
         expect(e[0]['dit:emailAddress']).to.be.equal(emails[index])
       })
+    })
+
+    it('filterContactList removes contacts with empty email address', () => {
+      const mockContactList = [
+        {
+          id: '9150ffcf-5b06-4229-9ede-5e5df836f213',
+          first_name: 'test',
+          last_name: 'no email',
+          name: 'test no email',
+          email: '',
+          created_on: '2023-02-23T15:25:05.287511Z',
+          modified_on: '2023-02-23T15:25:38.668575Z',
+        },
+        {
+          id: '9150ffcf-5b06-4229-9ede-5e5df836f214',
+          first_name: 'test',
+          last_name: 'with email',
+          name: 'test with email',
+          email: 'test@test.com',
+          created_on: '2023-02-23T15:25:05.287511Z',
+          modified_on: '2023-02-23T15:25:38.668575Z',
+        },
+      ]
+
+      expect(mockContactList.length).to.equal(2)
+
+      const removedEmailList = filterContactList(mockContactList)
+      expect(removedEmailList.length).to.equal(1)
+      expect(removedEmailList[0].name).to.equal('test with email')
     })
   })
 

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -25,7 +25,7 @@ const {
   eventsColListQueryBuilder,
   isEssActivity,
   augmentEssActivity,
-  filterContactList,
+  filterContactListOnEmail,
 } = require('../controllers')
 const { has, get } = require('lodash')
 
@@ -1393,8 +1393,10 @@ describe('Activity feed controllers', () => {
         expect(e[0]['dit:emailAddress']).to.be.equal(emails[index])
       })
     })
+  })
 
-    it('filterContactList removes contacts with empty email address', () => {
+  describe('#filterContactListOnEmail', () => {
+    it('filterContactListOnEmail removes contacts with empty email address', () => {
       const mockContactList = [
         {
           id: '9150ffcf-5b06-4229-9ede-5e5df836f213',
@@ -1418,7 +1420,7 @@ describe('Activity feed controllers', () => {
 
       expect(mockContactList.length).to.equal(2)
 
-      const removedEmailList = filterContactList(mockContactList)
+      const removedEmailList = filterContactListOnEmail(mockContactList)
       expect(removedEmailList.length).to.equal(1)
       expect(removedEmailList[0].name).to.equal('test with email')
     })

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -175,6 +175,13 @@ async function getMaxemailCampaigns(req, next, contacts) {
   }
 }
 
+// Filter unwanted Contacts, e.g. those with empty email addresses
+function filterContactList(contacts) {
+  const removeEmptyEmails = contacts.filter((contact) => contact.email != '')
+
+  return removeEmptyEmails
+}
+
 async function getAventriEventsAttendedByCompanyContacts(req, next, contacts) {
   try {
     // Fetch aventri attendee info for company contacts
@@ -322,10 +329,11 @@ async function fetchActivityFeedHandler(req, res, next) {
         .map((company) => company.id)
     }
 
+    const filteredContacts = filterContactList(company.contacts)
     const aventriEvents = await getAventriEventsAttendedByCompanyContacts(
       req,
       next,
-      company.contacts
+      filteredContacts
     )
     const aventriEventIds = Object.keys(aventriEvents)
 
@@ -368,7 +376,7 @@ async function fetchActivityFeedHandler(req, res, next) {
         const essContactEmail = activity.actor['dit:emailAddress']
         const essContact = getContactFromEmailAddress(
           essContactEmail,
-          company.contacts
+          filteredContacts
         )
         activity = augmentEssActivity(activity, essContact)
       }
@@ -717,4 +725,5 @@ module.exports = {
   fetchESSDetails,
   isEssActivity,
   augmentEssActivity,
+  filterContactList,
 }

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -175,10 +175,9 @@ async function getMaxemailCampaigns(req, next, contacts) {
   }
 }
 
-// Filter unwanted Contacts, e.g. those with empty email addresses
-function filterContactList(contacts) {
-  const removeEmptyEmails = contacts.filter((contact) => contact.email)
-  return removeEmptyEmails
+// Filter Contacts with empty email addresses or Null Emails
+function filterContactListOnEmail(contacts) {
+  return contacts.filter((contact) => contact.email)
 }
 
 async function getAventriEventsAttendedByCompanyContacts(req, next, contacts) {
@@ -328,7 +327,7 @@ async function fetchActivityFeedHandler(req, res, next) {
         .map((company) => company.id)
     }
 
-    const filteredContacts = filterContactList(company.contacts)
+    const filteredContacts = filterContactListOnEmail(company.contacts)
     const aventriEvents = await getAventriEventsAttendedByCompanyContacts(
       req,
       next,
@@ -724,5 +723,5 @@ module.exports = {
   fetchESSDetails,
   isEssActivity,
   augmentEssActivity,
-  filterContactList,
+  filterContactListOnEmail,
 }

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -177,8 +177,7 @@ async function getMaxemailCampaigns(req, next, contacts) {
 
 // Filter unwanted Contacts, e.g. those with empty email addresses
 function filterContactList(contacts) {
-  const removeEmptyEmails = contacts.filter((contact) => contact.email != '')
-
+  const removeEmptyEmails = contacts.filter((contact) => contact.email)
   return removeEmptyEmails
 }
 
@@ -343,7 +342,7 @@ async function fetchActivityFeedHandler(req, res, next) {
       from,
       size,
       companyIds: [company.id, ...dnbHierarchyIds],
-      contacts: company.contacts,
+      contacts: filteredContacts,
       user,
       aventriEventIds,
       getEssInteractions,


### PR DESCRIPTION
Some contacts in Datahub (especially when Archived) do not have an Email Address anymore. 

Aventri queries match events based on a Contact's email address for a company page. All contacts for a company are queried (and this included contacts with no email address) 

This meant that Events in Aventri that had contacts also with no Email Address (e.g. test registrations) were matching and showing on Companies that they should not have been.

This bugfix removes contacts with no email from the queried list of contacts, and should prevent this match happening in the future. 

## Description of change

Added a function to remove contacts with no email from the queried list. 

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
