### PR TITLE
Update link for Lead ITA to go to lead adviser tab

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/AccountManagementCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/AccountManagementCard.jsx
@@ -83,9 +83,7 @@ const AccountManagementCard = ({ company, queryString }) => {
         heading={company.isItaTierDAccount ? 'Lead ITA' : 'Account Manager'}
       >
         {company?.one_list_group_global_account_manager?.name ? (
-          <Link
-            href={`/contacts/${company.one_list_group_global_account_manager.id}`}
-          >
+          <Link href={`/companies/${company.id}/advisers`}>
             {company.one_list_group_global_account_manager.name}
           </Link>
         ) : (

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -263,7 +263,7 @@ describe('Company overview page', () => {
         .click()
       cy.location('pathname').should(
         'eq',
-        '/contacts/8eefe6b4-2816-4e47-94b5-a13409dcef70/details'
+        '/companies/w2c34b41-1d5a-4b4b-7685-7c53ff2868dg/advisers'
       )
       cy.go('back')
     })
@@ -291,7 +291,7 @@ describe('Company overview page', () => {
           .click()
         cy.location('pathname').should(
           'eq',
-          '/contacts/926440d6-b519-4b66-b4fd-af1646ae69ba/details'
+          '/companies/ba8fae21-2895-47cf-90ba-9273c94dab88/advisers'
         )
         cy.go('back')
       })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -263,7 +263,7 @@ describe('Company overview page', () => {
         .click()
       cy.location('pathname').should(
         'eq',
-        '/companies/w2c34b41-1d5a-4b4b-7685-7c53ff2868dg/advisers'
+        `/companies/${fixtures.company.oneListTierDita.id}/advisers`
       )
       cy.go('back')
     })
@@ -291,7 +291,7 @@ describe('Company overview page', () => {
           .click()
         cy.location('pathname').should(
           'eq',
-          '/companies/ba8fae21-2895-47cf-90ba-9273c94dab88/advisers'
+          `/companies/${fixtures.company.allOverviewDetails.id}/advisers`
         )
         cy.go('back')
       })


### PR DESCRIPTION
## Description of change

Lead ITA on account management tab was not linking correctly to the lead adviser tab. In the case that a company has an account manager instead, it will link to the core team tab.

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
