### PR TITLE
Update business details card to show turnover

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -67,9 +67,9 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
           )}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Turnover">
-          {!company.turnover && !company.turnover_range
+          {!company.turnover_gbp && !company.turnover_range
             ? 'Not set'
-            : company.turnover
+            : company.turnover_gbp
             ? currencyGBP(company.turnover_gbp, {
                 maximumSignificantDigits: 2,
               })

--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -67,10 +67,10 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
           )}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Turnover">
-          {!company.company_number || !company.turnover_range
+          {!company.turnover && !company.turnover_range
             ? 'Not set'
             : company.turnover
-            ? currencyGBP(company.turnover, {
+            ? currencyGBP(company.turnover_gbp, {
                 maximumSignificantDigits: 2,
               })
             : company.turnover_range?.name}

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -74,7 +74,7 @@ describe('Company overview page', () => {
           .parent()
           .next()
         cy.get('th').contains('Turnover')
-        cy.get('td').contains('£1,000,000').parent().next()
+        cy.get('td').contains('£720,000').parent().next()
         cy.get('th').contains('Number of Employees')
         cy.get('td').contains('260').parent().next()
         cy.get('th').contains('DBT Sector')

--- a/test/sandbox/fixtures/v4/company/company-no-overview-details.json
+++ b/test/sandbox/fixtures/v4/company/company-no-overview-details.json
@@ -29,10 +29,7 @@
   "transferred_by": null,
   "transferred_on": null,
   "transferred_to": null,
-  "turnover_range": {
-    "name": "£33.5M+",
-    "id": "7a4cd12a-6095-e211-a939-e4115bead28a"
-  },
+  "turnover_range": null,
   "turnover": null,
   "turnover_gbp": null,
   "is_turnover_estimated": false,


### PR DESCRIPTION
## Description of change

Business details card was always showing `not set` for turnover but now shows either the turnover range or turnover value when one is available

## Test instructions

_What should I see?_

## Screenshots

### Before
![Screenshot 2023-03-28 at 15 57 27](https://user-images.githubusercontent.com/54268863/228279906-033e941c-6523-4c33-86d1-e7034a1afebc.png)

### After
![Screenshot 2023-03-28 at 15 57 52](https://user-images.githubusercontent.com/54268863/228280024-f42c554b-9f61-41d0-a1c1-5ccc29f635fc.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
