### PR TITLE
Fixed contact activity feed order

### DIFF
--- a/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
@@ -1,20 +1,4 @@
-const sortCriteria = (sortOrder) => {
-  return {
-    _script: {
-      type: 'number',
-      script: {
-        lang: 'painless',
-        // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-        // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-        // in the list of activities, as opposed to when that activity was created.
-        source:
-          "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-          ": doc['published'].value.toInstant().toEpochMilli()",
-      },
-      order: `${sortOrder}`,
-    },
-  }
-}
+const { sortCriteria } = require('./sortCriteria')
 
 const contactActivityQuery = (
   from,

--- a/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
@@ -1,3 +1,21 @@
+const sortCriteria = (sortOrder) => {
+  return {
+    _script: {
+      type: 'number',
+      script: {
+        lang: 'painless',
+        // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
+        // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
+        // in the list of activities, as opposed to when that activity was created.
+        source:
+          "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
+          ": doc['published'].value.toInstant().toEpochMilli()",
+      },
+      order: `${sortOrder}`,
+    },
+  }
+}
+
 const contactActivityQuery = (
   from,
   size,
@@ -9,6 +27,7 @@ const contactActivityQuery = (
   return {
     from,
     size,
+    sort: sortCriteria(sortOrder),
     query: {
       bool: {
         must: [
@@ -86,14 +105,6 @@ const contactActivityQuery = (
         ],
       },
     },
-    sort: [
-      {
-        published: {
-          order: sortOrder,
-          unmapped_type: 'long',
-        },
-      },
-    ],
   }
 }
 

--- a/src/apps/companies/apps/activity-feed/es-queries/data-hub-and-activity-stream-services-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/data-hub-and-activity-stream-services-query.js
@@ -71,7 +71,7 @@ const dataHubAndActivityStreamServicesQuery = ({
   const dsl = {
     from,
     size,
-    sort: sortCriteria,
+    sort: sortCriteria('desc'),
     query: {
       bool: {
         filter: {

--- a/src/apps/companies/apps/activity-feed/es-queries/external-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/external-activity-query.js
@@ -105,7 +105,7 @@ const externalActivityQuery = ({
   const dsl = {
     from,
     size,
-    sort: sortCriteria,
+    sort: sortCriteria('desc'),
     query: {
       bool: {
         filter: {

--- a/src/apps/companies/apps/activity-feed/es-queries/my-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/my-activity-query.js
@@ -4,7 +4,7 @@ const myActivityQuery = ({ from, size, types, user, companyIds }) => {
   return {
     from,
     size,
-    sort: sortCriteria,
+    sort: sortCriteria('desc'),
     query: {
       bool: {
         must: [

--- a/src/apps/companies/apps/activity-feed/es-queries/sortCriteria.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/sortCriteria.js
@@ -1,17 +1,19 @@
-const sortCriteria = {
-  _script: {
-    type: 'number',
-    script: {
-      lang: 'painless',
-      // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-      // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-      // in the list of activities, as opposed to when that activity was created.
-      source:
-        "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-        ": doc['published'].value.toInstant().toEpochMilli()",
+const sortCriteria = (sortOrder) => {
+  return {
+    _script: {
+      type: 'number',
+      script: {
+        lang: 'painless',
+        // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
+        // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
+        // in the list of activities, as opposed to when that activity was created.
+        source:
+          "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
+          ": doc['published'].value.toInstant().toEpochMilli()",
+      },
+      order: sortOrder,
     },
-    order: 'desc',
-  },
+  }
 }
 
 module.exports = { sortCriteria }

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -101,11 +101,11 @@ exports.activityFeed = function (req, res) {
     }
 
     //if the sort by is newest
-    if (req.body.sort[0].published.order === 'desc') {
+    if (req.body.sort._script.order === 'desc') {
       return res.json(contactDataHubAndExternalActivities)
     }
     //if the story by is oldest
-    if (req.body.sort[0].published.order === 'asc') {
+    if (req.body.sort._script.order === 'asc') {
       return res.json(dataHubActivities)
     }
   }


### PR DESCRIPTION
## Description of change

At Contact activity interaction, a latest  feed not sorted as expected when showing contact record.

## Test instructions

From https://www.datahub.dev.uktrade.io/, navigate to Contact > e.g. Warren Buffet > Activity > Sort by Newest/Oldest

## Screenshots

### Before

<img width="342" alt="image" src="https://user-images.githubusercontent.com/28296624/225079825-a2703614-e58b-4a3e-b7ad-5f07a35c5f33.png">

### After

<img width="338" alt="image" src="https://user-images.githubusercontent.com/28296624/225025024-eb0527b1-1de4-43a7-b93d-474b7bbb4311.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
