### PR TITLE
Improve help centre error handling

### DIFF
--- a/src/client/components/PersonalisedDashboard/tasks.js
+++ b/src/client/components/PersonalisedDashboard/tasks.js
@@ -15,8 +15,7 @@ export const checkForInvestments = ({ adviser }) =>
 
 // This API call doesn't go through the conventional /api-proxy endpoint.
 // Instead, it goes through a another piece of middleware where the path
-// also starts with /api-proxy and requires the env var HELP_CENTRE_API_FEED
-// to be set. The middleware can be found in help-centre-api-proxy.js
+// also starts with /api-proxy. The middleware can be found in help-centre-api-proxy.js
 export const checkDataHubFeed = () =>
   apiProxyAxios.get('/api-proxy/help-centre/feed').then(({ data }) => ({
     dataHubFeed: data,

--- a/src/middleware/help-centre-api-proxy.js
+++ b/src/middleware/help-centre-api-proxy.js
@@ -7,13 +7,15 @@ const {
 const API_PROXY_PATH = '/api-proxy/help-centre/feed'
 
 module.exports = (app) => {
-  app.use(API_PROXY_PATH, async (req, res, next) => {
+  app.use(API_PROXY_PATH, async (req, res) => {
     try {
       const url = config.helpCentre.apiFeed
-      const isUrlValid = url.includes('data-services-help')
-      const responseData = isUrlValid
-        ? await hawkRequest(url, config.hawkCredentials.helpCentre, 1000)
-        : []
+      const responseData = await hawkRequest(
+        url,
+        config.hawkCredentials.helpCentre,
+        1000
+      )
+
       res.setHeader('Content-Type', 'application/json')
       const { articles } = responseData
       const articleFeed = formatHelpCentreAnnouncements(articles) || []
@@ -21,7 +23,9 @@ module.exports = (app) => {
       res.write(JSON.stringify(articleFeed))
       res.send()
     } catch (error) {
-      next(error)
+      // If the help centre is offline, we send an empty feed rather than displaying an error
+      res.write(JSON.stringify([]))
+      res.send()
     }
   })
 }


### PR DESCRIPTION
## Description of change
If the help centre is offline (or the env variables haven't been changed), the dashboard/investment homepage will crash and not be usable. The help centre middleware will now send an empty array (equivalent to an empty article feed) when the request fails.

I got around this in the last PR by including a check that the URL was correct, however this did not cater for the help centre itself being offline. Helpfully I only thought of this right after merging it 🤦‍♂️.

## Test instructions
In the frontend, open your `.env` file and change the `HELP_CENTRE_ANNOUNCEMENTS_URL` and `HELP_CENTRE_API_FEED` variables to dummy URLs and start the application. The dashboard/investment homepage should render with the 'No updates' message.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
