### PR TITLE
Add both export potential and status tags to each list item

### DIFF
--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import styled from 'styled-components'
+
+import Tag from '../../../../client/components/Tag'
+
+const TagContainer = styled('div')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  justifyContent: 'space-between',
+})
+
+const statusToColourMap = {
+  WON: 'green',
+  ACTIVE: 'blue',
+  INACTIVE: 'orange',
+}
+
+const ListItem = styled('li')({})
+
+const ItemRenderer = (item) => {
+  const status = item.status.toUpperCase()
+  const exportPotential = item.export_potential.toUpperCase()
+  return (
+    <ListItem key={item.id} data-test="export-item">
+      <TagContainer>
+        <Tag colour="grey">{`${exportPotential} POTENTIAL`}</Tag>
+        <Tag colour={statusToColourMap[status]}>{status}</Tag>
+      </TagContainer>
+    </ListItem>
+  )
+}
+
+export default ItemRenderer

--- a/src/client/modules/ExportPipeline/ExportList/List.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/List.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { SPACING } from '@govuk-react/constants'
+import styled from 'styled-components'
+
+const StyledList = styled('ol')({
+  li: {
+    marginBottom: SPACING.SCALE_2,
+  },
+})
+
+const List = ({ items, itemRenderer }) => (
+  <StyledList data-test="export-list">
+    {items.map((item) => itemRenderer(item))}
+  </StyledList>
+)
+
+export default List

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -5,6 +5,9 @@ import Task from '../../../components/Task'
 import { EXPORT__PIPELINE_LIST_LOADED } from '../../../actions'
 import { ID, TASK_GET_EXPORT_PIPELINE_LIST, state2props } from './state'
 
+import List from './List'
+import ListItemRenderer from './ItemRenderer'
+
 const ExportList = (data) => (
   <Task.Status
     name={TASK_GET_EXPORT_PIPELINE_LIST}
@@ -14,11 +17,7 @@ const ExportList = (data) => (
       onSuccessDispatch: EXPORT__PIPELINE_LIST_LOADED,
     }}
   >
-    {() => (
-      <pre>
-        <code>{JSON.stringify(data.results, null, 2)}</code>
-      </pre>
-    )}
+    {() => <List items={data.results} itemRenderer={ListItemRenderer} />}
   </Task.Status>
 )
 

--- a/test/functional/cypress/fakers/export.js
+++ b/test/functional/cypress/fakers/export.js
@@ -1,0 +1,54 @@
+import { faker } from '@faker-js/faker'
+
+import { listFaker } from './utils'
+import { sectorFaker } from './sectors'
+
+const exportFaker = (overrides = {}) => ({
+  id: faker.datatype.uuid(),
+  company: {
+    id: faker.datatype.uuid(),
+    name: faker.company.name(),
+  },
+  owner: {
+    id: faker.datatype.uuid(),
+    name: faker.name.fullName(),
+  },
+  team_members: [
+    {
+      id: faker.datatype.uuid(),
+      name: faker.name.fullName(),
+    },
+  ],
+  contacts: {
+    id: faker.datatype.uuid(),
+    name: faker.name.fullName(),
+  },
+  destination_country: {
+    id: faker.datatype.uuid(),
+    name: faker.address.country(),
+  },
+  sector: {
+    id: faker.datatype.uuid(),
+    name: sectorFaker(),
+  },
+  exporter_experience: faker.datatype.uuid(),
+  estimated_export_value_years: faker.random.numeric(5),
+  created_on: faker.date.past(),
+  modified_on: faker.date.past(),
+  title: faker.random.word(),
+  estimated_export_value_amount: faker.random.numeric(6),
+  estimated_win_date: faker.date.future(),
+  export_potential: faker.helpers.arrayElement(['high', 'medium', 'low']),
+  status: faker.helpers.arrayElement(['active', 'won', 'inactive']),
+  notes: faker.random.words(25),
+  created_by: faker.datatype.uuid(),
+  modified_by: faker.datatype.uuid(),
+  ...overrides,
+})
+
+const exportListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: exportFaker, length, overrides })
+
+export { exportFaker, exportListFaker }
+
+export default exportListFaker

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -1,0 +1,64 @@
+import { exportFaker, exportListFaker } from '../../fakers/export'
+import urls from '../../../../../src/lib/urls'
+
+const assertExportPotentialTag = (element, text) =>
+  cy.get(element).find('strong').eq(0).should('have.text', text)
+
+const assertStatusTag = (element, text) =>
+  cy.get(element).find('strong').eq(1).should('have.text', text)
+
+describe('Export pipeline list', () => {
+  const active = exportFaker({
+    export_potential: 'high',
+    status: 'active',
+  })
+  const won = exportFaker({
+    export_potential: 'medium',
+    status: 'won',
+  })
+  const inactive = exportFaker({
+    export_potential: 'low',
+    status: 'inactive',
+  })
+
+  const otherExports = exportListFaker(7)
+
+  const exportList = [active, won, inactive, ...otherExports]
+
+  before(() => {
+    cy.setUserFeatures(['export-pipeline'])
+    cy.intercept('GET', '/api-proxy/v4/export', {
+      body: {
+        count: exportList.length,
+        results: exportList,
+      },
+    }).as('apiRequest')
+    cy.visit(urls.exportPipeline.index())
+    cy.wait('@apiRequest')
+  })
+
+  beforeEach(() => {
+    cy.get('[data-test="export-list"]').as('exportList')
+    cy.get('[data-test="export-item"]').as('exportItems')
+    cy.get('@exportItems').eq(0).as('firstListItem')
+    cy.get('@exportItems').eq(1).as('secondListItem')
+    cy.get('@exportItems').eq(2).as('thirdListItem')
+  })
+
+  it('should display a list of exports', () => {
+    cy.get('[data-test="export-list"]').should('have.length', 1)
+    cy.get('[data-test="export-item"]').should('have.length', exportList.length)
+  })
+
+  it('should display export potential tags', () => {
+    assertExportPotentialTag('@firstListItem', 'HIGH POTENTIAL')
+    assertExportPotentialTag('@secondListItem', 'MEDIUM POTENTIAL')
+    assertExportPotentialTag('@thirdListItem', 'LOW POTENTIAL')
+  })
+
+  it('should display an export active tag', () => {
+    assertStatusTag('@firstListItem', 'ACTIVE')
+    assertStatusTag('@secondListItem', 'WON')
+    assertStatusTag('@thirdListItem', 'INACTIVE')
+  })
+})


### PR DESCRIPTION
## Description of change
Adds both export potential tag and status tags to each export pipeline list item.

## Test instructions
Add the `export-pipeline` user feature flag

## Screenshots

### Before
<img width="791" alt="Screenshot 2023-03-24 at 09 39 07" src="https://user-images.githubusercontent.com/964268/227483283-7e9ad939-7c63-43ee-8cb3-da24b6ddfdde.png">

### After (screenshot taken from Cypress)
<img width="988" alt="Screenshot 2023-03-24 at 09 10 12" src="https://user-images.githubusercontent.com/964268/227483020-418f5e68-a36c-4dba-9177-3dfe2a0ad133.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
