### PR TITLE
Add export pipeline delete form

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -27,6 +27,7 @@ const reactRoutes = [
   '/reminders/settings/companies-new-interactions',
   '/export/create',
   '/export/:exportId/edit',
+  '/export/:exportId/delete',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -348,6 +348,8 @@ import { getExportDetails } from '../client/modules/ExportPipeline/ExportDetails
 
 import { TASK_SAVE_EXPORT } from '../client/modules/ExportPipeline/ExportForm/state'
 import { saveExport } from '../client/modules/ExportPipeline/ExportForm/tasks'
+import { TASK_DELETE_EXPORT } from '../client/modules/ExportPipeline/ExportDelete/state'
+import { deleteExport } from '../client/modules/ExportPipeline/ExportDelete/tasks'
 
 import { TASK_GET_EXPORT_PIPELINE_LIST } from '../client/modules/ExportPipeline/ExportList/state.js'
 import { getExportPipelineList } from '../client/modules/ExportPipeline/ExportList/task.js'
@@ -576,6 +578,7 @@ function App() {
           [TASK_GET_ESS_INTERACTION_DETAILS]: getESSInteractionDetails,
           [TASK_GET_COMPANY_DETAIL]: getCompanyDetails,
           [TASK_GET_EXPORT_DETAIL]: getExportDetails,
+          [TASK_DELETE_EXPORT]: deleteExport,
           [TASK_SAVE_EXPORT]: saveExport,
           [TASK_GET_EXPORT_PIPELINE_LIST]: getExportPipelineList,
         }}

--- a/src/client/modules/ExportPipeline/ExportDelete/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDelete/index.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { useParams } from 'react-router-dom'
+import Task from '../../../components/Task'
+import { FORM_LAYOUT } from '../../../../common/constants'
+import urls from '../../../../lib/urls'
+import { DefaultLayout, Form, FormLayout } from '../../../components'
+import { TASK_DELETE_EXPORT, state2props } from './state'
+import {
+  ID as EXPORT_DETAILS_ID,
+  TASK_GET_EXPORT_DETAIL,
+} from '../ExportDetails/state'
+import { EXPORT_LOADED } from '../../../actions'
+import { RED } from '../../../../client/utils/colours'
+
+const DISPLAY_DELETE_EXPORT = 'Delete export'
+
+const getBreadcrumbs = (exportItem) => {
+  const defaultBreadcrumbs = [
+    {
+      link: urls.dashboard(),
+      text: 'Home',
+    },
+  ]
+
+  if (exportItem) {
+    return [
+      ...defaultBreadcrumbs,
+      {
+        link: urls.exportPipeline.edit(exportItem.id),
+        text: exportItem.title,
+      },
+      { text: 'Are you sure you want to delete...' },
+    ]
+  }
+
+  return defaultBreadcrumbs
+}
+
+const ExportFormDelete = ({ exportItem }) => {
+  const { exportId } = useParams()
+  return (
+    <DefaultLayout
+      heading=""
+      subheading={`Are you sure you want to delete the export ${exportItem?.company?.name} — ‘${exportItem?.title}’?`}
+      pageTitle={DISPLAY_DELETE_EXPORT}
+      breadcrumbs={getBreadcrumbs(exportItem)}
+    >
+      <Task.Status
+        name={TASK_GET_EXPORT_DETAIL}
+        id={EXPORT_DETAILS_ID}
+        progressMessage="Loading export details"
+        startOnRender={{
+          payload: exportId,
+          onSuccessDispatch: EXPORT_LOADED,
+        }}
+      >
+        {() => (
+          <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+            <Form
+              id="export-delete-form"
+              analyticsFormName="deleteExportForm"
+              cancelRedirectTo={() => urls.dashboard()}
+              redirectTo={() => urls.dashboard()}
+              submissionTaskName={TASK_DELETE_EXPORT}
+              initialValues={exportItem}
+              transformPayload={(values) => ({ exportId: values.id, values })}
+              submitButtonLabel={'Yes, delete this export'}
+              submitButtonColour={RED}
+              flashMessage={() => `‘${exportItem?.title}’ has been deleted`}
+            />
+          </FormLayout>
+        )}
+      </Task.Status>
+    </DefaultLayout>
+  )
+}
+
+export default connect(state2props)(ExportFormDelete)

--- a/src/client/modules/ExportPipeline/ExportDelete/state.js
+++ b/src/client/modules/ExportPipeline/ExportDelete/state.js
@@ -1,0 +1,7 @@
+import { ID as EXPORT_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
+
+export const TASK_DELETE_EXPORT = 'TASK_DELETE_EXPORT'
+
+export const state2props = (state) => ({
+  exportItem: state[EXPORT_DETAILS_ID].exportItem,
+})

--- a/src/client/modules/ExportPipeline/ExportDelete/tasks.js
+++ b/src/client/modules/ExportPipeline/ExportDelete/tasks.js
@@ -1,0 +1,4 @@
+import { apiProxyAxios } from '../../../../client/components/Task/utils'
+
+export const deleteExport = ({ exportId }) =>
+  apiProxyAxios.delete(`/v4/export/${exportId}`)

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -14,6 +14,7 @@ import {
   ExportFormAdd,
   ExportFormEdit,
 } from './modules/ExportPipeline/ExportForm'
+import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
 
 const routes = {
   companies: [
@@ -111,6 +112,11 @@ const routes = {
       path: '/export/:exportId/edit',
       module: 'datahub:companies',
       component: ExportFormEdit,
+    },
+    {
+      path: '/export/:exportId/delete',
+      module: 'datahub:companies',
+      component: ExportFormDelete,
     },
   ],
 }

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -532,5 +532,6 @@ module.exports = {
     index: url('/export'),
     create: url('/export/create'),
     edit: url('/export', '/:exportId/edit'),
+    delete: url('/export', '/:exportId/delete'),
   },
 }

--- a/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
@@ -1,0 +1,94 @@
+const urls = require('../../../../../src/lib/urls')
+const { assertUrl } = require('../../support/assertions')
+
+const {
+  assertBreadcrumbs,
+  assertFlashMessage,
+} = require('../../support/assertions')
+const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
+
+describe('Export pipeline delete', () => {
+  const exportItem = exportItems.results[0]
+
+  context('when deleting an export for unknown export id', () => {
+    before(() => {
+      cy.visit('/export/a/edit')
+    })
+
+    it('should render edit event breadcrumb', () => {
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+      })
+    })
+
+    it('should render the error message', () => {
+      cy.get('[data-test="error-dialog"]').should('be.visible')
+    })
+  })
+
+  context('when deleting an export for known export id', () => {
+    const deletePageUrl = urls.exportPipeline.delete(exportItem.id)
+
+    beforeEach(() => {
+      cy.intercept('GET', `/api-proxy/v4/export/${exportItem.id}`, {
+        body: exportItem,
+      }).as('getExportItemApiRequest')
+      cy.intercept('DELETE', `/api-proxy/v4/export/${exportItem.id}`).as(
+        'deleteExportItemApiRequest'
+      )
+      cy.visit(deletePageUrl)
+    })
+
+    context('when verifying the page', () => {
+      it('should render the header', () => {
+        cy.get('[data-test="subheading"]').should(
+          'have.text',
+          `Are you sure you want to delete the export ${exportItem?.company?.name} — ‘${exportItem?.title}’?`
+        )
+      })
+
+      it('should render the delete export breadcrumb', () => {
+        assertBreadcrumbs({
+          Home: urls.dashboard(),
+          [exportItem.title]: urls.exportPipeline.edit(exportItem.id),
+          ['Are you sure you want to delete...']: null,
+        })
+      })
+
+      it('should render a form with display a delete button', () => {
+        cy.get('[data-test=submit-button]').should(
+          'have.text',
+          'Yes, delete this export'
+        )
+      })
+
+      it('should render a form with a cancel link', () => {
+        cy.get('[data-test=cancel-button]')
+          .should('have.text', 'Cancel')
+          .should('have.attr', 'href', urls.dashboard())
+      })
+    })
+
+    context('when the form cancel button is clicked', () => {
+      it('the form should redirect to the dashboard page', () => {
+        cy.get('[data-test=cancel-button]').click()
+        assertUrl(urls.dashboard())
+      })
+    })
+
+    context('when the delete form is submitted', () => {
+      it('the form should return to the dashboard', () => {
+        cy.get('[data-test=submit-button]').click()
+
+        cy.wait('@deleteExportItemApiRequest').then(({ request }) => {
+          expect(request.url).to.contain(exportItem.id)
+        })
+
+        assertUrl(urls.dashboard())
+
+        assertFlashMessage(`‘${exportItem.title}’ has been deleted`)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

This adds new export pipeline delete form.

## Test instructions

You can obtain a known export ID and go to `/export/<export ID>/delete` to see the form.

## Screenshots

<img width="1157" alt="Screenshot 2023-03-28 at 09 24 06" src="https://user-images.githubusercontent.com/5889630/228176088-32277cd4-aaeb-4a54-bfbc-02bf32ab0d05.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
