### PR TITLE
RR-793-export-years-resource

### DIFF
--- a/src/client/components/Resource/ExportYears.js
+++ b/src/client/components/Resource/ExportYears.js
@@ -1,0 +1,3 @@
+import { createMetadataResource } from '.'
+
+export default createMetadataResource('ExportYears', 'export-years')

--- a/src/client/components/Resource/tasks.js
+++ b/src/client/components/Resource/tasks.js
@@ -19,6 +19,7 @@ import ContactAuditHistory from './ContactAuditHistory'
 import Interaction from './Interaction'
 import Event from './Event'
 import CompanyOneListTeam from './CompanyOneListTeam'
+import ExportYears from './ExportYears'
 
 export default {
   ...Advisers.tasks,
@@ -42,4 +43,5 @@ export default {
   ...Interaction.tasks,
   ...Event.tasks,
   ...CompanyOneListTeam.tasks,
+  ...ExportYears.tasks,
 }

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -98,6 +98,7 @@ const metadataItems = [
   ['export-experience-category', 'exportExperienceCategory'],
   ['likelihood-to-land', 'likelihoodToLandOptions'],
   ['trade-agreement', 'tradeAgreementOptions'],
+  ['export-years', 'exportYears'],
 ]
 
 const restrictedServiceKeys = [

--- a/src/middleware/metadata-api-proxy.js
+++ b/src/middleware/metadata-api-proxy.js
@@ -55,6 +55,7 @@ const ALLOWLIST = [
   '/v4/metadata/administrative-area',
   '/v4/metadata/large-capital-opportunity/opportunity-value-type',
   '/v4/metadata/large-capital-opportunity/opportunity-status',
+  '/v4/metadata/export-years',
 ]
 
 module.exports = (app) => {

--- a/test/sandbox/routes/v4/metadata/index.js
+++ b/test/sandbox/routes/v4/metadata/index.js
@@ -52,6 +52,7 @@ var capitalInvestmentValueTypes = require('../../../fixtures/metadata/capital-in
 var capitalInvestmentStatusTypes = require('../../../fixtures/metadata/capital-investment-opportunity-status-types.json')
 var oneListTier = require('../../../fixtures/v4/metadata/one-list-tier.json')
 var tradeAgreement = require('../../../fixtures/v4/metadata/trade-agreement.json')
+var estimatedYears = require('../../../fixtures/v4/export/estimated-years.json')
 
 exports.likelihoodToLand = function (req, res) {
   res.json(likelihoodToLand)
@@ -272,4 +273,8 @@ exports.oneListTier = function (req, res) {
 
 exports.tradeAgreement = function (req, res) {
   res.json(tradeAgreement)
+}
+
+exports.exportYears = function (req, res) {
+  res.json(estimatedYears)
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -319,6 +319,7 @@ app.get(
 )
 app.get('/v4/metadata/one-list-tier', v4Metadata.oneListTier)
 app.get('/v4/metadata/trade-agreement', v4Metadata.tradeAgreement)
+app.get('/v4/metadata/export-years', v4Metadata.exportYears)
 
 // Ping
 app.get('/ping.xml', healthcheck.ping)


### PR DESCRIPTION
## Description of change

Add a Resource component for retrieving the export years metadata. This will be needed in an upcoming PR

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
