### PR TITLE
Add show/hide details for an export pipeline list item

### DIFF
--- a/src/client/components/ToggleSection/BaseToggleSection.jsx
+++ b/src/client/components/ToggleSection/BaseToggleSection.jsx
@@ -64,6 +64,7 @@ const BaseToggleSection = ({
   label,
   badge = null,
   open,
+  onOpen,
   isOpen = false,
   children,
   justifyHeaderContent = false,
@@ -76,13 +77,19 @@ const BaseToggleSection = ({
           props.id && `${props.id}-toggle-button-${isOpen ? 'close' : 'open'}`
         }
         data-test="toggle-section-button"
-        onClick={() => open(!isOpen)}
+        onClick={() => {
+          open(!isOpen)
+          onOpen && onOpen(!isOpen)
+        }}
         isOpen={isOpen}
         aria-expanded={isOpen}
       >
         <ToggleButtonIcon
           src={icon}
-          onClick={() => open(!isOpen)}
+          onClick={() => {
+            open(!isOpen)
+            onOpen && onOpen(!isOpen)
+          }}
           isOpen={isOpen}
           alt="Toggle details"
         />
@@ -101,6 +108,7 @@ BaseToggleSection.propTypes = {
   label: PropTypes.string,
   badge: PropTypes.node,
   open: PropTypes.func,
+  onOpen: PropTypes.func,
   isOpen: PropTypes.bool,
   children: PropTypes.node,
   major: PropTypes.bool,

--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -1,17 +1,25 @@
-import React from 'react'
+import React, { useState } from 'react'
 import styled from 'styled-components'
 import Link from '@govuk-react/link'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
-import Tag from '../../../../client/components/Tag'
-import { MID_GREY } from '../../../../client/utils/colours.js'
+import Tag from '../../../components/Tag'
+import { ToggleSection } from '../../../components/ToggleSection'
+import { DARK_GREY, MID_GREY, BLACK } from '../../../../client/utils/colours.js'
+import {
+  formatShortDate,
+  formatMediumDateTime,
+} from '../../../../client/utils/date.js'
+import { currencyGBP } from '../../../../client/utils/number-utils'
 
 const ListItem = styled('li')({
   paddingTop: SPACING.SCALE_4,
-  paddingBottom: SPACING.SCALE_3,
   borderBottom: `1px solid ${MID_GREY}`,
   ['&:first-child']: {
     paddingTop: 0,
+  },
+  ['&:last-child']: {
+    borderBottom: 'none',
   },
 })
 
@@ -28,6 +36,27 @@ const Header = styled('h2')({
   fontWeight: FONT_WEIGHTS.bold,
 })
 
+const StyledDL = styled('dl')({
+  fontSize: FONT_SIZE.SIZE_16,
+})
+
+const lineHeightMixin = {
+  lineHeight: '1.5',
+}
+
+const StyledDT = styled('dt')({
+  color: DARK_GREY,
+  float: 'left',
+  clear: 'left',
+  marginRight: '5px',
+  ...lineHeightMixin,
+})
+
+const StyledDD = styled('dd')({
+  color: BLACK,
+  ...lineHeightMixin,
+})
+
 const statusToColourMap = {
   WON: 'green',
   ACTIVE: 'blue',
@@ -35,6 +64,7 @@ const statusToColourMap = {
 }
 
 const ItemRenderer = (item) => {
+  const [toggleLabel, setToggleLabel] = useState('Show')
   const status = item.status.toUpperCase()
   const exportPotential = item.export_potential.toUpperCase()
   return (
@@ -45,6 +75,31 @@ const ItemRenderer = (item) => {
       </TagContainer>
       <Header>{item.company.name}</Header>
       <Link href={`/export/${item.id}/details`}>{item.title}</Link>
+      <ToggleSection
+        onOpen={(open) =>
+          open ? setToggleLabel('Hide') : setToggleLabel('Show')
+        }
+        label={toggleLabel}
+        id={`${item.id}_toggle`}
+      >
+        <StyledDL data-test="export-details">
+          <StyledDT>Destination:</StyledDT>
+          <StyledDD>{item.destination_country.name}</StyledDD>
+          <StyledDT>Total estimated export value:</StyledDT>
+          <StyledDD>
+            {currencyGBP(item.estimated_export_value_amount)}{' '}
+            <span>({item.estimated_export_value_years.name})</span>
+          </StyledDD>
+          <StyledDT>Estimated date for win:</StyledDT>
+          <StyledDD>{formatShortDate(item.estimated_win_date)}</StyledDD>
+          <StyledDT>Main sector:</StyledDT>
+          <StyledDD>{item.sector.name}</StyledDD>
+          <StyledDT>Owner:</StyledDT>
+          <StyledDD>{item.owner.name}</StyledDD>
+          <StyledDT>Created on:</StyledDT>
+          <StyledDD>{formatMediumDateTime(item.created_on)}</StyledDD>
+        </StyledDL>
+      </ToggleSection>
     </ListItem>
   )
 }

--- a/test/functional/cypress/fakers/constants.js
+++ b/test/functional/cypress/fakers/constants.js
@@ -32,3 +32,30 @@ export const INVESTMENT_PROJECT_STATUSES_LIST = [
   'lost',
   'dormant',
 ]
+
+export const ESTIMATED_EXPORT_VALUE_YEARS = [
+  {
+    id: 'a30384b5-2852-4ec5-bc3e-561927328361',
+    name: '1 year',
+  },
+  {
+    id: 'b94fbe96-c013-4dca-9b69-3c443652fd8d',
+    name: '2 years',
+  },
+  {
+    id: '8f4548c6-6f68-42ec-9ddc-e979fe7a6bb8',
+    name: '3 years',
+  },
+  {
+    id: '3f289d56-aec1-4472-a046-10828cad4992',
+    name: '4 years',
+  },
+  {
+    id: 'a30b8a1a-70fe-4b47-b4f2-ffe662fd61c9',
+    name: '5 years',
+  },
+  {
+    id: 'b9af9007-619c-426d-bfc3-cad3b96a34dd',
+    name: 'Not yet known',
+  },
+]

--- a/test/functional/cypress/fakers/export.js
+++ b/test/functional/cypress/fakers/export.js
@@ -2,6 +2,9 @@ import { faker } from '@faker-js/faker'
 
 import { listFaker } from './utils'
 import { sectorFaker } from './sectors'
+import { contactFaker } from './contacts'
+
+import { ESTIMATED_EXPORT_VALUE_YEARS } from './constants'
 
 const exportFaker = (overrides = {}) => ({
   id: faker.datatype.uuid(),
@@ -9,30 +12,18 @@ const exportFaker = (overrides = {}) => ({
     id: faker.datatype.uuid(),
     name: faker.company.name(),
   },
-  owner: {
-    id: faker.datatype.uuid(),
-    name: faker.name.fullName(),
-  },
-  team_members: [
-    {
-      id: faker.datatype.uuid(),
-      name: faker.name.fullName(),
-    },
-  ],
-  contacts: {
-    id: faker.datatype.uuid(),
-    name: faker.name.fullName(),
-  },
+  owner: contactFaker(),
+  team_members: [contactFaker()],
+  contacts: [contactFaker()],
   destination_country: {
     id: faker.datatype.uuid(),
     name: faker.address.country(),
   },
-  sector: {
-    id: faker.datatype.uuid(),
-    name: sectorFaker(),
-  },
+  sector: sectorFaker(),
   exporter_experience: faker.datatype.uuid(),
-  estimated_export_value_years: faker.random.numeric(5),
+  estimated_export_value_years: faker.helpers.arrayElement(
+    ESTIMATED_EXPORT_VALUE_YEARS
+  ),
   created_on: faker.date.past(),
   modified_on: faker.date.past(),
   title: faker.random.word(),

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -11,6 +11,29 @@ const assertCompanyName = (element, text) => {
   cy.get(element).find('h2').should('have.text', text)
 }
 
+const assertDestination = (element, text) => {
+  cy.get(element).find('dd').eq(0).should('have.text', text)
+}
+
+const assertEstimatedExportAmount = (element, text) => {
+  cy.get(element).find('dd').eq(1).should('have.text', text)
+}
+
+const assertEstimatedWinDate = (element, text) => {
+  cy.get(element).find('dd').eq(2).should('have.text', text)
+}
+
+const assertSector = (element, text) => {
+  cy.get(element).find('dd').eq(3).should('have.text', text)
+}
+
+const assertOwner = (element, text) => {
+  cy.get(element).find('dd').eq(4).should('have.text', text)
+}
+const assertCreatedOnDate = (element, text) => {
+  cy.get(element).find('dd').eq(5).should('have.text', text)
+}
+
 const assertTitleLink = (element, href, text) => {
   cy.get(element)
     .find('a')
@@ -27,6 +50,21 @@ describe('Export pipeline list', () => {
       name: 'Coca-Cola',
     },
     title: 'Export Coca-Cola',
+    destination_country: {
+      name: 'Portugal',
+    },
+    estimated_export_value_amount: '957485',
+    estimated_export_value_years: {
+      name: '5 years',
+    },
+    estimated_win_date: '2023-10-08T11:54:19Z',
+    sector: {
+      name: 'Energy',
+    },
+    owner: {
+      name: 'Benjamin Graham',
+    },
+    created_on: '2023-03-20T09:19:39.998239Z',
   })
   const won = exportFaker({
     id: 2,
@@ -36,6 +74,21 @@ describe('Export pipeline list', () => {
       name: 'Alphabet',
     },
     title: 'Export Alphabet',
+    destination_country: {
+      name: 'Italy',
+    },
+    estimated_export_value_amount: '141851',
+    estimated_export_value_years: {
+      name: 'Not yet known',
+    },
+    estimated_win_date: '2023-05-08T11:54:19Z',
+    sector: {
+      name: 'Mass Transport',
+    },
+    owner: {
+      name: 'Warren Buffet',
+    },
+    created_on: '2023-02-19T09:29:39.998239Z',
   })
   const inactive = exportFaker({
     id: 3,
@@ -45,6 +98,21 @@ describe('Export pipeline list', () => {
       name: 'Meta',
     },
     title: 'Export Meta',
+    destination_country: {
+      name: 'Greece',
+    },
+    estimated_export_value_amount: '858211',
+    estimated_export_value_years: {
+      name: '4 years',
+    },
+    estimated_win_date: '2023-02-08T11:54:19Z',
+    sector: {
+      name: 'Security : Cyber Security',
+    },
+    owner: {
+      name: 'Peter Lynch',
+    },
+    created_on: '2023-01-18T09:39:39.998239Z',
   })
 
   const otherExports = exportListFaker(7)
@@ -97,5 +165,48 @@ describe('Export pipeline list', () => {
     assertTitleLink('@firstListItem', '/export/1/details', 'Export Coca-Cola')
     assertTitleLink('@secondListItem', '/export/2/details', 'Export Alphabet')
     assertTitleLink('@thirdListItem', '/export/3/details', 'Export Meta')
+  })
+
+  it('should display a destination', () => {
+    assertDestination('@firstListItem', 'Portugal')
+    assertDestination('@secondListItem', 'Italy')
+    assertDestination('@thirdListItem', 'Greece')
+  })
+
+  it('should display the total estimated export amount', () => {
+    assertEstimatedExportAmount('@firstListItem', '£957,485 (5 years)')
+    assertEstimatedExportAmount('@secondListItem', '£141,851 (Not yet known)')
+    assertEstimatedExportAmount('@thirdListItem', '£858,211 (4 years)')
+  })
+
+  it('should display an estimated win date', () => {
+    assertEstimatedWinDate('@firstListItem', 'October 2023')
+    assertEstimatedWinDate('@secondListItem', 'May 2023')
+    assertEstimatedWinDate('@thirdListItem', 'February 2023')
+  })
+
+  it('should display a sector', () => {
+    assertSector('@firstListItem', 'Energy')
+    assertSector('@secondListItem', 'Mass Transport')
+    assertSector('@thirdListItem', 'Security : Cyber Security')
+  })
+
+  it('should display an owner', () => {
+    assertOwner('@firstListItem', 'Benjamin Graham')
+    assertOwner('@secondListItem', 'Warren Buffet')
+    assertOwner('@thirdListItem', 'Peter Lynch')
+  })
+
+  it('should display a created on date', () => {
+    assertCreatedOnDate('@firstListItem', '20 Mar 2023, 9:19am')
+    assertCreatedOnDate('@secondListItem', '19 Feb 2023, 9:29am')
+    assertCreatedOnDate('@thirdListItem', '18 Jan 2023, 9:39am')
+  })
+
+  it('should show and hide the content on toggle', () => {
+    cy.get('[data-test="toggle-section-button"]').contains('Show').click()
+    cy.get('[data-test="export-details"]').should('be.visible')
+    cy.get('[data-test="toggle-section-button"]').contains('Hide').click()
+    cy.get('[data-test="export-details"]').should('not.be.visible')
   })
 })

--- a/test/sandbox/routes/v4/export/exports.js
+++ b/test/sandbox/routes/v4/export/exports.js
@@ -10,7 +10,6 @@ const generateExport = () => {
     faker.helpers.arrayElement(country)
   const { id: exportExperienceId } =
     faker.helpers.arrayElement(exporterExperience)
-  const { id: estimatedYearsId } = faker.helpers.arrayElement(estimatedYears)
 
   return {
     id: faker.datatype.uuid(),
@@ -24,7 +23,7 @@ const generateExport = () => {
     },
     sector: { id: sectorId, name: sectorName },
     exporter_experience: exportExperienceId,
-    estimated_export_value_years: estimatedYearsId,
+    estimated_export_value_years: faker.helpers.arrayElement(estimatedYears),
     created_on: faker.date.past(),
     modified_on: faker.date.past(),
     title: faker.random.word(),


### PR DESCRIPTION
## Description of change
Added the details section of an export pipeline list item allowing users to toggle show/hide.

## Test instructions
Add the `export-pipeline` user feature flag

## Screenshots

### Before
<img width="940" alt="Screenshot 2023-03-24 at 13 18 46" src="https://user-images.githubusercontent.com/964268/227532897-c628732c-7d0f-4d34-9c7b-15f610162fb3.png">

### After
<img width="1003" alt="Screenshot 2023-03-28 at 14 15 57" src="https://user-images.githubusercontent.com/964268/228253592-a6b2d3ca-e3ef-4811-a5ba-60b3977e67fb.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
