### PR TITLE
Update links on contacts page and interactions page to go to overview…

### DIFF
--- a/src/client/components/ContactLocalHeader/index.jsx
+++ b/src/client/components/ContactLocalHeader/index.jsx
@@ -73,7 +73,7 @@ const ContactLocalHeader = ({ contact, writeFlashMessage }) => {
           <GridCol>
             <StyledLink
               data-test="company-link"
-              href={urls.companies.details(contact.company.id)}
+              href={urls.companies.overview.index(contact.company.id)}
             >
               {contact.company.name}
             </StyledLink>

--- a/src/client/modules/Interactions/InteractionDetails/transformers.js
+++ b/src/client/modules/Interactions/InteractionDetails/transformers.js
@@ -47,7 +47,9 @@ export const transformCompany = (companyObject, companyArray) => {
     <SummaryTable.Row
       heading="Company"
       children={
-        <Link href={urls.companies.details(company.id)}>{company.name}</Link>
+        <Link href={urls.companies.overview.index(company.id)}>
+          {company.name}
+        </Link>
       }
     />
   )

--- a/test/component/cypress/specs/ContactLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/ContactLocalHeader.cy.jsx
@@ -9,7 +9,7 @@ const archivedContact = require('../../../sandbox/fixtures/v3/contact/contact-ar
 const notPrimaryContact = require('../../../sandbox/fixtures/v3/contact/contact-incomplete-details-uk.json')
 
 const companyName = primaryContact.company.name
-const companyLink = urls.companies.details(primaryContact.company.id)
+const companyLink = urls.companies.overview.index(primaryContact.company.id)
 const contactName = primaryContact.name
 const addInteractionUrl = urls.companies.interactions.create(
   primaryContact.company.id

--- a/test/functional/cypress/specs/interaction/details-spec.js
+++ b/test/functional/cypress/specs/interaction/details-spec.js
@@ -22,7 +22,7 @@ const {
 } = fixtures
 
 const companyObject = {
-  href: companies.details(fixtures.company.venusLtd.id),
+  href: companies.overview.index(fixtures.company.venusLtd.id),
   name: fixtures.company.venusLtd.name,
 }
 


### PR DESCRIPTION
… and not activity tabs

## Description of change

Links now redirect to overview tab and not activity tab to match reordering of tabs.

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
