### PR TITLE
RR-789-rename-sandbox-urls

### DIFF
--- a/test/sandbox/routes/v4/export/exports.js
+++ b/test/sandbox/routes/v4/export/exports.js
@@ -37,13 +37,15 @@ const generateExport = () => {
     modified_by: faker.datatype.uuid(),
   }
 }
-const generateExports = () => {
+const generateExports = (count = 10) => {
   return {
-    count: 10,
+    count: count,
     next: null,
     previous: null,
-    results: [...Array.from({ length: 10 })].map(generateExport),
+    results: [...Array.from({ length: count })].map(generateExport),
   }
 }
 
-module.exports = { generateExports }
+const exportItems = generateExports(20)
+
+module.exports = { exportItems }

--- a/test/sandbox/routes/v4/export/index.js
+++ b/test/sandbox/routes/v4/export/index.js
@@ -1,12 +1,15 @@
 const { faker } = require('@faker-js/faker')
-const { generateExports } = require('./exports')
+const { exportItems } = require('./exports')
 
 exports.getExportItems = function (req, res) {
-  return res.json(generateExports())
+  return res.json(exportItems)
 }
 
 exports.getExportItem = function (req, res) {
-  return res.json(generateExports()[0])
+  const exportItem = exportItems.results.find(
+    (x) => x.id == req.params.exportId
+  )
+  return exportItem ? res.json(exportItem) : res.sendStatus(404)
 }
 
 exports.createExportItem = function (req, res) {

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -644,11 +644,11 @@ app.post('/v4/large-capital-opportunity', (req, res) =>
 )
 
 // company exports
-app.get('/v4/exports', v4Export.getExportItems)
-app.get('/v4/exports/:exportId', v4Export.getExportItem)
-app.post('/v4/exports', v4Export.createExportItem)
-app.patch('/v4/exports/:exportId', v4Export.updateExportItem)
-app.delete('/v4/exports/:exportId', v4Export.deleteExportItem)
+app.get('/v4/export', v4Export.getExportItems)
+app.get('/v4/export/:exportId', v4Export.getExportItem)
+app.post('/v4/export', v4Export.createExportItem)
+app.patch('/v4/export/:exportId', v4Export.updateExportItem)
+app.delete('/v4/export/:exportId', v4Export.deleteExportItem)
 
 app.use((req, res) =>
   res.status(404).json({ message: 'Route' + req.url + ' Not found.' })


### PR DESCRIPTION

## Description of change

- Switch to singular urls over plural for export pipeline
- Generate a fixed list of export items on sandbox api start, instead of every request


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
