### PR TITLE
Setting companies collection and search urls to default to going to t…

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -27,14 +27,14 @@ const GLOBAL_NAV_ITEM = {
 
 const LOCAL_NAV = [
   {
-    path: 'activity',
-    label: 'Activity',
-    permissions: ['interaction.view_all_interaction'],
-  },
-  {
     path: 'overview',
     label: 'Overview',
     permissions: ['company.view_contact'],
+  },
+  {
+    path: 'activity',
+    label: 'Activity',
+    permissions: ['interaction.view_all_interaction'],
   },
   {
     path: 'business-details',

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -82,6 +82,10 @@ const CollectionItem = ({
           <Link as={RouterLink} to={headingUrl} onClick={onClick}>
             {headingText}
           </Link>
+        ) : location.pathname === '/companies' ? (
+          <Link href={`${headingUrl}/activity`} onClick={onClick}>
+            {headingText}
+          </Link>
         ) : (
           <Link href={headingUrl} onClick={onClick}>
             {headingText}

--- a/src/templates/_macros/entity/entity.njk
+++ b/src/templates/_macros/entity/entity.njk
@@ -26,6 +26,8 @@
     {% set highlightedName = props.name | highlight(props.highlightTerm) %}
     {% set containerElement = 'a' if props.isBlockLink and not props.isLinkDisabled else 'div' %}
 
+    <script> console.log( "{{ urlPrefix }}" )</script>
+
     <{{ containerElement }}
       class="c-entity c-entity--{{ props.type }}
       {{ 'c-entity--block-link' if props.isBlockLink }}
@@ -52,7 +54,7 @@
         <h3 class="c-entity__title">
           {% if props.id and not props.isBlockLink %}
             <a
-              href="{{ url }}"
+              href="{% if urlPrefix === 'companies/' %}{{ url }}/activity{% else %}{{ url }}{% endif %}"
               class="c-entity__link{% if props.index and props.type %} js-search-entity{% endif %}"
               data-search-result-rank="{{ props.index }}"
               data-search-category="{{ props.type }}"


### PR DESCRIPTION


## Description of change

Setting companies collection and search urls to default to going to the activities page

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
