### PR TITLE
RR-789-switch-to-shared-transformer-function

### DIFF
--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -1,4 +1,7 @@
-const mapApiToField = ({ id, name }) => ({ value: id, label: name })
+import {
+  transformArrayIdNameToValueLabel,
+  transformIdNameToValueLabel,
+} from '../../transformers'
 
 export const transformFormValuesForAPI = ({
   company,
@@ -27,8 +30,8 @@ export const transformAPIValuesForForm = ({
   company: company.id,
   id,
   title,
-  owner: mapApiToField(owner),
-  team_members: team_members.map(mapApiToField),
+  owner: transformIdNameToValueLabel(owner),
+  team_members: transformArrayIdNameToValueLabel(team_members),
   destination_country:
-    destination_country && mapApiToField(destination_country),
+    destination_country && transformIdNameToValueLabel(destination_country),
 })

--- a/src/client/transformers/__test__/index.test.js
+++ b/src/client/transformers/__test__/index.test.js
@@ -1,0 +1,58 @@
+import {
+  transformIdNameToValueLabel,
+  transformArrayIdNameToValueLabel,
+} from '../index'
+
+describe('transformIdNameToValueLabel', () => {
+  context('When value is missing', () => {
+    it('should return null', () => {
+      expect(transformIdNameToValueLabel()).to.be.null
+    })
+  })
+
+  context('When value is a valid object', () => {
+    it('should return expected transformed object', () => {
+      expect(transformIdNameToValueLabel({ id: 1 })).to.deep.equal({
+        value: 1,
+        label: undefined,
+      })
+      expect(transformIdNameToValueLabel({ name: 'a' })).to.deep.equal({
+        value: undefined,
+        label: 'a',
+      })
+      expect(transformIdNameToValueLabel({ id: 2, name: 'b' })).to.deep.equal({
+        value: 2,
+        label: 'b',
+      })
+    })
+  })
+})
+
+describe('transformArrayIdNameToValueLabel', () => {
+  context('When value is missing', () => {
+    it('should return null', () => {
+      expect(transformArrayIdNameToValueLabel()).to.be.empty
+    })
+  })
+  context('When value is not a populated array', () => {
+    it('should return null', () => {
+      expect(transformArrayIdNameToValueLabel([])).to.be.empty
+    })
+  })
+  context('When value is a populated array', () => {
+    it('should return an array with expected transformed object', () => {
+      expect(transformArrayIdNameToValueLabel([{ id: 1 }])).to.deep.equal([
+        { value: 1, label: undefined },
+      ])
+      expect(
+        transformArrayIdNameToValueLabel([
+          { id: 2, name: 'a' },
+          { id: 3, name: 'd' },
+        ])
+      ).to.deep.equal([
+        { value: 2, label: 'a' },
+        { value: 3, label: 'd' },
+      ])
+    })
+  })
+})

--- a/src/client/transformers/__test__/index.test.js
+++ b/src/client/transformers/__test__/index.test.js
@@ -30,12 +30,12 @@ describe('transformIdNameToValueLabel', () => {
 
 describe('transformArrayIdNameToValueLabel', () => {
   context('When value is missing', () => {
-    it('should return null', () => {
+    it('should return an empty array', () => {
       expect(transformArrayIdNameToValueLabel()).to.be.empty
     })
   })
   context('When value is not a populated array', () => {
-    it('should return null', () => {
+    it('should return an empty array', () => {
       expect(transformArrayIdNameToValueLabel([])).to.be.empty
     })
   })


### PR DESCRIPTION
## Description of change

Use the transformer function in the index file for mapping id and name, instead of the custom one in the export pipeline transformer


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
