### PR TITLE
Hints added to date pickers with specific data formatting

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -200,6 +200,7 @@ const ProjectsCollection = ({
           <Filters.Date
             type="month"
             label="Actual land date from"
+            hint="Date format month as text and year as four digits"
             name="actual_land_date_after"
             qsParamName="actual_land_date_after"
             data-test="actual-land-date-after-filter"
@@ -207,6 +208,7 @@ const ProjectsCollection = ({
           <Filters.Date
             type="month"
             label="Actual land date to"
+            hint="Date format month as text and year as four digits"
             name="actual_land_date_before"
             qsParamName="actual_land_date_before"
             data-test="actual-land-date-before-filter"
@@ -214,6 +216,7 @@ const ProjectsCollection = ({
           <Filters.Date
             type="month"
             label="Estimated land date from"
+            hint="Date format month as text and year as four digits"
             name="estimated_land_date_after"
             qsParamName="estimated_land_date_after"
             data-test="estimated-land-date-after-filter"
@@ -221,6 +224,7 @@ const ProjectsCollection = ({
           <Filters.Date
             type="month"
             label="Estimated land date to"
+            hint="Date format month as text and year as four digits"
             name="estimated_land_date_before"
             qsParamName="estimated_land_date_before"
             data-test="estimated-land-date-before-filter"

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -5,7 +5,7 @@ import urls from '../../../../../src/lib/urls'
 import { ukRegionFaker, ukRegionListFaker } from '../../fakers/regions'
 import {
   clickCheckboxGroupOption,
-  inputDateValue,
+  inputDateValueWithHint,
   removeChip,
   selectFirstAdvisersTypeaheadOption,
 } from '../../support/actions'
@@ -13,7 +13,7 @@ import {
   assertCheckboxGroupOption,
   assertChipsEmpty,
   assertChipExists,
-  assertDateInput,
+  assertDateInputWithHint,
   assertFieldEmpty,
   assertPayload,
   assertTypeaheadOptionSelected,
@@ -581,12 +581,12 @@ describe('Investments Collections Filter', () => {
         label: `Estimated land date from: ${formattedFromDate}`,
         position: 2,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Estimated land date from',
         value: fromDate,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Estimated land date to',
         value: toDate,
@@ -602,12 +602,12 @@ describe('Investments Collections Filter', () => {
       cy.get('[data-test="toggle-section-button"]')
         .contains('Land date details')
         .click()
-      inputDateValue({
+      inputDateValueWithHint({
         element: fromElement,
         value: fromDate,
       })
       cy.wait('@apiRequest')
-      inputDateValue({
+      inputDateValueWithHint({
         element: toElement,
         value: toDate,
       })
@@ -623,12 +623,12 @@ describe('Investments Collections Filter', () => {
         label: `Estimated land date from: ${formattedFromDate}`,
         position: 2,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Estimated land date from',
         value: fromDate,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Estimated land date to',
         value: toDate,
@@ -640,12 +640,12 @@ describe('Investments Collections Filter', () => {
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
 
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Estimated land date from',
         value: '',
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Estimated land date to',
         value: '',
@@ -684,12 +684,12 @@ describe('Investments Collections Filter', () => {
         label: `Actual land date from: ${formattedFromDate}`,
         position: 2,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Actual land date from',
         value: fromDate,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Actual land date to',
         value: toDate,
@@ -705,12 +705,12 @@ describe('Investments Collections Filter', () => {
       cy.get('[data-test="toggle-section-button"]')
         .contains('Land date details')
         .click()
-      inputDateValue({
+      inputDateValueWithHint({
         element: fromElement,
         value: fromDate,
       })
       cy.wait('@apiRequest')
-      inputDateValue({
+      inputDateValueWithHint({
         element: toElement,
         value: toDate,
       })
@@ -726,12 +726,12 @@ describe('Investments Collections Filter', () => {
         label: `Actual land date from: ${formattedFromDate}`,
         position: 2,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Actual land date from',
         value: fromDate,
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Actual land date to',
         value: toDate,
@@ -743,12 +743,12 @@ describe('Investments Collections Filter', () => {
       assertPayload('@apiRequest', minimumPayload)
       assertChipsEmpty()
 
-      assertDateInput({
+      assertDateInputWithHint({
         element: fromElement,
         label: 'Actual land date from',
         value: '',
       })
-      assertDateInput({
+      assertDateInputWithHint({
         element: toElement,
         label: 'Actual land date to',
         value: '',

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -68,6 +68,13 @@ export const inputDateValue = ({ element, value }) => {
 }
 
 /**
+ * Adds a date to the any given date input field that also has a hint
+ */
+export const inputDateValueWithHint = ({ element, value }) => {
+  cy.get(element).children().next().next().type(value)
+}
+
+/**
  * Adds a date object of {day, month, year} to the relevent input fields
  */
 export const clearAndInputDateValueObject = ({ element, value }) => {

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -624,6 +624,18 @@ const assertDateInput = ({ element, label, value }) => {
 }
 
 /**
+ * Assert that the label and value exist on the date input where a hint is provided
+ */
+const assertDateInputWithHint = ({ element, label, value }) => {
+  cy.get(element)
+    .find('label')
+    .should('contain', label)
+    .next()
+    .next()
+    .should('have.attr', 'value', value)
+}
+
+/**
  * Assert error summary passing in a list of errors as as an array
  */
 const assertErrorSummary = (errors) => {
@@ -747,6 +759,7 @@ module.exports = {
   assertNotQueryParams,
   assertPayload,
   assertDateInput,
+  assertDateInputWithHint,
   assertErrorSummary,
   assertVisible,
   assertNotExists,


### PR DESCRIPTION
## Description of change

There were date fields found which did not inform the user of the format required to enter data into these fields.

## Test instructions

On the projects page the date fields should now display a hint

## Screenshots

### Before

No change

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
