### PR TITLE
Feature/RR-849-edit-form-scaffolding

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -26,6 +26,7 @@ const reactRoutes = [
   '/reminders/settings/companies-no-recent-interactions',
   '/reminders/settings/companies-new-interactions',
   '/export/create',
+  '/export/:exportId/edit',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/ExportPipeline/ExportDetails/reducer.js
+++ b/src/client/modules/ExportPipeline/ExportDetails/reducer.js
@@ -1,11 +1,13 @@
 import { EXPORT_LOADED } from '../../../../client/actions'
 
-export default (state = {}, { type, result }) => {
+const initialState = { exportItem: null }
+
+export default (state = initialState, { type, result }) => {
   switch (type) {
     case EXPORT_LOADED:
       return {
         ...state,
-        ...result,
+        exportItem: result,
       }
     default:
       return state

--- a/src/client/modules/ExportPipeline/ExportDetails/tasks.js
+++ b/src/client/modules/ExportPipeline/ExportDetails/tasks.js
@@ -1,4 +1,6 @@
 import { apiProxyAxios } from '../../../components/Task/utils'
 
 export const getExportDetails = (exportId) =>
-  apiProxyAxios.get(`/v4/export/${exportId}`).then(({ data }) => data)
+  exportId
+    ? apiProxyAxios.get(`/v4/export/${exportId}`).then(({ data }) => data)
+    : Promise.resolve({})

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { connect } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
-import Task from '../../../components/Task'
 import urls from '../../../../lib/urls'
 import { COMPANY_LOADED } from '../../../actions'
 import { DefaultLayout } from '../../../components'
@@ -57,22 +56,19 @@ const ExportFormAdd = ({ company }) => {
       breadcrumbs={getBreadcrumbs(company)}
       useReactRouter={false}
     >
-      <Task.Status
-        name={TASK_GET_COMPANY_DETAIL}
-        id={COMPANY_DETAILS_ID}
-        progressMessage="Loading company details"
-        startOnRender={{
-          payload: companyId,
-          onSuccessDispatch: COMPANY_LOADED,
+      <ExportFormFields
+        companyId={companyId}
+        analyticsFormName={'addExportForm'}
+        taskProps={{
+          name: TASK_GET_COMPANY_DETAIL,
+          id: COMPANY_DETAILS_ID,
+          progressMessage: 'Loading company details',
+          startOnRender: {
+            payload: companyId,
+            onSuccessDispatch: COMPANY_LOADED,
+          },
         }}
-      >
-        {() => (
-          <ExportFormFields
-            companyId={companyId}
-            analyticsFormName={'addExportForm'}
-          />
-        )}
-      </Task.Status>
+      />
     </DefaultLayout>
   )
 }

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -35,7 +35,7 @@ const getBreadcrumbs = (company) => {
     return [
       ...defaultBreadcrumbs,
       {
-        link: urls.companies.detail(company.id),
+        link: urls.companies.activity.index(company.id),
         text: company.name,
       },
       { text: 'Add export' },
@@ -55,7 +55,7 @@ const ExportFormAdd = ({ company }) => {
       subheading={company?.name}
       pageTitle={DISPLAY_ADD_EXPORT}
       breadcrumbs={getBreadcrumbs(company)}
-      useReactRouter={true}
+      useReactRouter={false}
     >
       <Task.Status
         name={TASK_GET_COMPANY_DETAIL}

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -10,7 +10,6 @@ import { TASK_GET_EXPORT_DETAIL } from '../ExportDetails/state'
 
 import { ID as EXPORT_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
 
-import Task from '../../../components/Task'
 import { EXPORT_LOADED } from '../../../actions'
 
 const DISPLAY_EDIT_EXPORT = 'Edit export'
@@ -51,22 +50,19 @@ const ExportFormEdit = ({ exportItem }) => {
       breadcrumbs={getBreadcrumbs(exportItem)}
       useReactRouter={false}
     >
-      <Task.Status
-        name={TASK_GET_EXPORT_DETAIL}
-        id={EXPORT_DETAILS_ID}
-        progressMessage="Loading export details"
-        startOnRender={{
-          payload: exportId,
-          onSuccessDispatch: EXPORT_LOADED,
+      <ExportFormFields
+        analyticsFormName={'editExportForm'}
+        taskProps={{
+          name: TASK_GET_EXPORT_DETAIL,
+          id: EXPORT_DETAILS_ID,
+          progressMessage: 'Loading export details',
+          startOnRender: {
+            payload: exportId,
+            onSuccessDispatch: EXPORT_LOADED,
+          },
         }}
-      >
-        {() => (
-          <ExportFormFields
-            analyticsFormName={'editExportForm'}
-            initialValues={exportItem}
-          />
-        )}
-      </Task.Status>
+        exportItem={exportItem}
+      />
     </DefaultLayout>
   )
 }

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { useParams } from 'react-router-dom'
+
+import urls from '../../../../lib/urls'
+import { DefaultLayout } from '../../../components'
+import { state2props } from './state'
+import ExportFormFields from './ExportFormFields'
+import { TASK_GET_EXPORT_DETAIL } from '../ExportDetails/state'
+
+import { ID as EXPORT_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
+
+import Task from '../../../components/Task'
+import { EXPORT_LOADED } from '../../../actions'
+
+const DISPLAY_EDIT_EXPORT = 'Edit export'
+
+const getBreadcrumbs = (exportItem) => {
+  const defaultBreadcrumbs = [
+    {
+      link: urls.dashboard(),
+      text: 'Home',
+    },
+    {
+      link: urls.companies.index(),
+      text: 'Companies',
+    },
+  ]
+
+  if (exportItem) {
+    return [
+      ...defaultBreadcrumbs,
+      {
+        link: urls.companies.activity.index(exportItem.company.id),
+        text: exportItem.company.name,
+      },
+      { text: exportItem.title },
+    ]
+  }
+
+  return defaultBreadcrumbs
+}
+
+const ExportFormEdit = ({ exportItem }) => {
+  const { exportId } = useParams()
+  return (
+    <DefaultLayout
+      heading={DISPLAY_EDIT_EXPORT}
+      subheading={exportItem?.company?.name}
+      pageTitle={DISPLAY_EDIT_EXPORT}
+      breadcrumbs={getBreadcrumbs(exportItem)}
+      useReactRouter={false}
+    >
+      <Task.Status
+        name={TASK_GET_EXPORT_DETAIL}
+        id={EXPORT_DETAILS_ID}
+        progressMessage="Loading export details"
+        startOnRender={{
+          payload: exportId,
+          onSuccessDispatch: EXPORT_LOADED,
+        }}
+      >
+        {() => (
+          <ExportFormFields
+            analyticsFormName={'editExportForm'}
+            initialValues={exportItem}
+          />
+        )}
+      </Task.Status>
+    </DefaultLayout>
+  )
+}
+
+export default connect(state2props)(ExportFormEdit)

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -5,21 +5,31 @@ import { FormLayout } from '../../../../client/components'
 import { FORM_LAYOUT } from '../../../../common/constants'
 import urls from '../../../../lib/urls'
 import { TASK_SAVE_EXPORT } from './state'
+import Task from '../../../components/Task'
 
 const ExportFormFields = ({
   companyId,
+  exportItem,
   analyticsFormName,
-  initialValues = {},
+  taskProps = {},
 }) => (
-  <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
-    <Form
-      id="export-form"
-      analyticsFormName={analyticsFormName}
-      cancelRedirectTo={() => urls.companies.activity.index(companyId)}
-      submissionTaskName={TASK_SAVE_EXPORT}
-      initialValues={initialValues}
-    />
-  </FormLayout>
+  <Task.Status {...taskProps}>
+    {() => (
+      <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+        <Form
+          id="export-form"
+          analyticsFormName={analyticsFormName}
+          cancelRedirectTo={() =>
+            urls.companies.activity.index(
+              exportItem ? exportItem.company.id : companyId
+            )
+          }
+          submissionTaskName={TASK_SAVE_EXPORT}
+          initialValues={exportItem}
+        />
+      </FormLayout>
+    )}
+  </Task.Status>
 )
 
 export default ExportFormFields

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -6,13 +6,18 @@ import { FORM_LAYOUT } from '../../../../common/constants'
 import urls from '../../../../lib/urls'
 import { TASK_SAVE_EXPORT } from './state'
 
-const ExportFormFields = ({ companyId, analyticsFormName }) => (
+const ExportFormFields = ({
+  companyId,
+  analyticsFormName,
+  initialValues = {},
+}) => (
   <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
     <Form
       id="export-form"
       analyticsFormName={analyticsFormName}
       cancelRedirectTo={() => urls.companies.activity.index(companyId)}
       submissionTaskName={TASK_SAVE_EXPORT}
+      initialValues={initialValues}
     />
   </FormLayout>
 )

--- a/src/client/modules/ExportPipeline/ExportForm/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/index.jsx
@@ -1,3 +1,4 @@
 import ExportFormAdd from './ExportFormAdd'
+import ExportFormEdit from './ExportFormEdit'
 
-export { ExportFormAdd }
+export { ExportFormAdd, ExportFormEdit }

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -1,7 +1,9 @@
 import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
+import { ID as Export_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
 
 export const TASK_SAVE_EXPORT = 'TASK_SAVE_EXPORT'
 
 export const state2props = (state) => ({
   company: state[COMPANY_DETAILS_ID].company,
+  exportItem: state[Export_DETAILS_ID].exportItem,
 })

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -10,7 +10,10 @@ import ESSInteractionDetails from './modules/Interactions/ESSInteractionDetails'
 import EventAventriRegistrationStatus from './modules/Events/EventAventriRegistrationStatus'
 import Reminders from './modules/Reminders/Reminders'
 import { RemindersForms, RemindersSettings } from './modules/Reminders'
-import { ExportFormAdd } from './modules/ExportPipeline/ExportForm'
+import {
+  ExportFormAdd,
+  ExportFormEdit,
+} from './modules/ExportPipeline/ExportForm'
 
 const routes = {
   companies: [
@@ -103,6 +106,11 @@ const routes = {
       path: '/export/create',
       module: 'datahub:companies',
       component: ExportFormAdd,
+    },
+    {
+      path: '/export/:exportId/edit',
+      module: 'datahub:companies',
+      component: ExportFormEdit,
     },
   ],
 }

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -530,5 +530,6 @@ module.exports = {
   },
   exportPipeline: {
     create: url('/export/create'),
+    edit: url('/export', '/:exportId/edit'),
   },
 }

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -24,7 +24,7 @@ describe('Export pipeline create', () => {
     it('should render add event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
-        Companies: urls.companies.activity.index(),
+        Companies: urls.companies.index(),
         'Add export': null,
       })
     })
@@ -50,7 +50,7 @@ describe('Export pipeline create', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
         Companies: urls.companies.index(),
-        [company.name]: urls.companies.activity.detail(company.id),
+        [company.name]: urls.companies.activity.index(company.id),
         'Add export': null,
       })
     })

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -24,7 +24,7 @@ describe('Export pipeline create', () => {
     it('should render add event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
-        Companies: urls.companies.index(),
+        Companies: urls.companies.activity.index(),
         'Add export': null,
       })
     })
@@ -50,7 +50,7 @@ describe('Export pipeline create', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
         Companies: urls.companies.index(),
-        [company.name]: urls.companies.detail(company.id),
+        [company.name]: urls.companies.activity.detail(company.id),
         'Add export': null,
       })
     })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -16,7 +16,7 @@ describe('Export pipeline edit', () => {
       cy.intercept('GET', `/api-proxy/v4/export/${exportItem.id}`, {
         body: exportItem,
       }).as('apiRequest')
-      cy.visit(`/export/${exportItem.id}/edit`)
+      cy.visit(urls.exportPipeline.edit(exportItem.id))
     })
 
     it('should render the header', () => {

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -1,0 +1,60 @@
+const urls = require('../../../../../src/lib/urls')
+const { assertUrl } = require('../../support/assertions')
+
+const {
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
+
+describe('Export pipeline edit', () => {
+  const exportItem = exportItems.results[0]
+  context('when adding an export for known company id', () => {
+    before(() => {})
+
+    beforeEach(() => {
+      cy.intercept('GET', `/api-proxy/v4/export/${exportItem.id}`, {
+        body: exportItem,
+      }).as('apiRequest')
+      cy.visit(`/export/${exportItem.id}/edit`)
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Edit export')
+      cy.get('[data-test="subheading"]').should(
+        'have.text',
+        exportItem.company.name
+      )
+    })
+
+    it('should render the edit export breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+        [exportItem.company.name]: urls.companies.activity.index(
+          exportItem.company.id
+        ),
+        [exportItem.title]: null,
+      })
+    })
+
+    it('the form should display a save button', () => {
+      cy.get('[data-test=submit-button]').should('have.text', 'Save')
+    })
+
+    it('the form should display a cancel link', () => {
+      cy.get('[data-test=cancel-button]')
+        .should('have.text', 'Cancel')
+        .should(
+          'have.attr',
+          'href',
+          urls.companies.activity.index(exportItem.company.id)
+        )
+    })
+
+    it('the form should redirect to the company page when the cancel button is clicked', () => {
+      cy.get('[data-test=cancel-button]').click()
+      assertUrl(urls.companies.activity.index(exportItem.company.id))
+    })
+  })
+})

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -9,6 +9,29 @@ const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
 
 describe('Export pipeline edit', () => {
   const exportItem = exportItems.results[0]
+
+  context('when adding an export for unknown company id', () => {
+    beforeEach(() => {
+      cy.visit('/export/a/edit')
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('Edit export')
+      cy.get('[data-test="subheading"]').should('not.exist')
+    })
+
+    it('should render edit event breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+      })
+    })
+
+    it('should render the error message', () => {
+      cy.get('[data-test="error-dialog"]').should('be.visible')
+    })
+  })
+
   context('when adding an export for known company id', () => {
     before(() => {})
 


### PR DESCRIPTION
## Description of change

- Add a new page to allow editing of existing export pipeline items, along with the new url routing. The existing ExportFormFields and ExportFormAdd have been refactored to allow more shared logic to be held within the ExportFormFields  component.
- Updated the reducer to set the `exportItem` to null when the page first loads, to avoid having an empty object being passed between components when the api GET call is taking place
- Use the `/activity` endpoint for companies instead of `/detail` as there is a 301 redirect from details -> activity

## Test instructions

There is a test export in the api that can be viewed at the url http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit

## Screenshots

![image](https://user-images.githubusercontent.com/102232401/225668482-cf82ceb0-e729-4ca9-9968-cf7fad1ea076.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
