### PR TITLE
Modify Datahub - Orders DIT content options captions labels etc

### DIFF
--- a/src/apps/omis/apps/view/views/work-order.njk
+++ b/src/apps/omis/apps/view/views/work-order.njk
@@ -184,7 +184,7 @@
       label: 'Contacts the company already has in the market',
       value: values.existing_agents
     }, {
-      label: 'Specific people or organisations the company does not want DIT to talk to',
+      label: 'Specific people or organisations the company does not want DBT to talk to',
       value: values.contacts_not_to_approach,
       fallbackText: 'None added'
     }, {

--- a/src/apps/omis/locales/en/default.json
+++ b/src/apps/omis/locales/en/default.json
@@ -32,7 +32,7 @@
       "hint": "For example 28/10/2018 or 28 October 2018"
     },
     "contacts_not_to_approach": {
-      "label": "Specific people or organisations the company does not want DIT to talk to"
+      "label": "Specific people or organisations the company does not want DBT to talk to"
     },
     "existing_agents": {
       "label": "Contacts the company already has in the market",

--- a/test/sandbox/fixtures/metadata/order-cancellation-reason.json
+++ b/test/sandbox/fixtures/metadata/order-cancellation-reason.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "fce5a84b-c7ef-e311-8a2b-e4115bead28a",
-        "name": "Company not eligible for support from DIT",
+        "name": "Company not eligible for support from DBT",
         "disabled_on": null
     },
     {

--- a/test/sandbox/fixtures/v4/metadata/order-cancellation-reason.json
+++ b/test/sandbox/fixtures/v4/metadata/order-cancellation-reason.json
@@ -1,7 +1,7 @@
 [
     {
         "id": "fce5a84b-c7ef-e311-8a2b-e4115bead28a",
-        "name": "Company not eligible for support from DIT",
+        "name": "Company not eligible for support from DBT",
         "disabled_on": null
     },
     {


### PR DESCRIPTION
## Description of change

As the name of the department has changed from DIT to DBT, we will need to identify all content containing references to DIT (including both acronyms and the full department name) and update them to use the new name.

## Test instructions
Navigate Datahub front-end application into `OMIS`.

_What should I see?_
It was changed from `Department for International Trade` and `DIT` contents and acronyms into `Department for Business and Trade` and `DBT` within page title, header, options, caption, labels etc.


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
