### PR TITLE
Add label for unicorn campaign interactions

### DIFF
--- a/src/client/components/ActivityFeed/constants.js
+++ b/src/client/components/ActivityFeed/constants.js
@@ -103,6 +103,8 @@ export const INTERACTION_SERVICES = {
   'IST Specific Service': 'IST Service',
   'Proposition Development': 'Proposition Development',
   'Trade Agreement Implementation Activity': 'Implementation',
+  'GREAT - Unicorn Kingdom Campaign - North America (2023)':
+    'GREAT - Unicorn Kingdom Campaign',
 }
 
 export const INTERACTION_SERVICEOTHER = {


### PR DESCRIPTION
## Description of change

This adds an activity label for interactions tagged with the new [unicorn kingdom service](https://github.com/uktrade/data-hub-api/pull/4533).

## Test instructions

When adding an interaction with the new service, the new label should appear in the activity feed.

## Screenshots

### Before

<img width="813" alt="Screenshot 2023-03-15 at 10 32 19" src="https://user-images.githubusercontent.com/36161814/225285651-e0ea8f82-0ee4-4f02-86d0-9a4023ac5ec7.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
