### PR TITLE
RR-907-use-generic-task-error-handler-instead-of-custom

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { useLocation } from 'react-router-dom'
-import { ERROR_COLOUR } from 'govuk-colours'
-import { H3 } from '@govuk-react/heading'
 
 import Task from '../../../components/Task'
 import urls from '../../../../lib/urls'
@@ -11,7 +9,6 @@ import { DefaultLayout } from '../../../components'
 import { TASK_GET_COMPANY_DETAIL } from '../../Companies/CompanyDetails/state'
 import { state2props } from './state'
 import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
-import { StatusMessage } from '../../../../client/components/'
 import ExportFormFields from './ExportFormFields'
 
 const DISPLAY_ADD_EXPORT = 'Add export'
@@ -20,19 +17,6 @@ function useQuery() {
   const { search } = useLocation()
 
   return React.useMemo(() => new URLSearchParams(search), [search])
-}
-
-function ErrorHandler() {
-  return (
-    <StatusMessage
-      colour={ERROR_COLOUR}
-      aria-labelledby="company-load-error-summary-title"
-      role="alert"
-      data-test="company-load-error"
-    >
-      <H3 id="company-load-error-summary-title">Error loading company</H3>
-    </StatusMessage>
-  )
 }
 
 const getBreadcrumbs = (company) => {
@@ -81,7 +65,6 @@ const ExportFormAdd = ({ company }) => {
           payload: companyId,
           onSuccessDispatch: COMPANY_LOADED,
         }}
-        renderError={ErrorHandler}
       >
         {() => (
           <ExportFormFields

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -30,7 +30,7 @@ describe('Export pipeline create', () => {
     })
 
     it('should render the error message', () => {
-      cy.get('[data-test="company-load-error"]').should('be.visible')
+      cy.get('[data-test="error-dialog"]').should('be.visible')
     })
   })
 
@@ -46,7 +46,7 @@ describe('Export pipeline create', () => {
       cy.get('[data-test="subheading"]').should('have.text', company.name)
     })
 
-    it('should render the add event breadcrumb', () => {
+    it('should render the add export breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
         Companies: urls.companies.index(),


### PR DESCRIPTION
## Description of change

switch to using generic error handler for exports

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
