### PR TITLE
Issue ID: DAC_Focus_Order_01

### DIFF
--- a/src/client/components/Pagination/RoutedPagination.jsx
+++ b/src/client/components/Pagination/RoutedPagination.jsx
@@ -58,6 +58,31 @@ const StyledPaginationPiece = styled('li')`
 `
 
 const StyledPaginationLink = styled(Link)`
+  {
+    font-weight: bold;
+    font-size: ${FONT_SIZE.SIZE_16};
+    display: inline-block;
+    padding: ${SPACING.SCALE_1} 12px;
+    line-height: 1.9em;
+    text-decoration: none;
+    :hover {
+      background-color: ${GREY_3};
+      text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
+  }
+  ${({ $isActive }) =>
+    $isActive
+      ? `
+      color: ${WHITE};
+      background-color: ${LINK_COLOUR};
+      :hover {
+        color: ${WHITE};
+        background-color: ${LINK_COLOUR};
+      }
+      `
+      : `
+      color: ${LINK_COLOUR};
+      background-color: transparent;
+    `}
   &:link {
     cursor: pointer;
     font-weight: bold;
@@ -71,19 +96,8 @@ const StyledPaginationLink = styled(Link)`
       background-color: ${GREY_3};
       text-decoration-thickness: max(3px, 0.1875rem, 0.12em);
     }
-    ${({ $isActive }) =>
-      $isActive
-        ? `
-        color: ${WHITE};
-        background-color: ${LINK_COLOUR};
-        :hover {
-          background-color: ${LINK_COLOUR};
-        }
-       `
-        : `
-        color: ${LINK_COLOUR};
-        background-color: transparent;
-      `}
+
+
     ${(props) => props['data-page-number'] && `display: none;`}
     ${MEDIA_QUERIES.TABLET} {
       ${(props) => props['data-page-number'] && `display: block;`}
@@ -224,7 +238,8 @@ const Pagination = ({
                       aria-label={`Page ${page}`}
                       aria-current={isActive ? 'page' : false}
                       ref={(el) => (linkRefs.current[index] = el)}
-                      href="#"
+                      href={isActive ? null : '#'}
+                      aria-current={isActive}
                     >
                       {page}
                     </StyledPaginationLink>


### PR DESCRIPTION
When a keyboard user navigating the service using the tab key activates the ‘Companies’ link in the header of the landing page, they are then taken to the ‘Companies page’. However, when the user clicks ‘Tab’, they are taken to the pagination links at the bottom of the page. This is due to the link for ‘Companies’ being the same as the href="#" of the 1st page pagination link. 

## Description of change

Removed the link for the page the user is on to stop this behaviour.

## Test instructions

Tab through a collection page. This should not jump from the header down to the pagination

## Screenshots

N/A

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
