### PR TITLE
Update turnover value on business details value to be turnover_gbp

### DIFF
--- a/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
+++ b/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import Paragraph from '@govuk-react/paragraph'
 import { H4 } from '@govuk-react/heading'
 import { currencyGBP } from '../../../../../client/utils/number-utils'
+// const { roundToSignificantDigits } = require('../../../../../common/number')
 import {
   FieldInput,
   FieldSelect,
@@ -31,7 +32,7 @@ const CompanyMatched = ({
       data-test="company-matched-annual-turnover"
     >
       {company.turnover
-        ? currencyGBP(company.turnover, {
+        ? currencyGBP(company.turnover_gbp, {
             maximumSignificantDigits: 2,
           })
         : company.turnover_range.name}

--- a/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
+++ b/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import Paragraph from '@govuk-react/paragraph'
 import { H4 } from '@govuk-react/heading'
 import { currencyGBP } from '../../../../../client/utils/number-utils'
-// const { roundToSignificantDigits } = require('../../../../../common/number')
 import {
   FieldInput,
   FieldSelect,

--- a/test/functional/cypress/specs/companies/edit-spec.js
+++ b/test/functional/cypress/specs/companies/edit-spec.js
@@ -460,7 +460,7 @@ describe('Company edit', () => {
         {
           label: 'Annual turnover',
           hint: 'Amount in GBP',
-          value: currencyGBP(company.turnover, {
+          value: currencyGBP(company.turnover_gbp, {
             maximumSignificantDigits: 2,
           }),
           assert: assertFieldUneditable,


### PR DESCRIPTION
## Description of change

Updated the turnover value on the business details edit page to use `turnover_gbp`. This is because the business details page is using `turnover` which is mapped to `turnover_gbp` whereas the edit page was using the unmapped `turnover`, meaning the values were different.

## Test instructions

_What should I see?_

## Screenshots

### Before
#### Business details tab
<img width="483" alt="Screenshot 2023-03-27 at 12 05 47" src="https://user-images.githubusercontent.com/54268863/227924385-3d401cda-1f00-44fb-aab9-c943fb43d4ab.png">

#### Business details edit page
<img width="377" alt="Screenshot 2023-03-27 at 12 06 24" src="https://user-images.githubusercontent.com/54268863/227924512-b6938de1-c32d-4972-aa27-d260fa02c4cf.png">

### After
#### Business details tab
![Screenshot 2023-03-27 at 12 07 12](https://user-images.githubusercontent.com/54268863/227924700-faf138a2-dd6f-489d-b9f9-cf9b57635245.png)
#### Business details edit page
![Screenshot 2023-03-27 at 12 07 35](https://user-images.githubusercontent.com/54268863/227924779-ad64dce2-5ddd-4d53-a444-2db32508a87f.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
