### PR TITLE
bugfix/RR-798-fix-date-conversion-bug

### DIFF
--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -2,7 +2,7 @@ import {
   transformArrayIdNameToValueLabel,
   transformIdNameToValueLabel,
 } from '../../transformers'
-import { convertDateToFieldDateObject } from '../../utils/date'
+import { convertDateToFieldShortDateObject } from '../../utils/date'
 
 export const transformFormValuesForAPI = ({
   company,
@@ -59,7 +59,7 @@ export const transformAPIValuesForForm = ({
   team_members: transformArrayIdNameToValueLabel(team_members),
   estimated_export_value_years: estimated_export_value_years.id,
   estimated_export_value_amount: estimated_export_value_amount,
-  estimated_win_date: convertDateToFieldDateObject(estimated_win_date),
+  estimated_win_date: convertDateToFieldShortDateObject(estimated_win_date),
   destination_country:
     destination_country && transformIdNameToValueLabel(destination_country),
   sector: sector && transformIdNameToValueLabel(sector),

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -1,0 +1,23 @@
+import { convertDateToFieldShortDateObject } from '../date'
+
+describe('convertDateToFieldShortDateObject', () => {
+  context('when called with an invalid date', () => {
+    it('should return an empty short date format object', () => {
+      expect(convertDateToFieldShortDateObject('ab')).to.deep.equal({
+        month: '',
+        year: '',
+      })
+    })
+  })
+
+  context('when called with a valid date', () => {
+    it('should return a short date format object with month and year correctly populated', () => {
+      expect(
+        convertDateToFieldShortDateObject('2025-05-07T12:44:54')
+      ).to.deep.equal({
+        month: 5,
+        year: 2025,
+      })
+    })
+  })
+})

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -259,7 +259,7 @@ function formatStartAndEndDate(startDate, endDate) {
  * @param {*} date a string representing a date or a Date type
  * @returns an object of the format {month:'', year:''}
  */
-function convertDateToFieldDateObject(date) {
+function convertDateToFieldShortDateObject(date) {
   const parsedTime = parseISO(date)
   if (isValid(parsedTime)) {
     return {
@@ -267,7 +267,7 @@ function convertDateToFieldDateObject(date) {
       year: parsedTime.getFullYear(),
     }
   }
-  return date
+  return { month: '', year: '' }
 }
 
 module.exports = {
@@ -304,5 +304,5 @@ module.exports = {
   transformValueForAPI,
   createDateFromObject,
   formatStartAndEndDate,
-  convertDateToFieldDateObject,
+  convertDateToFieldShortDateObject,
 }


### PR DESCRIPTION
## Description of change

Fixes an issue where an invalid date should return an object in the format needed by a `<FieldDate />` component, not the original date string which causes rendering issues.

Rename the function to make it more explicit that the return value is in the short format


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
