### PR TITLE
RR-789-refactor-export-form-state

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -18,7 +18,7 @@ function useQuery() {
   return React.useMemo(() => new URLSearchParams(search), [search])
 }
 
-const getBreadcrumbs = (company) => {
+const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
       link: urls.dashboard(),
@@ -30,12 +30,12 @@ const getBreadcrumbs = (company) => {
     },
   ]
 
-  if (company) {
+  if (exportItem) {
     return [
       ...defaultBreadcrumbs,
       {
-        link: urls.companies.activity.index(company.id),
-        text: company.name,
+        link: urls.companies.activity.index(exportItem.company.id),
+        text: exportItem.company.name,
       },
       { text: 'Add export' },
     ]
@@ -44,16 +44,16 @@ const getBreadcrumbs = (company) => {
   return [...defaultBreadcrumbs, { text: 'Add export' }]
 }
 
-const ExportFormAdd = ({ company, currentAdviserId, currentAdviserName }) => {
+const ExportFormAdd = ({ exportItem }) => {
   let query = useQuery()
   const companyId = query.get('companyId')
 
   return (
     <DefaultLayout
       heading={DISPLAY_ADD_EXPORT}
-      subheading={company?.name}
+      subheading={exportItem?.company?.name}
       pageTitle={DISPLAY_ADD_EXPORT}
-      breadcrumbs={getBreadcrumbs(company)}
+      breadcrumbs={getBreadcrumbs(exportItem)}
       useReactRouter={false}
     >
       <ExportFormFields
@@ -67,18 +67,10 @@ const ExportFormAdd = ({ company, currentAdviserId, currentAdviserName }) => {
             onSuccessDispatch: COMPANY_LOADED,
           },
         }}
-        initialValues={{
-          owner: { id: currentAdviserId, name: currentAdviserName },
-          company: { id: companyId },
-          team_members: [],
-          estimated_export_value_years: {},
-          estimated_win_date: {},
-          exporter_experience: {},
-        }}
+        exportItem={exportItem}
         cancelRedirectUrl={urls.companies.activity.index(companyId)}
         redirectToUrl={urls.dashboard()}
         flashMessage={({ data }) => `'${data.title}' created`}
-        formDataLoaded={!!company}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -59,11 +59,10 @@ const ExportFormEdit = ({ exportItem }) => {
             onSuccessDispatch: EXPORT_LOADED,
           },
         }}
-        initialValues={exportItem}
+        exportItem={exportItem}
         cancelRedirectUrl={urls.dashboard()}
         redirectToUrl={urls.exportPipeline.edit(exportId)}
         flashMessage={({ data }) => `Changes saved to '${data.title}'`}
-        formDataLoaded={!!exportItem}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -30,17 +30,16 @@ import CountriesResource from '../../../../client/components/Resource/Countries'
 import ExportExperience from '../../../components/Resource/ExportExperience'
 
 const ExportFormFields = ({
-  initialValues,
   analyticsFormName,
   flashMessage,
   cancelRedirectUrl,
   redirectToUrl,
-  formDataLoaded,
+  exportItem,
   taskProps = {},
 }) => (
   <Task.Status {...taskProps}>
     {() =>
-      formDataLoaded && (
+      exportItem && (
         <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
           <Form
             id="export-form"
@@ -48,9 +47,7 @@ const ExportFormFields = ({
             cancelRedirectTo={() => cancelRedirectUrl}
             redirectTo={() => redirectToUrl}
             submissionTaskName={TASK_SAVE_EXPORT}
-            initialValues={
-              initialValues && transformAPIValuesForForm(initialValues)
-            }
+            initialValues={exportItem && transformAPIValuesForForm(exportItem)}
             transformPayload={(values) => ({ exportId: values.id, values })}
             flashMessage={flashMessage}
           >

--- a/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
+++ b/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
@@ -1,0 +1,65 @@
+import { ID as COMPANY_DETAILS_ID } from '../../../Companies/CompanyDetails/state'
+import { ID as EXPORT_DETAILS_ID } from '../../../ExportPipeline/ExportDetails/state'
+
+import { state2props } from '../state'
+
+describe('state2props', () => {
+  context('when company and exportItem state values are null', () => {
+    it('should return exportItem prop as empty object', () => {
+      expect(
+        state2props({ [COMPANY_DETAILS_ID]: {}, [EXPORT_DETAILS_ID]: {} })
+      ).to.deep.equal({
+        exportItem: null,
+      })
+    })
+  })
+
+  context(
+    'when company in state is not null and exportItem in state is null',
+    () => {
+      let state2propsResult
+      beforeEach(() => {
+        state2propsResult = state2props({
+          [COMPANY_DETAILS_ID]: { company: { id: 1, name: 'a' } },
+          [EXPORT_DETAILS_ID]: {},
+          currentAdviserId: 2,
+          currentAdviserName: 'b',
+        }).exportItem
+      })
+
+      it('should return exportItem prop with company details populated from the company in state and owner set to logged in user', () => {
+        expect(state2propsResult).to.deep.include({
+          company: { id: 1, name: 'a' },
+        })
+      })
+      it('should return exportItem prop with owner set to current adviser', () => {
+        expect(state2propsResult).to.deep.include({
+          owner: { id: 2, name: 'b' },
+        })
+      })
+      it('should return exportItem prop with empty defaults for meta data fields', () => {
+        expect(state2propsResult).to.deep.include({
+          team_members: [],
+          estimated_export_value_years: {},
+          estimated_win_date: {},
+          exporter_experience: {},
+        })
+      })
+    }
+  )
+
+  context('when company and exportItem state values are not null', () => {
+    it('should return exportItem prop with company details populated from the exportItem in state', () => {
+      expect(
+        state2props({
+          [COMPANY_DETAILS_ID]: { company: { id: 1, name: 'a' } },
+          [EXPORT_DETAILS_ID]: {
+            exportItem: { company: { id: 2, name: 'b' } },
+          },
+        })
+      ).to.deep.equal({
+        exportItem: { company: { id: 2, name: 'b' } },
+      })
+    })
+  })
+})

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -1,11 +1,30 @@
 import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
-import { ID as Export_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
+import { ID as EXPORT_DETAILS_ID } from '../../ExportPipeline/ExportDetails/state'
 
 export const TASK_SAVE_EXPORT = 'TASK_SAVE_EXPORT'
 
-export const state2props = (state) => ({
-  company: state[COMPANY_DETAILS_ID].company,
-  exportItem: state[Export_DETAILS_ID].exportItem,
-  currentAdviserId: state.currentAdviserId,
-  currentAdviserName: state.currentAdviserName,
-})
+export const state2props = (state) => {
+  const currentAdviserId = state.currentAdviserId
+  const currentAdviserName = state.currentAdviserName
+  const company = state[COMPANY_DETAILS_ID].company
+  const exportItem = state[EXPORT_DETAILS_ID].exportItem
+
+  if (exportItem) {
+    return { exportItem }
+  }
+
+  if (company) {
+    return {
+      exportItem: {
+        company,
+        owner: { id: currentAdviserId, name: currentAdviserName },
+        team_members: [],
+        estimated_export_value_years: {},
+        estimated_win_date: {},
+        exporter_experience: {},
+      },
+    }
+  }
+
+  return { exportItem: null }
+}

--- a/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
@@ -20,16 +20,16 @@ describe('ExportFormFields', () => {
     </DataHubProvider>
   )
 
-  context('When formDataLoaded is false', () => {
+  context('When exportItem is null', () => {
     it('should not render the <Form> component', () => {
-      cy.mount(<Component formDataLoaded={false} />)
+      cy.mount(<Component exportItem={null} />)
       cy.get('form').should('not.exist')
     })
   })
 
-  context('When formDataLoaded is true', () => {
+  context('When exportItem is an object', () => {
     it('should render the <Form> component', () => {
-      cy.mount(<Component formDataLoaded={true} />)
+      cy.mount(<Component exportItem={{ company: 1 }} />)
       cy.get('form').should('exist')
     })
   })

--- a/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/ExportFormFields.cy.jsx
@@ -29,7 +29,15 @@ describe('ExportFormFields', () => {
 
   context('When exportItem is an object', () => {
     it('should render the <Form> component', () => {
-      cy.mount(<Component exportItem={{ company: 1 }} />)
+      cy.mount(
+        <Component
+          exportItem={{
+            company: 1,
+            estimated_export_value_years: {},
+            exporter_experience: {},
+          }}
+        />
+      )
       cy.get('form').should('exist')
     })
   })


### PR DESCRIPTION
In preparation for an upcoming change where the state of the form needs to be saved to allow navigating to the add contact page, this PR simplifies the logic for state management of the form by moving all logic into the `state2props` function.


## Test instructions

All visible logic remains as is. Unit tests added to `src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js` to handle this change


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
