### PR TITLE
feature/RR-908-handle-form-submissions

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -57,7 +57,6 @@ const ExportFormAdd = ({ company }) => {
       useReactRouter={false}
     >
       <ExportFormFields
-        companyId={companyId}
         analyticsFormName="addExportForm"
         taskProps={{
           name: TASK_GET_COMPANY_DETAIL,
@@ -68,6 +67,9 @@ const ExportFormAdd = ({ company }) => {
             onSuccessDispatch: COMPANY_LOADED,
           },
         }}
+        cancelRedirectUrl={urls.companies.activity.index(companyId)}
+        redirectToUrl={urls.dashboard()}
+        flashMessage={({ data }) => `'${data.title}' created`}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -60,6 +60,9 @@ const ExportFormEdit = ({ exportItem }) => {
           },
         }}
         exportItem={exportItem}
+        cancelRedirectUrl={urls.dashboard()}
+        redirectToUrl={urls.exportPipeline.edit(exportId)}
+        flashMessage={({ data }) => `Changes saved to '${data.title}'`}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -3,15 +3,16 @@ import React from 'react'
 import Form from '../../../components/Form'
 import { FieldInput, FormLayout } from '../../../../client/components'
 import { FORM_LAYOUT } from '../../../../common/constants'
-import urls from '../../../../lib/urls'
 import { TASK_SAVE_EXPORT } from './state'
 import Task from '../../../components/Task'
 import { ERROR_MESSAGES } from './constants'
 
 const ExportFormFields = ({
-  companyId,
   exportItem,
   analyticsFormName,
+  flashMessage,
+  cancelRedirectUrl,
+  redirectToUrl,
   taskProps = {},
 }) => (
   <Task.Status {...taskProps}>
@@ -20,14 +21,12 @@ const ExportFormFields = ({
         <Form
           id="export-form"
           analyticsFormName={analyticsFormName}
-          cancelRedirectTo={() =>
-            urls.companies.activity.index(
-              exportItem ? exportItem.company.id : companyId
-            )
-          }
+          cancelRedirectTo={() => cancelRedirectUrl}
+          redirectTo={() => redirectToUrl}
           submissionTaskName={TASK_SAVE_EXPORT}
           initialValues={exportItem}
           transformPayload={(values) => ({ exportId: values.id, values })}
+          flashMessage={flashMessage}
         >
           {() => (
             <FieldInput

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Form from '../../../components/Form'
 import { FieldInput, FormLayout } from '../../../../client/components'
@@ -42,5 +43,14 @@ const ExportFormFields = ({
     )}
   </Task.Status>
 )
+
+ExportFormFields.propTypes = {
+  exportItem: PropTypes.object,
+  analyticsFormName: PropTypes.string.isRequired,
+  flashMessage: PropTypes.string.isRequired,
+  cancelRedirectUrl: PropTypes.string.isRequired,
+  redirectToUrl: PropTypes.string.isRequired,
+  taskProps: PropTypes.object,
+}
 
 export default ExportFormFields

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -96,7 +96,7 @@ describe('Export pipeline edit', () => {
       it('the form should stay on the current page', () => {
         cy.get('[data-test=submit-button]').click()
 
-        //While build the form do individual checks, can switch to assertPayload once all fields are added
+        //While building the form do individual checks, can switch to assertPayload once all fields are added
         cy.wait('@patchExportItemApiRequest').then(({ request }) => {
           expect(request.body).to.have.property('title', exportItem.title)
         })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -4,6 +4,7 @@ const { assertUrl } = require('../../support/assertions')
 const {
   assertLocalHeader,
   assertBreadcrumbs,
+  assertFlashMessage,
 } = require('../../support/assertions')
 const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
 const {
@@ -101,6 +102,8 @@ describe('Export pipeline edit', () => {
         })
 
         assertUrl(urls.exportPipeline.edit(exportItem.id))
+
+        assertFlashMessage(`Changes saved to '${exportItem.title}'`)
       })
     })
   })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -39,7 +39,10 @@ describe('Export pipeline edit', () => {
     beforeEach(() => {
       cy.intercept('GET', `/api-proxy/v4/export/${exportItem.id}`, {
         body: exportItem,
-      }).as('apiRequest')
+      }).as('getExportItemApiRequest')
+      cy.intercept('PATCH', `/api-proxy/v4/export/${exportItem.id}`).as(
+        'patchExportItemApiRequest'
+      )
       cy.visit(urls.exportPipeline.edit(exportItem.id))
     })
 
@@ -69,25 +72,36 @@ describe('Export pipeline edit', () => {
     it('the form should display a cancel link', () => {
       cy.get('[data-test=cancel-button]')
         .should('have.text', 'Cancel')
-        .should(
-          'have.attr',
-          'href',
-          urls.companies.activity.index(exportItem.company.id)
-        )
+        .should('have.attr', 'href', urls.dashboard())
     })
 
-    it('the form should redirect to the company page when the cancel button is clicked', () => {
+    it('the form should redirect to the dashboard page when the cancel button is clicked', () => {
       cy.get('[data-test=cancel-button]').click()
-      assertUrl(urls.companies.activity.index(exportItem.company.id))
+      assertUrl(urls.dashboard())
     })
 
-    it('the form should display validation error message for mandatory inputs', () => {
-      cy.get('[data-test="title-input"]').clear()
-      cy.get('[data-test=submit-button]').click()
-      cy.get('[data-test="field-title"] > fieldset > div > span').should(
-        'contain.text',
-        ERROR_MESSAGES.title
-      )
+    context('when the form contains invalid data and is submitted', () => {
+      it('the form should display validation error message for mandatory inputs', () => {
+        cy.get('[data-test="title-input"]').clear()
+        cy.get('[data-test=submit-button]').click()
+        cy.get('[data-test="field-title"] > fieldset > div > span').should(
+          'contain.text',
+          ERROR_MESSAGES.title
+        )
+      })
+    })
+
+    context('when the form contains valid data and is submitted', () => {
+      it('the form should stay on the current page', () => {
+        cy.get('[data-test=submit-button]').click()
+
+        //While build the form do individual checks, can switch to assertPayload once all fields are added
+        cy.wait('@patchExportItemApiRequest').then(({ request }) => {
+          expect(request.body).to.have.property('title', exportItem.title)
+        })
+
+        assertUrl(urls.exportPipeline.edit(exportItem.id))
+      })
     })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -725,7 +725,7 @@ const assertUrl = (url) => {
  * Assert url is exactly matches the current url
  */
 const assertExactUrl = (url) => {
-  cy.url().should('eq', `http://localhost:3000/${url}`)
+  cy.url().should('eq', `${Cypress.config('baseUrl')}/${url}`)
 }
 
 /**

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -722,7 +722,7 @@ const assertUrl = (url) => {
 }
 
 /**
- * Assert url is contained in current url
+ * Assert url is exactly matches the current url
  */
 const assertExactUrl = (url) => {
   cy.url().should('eq', `http://localhost:3000/${url}`)

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -722,6 +722,13 @@ const assertUrl = (url) => {
 }
 
 /**
+ * Assert url is contained in current url
+ */
+const assertExactUrl = (url) => {
+  cy.url().should('eq', `http://localhost:3000/${url}`)
+}
+
+/**
  * Assert flash message is contained
  */
 const assertFlashMessage = (message) => {
@@ -822,4 +829,5 @@ module.exports = {
   assertRequestBody,
   assertErrorDialog,
   assertAPIRequest,
+  assertExactUrl,
 }

--- a/test/sandbox/routes/v4/export/exports.js
+++ b/test/sandbox/routes/v4/export/exports.js
@@ -48,4 +48,4 @@ const generateExports = (count = 10) => {
 
 const exportItems = generateExports(20)
 
-module.exports = { exportItems }
+module.exports = { exportItems, generateExport }


### PR DESCRIPTION
## Description of change

- Added logic to handle the redirects when the export pipeline form is saved and cancelled. The add and edit modes have different destinations when these buttons are clicked.
- Added the flash message when creating a new export pipeline item
- Added the flash message when editing an existing export pipeline item

## Test instructions

Open the url http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit, change the title and use the Save button. The success flash message will appear

## Screenshots

### Creating export 
![image](https://user-images.githubusercontent.com/102232401/226384548-b343c584-a046-4523-8778-1e02257fd75a.png)


### Editing export
![image](https://user-images.githubusercontent.com/102232401/226384007-aab9598c-8f9a-4e1a-a066-f6ea13f2af1f.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
