### PR TITLE
Removed orphan closed auto generated dependencies PR for quarterly maintenance

### DIFF
--- a/docs/Dependabot.md
+++ b/docs/Dependabot.md
@@ -15,6 +15,7 @@ This is the process we have identified for dealing with Dependabot PRs that save
 11. If you are satisfied that everything is in order and all the tests have passed, request reviews as normal.
 12. After merging the PR, ensure that the `release-storybook` job has passed and that Storybook is running as expected.
 13. Ensure that the dev/staging deployments have succeeded. If they haven't, notify the TechEx team.
+14. Removed orphan closed PR dependencies every first working day in quarter of the year for those older than 90 days.
 
 ## Additional actions
 


### PR DESCRIPTION
## Description of change

As part of our Datahub maintenance(including related microservices) in order to improve the availability of the service. It plan every quarter starting next month April 2023 to removed orphan closed PR dependencies that merged into main excluding weekly chore branch of dependencies older than 90days.

Currently, auto generated dependencies update has been merged into weekly branch `chore/dependencies-[yyyy-mm-dd]` will be kept for future reference. Whilst all closed auto bot dependencies updates branch will be removed after 90days as part of routine maintenance.

As you can see, auto generated dependencies being accumulated since July 2019 with more than 1300 orphan branch in the repository.


## Screenshots
<img width="1379" alt="image" src="https://user-images.githubusercontent.com/28296624/228583253-664eb88f-1c50-46dd-a7a6-d1dae3694015.png">



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
