### PR TITLE
Ccit 214 header add interaction button

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 import GridCol from '@govuk-react/grid-col'
+import Button from '@govuk-react/button'
 import GridRow from '@govuk-react/grid-row'
 import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
 import Details from '@govuk-react/details'
@@ -35,6 +36,15 @@ const TypeWrapper = styled('div')`
     display: table-row;
   }
 `
+const StyledButtonContainer = styled('div')`
+  width: 100%;
+  display: inline-block;
+`
+
+const StyledButtonLink = styled.a({
+  marginBottom: 10,
+  float: 'right',
+})
 
 const BadgeWrapper = styled('div')`
   @media (min-width: ${BREAKPOINTS.TABLET}) {
@@ -125,6 +135,16 @@ const CompanyLocalHeader = ({
               </StyledAddress>
             </GridCol>
             <GridCol setWith="one-third">
+              <StyledButtonContainer>
+                <Button
+                  as={StyledButtonLink}
+                  href={urls.companies.interactions.create(company.id)}
+                  aria-label={`Add interaction with ${name}`}
+                >
+                  Add interaction
+                </Button>
+              </StyledButtonContainer>
+
               <ConnectedDropdownMenu
                 label="View options"
                 closedLabel="Hide options"

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -138,6 +138,7 @@ const CompanyLocalHeader = ({
               <StyledButtonContainer>
                 <Button
                   as={StyledButtonLink}
+                  data-test={'header-add-interaction'}
                   href={urls.companies.interactions.create(company.id)}
                   aria-label={`Add interaction with ${name}`}
                 >

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -10,6 +10,7 @@ const {
   assertExportCountryHistoryBreadcrumbs,
   assertOneListTierA,
   assertCoreTeam,
+  assertAddInteractionButton,
 } = require('../../../support/company-local-header-assertions')
 
 const companyLocalHeader = selectors.companyLocalHeader()
@@ -38,6 +39,10 @@ describe('Local header for archived company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -72,6 +77,10 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}/contacts`)
     })
@@ -100,6 +109,10 @@ describe('Local header for archived company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -132,6 +145,10 @@ describe('Local header for archived company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -168,6 +185,12 @@ describe('Local header for archived company', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -208,6 +231,10 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}/exports`)
     })
@@ -238,6 +265,10 @@ describe('Local header for archived company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -272,6 +303,10 @@ describe('Local header for archived company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -41,7 +41,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -77,7 +77,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -111,7 +111,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -147,7 +147,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -187,7 +187,7 @@ describe('Local header for archived company', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -231,7 +231,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -267,7 +267,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -305,7 +305,7 @@ describe('Local header for archived company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -45,7 +45,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -84,7 +84,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -119,7 +119,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -158,7 +158,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -199,7 +199,7 @@ describe('Local header for global ultimate company', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -245,7 +245,7 @@ describe('Local header for global ultimate company', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -289,7 +289,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -328,7 +328,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -369,7 +369,7 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -11,6 +11,7 @@ const {
   assertOneListTierA,
   assertCoreTeam,
   assertArchivePanelNotVisible,
+  assertAddInteractionButton,
 } = require('../../../support/company-local-header-assertions')
 
 const companyLocalHeader = selectors.companyLocalHeader()
@@ -42,6 +43,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -79,6 +84,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}`)
     })
@@ -108,6 +117,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -145,6 +158,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}/advisers`)
     })
@@ -180,6 +197,12 @@ describe('Local header for global ultimate company', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -222,6 +245,12 @@ describe('Local header for global ultimate company', () => {
         assertCompanyAddress(address)
       })
 
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
+      })
+
       it('should display the correct buttons', () => {
         assertButtons(
           `${addRemoveFromListUrl}?returnUrl=${detailsUrl}/investments/large-capital-profile`
@@ -260,6 +289,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}/exports`)
     })
@@ -293,6 +326,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {
@@ -330,6 +367,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -41,7 +41,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -85,7 +85,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -135,7 +135,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -185,7 +185,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -231,7 +231,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -279,7 +279,7 @@ describe('Local header for company under dnb investigation', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
@@ -324,7 +324,7 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
-      it('should click through to the add interaction page for the company', () => {
+      it('should display the correct add interaction button', () => {
         assertAddInteractionButton(
           `/companies/${company.id}/interactions/create`
         )
@@ -372,11 +372,7 @@ describe('Local header for company under dnb investigation', () => {
       assertCompanyAddress(address)
     })
 
-    it('should click through to the add interaction page for the company', () => {
-      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
-    })
-
-    it('should click through to the add interaction page for the company', () => {
+    it('should display the correct add interaction button', () => {
       assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -8,6 +8,7 @@ const {
   assertExportCountryHistoryBreadcrumbs,
   assertButtons,
   assertArchivePanelNotVisible,
+  assertAddInteractionButton,
 } = require('../../../support/company-local-header-assertions')
 
 const companyLocalHeader = selectors.companyLocalHeader()
@@ -38,6 +39,12 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -76,6 +83,12 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -122,6 +135,12 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
+      })
+
       it('should display the correct buttons', () => {
         assertButtons(
           `${addRemoveFromListUrl}?returnUrl=${detailsUrl}/advisers`
@@ -166,6 +185,12 @@ describe('Local header for company under dnb investigation', () => {
         assertCompanyAddress(address)
       })
 
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
+      })
+
       it('should display the correct buttons', () => {
         assertButtons(
           `${addRemoveFromListUrl}?returnUrl=${detailsUrl}/investments/projects`
@@ -204,6 +229,12 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -248,6 +279,10 @@ describe('Local header for company under dnb investigation', () => {
       assertCompanyAddress(address)
     })
 
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
     it('should display the correct buttons', () => {
       assertButtons(`${addRemoveFromListUrl}?returnUrl=${detailsUrl}/exports`)
     })
@@ -287,6 +322,12 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the company address', () => {
         assertCompanyAddress(address)
+      })
+
+      it('should click through to the add interaction page for the company', () => {
+        assertAddInteractionButton(
+          `/companies/${company.id}/interactions/create`
+        )
       })
 
       it('should display the correct buttons', () => {
@@ -329,6 +370,14 @@ describe('Local header for company under dnb investigation', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
+    })
+
+    it('should click through to the add interaction page for the company', () => {
+      assertAddInteractionButton(`/companies/${company.id}/interactions/create`)
     })
 
     it('should display the correct buttons', () => {

--- a/test/functional/cypress/support/company-local-header-assertions.js
+++ b/test/functional/cypress/support/company-local-header-assertions.js
@@ -36,6 +36,16 @@ const assertButtons = (url) => {
 }
 
 /**
+ * Asserts that the add interaction button has the correct URL
+ */
+const assertAddInteractionButton = (url) => {
+  cy.get('[data-test="header-add-interaction"]')
+    .click()
+    .should('have.attr', 'href', url)
+  cy.go('back')
+}
+
+/**
  * Asserts that the header breadcrumbs appear correctly
  */
 const assertBreadcrumbs = (companyName, detailsUrl, lastCrumb) => {
@@ -82,6 +92,7 @@ module.exports = {
   assertCompanyAddress,
   assertBadgeText,
   assertButtons,
+  assertAddInteractionButton,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
   assertOneListTierA,

--- a/test/functional/cypress/support/company-local-header-assertions.js
+++ b/test/functional/cypress/support/company-local-header-assertions.js
@@ -39,10 +39,11 @@ const assertButtons = (url) => {
  * Asserts that the add interaction button has the correct URL
  */
 const assertAddInteractionButton = (url) => {
-  cy.get('[data-test="header-add-interaction"]')
-    .click()
-    .should('have.attr', 'href', url)
-  cy.go('back')
+  cy.get('[data-test="header-add-interaction"]').should(
+    'have.attr',
+    'href',
+    url
+  )
 }
 
 /**


### PR DESCRIPTION
## Description of change

A green ‘Add interaction’ button added to the the companies local header.

## Test instructions

Button can be seen in the header and when clicked you are navigated to the correct add interaction page for that company.

## Screenshots

### Before
![Screenshot 2023-03-16 at 13 32 08](https://user-images.githubusercontent.com/72826129/225633062-fbf385ec-c02a-48b8-8bed-b583d8af2e0d.png)

### After
![Screenshot 2023-03-16 at 13 31 32](https://user-images.githubusercontent.com/72826129/225633119-423cde19-6127-4a57-ba2b-a91e77ec70a1.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
