### PR TITLE
RR-907-task-error-handler-refactor

### DIFF
--- a/src/client/components/Task/Error.jsx
+++ b/src/client/components/Task/Error.jsx
@@ -57,7 +57,7 @@ const Err = ({ errorMessage, retry, dismiss, noun, dismissable = true }) => (
 
 Err.propTypes = {
   noun: PropTypes.string.isRequired,
-  error: PropTypes.string.isRequired,
+  errorMessage: PropTypes.string.isRequired,
   retry: PropTypes.func.isRequired,
   clear: PropTypes.func.isRequired,
 }

--- a/src/client/components/Task/Error.jsx
+++ b/src/client/components/Task/Error.jsx
@@ -18,6 +18,7 @@ import { spacing } from '@govuk-react/lib'
 
 import FormActions from '../Form/elements/FormActions'
 import SecondaryButton from '../SecondaryButton'
+import { isString } from 'lodash'
 
 const StyledRoot = styled.div(
   {
@@ -44,7 +45,7 @@ const StyledSecondaryButton = styled(SecondaryButton)({
 const Err = ({ errorMessage, retry, dismiss, noun, dismissable = true }) => (
   <StyledRoot data-test="error-dialog">
     <H2 size="MEDIUM">Could not load {noun}</H2>
-    <p>Error: {errorMessage}</p>
+    {isString(errorMessage) && <p>Error: {errorMessage}</p>}
     <FormActions>
       <StyledSecondaryButton onClick={retry}>Retry</StyledSecondaryButton>
       {dismissable && (

--- a/test/component/cypress/specs/Task/Error.cy.jsx
+++ b/test/component/cypress/specs/Task/Error.cy.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import Err from '../../../../../src/client/components/Task/Error'
+
+describe('Err', () => {
+  const Component = (props) => <Err noun="noun" {...props} />
+  context('When the error message is not a string', () => {
+    const testData = [1, { a: 2 }, { Error: 'Page not found' }]
+    testData.forEach(function (value) {
+      it('should not render error message', () => {
+        cy.mount(<Component errorMessage={value} />)
+        cy.get('[data-test="error-dialog"] > p').should('not.exist')
+      })
+    })
+  })
+
+  context('When the error message is a string', () => {
+    it('should render error message', () => {
+      cy.mount(<Component errorMessage={'Page not found'} />)
+      cy.get('[data-test="error-dialog"] > p').should(
+        'have.text',
+        'Error: Page not found'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

When django receives an invalid query it returns an error page with HTML, instead of a JSON payload. Our default error handler in the `<Task />` component errors when HTML is returned, with the error `objects are not valid as a react child`. 

This change only renders the error message if it is a string

## Test instructions

_What should I see?_

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/225574289-cd019fc9-1cec-4593-b15e-71b1978657e5.png)

### After

![image](https://user-images.githubusercontent.com/102232401/225574128-0b6df072-4af6-4e2a-a55b-ed0e589f8e32.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
