### PR TITLE
WCAG A - Non-descriptive Label fix

### DIFF
--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -45,6 +45,7 @@ const RoutedAdvisersTypeahead = ({
 
 RoutedAdvisersTypeahead.propTypes = {
   name: PropTypes.string.isRequired,
+  label: PropTypes.string,
   taskProps: PropTypes.shape({
     name: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -46,7 +46,7 @@ const RoutedTypeahead = ({
         <StyledFieldWrapper label={label} name={name} hint={hint} {...props}>
           <Typeahead
             name={name}
-            aria-label={name}
+            aria-label={label ? label : name}
             placeholder={placeholder}
             initialOptions={options}
             closeMenuOnSelect={closeMenuOnSelect}

--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -54,7 +54,7 @@ export const EventFormFields = ({ values }) => (
               options={values?.metadata?.relatedTradeAgreements}
               placeholder="Search trade agreements"
               required="Select at least one trade agreement"
-              aria-label="Select a trade agreement"
+              aria-label="Related Trade Agreements"
               noOptionsMessage="No trade agreement found"
             />
           ),
@@ -74,7 +74,7 @@ export const EventFormFields = ({ values }) => (
       options={values?.metadata?.eventTypeOptions}
       placeholder="Select event type"
       required="Select at least one event type"
-      aria-label="Select an event type"
+      aria-label="Type of event"
       noOptionsMessage="No event type found"
     />
     <FieldDate
@@ -93,7 +93,7 @@ export const EventFormFields = ({ values }) => (
       label="Event location type (optional)"
       options={values?.metadata?.eventLocationTypes}
       placeholder="Select event"
-      aria-label="Select an event"
+      aria-label="Event location type (optional)"
       noOptionsMessage="No event location found"
     />
     <FieldInput
@@ -126,7 +126,7 @@ export const EventFormFields = ({ values }) => (
       options={values?.metadata?.countries}
       required="Enter a country"
       placeholder="Select country"
-      aria-label="Select a country"
+      aria-label="Country"
       noOptionsMessage="No country found"
     />
     {values.address_country?.value === UNITED_KINGDOM_ID && (
@@ -136,7 +136,7 @@ export const EventFormFields = ({ values }) => (
         options={values?.metadata?.ukRegions}
         required="Select a UK region"
         placeholder="Select region"
-        aria-label="Select a region"
+        aria-label="UK Region"
         noOptionsMessage="No region found"
       />
     )}
@@ -147,7 +147,7 @@ export const EventFormFields = ({ values }) => (
       options={values?.metadata?.teams}
       required="Select at least one team hosting the event"
       placeholder="Select team"
-      aria-label="Select a team"
+      aria-label="Team hosting the event"
       noOptionsMessage="No hosting team found"
     />
     <FieldTypeahead
@@ -156,7 +156,7 @@ export const EventFormFields = ({ values }) => (
       required="Select at least one service"
       options={values?.metadata?.services}
       placeholder="Select service"
-      aria-label="Select a service"
+      aria-label="Service"
       noOptionsMessage="No service found"
     />
     <FieldAdvisersTypeahead
@@ -181,7 +181,7 @@ export const EventFormFields = ({ values }) => (
               options={values?.metadata?.teams}
               placeholder="Select team"
               required="Select at least one team"
-              aria-label="Select at least one team"
+              aria-label="Teams"
               noOptionsMessage="No shared team found"
             />
           ),
@@ -196,7 +196,7 @@ export const EventFormFields = ({ values }) => (
       name="related_programmes"
       options={values?.metadata?.programmes}
       placeholder="Select programme"
-      aria-label="Select programme"
+      aria-label="Related programmes (optional)"
       noOptionsMessage="No programmes found"
     />
   </>


### PR DESCRIPTION
## Description of change

WCAG A - Non-descriptive Label - Page 25

Updated aria-labels for comboboxes to match box label

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
