### PR TITLE
RR-795-export-destination-field

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -6,6 +6,7 @@ import {
   FieldInput,
   FormLayout,
   FieldAdvisersTypeahead,
+  FieldTypeahead,
 } from '../../../../client/components'
 import { FORM_LAYOUT } from '../../../../common/constants'
 import { TASK_SAVE_EXPORT } from './state'
@@ -13,6 +14,8 @@ import Task from '../../../components/Task'
 import { ERROR_MESSAGES } from './constants'
 import { transformAPIValuesForForm } from '../transformers'
 import { validateTeamMembers } from './validation'
+import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
+import CountriesResource from '../../../../client/components/Resource/Countries'
 
 const ExportFormFields = ({
   initialValues,
@@ -60,6 +63,13 @@ const ExportFormFields = ({
                   hint="You can add up to 5 team members. Team members can view and edit export functionality"
                   isMulti={true}
                   validate={validateTeamMembers}
+                />
+                <ResourceOptionsField
+                  name="destination_country"
+                  label="Destination"
+                  required={ERROR_MESSAGES.destination_country}
+                  resource={CountriesResource}
+                  field={FieldTypeahead}
                 />
               </>
             )}

--- a/src/client/modules/ExportPipeline/ExportForm/constants.js
+++ b/src/client/modules/ExportPipeline/ExportForm/constants.js
@@ -2,4 +2,5 @@ export const ERROR_MESSAGES = {
   title: 'Enter an export title',
   owner: 'Enter an owner',
   team_members: 'You can only add 5 team members',
+  destination_country: 'Enter a destination',
 }

--- a/src/client/modules/ExportPipeline/__test__/transformers.test.js
+++ b/src/client/modules/ExportPipeline/__test__/transformers.test.js
@@ -16,6 +16,7 @@ describe('transformFormValuesForAPI', () => {
             { value: 'd', label: 'e' },
             { value: 'f', label: 'g' },
           ],
+          destination_country: { value: 'h', label: 'i' },
         })
       ).to.be.deep.equal({
         company: 456,
@@ -23,6 +24,7 @@ describe('transformFormValuesForAPI', () => {
         title: 'title',
         owner: 'b',
         team_members: ['d', 'f'],
+        destination_country: 'h',
       })
     })
   })
@@ -38,6 +40,7 @@ describe('transformAPIValuesForForm', () => {
           title: 'a',
           owner: { id: 'b', name: 'c' },
           team_members: [{ id: 'd', name: 'e' }],
+          destination_country: { id: 'f', name: 'g' },
         })
       ).to.be.deep.equal({
         id: 234,
@@ -45,6 +48,7 @@ describe('transformAPIValuesForForm', () => {
         title: 'a',
         owner: { value: 'b', label: 'c' },
         team_members: [{ value: 'd', label: 'e' }],
+        destination_country: { value: 'f', label: 'g' },
       })
     })
   })

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -6,12 +6,14 @@ export const transformFormValuesForAPI = ({
   title,
   owner,
   team_members,
+  destination_country,
 }) => ({
   company,
   id,
   title,
   owner: owner.value,
   team_members: team_members.map((x) => x.value),
+  destination_country: destination_country.value,
 })
 
 export const transformAPIValuesForForm = ({
@@ -20,10 +22,13 @@ export const transformAPIValuesForForm = ({
   title,
   owner,
   team_members,
+  destination_country,
 }) => ({
   company: company.id,
   id,
   title,
   owner: mapApiToField(owner),
   team_members: team_members.map(mapApiToField),
+  destination_country:
+    destination_country && mapApiToField(destination_country),
 })

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -22,6 +22,7 @@ const {
 const {
   fillTypeahead,
   fillMultiOptionTypeahead,
+  clearTypeahead,
 } = require('../../support/form-fillers')
 const autoCompleteAdvisers =
   require('../../../../sandbox/fixtures/autocomplete-adviser-list.json').results
@@ -122,6 +123,7 @@ describe('Export pipeline create', () => {
       it('the form should display validation error message for mandatory inputs', () => {
         //clear any default values first
         cy.get('[data-test="typeahead-input"]').clear()
+        clearTypeahead('[data-test=field-destination_country]')
 
         cy.get('[data-test=submit-button]').click()
 
@@ -132,6 +134,11 @@ describe('Export pipeline create', () => {
         assertFieldError(
           cy.get('[data-test="field-owner"]'),
           ERROR_MESSAGES.owner
+        )
+        assertFieldError(
+          cy.get('[data-test="field-destination_country"]'),
+          ERROR_MESSAGES.destination_country,
+          false
         )
       })
 
@@ -166,6 +173,10 @@ describe('Export pipeline create', () => {
 
           cy.get('[data-test=title-input]').type(newExport.title)
           fillTypeahead('[data-test=field-team_members]', teamMember.name)
+          fillTypeahead(
+            '[data-test=field-destination_country]',
+            newExport.destination_country.name
+          )
 
           cy.get('[data-test=submit-button]').click()
 
@@ -174,6 +185,7 @@ describe('Export pipeline create', () => {
             owner: '7d19d407-9aec-4d06-b190-d3f404627f21',
             team_members: [teamMember.id],
             company: company.id,
+            destination_country: newExport.destination_country.id,
           })
 
           assertExactUrl('')

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -14,7 +14,10 @@ const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
 const {
   ERROR_MESSAGES,
 } = require('../../../../../src/client/modules/ExportPipeline/ExportForm/constants')
-const { fillMultiOptionTypeahead } = require('../../support/form-fillers')
+const {
+  fillMultiOptionTypeahead,
+  clearTypeahead,
+} = require('../../support/form-fillers')
 const autoCompleteAdvisers =
   require('../../../../sandbox/fixtures/autocomplete-adviser-list.json').results
 const { faker } = require('@faker-js/faker')
@@ -108,6 +111,14 @@ describe('Export pipeline edit', () => {
           '[data-test="field-team_members"]',
           exportItem.team_members.map((t) => t.name)
         )
+        cy.get('[data-test="field-destination_country"]').then((element) => {
+          assertFieldTypeahead({
+            element,
+            label: 'Destination',
+            value: exportItem.destination_country.name,
+            isMulti: false,
+          })
+        })
       })
     })
 
@@ -123,6 +134,7 @@ describe('Export pipeline edit', () => {
         //clear any default values first
         cy.get('[data-test="title-input"]').clear()
         cy.get('[data-test="typeahead-input"]').clear()
+        clearTypeahead('[data-test=field-destination_country]')
 
         cy.get('[data-test=submit-button]').click()
 
@@ -133,6 +145,11 @@ describe('Export pipeline edit', () => {
         assertFieldError(
           cy.get('[data-test="field-owner"]'),
           ERROR_MESSAGES.owner
+        )
+        assertFieldError(
+          cy.get('[data-test="field-destination_country"]'),
+          ERROR_MESSAGES.destination_country,
+          false
         )
       })
 
@@ -166,6 +183,10 @@ describe('Export pipeline edit', () => {
           expect(request.body).to.have.property('owner', exportItem.owner.id)
           expect(request.body.team_members).to.deep.equal(
             exportItem.team_members.map((x) => x.id)
+          )
+          expect(request.body).to.have.property(
+            'destination_country',
+            exportItem.destination_country.id
           )
         })
 

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -783,10 +783,14 @@ const assertAPIRequest = (endPointAlias, assertCallback) =>
  * Assert the field element contains the expected error message
  * @param {*} element the field element that contains the error
  * @param {*} errorMessage the error message that should be displayed
+ * @param {*} hasHint whether this field has a hint
  * @returns
  */
-const assertFieldError = (element, errorMessage) =>
-  element.find('span').eq(1).should('have.text', errorMessage)
+const assertFieldError = (element, errorMessage, hasHint = true) =>
+  element
+    .find('span')
+    .eq(hasHint ? 1 : 0)
+    .should('have.text', errorMessage)
 
 /**
  * Assert the typeahead element contains a chip for each of the values

--- a/test/functional/cypress/support/form-fillers.js
+++ b/test/functional/cypress/support/form-fillers.js
@@ -45,3 +45,7 @@ export const clickSaveAndReturnButton = () => {
 export const clickReturnWithoutSavingButton = () => {
   cy.contains('Return without saving').click()
 }
+
+export const clearTypeahead = (selector) => {
+  cy.get(selector).find('input').clear().type('{esc}')
+}


### PR DESCRIPTION
## Description of change

- Added a new form field for the destination country property
- Modified `assertFieldError` to allow hint text to be optional, as the `.eq(1)` only works where the hint text span is present
- Added `clearTypeahead` function which types escape at the end of the `.clear()` to get rid of the available options for the FieldTypeahead

## Test instructions

- To add a new export use the following url, where company id can be any valid id: http://localhost:3000/export/create?companyId=c1ea5ee7-c6f5-4dd1-8c5e-785c5a115719
- To edit an existing export, use this url: http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit

## Screenshots

![image](https://user-images.githubusercontent.com/102232401/229479865-4e44ebb0-fc47-497b-a825-5b46a4edba1a.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
