### PR TITLE
Move not-verified status box above navigation tabs

### DIFF
--- a/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
+++ b/src/apps/companies/apps/activity-feed/client/CompanyActivityFeed.jsx
@@ -1,23 +1,14 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Button, Details, Paragraph, WarningText } from 'govuk-react'
-import styled from 'styled-components'
 
 import {
   ActivityFeedApp,
   ActivityFeedAction,
-  StatusMessage,
 } from '../../../../../client/components'
 import { companies } from '../../../../../lib/urls'
-import { BLACK } from '../../../../../client/utils/colours'
-
-const StyledLink = styled('a')`
-  margin-bottom: 0;
-`
 
 const CompanyActivityFeed = ({
   company,
-  showMatchingPrompt,
   activityTypeFilter,
   activityTypeFilters,
   isGlobalUltimate,
@@ -39,29 +30,6 @@ const CompanyActivityFeed = ({
 
   return (
     <>
-      {showMatchingPrompt && (
-        <StatusMessage colour={BLACK} id="ga-company-details-matching-prompt">
-          <WarningText>
-            Business details on this company record have not been verified and
-            could be wrong.
-          </WarningText>
-          <Details summary="Why verify?">
-            <Paragraph>
-              Using verified business details from a trusted third-party
-              supplier means we can keep certain information up to date
-              automatically. This helps reduce duplicate records, provide a
-              shared view of complex companies and make it more likely we can
-              link other data sources together.
-            </Paragraph>
-            <Paragraph>
-              Verification can often be done in just 4 clicks.
-            </Paragraph>
-          </Details>
-          <Button as={StyledLink} href={companies.match.index(company.id)}>
-            Verify business details
-          </Button>
-        </StatusMessage>
-      )}
       <ActivityFeedApp
         actions={!company.archived && actions}
         activityTypeFilter={activityTypeFilter}
@@ -83,7 +51,6 @@ CompanyActivityFeed.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,
   isGlobalUltimate: PropTypes.bool,
   dnbHierarchyCount: PropTypes.number,
-  showMatchingPrompt: PropTypes.bool,
 }
 
 CompanyActivityFeed.defaultProps = {
@@ -93,7 +60,6 @@ CompanyActivityFeed.defaultProps = {
   actions: null,
   isGlobalUltimate: false,
   dnbHierarchyCount: null,
-  showMatchingPrompt: false,
 }
 
 export default CompanyActivityFeed

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -75,8 +75,6 @@ async function renderActivityFeed(req, res, next) {
           isGlobalUltimate: company.is_global_ultimate,
           dnbHierarchyCount,
           dnbRelatedCompaniesCount,
-          showMatchingPrompt:
-            !company.duns_number && !company.pending_dnb_investigation,
         }
 
     const props = {

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -2,13 +2,14 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
-import GridCol from '@govuk-react/grid-col'
-import Button from '@govuk-react/button'
-import GridRow from '@govuk-react/grid-row'
-import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
-import Details from '@govuk-react/details'
 import Main from '@govuk-react/main'
-
+import GridCol from '@govuk-react/grid-col'
+import GridRow from '@govuk-react/grid-row'
+import Button from '@govuk-react/button'
+import Paragraph from '@govuk-react/paragraph'
+import WarningText from '@govuk-react/warning-text'
+import Details from '@govuk-react/details'
+import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
 import { GREY_3, PURPLE, BLACK } from '../../../client/utils/colours'
 import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 import LocalHeaderHeading from '../../../client/components/LocalHeader/LocalHeaderHeading'
@@ -113,6 +114,10 @@ const StyledMainMuted = styled(Main)`
   }
 `
 
+const StyledLink = styled('a')`
+  margin-bottom: 0;
+`
+
 const CompanyLocalHeader = ({
   breadcrumbs,
   flashMessages,
@@ -121,6 +126,8 @@ const CompanyLocalHeader = ({
   returnUrl,
 }) => {
   const queryString = returnUrl ? `${returnUrl}` : `/companies/${company.id}`
+  const showMatchingPrompt =
+    !company.duns_number && !company.pending_dnb_investigation
   return (
     company && (
       <>
@@ -217,6 +224,38 @@ const CompanyLocalHeader = ({
             </StyledDescription>
           )}
         </LocalHeader>
+
+        {showMatchingPrompt && (
+          <StyledMain>
+            <StatusMessage
+              colour={BLACK}
+              id="ga-company-details-matching-prompt"
+            >
+              <WarningText>
+                Business details on this company record have not been verified
+                and could be wrong.
+              </WarningText>
+              <Details summary="Why verify?">
+                <Paragraph>
+                  Using verified business details from a trusted third-party
+                  supplier means we can keep certain information up to date
+                  automatically. This helps reduce duplicate records, provide a
+                  shared view of complex companies and make it more likely we
+                  can link other data sources together.
+                </Paragraph>
+                <Paragraph>
+                  Verification can often be done in just 4 clicks.
+                </Paragraph>
+              </Details>
+              <Button
+                as={StyledLink}
+                href={urls.companies.match.index(company.id)}
+              >
+                Verify business details
+              </Button>
+            </StatusMessage>
+          </StyledMain>
+        )}
 
         {company.archived && (
           <ArchivePanel

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -6,8 +6,6 @@ import Main from '@govuk-react/main'
 import GridCol from '@govuk-react/grid-col'
 import GridRow from '@govuk-react/grid-row'
 import Button from '@govuk-react/button'
-import Paragraph from '@govuk-react/paragraph'
-import WarningText from '@govuk-react/warning-text'
 import Details from '@govuk-react/details'
 import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
 import { GREY_3, PURPLE, BLACK } from '../../../client/utils/colours'
@@ -114,10 +112,6 @@ const StyledMainMuted = styled(Main)`
   }
 `
 
-const StyledLink = styled('a')`
-  margin-bottom: 0;
-`
-
 const CompanyLocalHeader = ({
   breadcrumbs,
   flashMessages,
@@ -126,8 +120,6 @@ const CompanyLocalHeader = ({
   returnUrl,
 }) => {
   const queryString = returnUrl ? `${returnUrl}` : `/companies/${company.id}`
-  const showMatchingPrompt =
-    !company.duns_number && !company.pending_dnb_investigation
   return (
     company && (
       <>
@@ -224,38 +216,6 @@ const CompanyLocalHeader = ({
             </StyledDescription>
           )}
         </LocalHeader>
-
-        {showMatchingPrompt && (
-          <StyledMain>
-            <StatusMessage
-              colour={BLACK}
-              id="ga-company-details-matching-prompt"
-            >
-              <WarningText>
-                Business details on this company record have not been verified
-                and could be wrong.
-              </WarningText>
-              <Details summary="Why verify?">
-                <Paragraph>
-                  Using verified business details from a trusted third-party
-                  supplier means we can keep certain information up to date
-                  automatically. This helps reduce duplicate records, provide a
-                  shared view of complex companies and make it more likely we
-                  can link other data sources together.
-                </Paragraph>
-                <Paragraph>
-                  Verification can often be done in just 4 clicks.
-                </Paragraph>
-              </Details>
-              <Button
-                as={StyledLink}
-                href={urls.companies.match.index(company.id)}
-              >
-                Verify business details
-              </Button>
-            </StatusMessage>
-          </StyledMain>
-        )}
 
         {company.archived && (
           <ArchivePanel

--- a/src/client/components/CompanyTabbedLocalNavigation/index.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/index.jsx
@@ -3,6 +3,13 @@ import PropTypes from 'prop-types'
 
 import CompanyLocalTab from './CompanyLocalTab'
 import styled from 'styled-components'
+import Paragraph from '@govuk-react/paragraph'
+import WarningText from '@govuk-react/warning-text'
+import Details from '@govuk-react/details'
+import Button from '@govuk-react/button'
+import urls from '../../../lib/urls'
+import StatusMessage from '../../../client/components/StatusMessage'
+import { BLACK } from '../../../client/utils/colours'
 
 const StyledGridRow = styled.div`
   margin-right: -15px;
@@ -41,11 +48,42 @@ const StyledUnorderedList = styled.ul`
   }
 `
 
+const StyledLink = styled('a')`
+  margin-bottom: 0;
+`
+
 const CompanyTabbedLocalNavigation = (props) => {
   const { localNavItems } = props
+  const company = props.company
+  const showMatchingPrompt =
+    !company.duns_number && !company.pending_dnb_investigation
 
   return (
     <StyledGridRow>
+      {showMatchingPrompt && (
+        <StatusMessage colour={BLACK} id="ga-company-details-matching-prompt">
+          <WarningText>
+            Business details on this company record have not been verified and
+            could be wrong.
+          </WarningText>
+          <Details summary="Why verify?">
+            <Paragraph>
+              Using verified business details from a trusted third-party
+              supplier means we can keep certain information up to date
+              automatically. This helps reduce duplicate records, provide a
+              shared view of complex companies and make it more likely we can
+              link other data sources together.
+            </Paragraph>
+            <Paragraph>
+              Verification can often be done in just 4 clicks.
+            </Paragraph>
+          </Details>
+          <Button as={StyledLink} href={urls.companies.match.index(company.id)}>
+            Verify business details
+          </Button>
+        </StatusMessage>
+      )}
+
       <StyledGridColumn>
         <StyledNav aria-label="local navigation" data-test="tabbedLocalNav">
           <StyledUnorderedList data-test="tabbedLocalNavList">


### PR DESCRIPTION
## Description of change

The 'business not verified' status message was appearing as part of the activity tab only. It's now moved to above the tabs and will appear regardless of which tab you are on.

## Test instructions

_What should I see?_

## Screenshots

### Before
![Screenshot 2023-03-23 at 15 27 46](https://user-images.githubusercontent.com/54268863/227252943-9ff53c71-e50b-4311-ae7c-bb7962550167.png)

### After
![Screenshot 2023-03-24 at 11 20 52](https://user-images.githubusercontent.com/54268863/227508360-bb2eb5c1-b050-4f9d-8325-e274be20b646.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
