### PR TITLE
bugfix/field-select-broken-when-used-with-resource

### DIFF
--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -32,7 +32,7 @@ const FieldSelect = ({
         onChange={onChange}
         onBlur={onBlur}
         meta={{ error, touched }}
-        key={options.length > 0 ? value : undefined}
+        key={Array.isArray(options) && options.length > 0 ? value : undefined}
         input={{
           id: name,
           defaultValue: value,

--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -32,7 +32,7 @@ const FieldSelect = ({
         onChange={onChange}
         onBlur={onBlur}
         meta={{ error, touched }}
-        key={value}
+        key={options.length > 0 ? value : undefined}
         input={{
           id: name,
           defaultValue: value,

--- a/test/component/cypress/specs/Form/FieldSelect.cy.jsx
+++ b/test/component/cypress/specs/Form/FieldSelect.cy.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Form } from '../../../../../src/client/components'
+
+import FieldSelect from '../../../../../src/client/components/Form/elements/FieldSelect'
+import DataHubProvider from '../provider'
+
+describe('FieldSelect', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form id="export-form">
+        <FieldSelect id="select-test" {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+  context('When initialValue is not provided', () => {
+    it('the selected option should not be set', () => {
+      cy.mount(
+        <Component
+          options={[
+            { value: 'a', label: 'label 1' },
+            { value: 'b', label: 'label 2' },
+          ]}
+        />
+      )
+      cy.get('select option:selected').should('have.text', 'Please select')
+    })
+  })
+
+  context('When initialValue is provided', () => {
+    it('the selected option should be set to the initialValue', () => {
+      cy.mount(
+        <Component
+          options={[
+            { value: 'a', label: 'label 1' },
+            { value: 'b', label: 'label 2' },
+          ]}
+          initialValue="b"
+        />
+      )
+      cy.get('select option:selected').should('have.text', 'label 2')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

When using the `<FieldSelect />` component with a `<ResourceOptionsField />` component there is a bug present which blocks selected value from being chosen from the list of displayed options.

The reason for this is once the `key` prop for `<Select />` component is set, adding options later will append those options to the list but will not select the one matching the `initialValue`. 

When editing a form, we know the `initialValues` as these are loaded via redux already. However, the `<ResourceOptionsField />` will load the metadata values it needs after the `initialValues` are set by the form. At this point, the  `key` prop for `<Select />` component is set so the metadata loaded by the `<ResourceOptionsField />` won't be set to the metadata option that matches the `initialValue`

Our `<FieldSelect />` component is wrapping the `<Select />` component in this repo https://github.com/alphagov/govuk-frontend/tree/main/src/govuk/components/select

## Test instructions

This is only currently testable on a draft branch https://github.com/uktrade/data-hub-frontend/tree/feature/RR-793-export-value. To edit an existing export, use this url: http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit

## Screenshots

### Before
This export has the number of years set to 4 in the api, and so should display 4 year as the selected value. As can be seen from the gif, no value is selected
![chrome_l4Zt8dx00c](https://user-images.githubusercontent.com/102232401/228269821-d075504f-bf49-4661-bed0-f6cbea346838.gif)


### After
This is the same export with the number of years set to 4 in the api. In this gif with the fix applied, the option for 4 years is selected
![chrome_Fj7TuhRD2m](https://user-images.githubusercontent.com/102232401/228269573-c7a701d7-5521-4fcc-9443-d6df1d6c121b.gif)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
