### PR TITLE
Add a new export tab to both dashboards

### DIFF
--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -15,6 +15,7 @@ module.exports = {
       urls.pipeline.index(),
       urls.pipeline.active(),
       urls.pipeline.won(),
+      urls.exportPipeline.index(),
     ],
     spaBasePath(urls.dashboard.route),
     userFeatures('personalised-dashboard'),

--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -42,7 +42,7 @@ const DashboardTabs = ({
         ...(hasExportPipeline
           ? {
               [urls.exportPipeline.index()]: {
-                label: 'Export',
+                label: 'Export list',
                 content: <ExportList />,
               },
             }

--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -6,6 +6,7 @@ import NoInvestmentProjects from '../MyInvestmentProjects/NoInvestmentProjects'
 import MyInvestmentProjects from '../MyInvestmentProjects'
 import CompanyLists from '../CompanyLists'
 import Pipeline from '../../components/Pipeline'
+import ExportList from '../../modules/ExportPipeline/ExportList'
 import urls from '../../../lib/urls'
 import TabNav from '../TabNav'
 
@@ -13,7 +14,12 @@ const StyledDiv = styled('div')`
   padding-top: 16px;
 `
 
-const DashboardTabs = ({ id, adviser, hasInvestmentProjects }) => (
+const DashboardTabs = ({
+  id,
+  adviser,
+  hasInvestmentProjects,
+  hasExportPipeline,
+}) => (
   <StyledDiv data-test="dashboard-tabs">
     <TabNav
       id={`${id}.TabNav`}
@@ -33,10 +39,19 @@ const DashboardTabs = ({ id, adviser, hasInvestmentProjects }) => (
           label: 'Company lists',
           content: <CompanyLists />,
         },
-        [urls.pipeline.index.mountPoint]: {
-          label: 'Pipeline',
-          content: <Pipeline />,
-        },
+        ...(hasExportPipeline
+          ? {
+              [urls.exportPipeline.index()]: {
+                label: 'Export',
+                content: <ExportList />,
+              },
+            }
+          : {
+              [urls.pipeline.index.mountPoint]: {
+                label: 'Pipeline',
+                content: <Pipeline />,
+              },
+            }),
       }}
     />
   </StyledDiv>

--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -61,21 +61,23 @@ const state2props = (state) => {
   const { hasInvestmentProjects } = state[CHECK_FOR_INVESTMENTS_ID]
   const { dataHubFeed } = state[DATA_HUB_FEED_ID]
 
-  const activeFeatureGroups = state.activeFeatureGroups || []
-  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+  const hasInvestmentFeatureGroup = state.activeFeatureGroups.includes(
     'investment-notifications'
   )
-  const hasExportFeatureGroup = activeFeatureGroups.includes(
+  const hasExportFeatureGroup = state.activeFeatureGroups.includes(
     'export-notifications'
   )
+
+  const hasExportPipeline = state.activeFeatures.includes('export-pipeline')
 
   return {
     hasInvestmentProjects,
     dataHubFeed,
     remindersCount,
     reminderSummaryCount,
-    hasInvestmentFeatureGroup,
     hasExportFeatureGroup,
+    hasInvestmentFeatureGroup,
+    hasExportPipeline,
   }
 }
 
@@ -87,6 +89,7 @@ const PersonalisedDashboard = ({
   reminderSummaryCount,
   hasInvestmentProjects,
   dataHubFeed,
+  hasExportPipeline,
   hasInvestmentFeatureGroup,
   hasExportFeatureGroup,
 }) => (
@@ -161,6 +164,7 @@ const PersonalisedDashboard = ({
                 <DashboardTabs
                   id={id}
                   adviser={adviser}
+                  hasExportPipeline={hasExportPipeline}
                   hasInvestmentProjects={hasInvestmentProjects}
                 />
               </Main>

--- a/src/client/modules/Dashboard/Dashboard.jsx
+++ b/src/client/modules/Dashboard/Dashboard.jsx
@@ -87,7 +87,7 @@ const Dashboard = ({
                 ...(hasExportPipeline
                   ? {
                       [urls.exportPipeline.index()]: {
-                        label: 'Export',
+                        label: 'Export list',
                         content: <ExportList />,
                       },
                     }

--- a/src/client/modules/Dashboard/Dashboard.jsx
+++ b/src/client/modules/Dashboard/Dashboard.jsx
@@ -17,6 +17,7 @@ import urls from '../../../lib/urls'
 import CompanyLists from '../../components/CompanyLists'
 import ReferralList from '../../components/ReferralList'
 import Pipeline from '../../components/Pipeline'
+import ExportList from '../../modules/ExportPipeline/ExportList'
 import TabNav from '../../components/TabNav'
 
 const StyledDiv = styled('div')`
@@ -27,8 +28,9 @@ const StyledDiv = styled('div')`
 
 const state2props = (state) => {
   const { dataHubFeed } = state[DATA_HUB_FEED_ID]
+  const hasExportPipeline = state.activeFeatures.includes('export-pipeline')
 
-  return { dataHubFeed }
+  return { dataHubFeed, hasExportPipeline }
 }
 
 const Dashboard = ({
@@ -37,6 +39,7 @@ const Dashboard = ({
   dashboardTabId,
   userPermissions,
   dataHubFeed,
+  hasExportPipeline,
 }) => {
   const canViewDashboardTabs = userPermissions.includes(
     'company_list.view_companylist'
@@ -81,10 +84,19 @@ const Dashboard = ({
                     <ReferralList id={`${dashboardTabId}:ReferralList`} />
                   ),
                 },
-                [urls.pipeline.index.mountPoint]: {
-                  label: 'My pipeline',
-                  content: <Pipeline />,
-                },
+                ...(hasExportPipeline
+                  ? {
+                      [urls.exportPipeline.index()]: {
+                        label: 'Export',
+                        content: <ExportList />,
+                      },
+                    }
+                  : {
+                      [urls.pipeline.index.mountPoint]: {
+                        label: 'My pipeline',
+                        content: <Pipeline />,
+                      },
+                    }),
               }}
             />
           </StyledDiv>

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const ExportList = () => <>...</>
+
+export default ExportList

--- a/src/client/modules/ExportPipeline/contants.js
+++ b/src/client/modules/ExportPipeline/contants.js
@@ -1,3 +1,1 @@
-const EXPORT_PIPELINE_FEATURE_FLAG = 'export-pipeline'
-
-module.exports = { EXPORT_PIPELINE_FEATURE_FLAG }
+export const EXPORT_PIPELINE_FEATURE_FLAG = 'export-pipeline'

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -529,6 +529,7 @@ module.exports = {
     },
   },
   exportPipeline: {
+    index: url('/export'),
     create: url('/export/create'),
     edit: url('/export', '/:exportId/edit'),
   },

--- a/test/functional/cypress/specs/dashboard-new/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/my-pipeline-spec.js
@@ -49,7 +49,7 @@ describe('Dashboard', () => {
         .next()
         .should('have.text', 'Company lists')
         .next()
-        .should('have.text', 'Export')
+        .should('have.text', 'Export list')
     })
   })
 })

--- a/test/functional/cypress/specs/dashboard-new/my-pipeline-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/my-pipeline-spec.js
@@ -1,14 +1,14 @@
 describe('Dashboard', () => {
-  before(() => {
-    cy.setUserFeatures(['personalised-dashboard'])
-    cy.visit('/')
-  })
+  context('Tabs - default', () => {
+    before(() => {
+      cy.setUserFeatures(['personalised-dashboard'])
+      cy.visit('/')
+    })
 
-  after(() => {
-    cy.resetUser()
-  })
+    after(() => {
+      cy.resetUser()
+    })
 
-  describe('Tabs', () => {
     it('should display tabs in the right order', () => {
       cy.get('[data-test="dashboard-tabs"]')
         .should('exist')
@@ -23,6 +23,33 @@ describe('Dashboard', () => {
         .should('have.text', 'Company lists')
         .next()
         .should('have.text', 'Pipeline')
+    })
+  })
+
+  context('Tabs - Export', () => {
+    before(() => {
+      cy.setUserFeatures(['personalised-dashboard', 'export-pipeline'])
+      cy.visit('/')
+    })
+
+    after(() => {
+      cy.resetUser()
+    })
+
+    it('should display tabs in the right order', () => {
+      cy.get('[data-test="dashboard-tabs"]')
+        .should('exist')
+        .find('[data-test="tablist"]')
+        .eq(0)
+        .should('exist')
+        .children()
+        .should('have.length', 3)
+        .first()
+        .should('have.text', 'Investment projects')
+        .next()
+        .should('have.text', 'Company lists')
+        .next()
+        .should('have.text', 'Export')
     })
   })
 })

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -93,7 +93,7 @@ describe('Dashboard', () => {
         .next()
         .should('have.text', 'My referrals')
         .next()
-        .should('have.text', 'Export')
+        .should('have.text', 'Export list')
     })
   })
 })

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -69,4 +69,31 @@ describe('Dashboard', () => {
         .should('have.text', 'No updates available')
     })
   })
+
+  context('Tabs - Export', () => {
+    before(() => {
+      cy.setUserFeatures(['export-pipeline'])
+      cy.visit('/')
+    })
+
+    after(() => {
+      cy.resetUser()
+    })
+
+    it('should display tabs in the right order', () => {
+      cy.get('[data-test="dashboard-tabs"]')
+        .should('exist')
+        .find('[data-test="tablist"]')
+        .eq(0)
+        .should('exist')
+        .children()
+        .should('have.length', 3)
+        .first()
+        .should('have.text', 'My companies lists')
+        .next()
+        .should('have.text', 'My referrals')
+        .next()
+        .should('have.text', 'Export')
+    })
+  })
 })


### PR DESCRIPTION
## Description of change

Added a new dashboard export tab which is hidden behind the `export-pipeline` feature flag. The tab will contain a list of the user's exports. The new tab appears in both old and new dashboards.

## Test instructions
**Old dashboard**
Add the user feature flag `export-pipeline` to view the new tab (removes the old 'My pipeline' tab)

**New dashboard (AKA personalised dashboard)**
Add both user feature flags `personalised-dashboard` and `export-pipeline` to view the new tab (removes the 'Pipeline' tab)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
