### PR TITLE
Add styling for focus indicator

### DIFF
--- a/src/client/components/DataHubHeader/NavBar.jsx
+++ b/src/client/components/DataHubHeader/NavBar.jsx
@@ -51,17 +51,31 @@ const StyledListItem = styled.li({
   },
 })
 
-const styledLinkActive = {
+const styledLinkMixin = {
   content: '""',
   position: 'absolute',
   left: 0,
   right: 0,
   bottom: 0,
   borderBottom: `${BORDER_WIDTH} solid`,
+}
+
+const styledLinkActive = {
+  ...styledLinkMixin,
   borderColor: DARK_BLUE_LEGACY,
 }
 
+const styledLinkFocus = {
+  ...styledLinkMixin,
+  borderColor: BLACK,
+}
+
 const styledLink = {
+  '&:focus': {
+    backgroundColor: '#FFDD00',
+    boxShadow: 'none',
+    outline: 'none',
+  },
   '&:link, &:visited': {
     position: 'relative',
     display: 'block',
@@ -79,6 +93,7 @@ const styledLink = {
       padding: '8px 0',
       ':hover::after': styledLinkActive,
       '&.active::after': styledLinkActive,
+      ':focus::after': styledLinkFocus,
     },
   },
 }


### PR DESCRIPTION
## Description of change

When navigating the page with the tab key, there is a focus indicator around the list of links in the header.

## Test instructions

Using the GOV.UK Design System standard of having the yellow border with a black underline.

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/74972011/222169405-14df3514-f79a-4329-9e3a-9bee48d8920b.png)


### After

![image](https://user-images.githubusercontent.com/74972011/222169503-b8ca589d-acc0-4aba-8357-b577a7611160.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
