### PR TITLE
Switched the order of the company tabs

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -27,14 +27,14 @@ const GLOBAL_NAV_ITEM = {
 
 const LOCAL_NAV = [
   {
-    path: 'activity',
-    label: 'Activity',
-    permissions: ['interaction.view_all_interaction'],
-  },
-  {
     path: 'overview',
     label: 'Overview',
     permissions: ['company.view_contact'],
+  },
+  {
+    path: 'activity',
+    label: 'Activity',
+    permissions: ['interaction.view_all_interaction'],
   },
   {
     path: 'business-details',

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -388,7 +388,7 @@ describe('Add company form', () => {
         .location('pathname')
         .should(
           'eq',
-          urls.companies.activity.index(fixtures.company.someOtherCompany.id)
+          urls.companies.overview.index(fixtures.company.someOtherCompany.id)
         )
       cy.contains('Company added to Data Hub')
     })
@@ -575,7 +575,7 @@ describe('Add company form', () => {
     it('should redirect to the new company activity', () => {
       cy.location('pathname').should(
         'eq',
-        `/companies/${fixtures.company.investigationLimited.id}/activity`
+        `/companies/${fixtures.company.investigationLimited.id}/overview`
       )
     })
     it('should display the flash message', () => {
@@ -726,7 +726,7 @@ describe('Add company form', () => {
         .location('pathname')
         .should(
           'eq',
-          `/companies/${fixtures.company.someOtherCompany.id}/activity`
+          `/companies/${fixtures.company.someOtherCompany.id}/overview`
         )
       cy.contains('Company added to Data Hub')
     })

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -380,7 +380,7 @@ describe('Add company form', () => {
       cy.get(selectors.companyAdd.form).contains('Select DIT sector')
     })
 
-    it('should redirect to the new company activity when a sector is picked', () => {
+    it('should redirect to the new company overview when a sector is picked', () => {
       cy.get(selectors.companyAdd.sectorSelect)
         .select('Airports')
         .get(selectors.companyAdd.submitButton)
@@ -572,7 +572,7 @@ describe('Add company form', () => {
       )
       cy.get(selectors.companyAdd.submitButton).click()
     })
-    it('should redirect to the new company activity', () => {
+    it('should redirect to the new company overview', () => {
       cy.location('pathname').should(
         'eq',
         `/companies/${fixtures.company.investigationLimited.id}/overview`

--- a/test/functional/cypress/specs/companies/match-company-spec.js
+++ b/test/functional/cypress/specs/companies/match-company-spec.js
@@ -383,7 +383,7 @@ describe('Match a company', () => {
 
         cy.location('pathname').should(
           'eq',
-          urls.companies.activity.index(fixtures.company.venusLtd.id)
+          urls.companies.overview.index(fixtures.company.venusLtd.id)
         )
 
         cy.get(companyLocalHeader.flashMessageList).contains(
@@ -512,7 +512,7 @@ describe('Match a company', () => {
     it('should redirect to the company page', () => {
       cy.location('pathname').should(
         'eq',
-        urls.companies.activity.index(fixtures.company.venusLtd.id)
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
     })
 
@@ -616,7 +616,7 @@ describe('Match a company', () => {
     it('should redirect to the company page', () => {
       cy.location('pathname').should(
         'eq',
-        urls.companies.activity.index(fixtures.company.venusLtd.id)
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
     })
 

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -118,7 +118,7 @@ describe('Send a referral form', () => {
         cy.contains('a', 'Cancel').click()
         cy.url().should(
           'contain',
-          urls.companies.activity.index(fixtures.company.withContacts.id)
+          urls.companies.overview.index(fixtures.company.withContacts.id)
         )
       })
     })
@@ -300,7 +300,7 @@ describe('Send a referral form', () => {
         cy.contains('Cancel').click()
         cy.url().should(
           'contain',
-          urls.companies.activity.index(fixtures.company.withContacts.id)
+          urls.companies.overview.index(fixtures.company.withContacts.id)
         )
       })
     }
@@ -323,7 +323,7 @@ describe('Send a referral form', () => {
         cy.contains('button', 'Send referral').click()
         cy.url().should(
           'contain',
-          urls.companies.activity.index(fixtures.company.withContacts.id)
+          urls.companies.overview.index(fixtures.company.withContacts.id)
         )
         cy.get(selectors.companyLocalHeader().flashMessageList).contains(
           'Referral sent'


### PR DESCRIPTION
## Description of change

Set the overview tab as the default view on the company page

## Test instructions

Click on a company and see that the tab displayed is the Overview

## Screenshots

### Before

![Screenshot 2023-03-28 at 10 27 40](https://user-images.githubusercontent.com/72826129/228193181-d05ca62c-dd4f-4563-a139-a7ee3953d2e1.png)

### After

![Screenshot 2023-03-28 at 10 28 07](https://user-images.githubusercontent.com/72826129/228193252-f0d5fc7d-d3a7-42da-950b-a892965998b1.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
