### PR TITLE
Modify Datahub DIT into DBT content header, title and test specs

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -142,8 +142,8 @@ const ExportsIndex = ({
       </p>
       <Details summary="What is an Export Win">
         <p>
-          Export wins capture the export deals that Department of International
-          Trade (DIT) support and quantify their expected export value. If
+          Export wins capture the export deals that Department for Business and
+          Trade (BDT) support and quantify their expected export value. If
           applicable, they also quantify the non-export and outward direct
           investment (ODI) value, up to a 5-year period. They give a picture of
           DIT support for business.

--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -143,7 +143,7 @@ const ExportsIndex = ({
       <Details summary="What is an Export Win">
         <p>
           Export wins capture the export deals that Department for Business and
-          Trade (BDT) support and quantify their expected export value. If
+          Trade (DBT) support and quantify their expected export value. If
           applicable, they also quantify the non-export and outward direct
           investment (ODI) value, up to a 5-year period. They give a picture of
           DIT support for business.

--- a/src/apps/investments/controllers/admin.js
+++ b/src/apps/investments/controllers/admin.js
@@ -11,7 +11,7 @@ async function renderAdminView(req, res) {
   }
   const stages = orderStages(await getOptions(req, 'investment-project-stage'))
 
-  res.locals.title = `Admin - ${name} - Projects - Investments - DIT Data Hub`
+  res.locals.title = `Admin - ${name} - Projects - Investments - DBT Data Hub`
   res.render('investments/views/admin/client-container.njk', {
     props: {
       projectId: id,

--- a/src/client/components/DataHubHeader/DataHubBar.jsx
+++ b/src/client/components/DataHubHeader/DataHubBar.jsx
@@ -158,7 +158,7 @@ const DataHubBar = ({
   <Layout>
     <RootContainer>
       <DataHubContainer>
-        <VisuallyHidden>Department for International Trade</VisuallyHidden>
+        <VisuallyHidden>Department for Business and Trade</VisuallyHidden>
         <StyledLogoNavLink as="a" href="/">
           Data Hub
         </StyledLogoNavLink>

--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -26,7 +26,7 @@ const DefaultLayout = ({
 }) => {
   const [showVerticalNav, setShowVerticalNav] = useState(false)
   useEffect(() => {
-    document.title = `${pageTitle} - DIT Data Hub`
+    document.title = `${pageTitle} - DBT Data Hub`
   }, [pageTitle])
   return (
     <>

--- a/src/config/nunjucks/globals.js
+++ b/src/config/nunjucks/globals.js
@@ -6,7 +6,7 @@ const urls = require('../../lib/urls')
 module.exports = {
   serviceTitle: 'Data Hub',
   description:
-    'Data Hub is a customer relationship, project management and analytical tool for Department for International Trade.',
+    'Data Hub is a customer relationship, project management and analytical tool for Department for Business and Trade.',
   assign,
   urls,
 

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -19,7 +19,7 @@
 {# Remove the skipLink from the base template #}
 {% block skipLink %}{% endblock %}
 
-{% set pageTitle = [getPageTitle() if getPageTitle, 'DIT Data Hub'] | removeNilAndEmpty | flatten | join(' - ') %}
+{% set pageTitle = [getPageTitle() if getPageTitle, 'DBT Data Hub'] | removeNilAndEmpty | flatten | join(' - ') %}
 {%- set titleDefault = 'Department for Business and  Trade' -%}
 {%- set htmlClasses = 'no-js' -%}
 

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -20,7 +20,7 @@
 {% block skipLink %}{% endblock %}
 
 {% set pageTitle = [getPageTitle() if getPageTitle, 'DIT Data Hub'] | removeNilAndEmpty | flatten | join(' - ') %}
-{%- set titleDefault = 'Department for International Trade' -%}
+{%- set titleDefault = 'Department for Business and  Trade' -%}
 {%- set htmlClasses = 'no-js' -%}
 
 {% block pageTitle %}

--- a/test/functional/cypress/specs/companies/contact-collection-spec.js
+++ b/test/functional/cypress/specs/companies/contact-collection-spec.js
@@ -270,7 +270,7 @@ describe('Company Contacts Collections', () => {
     it('should render a meta title', () => {
       cy.title().should(
         'eq',
-        'Contacts - Archived Ltd - Companies - DIT Data Hub'
+        'Contacts - Archived Ltd - Companies - DBT Data Hub'
       )
     })
 

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -62,7 +62,7 @@ describe('Company Export tab', () => {
       })
 
       it('should render a meta title', () => {
-        cy.title().should('eq', 'Export - DnB Corp - Companies - DIT Data Hub')
+        cy.title().should('eq', 'Export - DnB Corp - Companies - DBT Data Hub')
       })
 
       it('should render breadcrumbs', () => {
@@ -135,7 +135,7 @@ describe('Company Export tab', () => {
       it('should render the "What is an Export Win" details', () => {
         cy.contains('What is an Export Win')
         cy.contains(
-          'Export wins capture the export deals that Department of International Trade (DIT)'
+          'Export wins capture the export deals that Department for Business and Trade (DBT)'
         )
       })
 

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -107,7 +107,7 @@ describe('Company Investments Collection Page', () => {
     it('should render a meta title', () => {
       cy.title().should(
         'eq',
-        'Investments - DnB Corp - Companies - DIT Data Hub'
+        'Investments - DnB Corp - Companies - DBT Data Hub'
       )
     })
 

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -17,7 +17,7 @@ describe('Company Investments and Large capital profile', () => {
     it('should render a meta title', () => {
       cy.title().should(
         'eq',
-        'Large capital profile - One List Corp - Companies - DIT Data Hub'
+        'Large capital profile - One List Corp - Companies - DBT Data Hub'
       )
     })
 

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -12,7 +12,7 @@ describe('Lead advisers', () => {
     it('should render a meta title', () => {
       cy.title().should(
         'eq',
-        'Lead adviser - Mars Exports Ltd - Companies - DIT Data Hub'
+        'Lead adviser - Mars Exports Ltd - Companies - DBT Data Hub'
       )
     })
 

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -87,7 +87,7 @@ describe('Company Orders (OMIS) Collection Page', () => {
   })
 
   it('should render a meta title', () => {
-    cy.title().should('eq', 'Orders - One List Corp - Companies - DIT Data Hub')
+    cy.title().should('eq', 'Orders - One List Corp - Companies - DBT Data Hub')
   })
 
   assertRemoveAllFiltersNotPresent()

--- a/test/functional/cypress/specs/companies/pipeline-spec.js
+++ b/test/functional/cypress/specs/companies/pipeline-spec.js
@@ -22,7 +22,7 @@ describe('Company add to pipeline form', () => {
     it('should render a meta title', () => {
       cy.title().should(
         'eq',
-        'Add to your pipeline - Minimally Minimal Ltd - Companies - DIT Data Hub'
+        'Add to your pipeline - Minimally Minimal Ltd - Companies - DBT Data Hub'
       )
     })
 


### PR DESCRIPTION
## Description of change

As the name of the department has changed from DIT to DBT, we will need to identify all content containing references to DIT (including both acronyms and the full department name) and update them to use the new name.

## Test instructions
Navigate Datahub front-end application headers e.g. `Companies`, `Contacts`, `Events`, `Interactions`, `Investments`, `Orders` and `Support`.

_What should I see?_
It was changed from `Department for International Trade` and `DIT` content into `Department for Business and Trade` and `DBT` within page title, header, options, caption, labels etc.


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
