### PR TITLE
RR-793-only-render-form-once-api-call-completes

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -75,6 +75,7 @@ const ExportFormAdd = ({ company, currentAdviserId, currentAdviserName }) => {
         cancelRedirectUrl={urls.companies.activity.index(companyId)}
         redirectToUrl={urls.dashboard()}
         flashMessage={({ data }) => `'${data.title}' created`}
+        formDataLoaded={!!company}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -63,6 +63,7 @@ const ExportFormEdit = ({ exportItem }) => {
         cancelRedirectUrl={urls.dashboard()}
         redirectToUrl={urls.exportPipeline.edit(exportId)}
         flashMessage={({ data }) => `Changes saved to '${data.title}'`}
+        formDataLoaded={!!exportItem}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -20,50 +20,53 @@ const ExportFormFields = ({
   flashMessage,
   cancelRedirectUrl,
   redirectToUrl,
+  formDataLoaded,
   taskProps = {},
 }) => (
   <Task.Status {...taskProps}>
-    {() => (
-      <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
-        <Form
-          id="export-form"
-          analyticsFormName={analyticsFormName}
-          cancelRedirectTo={() => cancelRedirectUrl}
-          redirectTo={() => redirectToUrl}
-          submissionTaskName={TASK_SAVE_EXPORT}
-          initialValues={
-            initialValues && transformAPIValuesForForm(initialValues)
-          }
-          transformPayload={(values) => ({ exportId: values.id, values })}
-          flashMessage={flashMessage}
-        >
-          {() => (
-            <>
-              <FieldInput
-                name="title"
-                label="Export title"
-                hint="It helps to give export details in the title, for example product and destination"
-                type="text"
-                required={ERROR_MESSAGES.title}
-              />
-              <FieldAdvisersTypeahead
-                name="owner"
-                label="Owner"
-                hint="When creating the record your name will appear. You can change the name to transfer ownership to someone else"
-                required={ERROR_MESSAGES.owner}
-              />
-              <FieldAdvisersTypeahead
-                name="team_members"
-                label="Team members (optional)"
-                hint="You can add up to 5 team members. Team members can view and edit export functionality"
-                isMulti={true}
-                validate={validateTeamMembers}
-              />
-            </>
-          )}
-        </Form>
-      </FormLayout>
-    )}
+    {() =>
+      formDataLoaded && (
+        <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
+          <Form
+            id="export-form"
+            analyticsFormName={analyticsFormName}
+            cancelRedirectTo={() => cancelRedirectUrl}
+            redirectTo={() => redirectToUrl}
+            submissionTaskName={TASK_SAVE_EXPORT}
+            initialValues={
+              initialValues && transformAPIValuesForForm(initialValues)
+            }
+            transformPayload={(values) => ({ exportId: values.id, values })}
+            flashMessage={flashMessage}
+          >
+            {() => (
+              <>
+                <FieldInput
+                  name="title"
+                  label="Export title"
+                  hint="It helps to give export details in the title, for example product and destination"
+                  type="text"
+                  required={ERROR_MESSAGES.title}
+                />
+                <FieldAdvisersTypeahead
+                  name="owner"
+                  label="Owner"
+                  hint="When creating the record your name will appear. You can change the name to transfer ownership to someone else"
+                  required={ERROR_MESSAGES.owner}
+                />
+                <FieldAdvisersTypeahead
+                  name="team_members"
+                  label="Team members (optional)"
+                  hint="You can add up to 5 team members. Team members can view and edit export functionality"
+                  isMulti={true}
+                  validate={validateTeamMembers}
+                />
+              </>
+            )}
+          </Form>
+        </FormLayout>
+      )
+    }
   </Task.Status>
 )
 
@@ -74,6 +77,11 @@ ExportFormFields.propTypes = {
   cancelRedirectUrl: PropTypes.string.isRequired,
   redirectToUrl: PropTypes.string.isRequired,
   taskProps: PropTypes.object,
+  formDataLoaded: PropTypes.bool,
+}
+
+ExportFormFields.defaultProps = {
+  formDataLoaded: false,
 }
 
 export default ExportFormFields

--- a/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import ExportFormFields from '../../../../../src/client/modules/ExportPipeline/ExportForm/ExportFormFields'
+import DataHubProvider from '../provider'
+
+const RESET_ACTION = {
+  type: 'RESET',
+}
+
+describe('ExportFormFields', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <ExportFormFields
+        {...props}
+        taskProps={{
+          name: RESET_ACTION,
+          id: 'test',
+          progressMessage: 'Loading company details',
+        }}
+      />
+    </DataHubProvider>
+  )
+
+  context('When formDataLoaded is false', () => {
+    it('should not render the <Form> component', () => {
+      cy.mount(<Component formDataLoaded={false} />)
+      cy.get('form').should('not.exist')
+    })
+  })
+
+  context('When formDataLoaded is true', () => {
+    it('should render the <Form> component', () => {
+      cy.mount(<Component formDataLoaded={true} />)
+      cy.get('form').should('exist')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Only render the form when the required api data is in the redux store, to avoid the `<Form />` component rendering twice and triggering multiple calls to metadata endpoints


## Screenshots

### Before
You can see in the network tab, the metadata resource for export-years is being called twice
![chrome_048yMnQJHi](https://user-images.githubusercontent.com/102232401/229091282-a9fdea14-3efd-44ff-896a-cb698b348f27.gif)

### After
With this fix, the metadata resource for export-years is only called once
![chrome_0GGsdPgzMg](https://user-images.githubusercontent.com/102232401/229091345-bfa5fe46-c049-433b-8846-1b80b259095f.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
