### PR TITLE
Add pagination to the export pipeline list

### DIFF
--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -351,8 +351,8 @@ import { saveExport } from '../client/modules/ExportPipeline/ExportForm/tasks'
 import { TASK_DELETE_EXPORT } from '../client/modules/ExportPipeline/ExportDelete/state'
 import { deleteExport } from '../client/modules/ExportPipeline/ExportDelete/tasks'
 
-import { TASK_GET_EXPORT_PIPELINE_LIST } from '../client/modules/ExportPipeline/ExportList/state.js'
-import { getExportPipelineList } from '../client/modules/ExportPipeline/ExportList/task.js'
+import { TASK_GET_EXPORT_PIPELINE_LIST } from '../client/modules/ExportPipeline/ExportList/state'
+import { getExportPipelineList } from '../client/modules/ExportPipeline/ExportList/task'
 
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}

--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Link from '@govuk-react/link'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
@@ -102,6 +103,27 @@ const ItemRenderer = (item) => {
       </ToggleSection>
     </ListItem>
   )
+}
+
+const shape = PropTypes.shape({
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+}).isRequired
+
+ItemRenderer.propTypes = {
+  item: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    company: shape,
+    owner: shape,
+    destination_country: shape,
+    sector: shape,
+    estimated_export_value_years: shape,
+    created_on: PropTypes.string.isRequired,
+    estimated_export_value_amount: PropTypes.string.isRequired,
+    estimated_win_date: PropTypes.string.isRequired,
+    export_potential: PropTypes.string.isRequired,
+    status: PropTypes.string.isRequired,
+  }),
 }
 
 export default ItemRenderer

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -9,7 +9,7 @@ import Pagination from '../../../components/Pagination'
 
 import { EXPORT__PIPELINE_LIST_LOADED } from '../../../actions'
 import { ID, TASK_GET_EXPORT_PIPELINE_LIST, state2props } from './state'
-import { parsePage } from '../../../../client/utils/pagination.js'
+import { parsePage } from '../../../../client/utils/pagination'
 
 import List from './List'
 import ListItemRenderer from './ItemRenderer'

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -1,24 +1,67 @@
 import React from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
 import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import qs from 'qs'
 
 import Task from '../../../components/Task'
+import Pagination from '../../../components/Pagination'
+
 import { EXPORT__PIPELINE_LIST_LOADED } from '../../../actions'
 import { ID, TASK_GET_EXPORT_PIPELINE_LIST, state2props } from './state'
+import { parsePage } from '../../../../client/utils/pagination.js'
 
 import List from './List'
 import ListItemRenderer from './ItemRenderer'
 
-const ExportList = (data) => (
-  <Task.Status
-    name={TASK_GET_EXPORT_PIPELINE_LIST}
-    id={ID}
-    progressMessage="loading export pipeline list"
-    startOnRender={{
-      onSuccessDispatch: EXPORT__PIPELINE_LIST_LOADED,
-    }}
-  >
-    {() => <List items={data.results} itemRenderer={ListItemRenderer} />}
-  </Task.Status>
-)
+const ExportList = ({ count, results, itemsPerPage, maxItemsToPaginate }) => {
+  const history = useHistory()
+  const location = useLocation()
+
+  const qsParams = qs.parse(location.search.slice(1))
+  const initialPage = parsePage(qsParams.page)
+  const maxItems = Math.min(count, maxItemsToPaginate)
+  const totalPages = Math.ceil(maxItems / itemsPerPage)
+
+  return (
+    <Task.Status
+      name={TASK_GET_EXPORT_PIPELINE_LIST}
+      id={ID}
+      progressMessage="loading export pipeline list"
+      startOnRender={{
+        payload: {
+          page: initialPage,
+        },
+        onSuccessDispatch: EXPORT__PIPELINE_LIST_LOADED,
+      }}
+    >
+      {() => (
+        <>
+          <List items={results} itemRenderer={ListItemRenderer} />
+          <Pagination
+            totalPages={totalPages}
+            activePage={initialPage}
+            onPageClick={(page, e) => {
+              e.preventDefault()
+              history.push({
+                search: qs.stringify({
+                  ...qsParams,
+                  page,
+                }),
+              })
+            }}
+          />
+        </>
+      )}
+    </Task.Status>
+  )
+}
+
+ExportList.propTypes = {
+  count: PropTypes.number,
+  results: PropTypes.array,
+  itemsPerPage: PropTypes.number,
+  maxItemsToPaginate: PropTypes.number,
+}
 
 export default connect(state2props)(ExportList)

--- a/src/client/modules/ExportPipeline/ExportList/reducer.js
+++ b/src/client/modules/ExportPipeline/ExportList/reducer.js
@@ -2,15 +2,16 @@ import { EXPORT__PIPELINE_LIST_LOADED } from '../../../../client/actions'
 
 const initialState = {
   count: 0,
-  next: null,
-  previous: null,
   results: [],
+  itemsPerPage: 10,
+  maxItemsToPaginate: 10000,
 }
 
 export default (state = initialState, { type, result }) => {
   switch (type) {
     case EXPORT__PIPELINE_LIST_LOADED:
       return {
+        ...state,
         ...result,
       }
     default:

--- a/src/client/modules/ExportPipeline/ExportList/task.js
+++ b/src/client/modules/ExportPipeline/ExportList/task.js
@@ -1,4 +1,14 @@
+import qs from 'qs'
+
+import { getPageOffset } from '../../../../client/utils/pagination.js'
 import { apiProxyAxios } from '../../../components/Task/utils'
 
-export const getExportPipelineList = () =>
-  apiProxyAxios.get('/v4/export').then(({ data }) => data)
+export const getExportPipelineList = ({ limit = 10, page = 1 }) => {
+  const offset = getPageOffset({ limit, page })
+  const queryParams = qs.stringify({
+    limit,
+    page,
+    offset,
+  })
+  return apiProxyAxios.get(`/v4/export?${queryParams}`).then(({ data }) => data)
+}

--- a/src/client/utils/pagination.js
+++ b/src/client/utils/pagination.js
@@ -6,4 +6,9 @@
 const getPageOffset = ({ limit, page, maxItems = 10000 }) =>
   Math.min(limit * (page - 1), maxItems - limit) || 0
 
-module.exports = { getPageOffset }
+const parsePage = (page, defaultValue = 1) => {
+  const pageNumber = parseInt(page, 10)
+  return isNaN(pageNumber) ? defaultValue : pageNumber
+}
+
+module.exports = { getPageOffset, parsePage }

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -120,7 +120,7 @@ describe('Export pipeline list', () => {
 
   before(() => {
     cy.setUserFeatures(['export-pipeline'])
-    cy.intercept('GET', '/api-proxy/v4/export?limit=10&page=1', {
+    cy.intercept('GET', '/api-proxy/v4/export?limit=10&page=1&offset=0', {
       body: {
         count: exportList.length,
         results: exportList,

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -115,12 +115,12 @@ describe('Export pipeline list', () => {
     created_on: '2023-01-18T09:39:39.998239Z',
   })
 
-  const otherExports = exportListFaker(7)
+  const otherExports = exportListFaker(8)
   const exportList = [active, won, inactive, ...otherExports]
 
   before(() => {
     cy.setUserFeatures(['export-pipeline'])
-    cy.intercept('GET', '/api-proxy/v4/export', {
+    cy.intercept('GET', '/api-proxy/v4/export?limit=10&page=1', {
       body: {
         count: exportList.length,
         results: exportList,
@@ -208,5 +208,12 @@ describe('Export pipeline list', () => {
     cy.get('[data-test="export-details"]').should('be.visible')
     cy.get('[data-test="toggle-section-button"]').contains('Hide').click()
     cy.get('[data-test="export-details"]').should('not.be.visible')
+  })
+
+  it('should show the pagination', () => {
+    cy.get('[data-test="pagination"]').should('be.visible')
+    cy.get('[data-test="page-number-active"]').should('have.text', '1')
+    cy.get('[data-test="page-number"]').and('have.text', 2)
+    cy.get('[data-test="next"]').should('be.visible')
   })
 })


### PR DESCRIPTION
## Description of change
Adds pagination to the export pipeline list

## Test instructions
Within the dev environment add the `export-pipeline` user feature flag and go to `/export` in the browser.

## Screenshots
### Before
<img width="783" alt="Screenshot 2023-04-03 at 13 46 25" src="https://user-images.githubusercontent.com/964268/229513888-d20b5d53-c66a-415e-8ba0-34b952f6e5d5.png">

### After
<img width="776" alt="Screenshot 2023-04-03 at 13 42 26" src="https://user-images.githubusercontent.com/964268/229512714-6b8fd87e-c72b-498a-8569-7db3760cc41d.png">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
