### PR TITLE
Feature/rr 791 export owner

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -44,7 +44,7 @@ const getBreadcrumbs = (company) => {
   return [...defaultBreadcrumbs, { text: 'Add export' }]
 }
 
-const ExportFormAdd = ({ company }) => {
+const ExportFormAdd = ({ company, currentAdviserId, currentAdviserName }) => {
   let query = useQuery()
   const companyId = query.get('companyId')
 
@@ -66,6 +66,10 @@ const ExportFormAdd = ({ company }) => {
             payload: companyId,
             onSuccessDispatch: COMPANY_LOADED,
           },
+        }}
+        initialValues={{
+          owner: { id: currentAdviserId, name: currentAdviserName },
+          company: { id: companyId },
         }}
         cancelRedirectUrl={urls.companies.activity.index(companyId)}
         redirectToUrl={urls.dashboard()}

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -59,7 +59,7 @@ const ExportFormEdit = ({ exportItem }) => {
             onSuccessDispatch: EXPORT_LOADED,
           },
         }}
-        exportItem={exportItem}
+        initialValues={exportItem}
         cancelRedirectUrl={urls.dashboard()}
         redirectToUrl={urls.exportPipeline.edit(exportId)}
         flashMessage={({ data }) => `Changes saved to '${data.title}'`}

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -30,7 +30,9 @@ const ExportFormFields = ({
           cancelRedirectTo={() => cancelRedirectUrl}
           redirectTo={() => redirectToUrl}
           submissionTaskName={TASK_SAVE_EXPORT}
-          initialValues={transformAPIValuesForForm(initialValues)}
+          initialValues={
+            initialValues && transformAPIValuesForForm(initialValues)
+          }
           transformPayload={(values) => ({ exportId: values.id, values })}
           flashMessage={flashMessage}
         >

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -58,9 +58,9 @@ const ExportFormFields = ({
 )
 
 ExportFormFields.propTypes = {
-  exportItem: PropTypes.object,
+  initialValues: PropTypes.object,
   analyticsFormName: PropTypes.string.isRequired,
-  flashMessage: PropTypes.string.isRequired,
+  flashMessage: PropTypes.func.isRequired,
   cancelRedirectUrl: PropTypes.string.isRequired,
   redirectToUrl: PropTypes.string.isRequired,
   taskProps: PropTypes.object,

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -2,14 +2,19 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import Form from '../../../components/Form'
-import { FieldInput, FormLayout } from '../../../../client/components'
+import {
+  FieldInput,
+  FormLayout,
+  FieldAdvisersTypeahead,
+} from '../../../../client/components'
 import { FORM_LAYOUT } from '../../../../common/constants'
 import { TASK_SAVE_EXPORT } from './state'
 import Task from '../../../components/Task'
 import { ERROR_MESSAGES } from './constants'
+import { transformAPIValuesForForm } from './transformers'
 
 const ExportFormFields = ({
-  exportItem,
+  initialValues,
   analyticsFormName,
   flashMessage,
   cancelRedirectUrl,
@@ -25,18 +30,26 @@ const ExportFormFields = ({
           cancelRedirectTo={() => cancelRedirectUrl}
           redirectTo={() => redirectToUrl}
           submissionTaskName={TASK_SAVE_EXPORT}
-          initialValues={exportItem}
+          initialValues={transformAPIValuesForForm(initialValues)}
           transformPayload={(values) => ({ exportId: values.id, values })}
           flashMessage={flashMessage}
         >
           {() => (
-            <FieldInput
-              name="title"
-              label="Export title"
-              hint="It helps to give export details in the title, for example product and destination"
-              type="text"
-              required={ERROR_MESSAGES.title}
-            />
+            <>
+              <FieldInput
+                name="title"
+                label="Export title"
+                hint="It helps to give export details in the title, for example product and destination"
+                type="text"
+                required={ERROR_MESSAGES.title}
+              />
+              <FieldAdvisersTypeahead
+                name="owner"
+                label="Owner"
+                hint="When creating the record your name will appear. You can change the name to transfer ownership to someone else"
+                required={ERROR_MESSAGES.owner}
+              />
+            </>
           )}
         </Form>
       </FormLayout>

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -11,7 +11,7 @@ import { FORM_LAYOUT } from '../../../../common/constants'
 import { TASK_SAVE_EXPORT } from './state'
 import Task from '../../../components/Task'
 import { ERROR_MESSAGES } from './constants'
-import { transformAPIValuesForForm } from './transformers'
+import { transformAPIValuesForForm } from '../transformers'
 
 const ExportFormFields = ({
   initialValues,

--- a/src/client/modules/ExportPipeline/ExportForm/constants.js
+++ b/src/client/modules/ExportPipeline/ExportForm/constants.js
@@ -1,3 +1,4 @@
 export const ERROR_MESSAGES = {
   title: 'Enter an export title',
+  owner: 'Enter an owner',
 }

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -6,4 +6,6 @@ export const TASK_SAVE_EXPORT = 'TASK_SAVE_EXPORT'
 export const state2props = (state) => ({
   company: state[COMPANY_DETAILS_ID].company,
   exportItem: state[Export_DETAILS_ID].exportItem,
+  currentAdviserId: state.currentAdviserId,
+  currentAdviserName: state.currentAdviserName,
 })

--- a/src/client/modules/ExportPipeline/ExportForm/tasks.js
+++ b/src/client/modules/ExportPipeline/ExportForm/tasks.js
@@ -1,7 +1,8 @@
 import { apiProxyAxios } from '../../../../client/components/Task/utils'
+import { transformFormValuesForAPI } from './transformers'
 
 export const saveExport = ({ exportId, values }) => {
   const request = exportId ? apiProxyAxios.patch : apiProxyAxios.post
   const endpoint = exportId ? `/v4/export/${exportId}` : '/v4/export'
-  return request(endpoint, values)
+  return request(endpoint, transformFormValuesForAPI(values))
 }

--- a/src/client/modules/ExportPipeline/ExportForm/tasks.js
+++ b/src/client/modules/ExportPipeline/ExportForm/tasks.js
@@ -1,5 +1,5 @@
 import { apiProxyAxios } from '../../../../client/components/Task/utils'
-import { transformFormValuesForAPI } from './transformers'
+import { transformFormValuesForAPI } from '../transformers'
 
 export const saveExport = ({ exportId, values }) => {
   const request = exportId ? apiProxyAxios.patch : apiProxyAxios.post

--- a/src/client/modules/ExportPipeline/ExportForm/transformers.js
+++ b/src/client/modules/ExportPipeline/ExportForm/transformers.js
@@ -1,0 +1,19 @@
+//TODO
+export const transformFormValuesForAPI = (values) => ({
+  ...values,
+  owner: { id: values.owner.value },
+})
+
+const mapApiToField = (value) =>
+  value ? { value: value.id, label: value.name } : {}
+//TO test
+export const transformAPIValuesForForm = (initialValues) => {
+  if (!initialValues) {
+    return initialValues
+  }
+
+  return {
+    ...initialValues,
+    owner: mapApiToField(initialValues.owner),
+  }
+}

--- a/src/client/modules/ExportPipeline/__test__/transformers.test.js
+++ b/src/client/modules/ExportPipeline/__test__/transformers.test.js
@@ -1,0 +1,51 @@
+import {
+  transformFormValuesForAPI,
+  transformAPIValuesForForm,
+} from '../transformers'
+
+describe('#transformFormValuesForAPI', () => {
+  context('When values prop is not passed ', () => {
+    it('Should return the same value', () => {
+      expect(transformFormValuesForAPI()).to.be.undefined
+    })
+  })
+  context('When a values object is passed as a prop', () => {
+    it('Should return the mapped value when the form field is present', () => {
+      expect(
+        transformFormValuesForAPI({
+          title: 'title',
+          owner: { value: 'b', label: 'c' },
+        })
+      ).to.be.deep.equal({ title: 'title', owner: { id: 'b' } })
+    })
+
+    it('Should return the default value when the api field is missing', () => {
+      expect(transformFormValuesForAPI({ title: 'title' })).to.be.deep.equal({
+        title: 'title',
+        owner: { id: undefined },
+      })
+    })
+  })
+})
+
+describe('#transformAPIValuesForForm', () => {
+  context('When initialValues prop is not passed ', () => {
+    it('Should return the same value', () => {
+      expect(transformAPIValuesForForm()).to.be.undefined
+    })
+  })
+  context('When an initialValues object is passed as a prop', () => {
+    it('Should return the mapped value when the api field is present', () => {
+      expect(
+        transformAPIValuesForForm({ name: 'a', owner: { id: 'b', name: 'c' } })
+      ).to.be.deep.equal({ name: 'a', owner: { value: 'b', label: 'c' } })
+    })
+
+    it('Should return the default value when the api field is missing', () => {
+      expect(transformAPIValuesForForm({ name: 'a' })).to.be.deep.equal({
+        name: 'a',
+        owner: {},
+      })
+    })
+  })
+})

--- a/src/client/modules/ExportPipeline/__test__/transformers.test.js
+++ b/src/client/modules/ExportPipeline/__test__/transformers.test.js
@@ -3,48 +3,33 @@ import {
   transformAPIValuesForForm,
 } from '../transformers'
 
-describe('#transformFormValuesForAPI', () => {
-  context('When values prop is not passed ', () => {
-    it('Should return the same value', () => {
-      expect(transformFormValuesForAPI()).to.be.undefined
-    })
-  })
+describe('transformFormValuesForAPI', () => {
   context('When a values object is passed as a prop', () => {
     it('Should return the mapped value when the form field is present', () => {
       expect(
         transformFormValuesForAPI({
+          id: 1234,
           title: 'title',
           owner: { value: 'b', label: 'c' },
         })
-      ).to.be.deep.equal({ title: 'title', owner: { id: 'b' } })
-    })
-
-    it('Should return the default value when the api field is missing', () => {
-      expect(transformFormValuesForAPI({ title: 'title' })).to.be.deep.equal({
-        title: 'title',
-        owner: { id: undefined },
-      })
+      ).to.be.deep.equal({ id: 1234, title: 'title', owner: { id: 'b' } })
     })
   })
 })
 
-describe('#transformAPIValuesForForm', () => {
-  context('When initialValues prop is not passed ', () => {
-    it('Should return the same value', () => {
-      expect(transformAPIValuesForForm()).to.be.undefined
-    })
-  })
+describe('transformAPIValuesForForm', () => {
   context('When an initialValues object is passed as a prop', () => {
     it('Should return the mapped value when the api field is present', () => {
       expect(
-        transformAPIValuesForForm({ name: 'a', owner: { id: 'b', name: 'c' } })
-      ).to.be.deep.equal({ name: 'a', owner: { value: 'b', label: 'c' } })
-    })
-
-    it('Should return the default value when the api field is missing', () => {
-      expect(transformAPIValuesForForm({ name: 'a' })).to.be.deep.equal({
-        name: 'a',
-        owner: {},
+        transformAPIValuesForForm({
+          id: 234,
+          title: 'a',
+          owner: { id: 'b', name: 'c' },
+        })
+      ).to.be.deep.equal({
+        id: 234,
+        title: 'a',
+        owner: { value: 'b', label: 'c' },
       })
     })
   })

--- a/src/client/modules/ExportPipeline/__test__/transformers.test.js
+++ b/src/client/modules/ExportPipeline/__test__/transformers.test.js
@@ -8,11 +8,12 @@ describe('transformFormValuesForAPI', () => {
     it('Should return the mapped value when the form field is present', () => {
       expect(
         transformFormValuesForAPI({
+          company: 456,
           id: 1234,
           title: 'title',
           owner: { value: 'b', label: 'c' },
         })
-      ).to.be.deep.equal({ id: 1234, title: 'title', owner: { id: 'b' } })
+      ).to.be.deep.equal({ company: 456, id: 1234, title: 'title', owner: 'b' })
     })
   })
 })
@@ -23,11 +24,13 @@ describe('transformAPIValuesForForm', () => {
       expect(
         transformAPIValuesForForm({
           id: 234,
+          company: { id: 987 },
           title: 'a',
           owner: { id: 'b', name: 'c' },
         })
       ).to.be.deep.equal({
         id: 234,
+        company: 987,
         title: 'a',
         owner: { value: 'b', label: 'c' },
       })

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -1,14 +1,14 @@
 const mapApiToField = ({ id, name }) => ({ value: id, label: name })
 
-export const transformFormValuesForAPI = ({ id, title, owner }) => ({
+export const transformFormValuesForAPI = ({ company, id, title, owner }) => ({
+  company,
   id,
   title,
-  owner: {
-    id: owner.value,
-  },
+  owner: owner.value,
 })
 
-export const transformAPIValuesForForm = ({ id, title, owner }) => ({
+export const transformAPIValuesForForm = ({ company, id, title, owner }) => ({
+  company: company.id,
   id,
   title,
   owner: mapApiToField(owner),

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -1,4 +1,3 @@
-//TODO
 export const transformFormValuesForAPI = (values) => {
   if (!values) {
     return values

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -1,20 +1,15 @@
-export const transformFormValuesForAPI = (values) => {
-  if (!values) {
-    return values
-  }
-  return { ...values, owner: { id: values.owner?.value } }
-}
+const mapApiToField = ({ id, name }) => ({ value: id, label: name })
 
-const mapApiToField = (value) =>
-  value ? { value: value.id, label: value.name } : {}
+export const transformFormValuesForAPI = ({ id, title, owner }) => ({
+  id,
+  title,
+  owner: {
+    id: owner.value,
+  },
+})
 
-export const transformAPIValuesForForm = (initialValues) => {
-  if (!initialValues) {
-    return initialValues
-  }
-
-  return {
-    ...initialValues,
-    owner: mapApiToField(initialValues.owner),
-  }
-}
+export const transformAPIValuesForForm = ({ id, title, owner }) => ({
+  id,
+  title,
+  owner: mapApiToField(owner),
+})

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -1,12 +1,14 @@
 //TODO
-export const transformFormValuesForAPI = (values) => ({
-  ...values,
-  owner: { id: values.owner.value },
-})
+export const transformFormValuesForAPI = (values) => {
+  if (!values) {
+    return values
+  }
+  return { ...values, owner: { id: values.owner?.value } }
+}
 
 const mapApiToField = (value) =>
   value ? { value: value.id, label: value.name } : {}
-//TO test
+
 export const transformAPIValuesForForm = (initialValues) => {
   if (!initialValues) {
     return initialValues

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -159,6 +159,7 @@ const parseProps = (domNode) => {
     return {
       modulePermissions: [],
       currentAdviserId: '',
+      currentAdviserName: '',
       activeFeatures: null,
       activeFeatureGroups: null,
     }
@@ -171,12 +172,14 @@ const appWrapper = document.getElementById('react-app')
 const {
   modulePermissions,
   currentAdviserId,
+  currentAdviserName,
   activeFeatures,
   activeFeatureGroups,
 } = parseProps(appWrapper)
 
 const reducer = {
   currentAdviserId: () => currentAdviserId,
+  currentAdviserName: () => currentAdviserName,
   activeFeatures: () => activeFeatures,
   activeFeatureGroups: () => activeFeatureGroups,
   modulePermissions: () => modulePermissions,

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -17,6 +17,7 @@ module.exports = () => {
         ...res.locals.PERMITTED_APPLICATIONS.map(({ key }) => key),
       ]),
       currentAdviserId: req.session?.user?.id,
+      currentAdviserName: req.session?.user?.name,
       activeFeatures: req.session?.user?.active_features || [],
       activeFeatureGroups: req.session?.user?.active_feature_groups || [],
     }

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -36,7 +36,7 @@ describe('Export pipeline create', () => {
     it('should render add event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
-        Companies: urls.companies.activity.index(),
+        Companies: urls.companies.index(),
         'Add export': null,
       })
     })

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -11,6 +11,9 @@ const {
   assertLocalHeader,
   assertBreadcrumbs,
 } = require('../../support/assertions')
+const {
+  ERROR_MESSAGES,
+} = require('../../../../../src/client/modules/ExportPipeline/ExportForm/constants')
 
 const {
   ERROR_MESSAGES,

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -36,7 +36,7 @@ describe('Export pipeline create', () => {
     it('should render add event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.dashboard(),
-        Companies: urls.companies.index(),
+        Companies: urls.companies.activity.index(),
         'Add export': null,
       })
     })

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -1,5 +1,12 @@
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
+const {
+  assertUrl,
+  assertExactUrl,
+  assertFlashMessage,
+  assertPayload,
+  assertFieldTypeahead,
+} = require('../../support/assertions')
 
 const {
   assertUrl,
@@ -14,6 +21,9 @@ const {
 const {
   ERROR_MESSAGES,
 } = require('../../../../../src/client/modules/ExportPipeline/ExportForm/constants')
+const {
+  generateExport,
+} = require('../../../../sandbox/routes/v4/export/exports')
 
 const {
   ERROR_MESSAGES,
@@ -88,6 +98,17 @@ describe('Export pipeline create', () => {
       assertUrl(urls.companies.activity.index(company.id))
     })
 
+    it('the form should display with default values set', () => {
+      cy.get('[data-test="field-owner"]').then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Owner',
+          value: 'DIT Staff',
+          isMulti: false,
+        })
+      })
+    })
+
     context('when the form contains invalid data and is submitted', () => {
       it('the form should display validation error message for mandatory inputs', () => {
         //clear any default values first
@@ -98,25 +119,10 @@ describe('Export pipeline create', () => {
           'contain.text',
           ERROR_MESSAGES.title
         )
-      })
-    })
-
-    context('when the form contains valid data', () => {
-      it('the form should display with default values set', () => {
-        cy.get(
-          '[data-test="field-owner"] > fieldset > div > div > div > input'
-        ).should('have.value', 'user')
-      })
-
-      context('when the form is submitted', () => {
-        // it('the form should send expected values to the api', () => {
-        //   cy.get('[data-test=submit-button]').click()
-        // })
-
-        it('the form should redirect to the dashboard page and display a success message', () => {
-          cy.get('[data-test=submit-button]').click()
-          assertUrl(urls.dashboard())
-        })
+        cy.get('[data-test="field-owner"] > fieldset > div > span').should(
+          'contain.text',
+          ERROR_MESSAGES.owner
+        )
       })
     })
 
@@ -126,10 +132,14 @@ describe('Export pipeline create', () => {
         it('the form should redirect to the dashboard page and display a success message', () => {
           const newExport = generateExport()
 
-          cy.get('[data-test="title-input"]').type(newExport.title)
+          cy.get('[data-test=title-input]').type(newExport.title)
           cy.get('[data-test=submit-button]').click()
 
-          assertPayload('@postExportItemApiRequest', { title: newExport.title })
+          assertPayload('@postExportItemApiRequest', {
+            title: newExport.title,
+            owner: { id: '7d19d407-9aec-4d06-b190-d3f404627f21' },
+            company: { id: company.id },
+          })
 
           assertExactUrl('')
           assertFlashMessage(`'${newExport.title}' created`)

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -147,8 +147,8 @@ describe('Export pipeline create', () => {
 
           assertPayload('@postExportItemApiRequest', {
             title: newExport.title,
-            owner: { id: '7d19d407-9aec-4d06-b190-d3f404627f21' },
-            company: { id: company.id },
+            owner: '7d19d407-9aec-4d06-b190-d3f404627f21',
+            company: company.id,
           })
 
           assertExactUrl('')

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -90,11 +90,33 @@ describe('Export pipeline create', () => {
 
     context('when the form contains invalid data and is submitted', () => {
       it('the form should display validation error message for mandatory inputs', () => {
+        //clear any default values first
+        cy.get('[data-test="typeahead-input"]').clear()
+
         cy.get('[data-test=submit-button]').click()
         cy.get('[data-test="field-title"] > fieldset > div > span').should(
           'contain.text',
           ERROR_MESSAGES.title
         )
+      })
+    })
+
+    context('when the form contains valid data', () => {
+      it('the form should display with default values set', () => {
+        cy.get(
+          '[data-test="field-owner"] > fieldset > div > div > div > input'
+        ).should('have.value', 'user')
+      })
+
+      context('when the form is submitted', () => {
+        // it('the form should send expected values to the api', () => {
+        //   cy.get('[data-test=submit-button]').click()
+        // })
+
+        it('the form should redirect to the dashboard page and display a success message', () => {
+          cy.get('[data-test=submit-button]').click()
+          assertUrl(urls.dashboard())
+        })
       })
     })
 

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -6,7 +6,7 @@ const {
   assertBreadcrumbs,
   assertFlashMessage,
   assertFieldTypeahead,
-
+  assertFieldError,
   assertFieldInput,
 } = require('../../support/assertions')
 const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -106,5 +106,14 @@ describe('Export pipeline edit', () => {
         assertFlashMessage(`Changes saved to '${exportItem.title}'`)
       })
     })
+
+    it('the form should display validation error message for mandatory inputs', () => {
+      cy.get('[data-test="title-input"]').clear()
+      cy.get('[data-test=submit-button]').click()
+      cy.get('[data-test="field-title"] > fieldset > div > span').should(
+        'contain.text',
+        ERROR_MESSAGES.title
+      )
+    })
   })
 })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -134,8 +134,14 @@ describe('Export pipeline edit', () => {
 
         //While building the form do individual checks, can switch to assertPayload once all fields are added
         cy.wait('@patchExportItemApiRequest').then(({ request }) => {
+          expect(request.body).to.have.property('id', exportItem.id)
+
+          expect(request.body).to.have.property(
+            'company',
+            exportItem.company.id
+          )
           expect(request.body).to.have.property('title', exportItem.title)
-          expect(request.body.owner).to.have.property('id', exportItem.owner.id)
+          expect(request.body).to.have.property('owner', exportItem.owner.id)
         })
 
         assertUrl(urls.exportPipeline.edit(exportItem.id))

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -91,29 +91,5 @@ describe('Export pipeline edit', () => {
         )
       })
     })
-
-    context('when the form contains valid data and is submitted', () => {
-      it('the form should stay on the current page', () => {
-        cy.get('[data-test=submit-button]').click()
-
-        //While building the form do individual checks, can switch to assertPayload once all fields are added
-        cy.wait('@patchExportItemApiRequest').then(({ request }) => {
-          expect(request.body).to.have.property('title', exportItem.title)
-        })
-
-        assertUrl(urls.exportPipeline.edit(exportItem.id))
-
-        assertFlashMessage(`Changes saved to '${exportItem.title}'`)
-      })
-    })
-
-    it('the form should display validation error message for mandatory inputs', () => {
-      cy.get('[data-test="title-input"]').clear()
-      cy.get('[data-test=submit-button]').click()
-      cy.get('[data-test="field-title"] > fieldset > div > span').should(
-        'contain.text',
-        ERROR_MESSAGES.title
-      )
-    })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -775,6 +775,9 @@ const assertErrorDialog = (taskName, errorMessage) => {
 const assertAPIRequest = (endPointAlias, assertCallback) =>
   cy.wait(`@${endPointAlias}`).then((xhr) => assertCallback(xhr))
 
+const assertFieldError = (element, errorMessage) =>
+  element.find('span').should('contain.text', errorMessage)
+
 module.exports = {
   assertKeyValueTable,
   assertValueTable,
@@ -831,4 +834,5 @@ module.exports = {
   assertErrorDialog,
   assertAPIRequest,
   assertExactUrl,
+  assertFieldError,
 }

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -346,11 +346,11 @@ const assertFieldInput = ({
           .should('have.text', hint || '')
           .next()
     )
-    .then(($el) => {
+    .then(
       //in the scenario where we don't need to validate what the hint is, but a hint is still
       //being rendered, skip over the hint without validating it to get to the next element
-      return ignoreHint && value ? cy.wrap($el).next() : undefined
-    })
+      ($el) => (ignoreHint && value ? cy.wrap($el).next() : undefined)
+    )
     .find('input')
     .then(
       ($el) =>

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -286,7 +286,7 @@ const assertFieldTypeahead = ({
     label
       ? expect($typeahead.find('label')).to.contain(label)
       : expect($typeahead.find('label')).to.not.exist
-
+    // cy.log($typeahead.find('input'))
     isMulti
       ? value && expect($typeahead).to.contain(value)
       : value && expect($typeahead.find('input')).to.have.attr('value', value)
@@ -330,6 +330,7 @@ const assertFieldInput = ({
   label,
   hint = undefined,
   value = undefined,
+  ignoreHint = false,
 }) =>
   cy
     .wrap(element)
@@ -345,7 +346,7 @@ const assertFieldInput = ({
           .should('have.text', hint || '')
           .next()
     )
-
+    .then(($el) => ignoreHint && value && cy.wrap($el).next())
     .find('input')
     .then(
       ($el) =>

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -346,7 +346,11 @@ const assertFieldInput = ({
           .should('have.text', hint || '')
           .next()
     )
-    .then(($el) => ignoreHint && value && cy.wrap($el).next())
+    .then(($el) => {
+      //in the scenario where we don't need to validate what the hint is, but a hint is still
+      //being rendered, skip over the hint without validating it to get to the next element
+      return ignoreHint && value ? cy.wrap($el).next() : undefined
+    })
     .find('input')
     .then(
       ($el) =>

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -786,7 +786,7 @@ const assertAPIRequest = (endPointAlias, assertCallback) =>
  * @returns
  */
 const assertFieldError = (element, errorMessage) =>
-  element.find('span').should('have.text', errorMessage)
+  element.find('span').eq(1).should('have.text', errorMessage)
 
 module.exports = {
   assertKeyValueTable,

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -286,7 +286,7 @@ const assertFieldTypeahead = ({
     label
       ? expect($typeahead.find('label')).to.contain(label)
       : expect($typeahead.find('label')).to.not.exist
-    // cy.log($typeahead.find('input'))
+
     isMulti
       ? value && expect($typeahead).to.contain(value)
       : value && expect($typeahead.find('input')).to.have.attr('value', value)
@@ -779,8 +779,14 @@ const assertErrorDialog = (taskName, errorMessage) => {
 const assertAPIRequest = (endPointAlias, assertCallback) =>
   cy.wait(`@${endPointAlias}`).then((xhr) => assertCallback(xhr))
 
+/**
+ * Assert the field element contains the expected error message
+ * @param {*} element the field element that contains the error
+ * @param {*} errorMessage the error message that should be displayed
+ * @returns
+ */
 const assertFieldError = (element, errorMessage) =>
-  element.find('span').should('contain.text', errorMessage)
+  element.find('span').should('have.text', errorMessage)
 
 module.exports = {
   assertKeyValueTable,


### PR DESCRIPTION
## Description of change

- Added current advisor name to the global props, as this is needed along with the current advisor id for the owner dropdown
- Added the new owner field to the export item form
- Added logic to transform api responses into values needed by the form field components `{id, name} => {value, label}`
- Added logic to transform form field values back into values needed by the api `{value, label} => {id, name}`
- Where possible in cypress tests, switch from `beforeEach()` to `before()` for visiting pages to improve performance


## Screenshots

### Adding

![image](https://user-images.githubusercontent.com/102232401/226584404-9f2fbb5a-da80-4f59-98ed-86e416005cf5.png)


### Editing

![image](https://user-images.githubusercontent.com/102232401/226584530-1e3f25af-7b9b-4f16-9b6e-a57bc5169525.png)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
