### PR TITLE
Add cost filters for OMIS reconciliation list

### DIFF
--- a/src/client/modules/Omis/CollectionList/OrdersReconciliationCollection.jsx
+++ b/src/client/modules/Omis/CollectionList/OrdersReconciliationCollection.jsx
@@ -119,6 +119,22 @@ const OrdersReconciliationCollection = ({
           placeholder="Search company name"
           data-test="company-name-filter"
         />
+        <Filters.Input
+          id="OrdersReconciliationCollection.net-amount"
+          qsParam="subtotal_cost"
+          name="subtotal_cost"
+          label={LABELS.netAmount}
+          placeholder="Search net amount"
+          data-test="net-amount-filter"
+        />
+        <Filters.Input
+          id="OrdersReconciliationCollection.gross-amount"
+          qsParam="total_cost"
+          name="total_cost"
+          label={LABELS.grossAmount}
+          placeholder="Search gross amount"
+          data-test="gross-amount-filter"
+        />
       </CollectionFilters>
     </FilteredCollectionList>
   )

--- a/src/client/modules/Omis/CollectionList/constants.js
+++ b/src/client/modules/Omis/CollectionList/constants.js
@@ -10,6 +10,8 @@ export const LABELS = {
   completedOnBefore: 'Completed date to',
   deliveryDateAfter: 'Expected delivery date from',
   deliveryDateBefore: 'Expected delivery date to',
+  grossAmount: 'Gross amount',
+  netAmount: 'Net amount',
 }
 
 export const SORT_OPTIONS = [

--- a/src/client/modules/Omis/CollectionList/filters.js
+++ b/src/client/modules/Omis/CollectionList/filters.js
@@ -88,4 +88,18 @@ export const buildSelectedFilters = (queryParams, metadata) => ({
       categoryLabel: LABELS.ukRegion,
     }),
   },
+  netAmount: {
+    queryParam: 'subtotal_cost',
+    options: buildInputFieldFilter({
+      value: queryParams.subtotal_cost,
+      categoryLabel: LABELS.netAmount,
+    }),
+  },
+  grossAmount: {
+    queryParam: 'total_cost',
+    options: buildInputFieldFilter({
+      value: queryParams.total_cost,
+      categoryLabel: LABELS.grossAmount,
+    }),
+  },
 })

--- a/src/client/modules/Omis/CollectionList/tasks.js
+++ b/src/client/modules/Omis/CollectionList/tasks.js
@@ -1,5 +1,6 @@
 import { getMetadataOptions } from '../../../metadata'
 import {
+  transformOrderCost,
   transformResponseToCollection,
   transformResponseToReconciliationCollection,
 } from './transformers'
@@ -57,10 +58,11 @@ export const getOrdersReconciliation = ({
   company_name,
   payment_due_date,
   subtotal_cost,
-  net_cost,
   total_cost,
-}) =>
-  apiProxyAxios
+}) => {
+  const transformedTotalCost = transformOrderCost(total_cost)
+  const transformedSubtotalCost = transformOrderCost(subtotal_cost)
+  return apiProxyAxios
     .post('/v3/search/order', {
       limit,
       offset: getPageOffset({ limit, page }),
@@ -71,11 +73,11 @@ export const getOrdersReconciliation = ({
       company: companyId,
       company_name,
       payment_due_date,
-      subtotal_cost,
-      total_cost,
-      net_cost,
+      subtotal_cost: transformedSubtotalCost,
+      total_cost: transformedTotalCost,
     })
     .then(({ data }) => transformResponseToReconciliationCollection(data))
+}
 
 export const getOrdersMetadata = () =>
   Promise.all([

--- a/src/client/modules/Omis/CollectionList/transformers.js
+++ b/src/client/modules/Omis/CollectionList/transformers.js
@@ -10,6 +10,8 @@ const {
   formatMediumDateTime,
 } = require('../../../utils/date')
 
+export const transformOrderCost = (cost) => (cost ? cost * 100 : undefined)
+
 export const transformOrderToListItem = ({
   id,
   status,


### PR DESCRIPTION
## Description of change

UKSBS users have requested two cost filters for the OMIS reconciliation list.

## Test instructions

Navigate to [the reconciliation list](http://localhost:3000/omis/reconciliation). You should be able to filter by net and gross costs.

## Screenshots

<img width="812" alt="Screenshot 2023-03-07 at 11 05 26" src="https://user-images.githubusercontent.com/36161814/223404935-540d9787-3acc-4a4c-a055-7fd7ef1c8616.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
