### PR TITLE
Add generic number validator

### DIFF
--- a/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityDetailsForm.jsx
@@ -32,6 +32,7 @@ import { idNamesToValueLabels } from '../../../../../client/utils'
 import { FieldOpportunityValueTypeRadios } from '../../../../../client/components/Form/elements/FieldOpportunityValueType'
 import { apiProxyAxios } from '../../../../../client/components/Task/utils'
 import { FORM_LAYOUT } from '../../../../../common/constants'
+import { number } from '../../../../../client/components/Form/validators'
 
 function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
   const {
@@ -49,8 +50,6 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
     promoters,
     otherDitContacts,
   } = opportunity.detailsFields
-
-  const IS_NUMBER = /^[0-9]*$/
 
   return (
     <Main>
@@ -178,9 +177,7 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
                       initialValue={opportunityValue.value}
                       type="text"
                       validate={(value) =>
-                        !value || IS_NUMBER.test(value)
-                          ? null
-                          : 'Value must be a number'
+                        number(value, 'Value must be a number')
                       }
                     />
                   ),

--- a/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
+++ b/src/apps/investments/client/opportunities/Details/OpportunityRequirementsForm.jsx
@@ -34,6 +34,7 @@ import {
   TIME_HORIZONS_FIELD_NAME,
 } from '../Details/constants'
 import { FORM_LAYOUT } from '../../../../../common/constants'
+import { number } from '../../../../../client/components/Form/validators'
 
 const StyledFieldCheckboxes = styled(FieldCheckboxes)`
   margin-bottom: 0;
@@ -42,8 +43,6 @@ const StyledFieldCheckboxes = styled(FieldCheckboxes)`
 const StyledP = styled('p')`
   margin-bottom: ${SPACING.SCALE_5};
 `
-
-const IS_NUMBER = /^[0-9]*$/ // Input validation to eliminates input script injection
 
 const OpportunityRequirementsForm = (state) => {
   const { opportunityId, opportunity, metadata, dispatch } = state
@@ -96,9 +95,10 @@ const OpportunityRequirementsForm = (state) => {
                     initialValue={totalInvestmentSought}
                     type="text"
                     validate={(value) =>
-                      !value || IS_NUMBER.test(value)
-                        ? null
-                        : 'Total investment sought value must be a number'
+                      number(
+                        value,
+                        'Total investment sought value must be a number'
+                      )
                     }
                   />
                   <FieldInput
@@ -108,9 +108,10 @@ const OpportunityRequirementsForm = (state) => {
                     initialValue={currentInvestmentSecured}
                     type="text"
                     validate={(value) =>
-                      !value || IS_NUMBER.test(value)
-                        ? null
-                        : 'Investment secured so far value must be a number'
+                      number(
+                        value,
+                        'Investment secured so far value must be a number'
+                      )
                     }
                   />
                 </FormLayout>

--- a/src/apps/my-pipeline/client/PipelineForm.jsx
+++ b/src/apps/my-pipeline/client/PipelineForm.jsx
@@ -10,6 +10,7 @@ import {
 
 import Form from '../../../client/components/Form'
 import Resource from '../../../client/components/Resource'
+import { number } from '../../../client/components/Form/validators'
 
 import { ID as STATE_ID, TASK_GET_PIPELINE_COMPANY_CONTACTS } from './state'
 import { STATUS_VALUES, LIKELIHOOD_VALUES } from './constants'
@@ -21,7 +22,6 @@ const statusOptions = STATUS_VALUES.map(({ value, label }) => ({
 
 const likelihoodOptions = Object.values(LIKELIHOOD_VALUES)
 
-const IS_NUMBER = /^[0-9]*$/
 function PipelineForm({
   analyticsFormName,
   submissionTaskName,
@@ -116,9 +116,7 @@ function PipelineForm({
             spellcheck="false"
             className="govuk-input--width-10"
             validate={(value) =>
-              !value || IS_NUMBER.test(value)
-                ? null
-                : 'Potential export value must be a number'
+              number(value, 'Potential export value must be a number')
             }
           />
           <FieldDate

--- a/src/client/components/Form/validators.js
+++ b/src/client/components/Form/validators.js
@@ -1,7 +1,12 @@
 const EMAIL_PATTERN =
   /(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
 
+const IS_NUMBER = /^[0-9]*$/
+
 export const email = (x) =>
   EMAIL_PATTERN.test(x)
     ? null
     : 'Enter an email address in the correct format, like name@example.com'
+
+export const number = (x, errorMessage) =>
+  !x || IS_NUMBER.test(x) ? null : errorMessage


### PR DESCRIPTION
## Description of change

I have noticed that there were some duplicate number validators used in the forms so I have consolidated these into a generic validator function.

## Test instructions

Updated fields should validate as normal.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
