### PR TITLE
RR-849-add-form-scaffolding

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -25,6 +25,7 @@ const reactRoutes = [
   '/reminders/settings/investments-no-recent-interactions',
   '/reminders/settings/companies-no-recent-interactions',
   '/reminders/settings/companies-new-interactions',
+  '/export/create',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -336,6 +336,9 @@ import { getCompanyDetails } from '../client/modules/Companies/CompanyDetails/ta
 import { TASK_GET_EXPORT_DETAIL } from '../client/modules/ExportPipeline/ExportDetails/state'
 import { getExportDetails } from '../client/modules/ExportPipeline/ExportDetails/tasks'
 
+import { TASK_SAVE_EXPORT } from '../client/modules/ExportPipeline/ExportForm/state'
+import { saveExport } from '../client/modules/ExportPipeline/ExportForm/tasks'
+
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
 }
@@ -556,6 +559,7 @@ function App() {
           [TASK_GET_ESS_INTERACTION_DETAILS]: getESSInteractionDetails,
           [TASK_GET_COMPANY_DETAIL]: getCompanyDetails,
           [TASK_GET_EXPORT_DETAIL]: getExportDetails,
+          [TASK_SAVE_EXPORT]: saveExport,
         }}
       >
         <Mount selector="#data-hub-header">

--- a/src/client/modules/Companies/CompanyDetails/reducer.js
+++ b/src/client/modules/Companies/CompanyDetails/reducer.js
@@ -1,11 +1,13 @@
 import { COMPANY_LOADED } from '../../../../client/actions'
 
-export default (state = {}, { type, result }) => {
+const initialState = { company: null }
+
+export default (state = initialState, { type, result }) => {
   switch (type) {
     case COMPANY_LOADED:
       return {
         ...state,
-        ...result,
+        company: result,
       }
     default:
       return state

--- a/src/client/modules/Companies/CompanyDetails/state.js
+++ b/src/client/modules/Companies/CompanyDetails/state.js
@@ -2,6 +2,4 @@ export const TASK_GET_COMPANY_DETAIL = 'TASK_GET_COMPANY_DETAIL'
 
 export const ID = 'companyDetails'
 
-export const state2props = ({ ...state }) => ({
-  ...state[ID],
-})
+export const state2props = (state) => state[ID]

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { useLocation } from 'react-router-dom'
+import { ERROR_COLOUR } from 'govuk-colours'
+import { H3 } from '@govuk-react/heading'
+
+import Task from '../../../components/Task'
+import urls from '../../../../lib/urls'
+import { COMPANY_LOADED } from '../../../actions'
+import { DefaultLayout } from '../../../components'
+import { TASK_GET_COMPANY_DETAIL } from '../../Companies/CompanyDetails/state'
+import { state2props } from './state'
+import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
+import { StatusMessage } from '../../../../client/components/'
+import ExportFormFields from './ExportFormFields'
+
+const DISPLAY_ADD_EXPORT = 'Add export'
+
+function useQuery() {
+  const { search } = useLocation()
+
+  return React.useMemo(() => new URLSearchParams(search), [search])
+}
+
+function ErrorHandler() {
+  return (
+    <StatusMessage
+      colour={ERROR_COLOUR}
+      aria-labelledby="company-load-error-summary-title"
+      role="alert"
+      data-test="company-load-error"
+    >
+      <H3 id="company-load-error-summary-title">Error loading company</H3>
+    </StatusMessage>
+  )
+}
+
+const getBreadcrumbs = (company) => {
+  const breadcrumbs = [
+    {
+      link: urls.dashboard(),
+      text: 'Home',
+    },
+    {
+      link: urls.companies.index(),
+      text: 'Companies',
+    },
+    { text: 'Add export' },
+  ]
+
+  if (Object.keys(company).length > 0) {
+    return [
+      ...breadcrumbs.slice(0, 2),
+      {
+        link: urls.companies.detail(company.id),
+        text: company.name,
+      },
+      ...breadcrumbs.slice(2, breadcrumbs.length),
+    ]
+  }
+
+  return breadcrumbs
+}
+
+const ExportFormAdd = ({ company }) => {
+  let query = useQuery()
+  const companyId = query.get('companyId')
+
+  return (
+    <DefaultLayout
+      heading={DISPLAY_ADD_EXPORT}
+      subheading={company.name ? company.name : undefined}
+      pageTitle={DISPLAY_ADD_EXPORT}
+      breadcrumbs={getBreadcrumbs(company)}
+      useReactRouter={true}
+    >
+      <Task.Status
+        name={TASK_GET_COMPANY_DETAIL}
+        id={COMPANY_DETAILS_ID}
+        progressMessage="Loading company details"
+        startOnRender={{
+          payload: companyId,
+          onSuccessDispatch: COMPANY_LOADED,
+        }}
+        renderError={ErrorHandler}
+      >
+        {() => (
+          <ExportFormFields
+            companyId={company.id}
+            analyticsFormName={'addExportForm'}
+          />
+        )}
+      </Task.Status>
+    </DefaultLayout>
+  )
+}
+
+export default connect(state2props)(ExportFormAdd)

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -36,7 +36,7 @@ function ErrorHandler() {
 }
 
 const getBreadcrumbs = (company) => {
-  const breadcrumbs = [
+  const defaultBreadcrumbs = [
     {
       link: urls.dashboard(),
       text: 'Home',
@@ -45,21 +45,20 @@ const getBreadcrumbs = (company) => {
       link: urls.companies.index(),
       text: 'Companies',
     },
-    { text: 'Add export' },
   ]
 
-  if (Object.keys(company).length > 0) {
+  if (company) {
     return [
-      ...breadcrumbs.slice(0, 2),
+      ...defaultBreadcrumbs,
       {
         link: urls.companies.detail(company.id),
         text: company.name,
       },
-      ...breadcrumbs.slice(2, breadcrumbs.length),
+      { text: 'Add export' },
     ]
   }
 
-  return breadcrumbs
+  return [...defaultBreadcrumbs, { text: 'Add export' }]
 }
 
 const ExportFormAdd = ({ company }) => {
@@ -69,7 +68,7 @@ const ExportFormAdd = ({ company }) => {
   return (
     <DefaultLayout
       heading={DISPLAY_ADD_EXPORT}
-      subheading={company.name ? company.name : undefined}
+      subheading={company?.name}
       pageTitle={DISPLAY_ADD_EXPORT}
       breadcrumbs={getBreadcrumbs(company)}
       useReactRouter={true}
@@ -86,7 +85,7 @@ const ExportFormAdd = ({ company }) => {
       >
         {() => (
           <ExportFormFields
-            companyId={company.id}
+            companyId={companyId}
             analyticsFormName={'addExportForm'}
           />
         )}

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -12,7 +12,7 @@ const ExportFormFields = ({ companyId, analyticsFormName }) => {
       <Form
         id="export-form"
         analyticsFormName={analyticsFormName}
-        cancelRedirectTo={() => urls.companies.details(companyId)}
+        cancelRedirectTo={() => urls.companies.activity.index(companyId)}
         submissionTaskName={TASK_SAVE_EXPORT}
       />
     </FormLayout>

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+import Form from '../../../components/Form'
+import { FormLayout } from '../../../../client/components'
+import { FORM_LAYOUT } from '../../../../common/constants'
+import urls from '../../../../lib/urls'
+import { TASK_SAVE_EXPORT } from './state'
+
+const ExportFormFields = ({ companyId, analyticsFormName }) => {
+  return (
+    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+      <Form
+        id="export-form"
+        analyticsFormName={analyticsFormName}
+        cancelRedirectTo={() => urls.companies.details(companyId)}
+        submissionTaskName={TASK_SAVE_EXPORT}
+      />
+    </FormLayout>
+  )
+}
+
+export default ExportFormFields

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -6,17 +6,15 @@ import { FORM_LAYOUT } from '../../../../common/constants'
 import urls from '../../../../lib/urls'
 import { TASK_SAVE_EXPORT } from './state'
 
-const ExportFormFields = ({ companyId, analyticsFormName }) => {
-  return (
-    <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
-      <Form
-        id="export-form"
-        analyticsFormName={analyticsFormName}
-        cancelRedirectTo={() => urls.companies.activity.index(companyId)}
-        submissionTaskName={TASK_SAVE_EXPORT}
-      />
-    </FormLayout>
-  )
-}
+const ExportFormFields = ({ companyId, analyticsFormName }) => (
+  <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+    <Form
+      id="export-form"
+      analyticsFormName={analyticsFormName}
+      cancelRedirectTo={() => urls.companies.activity.index(companyId)}
+      submissionTaskName={TASK_SAVE_EXPORT}
+    />
+  </FormLayout>
+)
 
 export default ExportFormFields

--- a/src/client/modules/ExportPipeline/ExportForm/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/index.jsx
@@ -1,0 +1,3 @@
+import ExportFormAdd from './ExportFormAdd'
+
+export { ExportFormAdd }

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -1,0 +1,7 @@
+import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
+
+export const TASK_SAVE_EXPORT = 'TASK_SAVE_EXPORT'
+
+export const state2props = ({ ...state }) => ({
+  company: { ...state[COMPANY_DETAILS_ID] },
+})

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -2,6 +2,6 @@ import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
 
 export const TASK_SAVE_EXPORT = 'TASK_SAVE_EXPORT'
 
-export const state2props = ({ ...state }) => ({
-  company: { ...state[COMPANY_DETAILS_ID] },
+export const state2props = (state) => ({
+  company: state[COMPANY_DETAILS_ID].company,
 })

--- a/src/client/modules/ExportPipeline/ExportForm/tasks.js
+++ b/src/client/modules/ExportPipeline/ExportForm/tasks.js
@@ -1,0 +1,1 @@
+export const saveExport = () => {}

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -10,6 +10,7 @@ import ESSInteractionDetails from './modules/Interactions/ESSInteractionDetails'
 import EventAventriRegistrationStatus from './modules/Events/EventAventriRegistrationStatus'
 import Reminders from './modules/Reminders/Reminders'
 import { RemindersForms, RemindersSettings } from './modules/Reminders'
+import { ExportFormAdd } from './modules/ExportPipeline/ExportForm'
 
 const routes = {
   companies: [
@@ -95,6 +96,13 @@ const routes = {
       path: ['/reminders/:reminderType', '/reminders'],
       module: 'datahub:companies',
       component: Reminders,
+    },
+  ],
+  exportPipeline: [
+    {
+      path: '/export/create',
+      module: 'datahub:companies',
+      component: ExportFormAdd,
     },
   ],
 }

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -525,4 +525,7 @@ module.exports = {
       },
     },
   },
+  exportPipeline: {
+    create: url('/export/create'),
+  },
 }

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -61,7 +61,7 @@ describe('Export pipeline create', () => {
     it('the form should display a cancel link', () => {
       cy.get('[data-test=cancel-button]')
         .should('have.text', 'Cancel')
-        .should('have.attr', 'href', '/')
+        .should('have.attr', 'href', urls.companies.detail(company.id))
     })
 
     it('the form should redirect to the company page when the cancel button is clicked', () => {

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -1,5 +1,6 @@
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
+const { assertUrl } = require('../../support/assertions')
 
 const {
   assertLocalHeader,
@@ -61,12 +62,12 @@ describe('Export pipeline create', () => {
     it('the form should display a cancel link', () => {
       cy.get('[data-test=cancel-button]')
         .should('have.text', 'Cancel')
-        .should('have.attr', 'href', urls.companies.detail(company.id))
+        .should('have.attr', 'href', urls.companies.activity.index(company.id))
     })
 
     it('the form should redirect to the company page when the cancel button is clicked', () => {
       cy.get('[data-test=cancel-button]').click()
-      assertUrl(urls.companies.detail(company.id))
+      assertUrl(urls.companies.activity.index(company.id))
     })
   })
 })

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -1,0 +1,72 @@
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+const {
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+
+describe('Export pipeline create', () => {
+  context('when adding an export for unknown company id', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api-proxy/v4/company/not_real', {
+        statusCode: 404,
+      }).as('getServerFailure')
+      cy.visit('/export/create?companyId=not_real')
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Add export')
+      cy.get('[data-test="subheading"]').should('not.exist')
+    })
+
+    it('should render add event breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        'Add export': null,
+      })
+    })
+
+    it('should render the error message', () => {
+      cy.get('[data-test="company-load-error"]').should('be.visible')
+    })
+  })
+
+  context('when adding an export for known company id', () => {
+    const company = fixtures.company.venusLtd
+
+    beforeEach(() => {
+      cy.visit(`/export/create?companyId=${company.id}`)
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Add export')
+      cy.get('[data-test="subheading"]').should('have.text', company.name)
+    })
+
+    it('should render the add event breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [company.name]: urls.companies.detail(company.id),
+        'Add export': null,
+      })
+    })
+
+    it('the form should display a save button', () => {
+      cy.get('[data-test=submit-button]').should('have.text', 'Save')
+    })
+
+    it('the form should display a cancel link', () => {
+      cy.get('[data-test=cancel-button]')
+        .should('have.text', 'Cancel')
+        .should('have.attr', 'href', '/')
+    })
+
+    it('the form should redirect to the company page when the cancel button is clicked', () => {
+      cy.get('[data-test=cancel-button]').click()
+      assertUrl(urls.companies.detail(company.id))
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

- Added a new page with an empty form to add new export pipeline items, along with the routing needed to access the page
- The same form will be used by both the add and edit pages, so a separate ExportFormFields.jsx component has been created ready

## Test instructions

Use the url `http://localhost:3000/export/create?companyId=c1ea5ee7-c6f5-4dd1-8c5e-785c5a115719` to load the new page (you can use any valid company id). There should be a breadcrumb with the company name, and the same company name as a sub heading.
The form will be empty, but clicking cancel will redirect to the company page that is provided in the `?companyId` query string

To test the error screen, use the url `http://localhost:3000/export/create?companyId=not_real`

## Screenshots

### Valid company:
![image](https://user-images.githubusercontent.com/102232401/223772848-28366e19-cf62-4f86-a30e-a86aaf6d75fc.png)

### Invalid company
![image](https://user-images.githubusercontent.com/102232401/223772926-1a1e791b-cddd-48c5-8edd-b49023d2e367.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
