### PR TITLE
Highlight typeahead list box option for onKeyDown event

### DIFF
--- a/src/client/components/Typeahead/utils.js
+++ b/src/client/components/Typeahead/utils.js
@@ -76,6 +76,9 @@ export const getNewSelectedOptions = ({ selectedOptions, option, isMulti }) =>
  * Converts value to an array if it is not one already.
  *
  * If value is undefined, returns an empty array.
+ *
+ * If scrollTop is equal to 0 then set onkeydown scroll to top
+ *
  **/
 export const valueAsArray = (value) =>
   value ? (Array.isArray(value) ? value : [value]) : []
@@ -87,7 +90,7 @@ export const maintainScrollVisibility = ({ parent, target }) => {
   const { offsetHeight: parentOffsetHeight, scrollTop } = parent
   const { offsetHeight, offsetTop } = target
 
-  if (offsetTop < scrollTop) {
+  if (offsetTop <= scrollTop) {
     parent.scrollTo(0, offsetTop)
   } else if (offsetTop + offsetHeight > scrollTop + parentOffsetHeight) {
     parent.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight)


### PR DESCRIPTION
## Description of change

The Typeahead component e.g. ‘Type of Event’ dropdown page is inaccessible to keyboard users attempting to navigate it with the arrow keys to locate the desired item in the list. This is due to the content not scrolling when a keyboard only user navigate the drop-down menu with arrow keys, as the focus keeps moving down the list while the viewport remains at the top of the list.

## Test instructions

Navigate `Edit Interaction` then at `Event` dropdown(Typeahead) navigate from option using arrow keys.  

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/28296624/223168424-4c552599-ca63-4297-b926-e1cc310421ba.png)

### After

![image](https://user-images.githubusercontent.com/28296624/223168600-2431d24d-ed36-4ac3-97c6-6b0054222934.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
