### PR TITLE
RR-799-export-experience-metadata

### DIFF
--- a/src/client/components/Resource/ExportExperience.js
+++ b/src/client/components/Resource/ExportExperience.js
@@ -1,0 +1,3 @@
+import { createMetadataResource } from '.'
+
+export default createMetadataResource('ExportExperience', 'export-experience')

--- a/src/client/components/Resource/tasks.js
+++ b/src/client/components/Resource/tasks.js
@@ -21,6 +21,7 @@ import Event from './Event'
 import CompanyOneListTeam from './CompanyOneListTeam'
 import ExportYears from './ExportYears'
 import ExportExperienceCategories from './ExportExperienceCategories'
+import ExportExperience from './ExportExperience'
 
 export default {
   ...Advisers.tasks,
@@ -46,4 +47,5 @@ export default {
   ...CompanyOneListTeam.tasks,
   ...ExportYears.tasks,
   ...ExportExperienceCategories.tasks,
+  ...ExportExperience.tasks,
 }

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -99,6 +99,7 @@ const metadataItems = [
   ['likelihood-to-land', 'likelihoodToLandOptions'],
   ['trade-agreement', 'tradeAgreementOptions'],
   ['export-years', 'exportYears'],
+  ['export-experience', 'exportExperience'],
 ]
 
 const restrictedServiceKeys = [

--- a/src/middleware/metadata-api-proxy.js
+++ b/src/middleware/metadata-api-proxy.js
@@ -57,6 +57,7 @@ const ALLOWLIST = [
   '/v4/metadata/large-capital-opportunity/opportunity-status',
   '/v4/metadata/export-years',
   '/v4/metadata/export-experience-category',
+  '/v4/metadata/export-experience',
 ]
 
 module.exports = (app) => {

--- a/test/sandbox/routes/v4/export/exports.js
+++ b/test/sandbox/routes/v4/export/exports.js
@@ -8,7 +8,7 @@ const generateExport = () => {
   const { id: sectorId, name: sectorName } = faker.helpers.arrayElement(sector)
   const { id: countryId, name: countryName } =
     faker.helpers.arrayElement(country)
-  const { id: exportExperienceId } =
+  const { id: exportExperienceId, name: exportExperienceName } =
     faker.helpers.arrayElement(exporterExperience)
 
   return {
@@ -25,7 +25,7 @@ const generateExport = () => {
       name: countryName,
     },
     sector: { id: sectorId, name: sectorName },
-    exporter_experience: exportExperienceId,
+    exporter_experience: { id: exportExperienceId, name: exportExperienceName },
     estimated_export_value_years: faker.helpers.arrayElement(estimatedYears),
     created_on: faker.date.past(),
     modified_on: faker.date.past(),

--- a/test/sandbox/routes/v4/metadata/index.js
+++ b/test/sandbox/routes/v4/metadata/index.js
@@ -53,6 +53,7 @@ var capitalInvestmentStatusTypes = require('../../../fixtures/metadata/capital-i
 var oneListTier = require('../../../fixtures/v4/metadata/one-list-tier.json')
 var tradeAgreement = require('../../../fixtures/v4/metadata/trade-agreement.json')
 var estimatedYears = require('../../../fixtures/v4/export/estimated-years.json')
+var exportExperience = require('../../../fixtures/v4/export/export-experience.json')
 
 exports.likelihoodToLand = function (req, res) {
   res.json(likelihoodToLand)
@@ -277,4 +278,8 @@ exports.tradeAgreement = function (req, res) {
 
 exports.exportYears = function (req, res) {
   res.json(estimatedYears)
+}
+
+exports.exportExperience = function (req, res) {
+  res.json(exportExperience)
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -320,6 +320,7 @@ app.get(
 app.get('/v4/metadata/one-list-tier', v4Metadata.oneListTier)
 app.get('/v4/metadata/trade-agreement', v4Metadata.tradeAgreement)
 app.get('/v4/metadata/export-years', v4Metadata.exportYears)
+app.get('/v4/metadata/export-experience', v4Metadata.exportExperience)
 
 // Ping
 app.get('/ping.xml', healthcheck.ping)


### PR DESCRIPTION
## Description of change

- Added metadata resource for export experience, needed in future PR
- Updated exports faker file so `exporter_experience` has an `id` and `name` property, to match the api


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
