### PR TITLE
Add breakpoint to footer links.

### DIFF
--- a/src/client/components/Footer/index.jsx
+++ b/src/client/components/Footer/index.jsx
@@ -14,6 +14,11 @@ import govukCrest from './govuk-crest-2x.png'
 import urls from '../../../lib/urls'
 import { InnerContainer } from '../Main'
 
+// when screen is zoomed in so that the width becomes smaller than BREAKPOINT_ZOOMED_IN, we
+// ensure that footer links are shown in a column rather than a row, so they can be visible
+// at all times
+const BREAKPOINT_ZOOMED_IN = '340px'
+
 const StyledFooter = styled('footer')(
   {
     clear: 'both',
@@ -38,6 +43,26 @@ const StyleList = styled.ul`
     margin-left: ${SPACING.SCALE_3};
   }
   margin-bottom: ${SPACING.SCALE_3};
+
+  @media (max-width: ${BREAKPOINT_ZOOMED_IN}) {
+    margin-bottom: -${SPACING.SCALE_3};
+    margin-right: ${SPACING.SCALE_5};
+    flex-direction: column;
+    flex-wrap: wrap;
+
+    li + li {
+      margin-left: 0;
+    }
+
+    li {
+      margin-left: 0;
+      margin-bottom: ${SPACING.SCALE_3};
+    }
+
+    li:last-child {
+      margin-bottom: ${SPACING.SCALE_5};
+    }
+  }
 `
 
 const FooterLink = styled.a`
@@ -68,6 +93,9 @@ const CopyrightLink = styled(FooterLink)`
   text-decoration: none;
   white-space: nowrap;
   margin-bottom: ${SPACING.SCALE_3};
+  @media (max-width: ${BREAKPOINT_ZOOMED_IN}) {
+    margin-bottom: ${SPACING.SCALE_5};
+  }
 `
 
 const Container = styled(InnerContainer)`


### PR DESCRIPTION
## Description of change

When the screen width is smaller than ~340px, the footer links get out of frame and become partially visible.
This adds a breakpoint at 340px and ensures the links are shown in a column rather than a row when the screen width is small.

## Test instructions

When zooming the page in as close as possible, you should see the links in the footer are not going out of frame.

## Screenshots

### Before

<img width="410" alt="Screenshot 2023-03-10 at 09 28 40" src="https://user-images.githubusercontent.com/5889630/224278801-53f32ad7-dd5a-4c4e-90a2-c67b359d794b.png">

### After

<img width="410" alt="Screenshot 2023-03-10 at 09 28 44" src="https://user-images.githubusercontent.com/5889630/224278849-2df82771-8fe5-474e-b7d6-f6b03903ed9f.png">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
