### PR TITLE
RR-793-field-labels-optional-bold

### DIFF
--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -107,7 +107,7 @@ const StyledLegendNoStyle = styled('legend')`
 
 const StyledLabel = styled(Label)`
   padding-bottom: ${SPACING.SCALE_1};
-  font-weight: ${FONT_WEIGHTS.bold};
+  ${(props) => props.boldLabel && ` font-weight: ${FONT_WEIGHTS.bold};`}
 `
 
 const StyledHint = styled(HintText)`
@@ -165,6 +165,7 @@ const FieldWrapper = ({
   children,
   reduced,
   groupId,
+  boldLabel = true,
   ...rest
 }) => (
   <StyledFormGroup
@@ -185,7 +186,7 @@ const FieldWrapper = ({
         >
           {label && (
             <StyledLegendNoStyle>
-              <StyledLabel error={error} htmlFor={name}>
+              <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
                 {label}
               </StyledLabel>
             </StyledLegendNoStyle>
@@ -207,7 +208,7 @@ const FieldWrapper = ({
         groupId={groupId}
       >
         {label && (
-          <StyledLabel error={error} htmlFor={name}>
+          <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
             {label}
           </StyledLabel>
         )}
@@ -271,6 +272,10 @@ FieldWrapper.propTypes = {
    * Node for children elements
    */
   children: PropTypes.node,
+  /**
+   * Boolean for rendering the label in bold or not
+   */
+  boldLabel: PropTypes.bool,
 }
 
 FieldWrapper.defaultProps = {
@@ -280,6 +285,7 @@ FieldWrapper.defaultProps = {
   error: null,
   showBorder: false,
   children: null,
+  boldLabel: true,
 }
 
 export default FieldWrapper

--- a/src/client/components/Form/elements/__stories__/FieldWrapper.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldWrapper.stories.jsx
@@ -29,6 +29,15 @@ storiesOf('Form/Form Elements/FieldWrapper', module)
           >
             {testInput}
           </FieldWrapper>
+          <FieldWrapper
+            legend="Label without bold font weight"
+            name="testField2"
+            hint="Some hint"
+            error={form.errors.testField}
+            boldLabel={false}
+          >
+            {testInput}
+          </FieldWrapper>
         </>
       )}
     </Form>


### PR DESCRIPTION
## Description of change

Added option to not render labels with bold weighting

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
