### PR TITLE
RR-793-field-currency

### DIFF
--- a/src/client/components/Form/elements/FieldCurrency/index.jsx
+++ b/src/client/components/Form/elements/FieldCurrency/index.jsx
@@ -80,7 +80,7 @@ const FieldCurrency = ({
   hint,
   initialValue,
   reduced,
-  boldLabel = true,
+  boldLabel,
   ...rest
 }) => {
   const { value, error, touched, onChange, onBlur } = useField({

--- a/src/client/components/Form/elements/FieldCurrency/index.jsx
+++ b/src/client/components/Form/elements/FieldCurrency/index.jsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { kebabCase } from 'lodash'
+
+import Input from '@govuk-react/input'
+import ErrorText from '@govuk-react/error-text'
+import {
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+  BORDER_WIDTH,
+  BORDER_WIDTH_FORM_ELEMENT,
+  SPACING,
+  BREAKPOINTS,
+  FONT_SIZE,
+} from '@govuk-react/constants'
+import {
+  ERROR_COLOUR,
+  BLACK,
+  LIGHT_GREY,
+} from '../../../../../client/utils/colours'
+
+import { useField } from '../../hooks'
+import FieldWrapper from '../FieldWrapper'
+import { number } from '../../../../../client/components/Form/validators'
+
+const StyledInputWrapper = styled('div')`
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+`
+
+const StyledText = styled('span')({
+  paddingLeft: SPACING.SCALE_2,
+})
+
+const StyledCurrencyPrefix = styled('div')`
+  border: ${BORDER_WIDTH_FORM_ELEMENT} solid ${BLACK};
+  border-right: 0px;
+  display: inline-block;
+  height: 40px;
+  padding: ${BORDER_WIDTH};
+  min-width: 40px;
+  box-sizing: border-box;
+  text-align: center;
+  flex: 0 0 auto;
+  cursor: default;
+  font-size: ${FONT_SIZE.SIZE_19};
+  background-color: ${LIGHT_GREY};
+
+  @media (max-width: ${BREAKPOINTS.TABLET}) {
+    line-height: 1.6;
+    font-size: ${FONT_SIZE.SIZE_16};
+  }
+  ${(props) =>
+    props.error &&
+    `
+    border: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    border-right: 0px;
+    `}
+`
+
+const StyledCurrencyWrapper = styled('div')`
+  display: flex;
+`
+
+/**
+ * A basic currency field for numbers.
+ */
+const FieldCurrency = ({
+  name,
+  validate,
+  required,
+  label,
+  text,
+  legend,
+  hint,
+  initialValue,
+  reduced,
+  boldLabel = true,
+  ...rest
+}) => {
+  const { value, error, touched, onChange, onBlur } = useField({
+    name,
+    validate,
+    required,
+    initialValue,
+  })
+  return (
+    <FieldWrapper {...{ name, label, legend, hint, error, reduced, boldLabel }}>
+      <StyledInputWrapper error={error}>
+        {touched && error && <ErrorText>{error}</ErrorText>}
+        <StyledCurrencyWrapper>
+          <StyledCurrencyPrefix
+            error={touched && Boolean(error)}
+            aria-hidden="true"
+          >
+            £
+          </StyledCurrencyPrefix>
+          <Input
+            key={name}
+            error={touched && Boolean(error)}
+            id={name}
+            type="text"
+            name={name}
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            data-test={kebabCase(`${name}-'input'`)}
+            {...rest}
+          />
+        </StyledCurrencyWrapper>
+        {text && <StyledText>{text}</StyledText>}
+      </StyledInputWrapper>
+    </FieldWrapper>
+  )
+}
+
+FieldCurrency.propTypes = {
+  /**
+   * Text for name attribute value
+   */
+  name: PropTypes.string.isRequired,
+  /**
+   * Validate functions for input
+   */
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
+  /**
+   * Text 'required' sets wether the input is required or not
+   */
+  required: PropTypes.string,
+  /**
+   * Text for the label element
+   */
+  label: PropTypes.node,
+  /**
+   * Node for legend element
+   */
+  legend: PropTypes.node,
+  /**
+   * Node for hint element
+   */
+  hint: PropTypes.node,
+  /**
+   * Sets initial value of the input
+   */
+  initialValue: PropTypes.string,
+  /**
+   * Toggles wether the element is a filter or not
+   */
+  reduced: PropTypes.bool,
+  /**
+   * Boolean for rendering the label in bold or not
+   */
+  boldLabel: PropTypes.bool,
+}
+
+FieldCurrency.defaultProps = {
+  validate: (value) => number(value, 'Value must be a number'),
+  required: null,
+  label: null,
+  legend: null,
+  hint: null,
+  initialValue: '',
+  reduced: false,
+  boldLabel: true,
+}
+
+export default FieldCurrency

--- a/src/client/components/Form/elements/__stories__/FieldCurrency.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCurrency.stories.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import FieldCurrency from '../FieldCurrency'
+import Form from '../../../Form'
+
+storiesOf('Form/Form Elements/Currency', module)
+  .addParameters({ component: FieldCurrency })
+  .add('FieldCurrency - default validation', () => (
+    <Form
+      id="fieldCurrencyExample"
+      analyticsFormName="fieldCurrencyExample"
+      submissionTaskName="Submit Form example"
+    >
+      {() => (
+        <>
+          <FieldCurrency
+            name="currency1"
+            label="Estimate amount in pounds (bold label)"
+            hint="For example, £1,000"
+            required="Enter amount in pounds"
+          />
+
+          <FieldCurrency
+            name="currency2"
+            label="Estimate amount in pounds (not bold label)"
+            hint="For example, £1,000"
+            required="Enter amount in pounds"
+            boldLabel={false}
+          />
+        </>
+      )}
+    </Form>
+  ))


### PR DESCRIPTION
## Description of change

Added a new form field component to handle currency. The current version does not do any formatting of entered values, but there is validation to ensure only a number is entered

Formatting of input to come in future ticket: https://uktrade.atlassian.net/browse/RR-933

## Test instructions

Run npm run storybook, then use the component at the path /story/form-form-elements-currency--fieldcurrency-default-validation

## Screenshots

![image](https://user-images.githubusercontent.com/102232401/228876987-81cbf1ec-55f7-4b8a-8173-a939b132678e.png)

![image](https://user-images.githubusercontent.com/102232401/228877210-51bbb578-4129-43cc-b393-f2afc62884e8.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
