### PR TITLE
Remove Celery references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ start-e2e-dit:
 	$(docker-e2e) $(log-command) &
 start-dev:
 	@echo "*** To stop this stack run 'make stop-dev' ***"
-	@echo "*** IMPORTANT This will now use ../data-hub-api/.env for 'api' and 'celery' services ***"
+	@echo "*** IMPORTANT This will now use ../data-hub-api/.env for 'api' and 'rq' services ***"
 	$(MAKE) -C ../data-hub-api start-dev
 	$(docker-dev) $(start-command)
 start-storybook:

--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -29,20 +29,10 @@ services:
       - postgres
       - opensearch
       - redis
-      - celery
+      - rq
       - mock-sso
     entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://opensearch:9200 -wait tcp://redis:6379 -timeout 5m
     command: /app/setup-uat.sh || echo "all good"
-
-  celery:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
-    env_file: .env
-    depends_on:
-      - postgres
-      - opensearch
-      - redis
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://opensearch:9200 -wait tcp://redis:6379 -timeout 5m
-    command: celery -A config worker -l info -Q celery -B
 
   rq:
     image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main

--- a/src/apps/companies/apps/edit-history/__test__/transformers.test.js
+++ b/src/apps/companies/apps/edit-history/__test__/transformers.test.js
@@ -239,7 +239,7 @@ describe('Edit history transformers', () => {
           id: 234,
           user: null,
           timestamp: '2019-12-10T14:39:28.768359Z',
-          comment: 'Updated from D&B [celery:company_update]',
+          comment: 'Updated from D&B [rq:company_update]',
           changes: {
             address_1: ['1600 Amphitheatre Pkwyz', '1600 Amphitheatre Pkwy'],
             dnb_modified_on: [null, '2019-12-10T14:39:28.768000Z'],

--- a/test/sandbox/fixtures/v4/company-audit/company-audit.json
+++ b/test/sandbox/fixtures/v4/company-audit/company-audit.json
@@ -100,7 +100,7 @@
         "id": 5,
         "user": null,
         "timestamp": "2020-01-09T00:00:00.274066Z",
-        "comment": "Updated from D&B [celery:get_company_updates:ddf50721-d4bf-4482-84f1-74f4c78c46aa]",
+        "comment": "Updated from D&B [rq:get_company_updates:ddf50721-d4bf-4482-84f1-74f4c78c46aa]",
         "changes": {
             "turnover": [
                 2382813,


### PR DESCRIPTION
## Description of change

As Celery has now been fully removed from the API, I've removed all the references to it from the frontend.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
