### PR TITLE
Move likelihood-to-land to add and edit investment pages

### DIFF
--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -288,6 +288,14 @@ const InvestmentDetailsStep = ({ values, errors, company }) => {
           data-test="estimated-land-date"
         />
 
+        <FieldTypeahead
+          name="likelihood_to_land"
+          label="Likelihood of landing"
+          options={values.likelihoodToLand}
+          placeholder="Select a likelihood of landing value"
+          data-test="likelihood-to-land"
+        />
+
         <FieldDate
           name="actual_land_date"
           label="Actual land date (optional)"
@@ -345,6 +353,7 @@ InvestmentDetailsStep.propTypes = {
     investmentInvestorType: PropTypes.arrayOf(optionProp),
     investmentInvolvement: PropTypes.arrayOf(optionProp),
     investmentSpecificProgramme: PropTypes.arrayOf(optionProp),
+    likelihoodToLand: PropTypes.arrayOf(optionProp),
   }),
 }
 

--- a/src/apps/investments/client/projects/create/tasks.js
+++ b/src/apps/investments/client/projects/create/tasks.js
@@ -98,6 +98,7 @@ const fetchValuesFromAPI = () =>
     getMetadataOptions(urls.metadata.investmentInvolvement()),
     getMetadataOptions(urls.metadata.investmentSpecificProgramme()),
     getMetadataOptions(urls.metadata.investmentBusinessActivity()),
+    getMetadataOptions(urls.metadata.likelihoodToLand()),
   ]).then(
     ([
       adviser,
@@ -112,6 +113,7 @@ const fetchValuesFromAPI = () =>
       investmentInvolvement,
       investmentSpecificProgramme,
       investmentBusinessActivity,
+      likelihoodToLand,
     ]) => ({
       adviser,
       advisers,
@@ -125,5 +127,6 @@ const fetchValuesFromAPI = () =>
       investmentInvolvement,
       investmentSpecificProgramme,
       investmentBusinessActivity,
+      likelihoodToLand,
     })
   )

--- a/src/apps/investments/labels.js
+++ b/src/apps/investments/labels.js
@@ -15,6 +15,7 @@ const labels = {
       description: 'Project description',
       anonymous_description: 'Anonymised description',
       estimated_land_date: 'Estimated land date',
+      likelihood_to_land: 'Likelihood to land',
       actual_land_date: 'Actual land date',
       investor_type: 'New or existing investor',
       level_of_involvement: 'Level of involvement',
@@ -36,7 +37,6 @@ const labels = {
       associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
       new_tech_to_uk: 'New-to-world tech',
       export_revenue: 'Export revenue',
-      likelihood_to_land: 'Likelihood to land',
     },
     edit: {
       government_assistance:

--- a/src/apps/investments/middleware/forms/__test__/details.test.js
+++ b/src/apps/investments/middleware/forms/__test__/details.test.js
@@ -25,12 +25,12 @@ const metadataMock = {
     { id: '2', name: 'f2', disabled_on: yesterday },
     { id: '3', name: 'f3', disabled_on: null },
   ],
-  referralSoureMarketingOptions: [
+  referralSourceMarketingOptions: [
     { id: '1', name: 'rsm1', disabled_on: null },
     { id: '2', name: 'rsm2', disabled_on: yesterday },
     { id: '3', name: 'rsm3', disabled_on: null },
   ],
-  referralSoureWebsiteOptions: [
+  referralSourceWebsiteOptions: [
     { id: '1', name: 'rsm1', disabled_on: null },
     { id: '2', name: 'rsm2', disabled_on: yesterday },
     { id: '3', name: 'rsm3', disabled_on: null },
@@ -59,6 +59,11 @@ const metadataMock = {
     { id: '1', name: 'iio1', disabled_on: null },
     { id: '2', name: 'iio2', disabled_on: yesterday },
     { id: '3', name: 'iio3', disabled_on: null },
+  ],
+  likelihoodToLandOptions: [
+    { id: '1', name: 'ltl1', disabled_on: null },
+    { id: '2', name: 'ltl2', disabled_on: yesterday },
+    { id: '3', name: 'ltl3', disabled_on: null },
   ],
 }
 
@@ -296,9 +301,9 @@ describe('investment details middleware', () => {
           .get('/v4/metadata/fdi-type')
           .reply(200, metadataMock.fdiValueOptions)
           .get('/v4/metadata/referral-source-marketing')
-          .reply(200, metadataMock.referralSoureMarketingOptions)
+          .reply(200, metadataMock.referralSourceMarketingOptions)
           .get('/v4/metadata/referral-source-website')
-          .reply(200, metadataMock.referralSoureWebsiteOptions)
+          .reply(200, metadataMock.referralSourceWebsiteOptions)
           .get('/v4/metadata/sector')
           .reply(200, metadataMock.sectorOptions)
           .get('/v4/metadata/investment-business-activity')
@@ -309,6 +314,8 @@ describe('investment details middleware', () => {
           .reply(200, metadataMock.investmentsInvestorTypeOptions)
           .get('/v4/metadata/investment-involvement')
           .reply(200, metadataMock.investmentInvolvementOptions)
+          .get('/v4/metadata/likelihood-to-land')
+          .reply(200, metadataMock.likelihoodToLandOptions)
 
         this.req.params = assign({}, this.req.params, {
           equityCompanyId: uuid(),
@@ -357,9 +364,9 @@ describe('investment details middleware', () => {
           .get('/v4/metadata/fdi-type')
           .reply(200, metadataMock.fdiValueOptions)
           .get('/v4/metadata/referral-source-marketing')
-          .reply(200, metadataMock.referralSoureMarketingOptions)
+          .reply(200, metadataMock.referralSourceMarketingOptions)
           .get('/v4/metadata/referral-source-website')
-          .reply(200, metadataMock.referralSoureWebsiteOptions)
+          .reply(200, metadataMock.referralSourceWebsiteOptions)
           .get('/v4/metadata/sector')
           .reply(200, metadataMock.sectorOptions)
           .get('/v4/metadata/investment-business-activity')
@@ -370,6 +377,8 @@ describe('investment details middleware', () => {
           .reply(200, metadataMock.investmentsInvestorTypeOptions)
           .get('/v4/metadata/investment-involvement')
           .reply(200, metadataMock.investmentInvolvementOptions)
+          .get('/v4/metadata/likelihood-to-land')
+          .reply(200, metadataMock.likelihoodToLandOptions)
 
         this.res.locals = assign({}, this.res.locals, {
           investment: {

--- a/src/apps/investments/middleware/forms/details.js
+++ b/src/apps/investments/middleware/forms/details.js
@@ -114,6 +114,9 @@ async function populateForm(req, res, next) {
         investmentInvolvement: await getOptions(req, 'investment-involvement', {
           createdOn,
         }),
+        likelihoodToLand: await getOptions(req, 'likelihood-to-land', {
+          createdOn,
+        }),
       },
     })
 

--- a/src/apps/investments/transformers/__test__/project.test.js
+++ b/src/apps/investments/transformers/__test__/project.test.js
@@ -434,19 +434,19 @@ describe('Investment project transformers', () => {
       })
     })
 
-    // context('when an estimated land date is not provided', () => {
-    //   beforeEach(() => {
-    //     const data = assign({}, investmentData, {
-    //       estimated_land_date: null,
-    //     })
+    context('when a likelihood to land value is not provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          likelihood_to_land: null,
+        })
 
-    //     this.result = transformInvestmentForView(data)
-    //   })
+        this.result = transformInvestmentForView(data)
+      })
 
-    //   it('should set the estimated land date as null', () => {
-    //     expect(this.result).to.have.property('estimated_land_date', null)
-    //   })
-    // })
+      it('should set the likelihood to land value as null', () => {
+        expect(this.result).to.have.property('likelihood_to_land', null)
+      })
+    })
 
     context('when an actual land date is provided', () => {
       beforeEach(() => {

--- a/src/apps/investments/transformers/__test__/project.test.js
+++ b/src/apps/investments/transformers/__test__/project.test.js
@@ -27,6 +27,7 @@ describe('Investment project transformers', () => {
           'level_of_involvement',
           'specific_programme',
           'estimated_land_date',
+          'likelihood_to_land',
           'actual_land_date',
         ])
       })
@@ -418,6 +419,34 @@ describe('Investment project transformers', () => {
         expect(this.result).to.have.property('estimated_land_date', null)
       })
     })
+
+    context('when a likelihood to land value is provided', () => {
+      beforeEach(() => {
+        const data = assign({}, investmentData, {
+          likelihood_to_land: 'low',
+        })
+
+        this.result = transformInvestmentForView(data)
+      })
+
+      it('should include the likelihood to land value', () => {
+        expect(this.result).to.have.property('likelihood_to_land', 'low')
+      })
+    })
+
+    // context('when an estimated land date is not provided', () => {
+    //   beforeEach(() => {
+    //     const data = assign({}, investmentData, {
+    //       estimated_land_date: null,
+    //     })
+
+    //     this.result = transformInvestmentForView(data)
+    //   })
+
+    //   it('should set the estimated land date as null', () => {
+    //     expect(this.result).to.have.property('estimated_land_date', null)
+    //   })
+    // })
 
     context('when an actual land date is provided', () => {
       beforeEach(() => {

--- a/src/apps/investments/transformers/__test__/value.test.js
+++ b/src/apps/investments/transformers/__test__/value.test.js
@@ -51,7 +51,6 @@ describe('Investment project transformers', () => {
           business_activities: 'No',
           associated_non_fdi_r_and_d_project:
             'Not linked to a non-FDI R&D project',
-          likelihood_to_land: null,
         }
 
         expect(this.actualInvestmentValue).to.deep.equal(
@@ -145,10 +144,6 @@ describe('Investment project transformers', () => {
               },
             ],
           },
-          likelihood_to_land: {
-            name: 'Low',
-            id: 'b3515282-dc36-487a-a5af-320cde165575',
-          },
         }
 
         expect(this.actualInvestmentValue).to.deep.equal(
@@ -233,10 +228,6 @@ describe('Investment project transformers', () => {
                   test: 'remove-associated-link',
                 },
               ],
-            },
-            likelihood_to_land: {
-              name: 'Low',
-              id: 'b3515282-dc36-487a-a5af-320cde165575',
             },
           }
 

--- a/src/apps/investments/transformers/project.js
+++ b/src/apps/investments/transformers/project.js
@@ -165,12 +165,12 @@ function transformInvestmentForView({
     description,
     anonymous_description,
     investor_type,
-    likelihood_to_land,
     level_of_involvement,
     specific_programme,
     estimated_land_date: !isEmpty(estimated_land_date)
       ? format(estimated_land_date, 'MMMM yyyy')
       : null,
+    likelihood_to_land,
     actual_land_date: !isEmpty(actual_land_date)
       ? {
           type: 'date',

--- a/src/apps/investments/transformers/project.js
+++ b/src/apps/investments/transformers/project.js
@@ -134,6 +134,7 @@ function transformInvestmentForView({
   specific_programme,
   estimated_land_date,
   actual_land_date,
+  likelihood_to_land,
 } = {}) {
   function transformClientContacts(contacts) {
     return map(contacts, ({ name, id }) => {
@@ -164,6 +165,7 @@ function transformInvestmentForView({
     description,
     anonymous_description,
     investor_type,
+    likelihood_to_land,
     level_of_involvement,
     specific_programme,
     estimated_land_date: !isEmpty(estimated_land_date)

--- a/src/apps/investments/transformers/value.js
+++ b/src/apps/investments/transformers/value.js
@@ -50,7 +50,6 @@ function transformInvestmentValueForView({
   non_fdi_r_and_d_budget,
   id,
   associated_non_fdi_r_and_d_project,
-  likelihood_to_land,
 }) {
   function formatBoolean(boolean, { pos, neg }) {
     if (isNull(boolean)) {
@@ -93,7 +92,6 @@ function transformInvestmentValueForView({
       pos: 'Yes, will create significant export revenue',
       neg: 'No, will not create significant export revenue',
     }),
-    likelihood_to_land: likelihood_to_land,
     average_salary: get(average_salary, 'name'),
     sector_name: get(sector, 'name'),
     account_tier: get(investor_company, 'one_list_group_tier.name'),

--- a/src/apps/investments/views/_details-form.njk
+++ b/src/apps/investments/views/_details-form.njk
@@ -300,6 +300,15 @@
     }
   }) }}
 
+  {{ MultipleChoiceField({
+      name: 'likelihood_to_land',
+      label: 'Likelihood to land',
+      error: form.errors.messages.likelihood_to_land,
+      value: form.state.likelihood_to_land,
+      options: form.options.likelihoodToLand,
+      initialOption: '-- Select a likelihood to land value --'
+    }) }}
+
   {{ DateFieldset({
     name: 'actual_land_date',
     label: 'Actual land date',

--- a/src/apps/investments/views/value-edit.njk
+++ b/src/apps/investments/views/value-edit.njk
@@ -111,15 +111,6 @@
     {% endif %}
 
     {{ MultipleChoiceField({
-      name: 'likelihood_to_land',
-      label: form.labels.likelihood_to_land,
-      value: form.state.likelihood_to_land,
-      error: errors.messages.likelihood_to_land,
-      initialOption: '-- Select a likelihood to land value --',
-      options: form.options.likelihoodToLand
-    }) }}
-
-    {{ MultipleChoiceField({
       name: 'government_assistance',
       type: 'radio',
       modifier: 'inline',

--- a/test/unit/data/investment/investment-data.json
+++ b/test/unit/data/investment/investment-data.json
@@ -5,6 +5,10 @@
   "description": "ACHME hotels wishes to open in a new part of Manchester under-served by its existing hotels",
   "anonymous_description": "International hotel chain looking to expand into England.",
   "estimated_land_date": "2018-05-01",
+  "likelihood_to_land": {
+    "name": "Low",
+    "id": "b3515282-dc36-487a-a5af-320cde165575"
+  },
   "actual_land_date": null,
   "likelihood_of_landing": null,
   "priority": null,


### PR DESCRIPTION
## Description of change

Moved the 'likelihood to land' dropdown from the investment edit value form to the add investment form. Also display 'likelihood to land' under investment project summary instead of the value.
This work is solely to move the existing boxes and not to update them.

## Test instructions

_What should I see?_

## Screenshots

### Before

Add investment screen:
![Screenshot 2023-03-31 at 16 45 33](https://user-images.githubusercontent.com/54268863/229168089-cb483fc0-be0a-482e-9ae7-a7d5f2568b9a.png)
Edit investment screen:
![Screenshot 2023-03-31 at 16 47 03](https://user-images.githubusercontent.com/54268863/229168453-d139e2b1-9f78-4267-a487-0cdb0bca8dd7.png)
Investment project summary:
![Screenshot 2023-03-31 at 16 44 50](https://user-images.githubusercontent.com/54268863/229167862-e20bfc12-15ed-494c-9bd3-c0d97ef33737.png)


### After
Add investment screen:
![Screenshot 2023-03-31 at 16 43 24](https://user-images.githubusercontent.com/54268863/229167449-702d7165-1181-4725-a353-e6b972e08f8e.png)
Edit investment screen:
![Screenshot 2023-03-31 at 16 43 38](https://user-images.githubusercontent.com/54268863/229167511-dffaf891-e319-426a-84fa-1c064e4a1cec.png)
Investment project summary:
![Screenshot 2023-03-31 at 16 43 47](https://user-images.githubusercontent.com/54268863/229167569-a69259d5-3785-4fa2-bb3b-4ab584574845.png)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
