### PR TITLE
Ccit 368 max 10 overview export country list

### DIFF
--- a/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
+++ b/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
@@ -21,7 +21,8 @@ const CompanyOverview = ({
   company,
   companiesHouseLink,
   exportCountriesInformation,
-  futureInterestCountries,
+  numberOfFutureInterestCountries,
+  maximumTenFutureInterestCountries,
 }) => {
   const queryString = `/companies/${company.id}`
   return (
@@ -47,7 +48,10 @@ const CompanyOverview = ({
               company={company}
               queryString={queryString}
               exportCountriesInformation={exportCountriesInformation}
-              futureInterestCountries={futureInterestCountries}
+              numberOfFutureInterestCountries={numberOfFutureInterestCountries}
+              maximumTenFutureInterestCountries={
+                maximumTenFutureInterestCountries
+              }
             />
           </CardContainer>
           <CardContainer>

--- a/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
+++ b/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
@@ -20,7 +20,6 @@ const CardContainer = styled('div')`
 const CompanyOverview = ({
   company,
   companiesHouseLink,
-  exportCountriesInformation,
   numberOfCurrentExportCountries,
   maximumTenCurrentExportCountries,
   numberOfFutureInterestCountries,
@@ -49,7 +48,6 @@ const CompanyOverview = ({
             <ExportStatus
               company={company}
               queryString={queryString}
-              exportCountriesInformation={exportCountriesInformation}
               numberOfCurrentExportCountries={numberOfCurrentExportCountries}
               maximumTenCurrentExportCountries={
                 maximumTenCurrentExportCountries

--- a/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
+++ b/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
@@ -21,6 +21,8 @@ const CompanyOverview = ({
   company,
   companiesHouseLink,
   exportCountriesInformation,
+  numberOfCurrentExportCountries,
+  maximumTenCurrentExportCountries,
   numberOfFutureInterestCountries,
   maximumTenFutureInterestCountries,
 }) => {
@@ -48,6 +50,10 @@ const CompanyOverview = ({
               company={company}
               queryString={queryString}
               exportCountriesInformation={exportCountriesInformation}
+              numberOfCurrentExportCountries={numberOfCurrentExportCountries}
+              maximumTenCurrentExportCountries={
+                maximumTenCurrentExportCountries
+              }
               numberOfFutureInterestCountries={numberOfFutureInterestCountries}
               maximumTenFutureInterestCountries={
                 maximumTenFutureInterestCountries

--- a/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
+++ b/src/apps/companies/apps/company-overview/client/CompanyOverview.jsx
@@ -17,7 +17,12 @@ const CardContainer = styled('div')`
   margin-bottom: 20px;
 `
 
-const CompanyOverview = ({ company, companiesHouseLink }) => {
+const CompanyOverview = ({
+  company,
+  companiesHouseLink,
+  exportCountriesInformation,
+  futureInterestCountries,
+}) => {
   const queryString = `/companies/${company.id}`
   return (
     <>
@@ -38,7 +43,12 @@ const CompanyOverview = ({ company, companiesHouseLink }) => {
             />
           </CardContainer>
           <CardContainer>
-            <ExportStatus company={company} queryString={queryString} />
+            <ExportStatus
+              company={company}
+              queryString={queryString}
+              exportCountriesInformation={exportCountriesInformation}
+              futureInterestCountries={futureInterestCountries}
+            />
           </CardContainer>
           <CardContainer>
             <InvestmentStatusCard

--- a/src/apps/companies/apps/company-overview/controllers.js
+++ b/src/apps/companies/apps/company-overview/controllers.js
@@ -24,17 +24,22 @@ async function renderOverview(req, res) {
   const { exportCountriesInformation } =
     transformCompanyToExportDetailsView(company)
 
-  const numberOfCurrentExportCountries =
-    exportCountriesInformation[0].values.length
+  const maximumTenCountries = (countries, maxCount) =>
+    countries.slice(0, maxCount)
 
-  const maximumTenCurrentExportCountries =
-    exportCountriesInformation[0].values.slice(0, 10)
+  const numberOfCurrentExportCountries =
+    exportCountriesInformation[0]?.values?.length || 0
+  const maximumTenCurrentExportCountries = maximumTenCountries(
+    exportCountriesInformation[0]?.values || [],
+    10
+  )
 
   const numberOfFutureInterestCountries =
-    exportCountriesInformation[1].values.length
-
-  const maximumTenFutureInterestCountries =
-    exportCountriesInformation[1].values.slice(0, 10)
+    exportCountriesInformation[1]?.values?.length || 0
+  const maximumTenFutureInterestCountries = maximumTenCountries(
+    exportCountriesInformation[1]?.values || [],
+    10
+  )
 
   res.render('companies/apps/company-overview/views/client-container', {
     props: {

--- a/src/apps/companies/apps/company-overview/controllers.js
+++ b/src/apps/companies/apps/company-overview/controllers.js
@@ -24,6 +24,12 @@ async function renderOverview(req, res) {
   const { exportCountriesInformation } =
     transformCompanyToExportDetailsView(company)
 
+  const numberOfCurrentExportCountries =
+    exportCountriesInformation[0].values.length
+
+  const maximumTenCurrentExportCountries =
+    exportCountriesInformation[0].values.slice(0, 10)
+
   const numberOfFutureInterestCountries =
     exportCountriesInformation[1].values.length
 
@@ -38,6 +44,8 @@ async function renderOverview(req, res) {
       urls,
       companiesHouseLink,
       exportCountriesInformation,
+      numberOfCurrentExportCountries,
+      maximumTenCurrentExportCountries,
       numberOfFutureInterestCountries,
       maximumTenFutureInterestCountries,
     },

--- a/src/apps/companies/apps/company-overview/controllers.js
+++ b/src/apps/companies/apps/company-overview/controllers.js
@@ -1,5 +1,9 @@
 const urls = require('../../../../lib/urls')
 
+const {
+  transformCompanyToExportDetailsView,
+} = require('../exports/transformer')
+
 async function renderOverview(req, res) {
   const { company } = res.locals
 
@@ -17,6 +21,14 @@ async function renderOverview(req, res) {
     company.company_number
   )
 
+  const { exportCountriesInformation } =
+    transformCompanyToExportDetailsView(company)
+
+  const futureInterestCountries = []
+  for (let i in exportCountriesInformation[1].values) {
+    futureInterestCountries.push(i.name)
+  }
+
   res.render('companies/apps/company-overview/views/client-container', {
     props: {
       breadcrumbs,
@@ -24,6 +36,8 @@ async function renderOverview(req, res) {
       localNavItems: res.locals.localNavItems,
       urls,
       companiesHouseLink,
+      exportCountriesInformation,
+      futureInterestCountries,
     },
   })
 }

--- a/src/apps/companies/apps/company-overview/controllers.js
+++ b/src/apps/companies/apps/company-overview/controllers.js
@@ -24,10 +24,11 @@ async function renderOverview(req, res) {
   const { exportCountriesInformation } =
     transformCompanyToExportDetailsView(company)
 
-  const futureInterestCountries = []
-  for (let i in exportCountriesInformation[1].values) {
-    futureInterestCountries.push(i.name)
-  }
+  const numberOfFutureInterestCountries =
+    exportCountriesInformation[1].values.length
+
+  const maximumTenFutureInterestCountries =
+    exportCountriesInformation[1].values.slice(0, 10)
 
   res.render('companies/apps/company-overview/views/client-container', {
     props: {
@@ -37,7 +38,8 @@ async function renderOverview(req, res) {
       urls,
       companiesHouseLink,
       exportCountriesInformation,
-      futureInterestCountries,
+      numberOfFutureInterestCountries,
+      maximumTenFutureInterestCountries,
     },
   })
 }

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -125,7 +125,6 @@ const ExportStatus = ({
   activePage,
   company,
   queryString,
-  exportCountriesInformation,
   numberOfCurrentExportCountries,
   maximumTenCurrentExportCountries,
   numberOfFutureInterestCountries,

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -31,6 +31,13 @@ const StyledTD = styled('td')`
   border: 0;
 `
 
+const StyledDiv = styled('div')`
+  display: flex;
+  flex-wrap: wrap;
+  padding: 0;
+  border: 0;
+`
+
 const StyledLastTableCell = styled(Table.Cell)`
   border: 0;
   padding-bottom: 0;
@@ -79,18 +86,18 @@ const CurrentExportingCountries = ({
   company,
 }) => {
   return (
-    <StyledTD>
+    <StyledDiv data-test="current-export-list">
       {maximumTenCurrentExportCountries.map((country) => (
         <div key={country.id}>
           <StyledLink
             href={`/companies/${company.id}/exports/history/${country.id}`}
-            data-test="export-status-country-of-interest-link"
+            data-test={`current-export-country-link ${country.name}`}
           >
             {country.name}
           </StyledLink>
         </div>
       ))}
-    </StyledTD>
+    </StyledDiv>
   )
 }
 
@@ -99,18 +106,18 @@ const FutureInterestCountries = ({
   company,
 }) => {
   return (
-    <StyledTD>
+    <StyledDiv data-test="future-interest-list">
       {maximumTenFutureInterestCountries.map((country) => (
         <div key={country.id}>
           <StyledLink
             href={`/companies/${company.id}/exports/history/${country.id}`}
-            data-test="export-status-country-of-interest-link"
+            data-test={`export-future-country-of-interest-link ${country.name}`}
           >
             {country.name}
           </StyledLink>
         </div>
       ))}
-    </StyledTD>
+    </StyledDiv>
   )
 }
 

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -43,6 +43,12 @@ const StyledLink = styled(Link)`
   color: grey;
   margin-right: 5px;
 `
+const StyledViewMoreLink = styled(Link)`
+  font-size: 12px;
+  color: grey;
+  margin-right: 5px;
+`
+
 const GreenLabel = styled('span')`
   background-color: #cce2d9;
   color: #005b30;
@@ -66,6 +72,26 @@ export const SUBSEGMENT = {
   promote_communicate_benefits: 'Promote: communicate benefits',
   promote_change_the_game: 'Promote: change the game',
   challenge: 'Challenge',
+}
+
+const CurrentExportingCountries = ({
+  maximumTenCurrentExportCountries,
+  company,
+}) => {
+  return (
+    <StyledTD>
+      {maximumTenCurrentExportCountries.map((country) => (
+        <div key={country.id}>
+          <StyledLink
+            href={`/companies/${company.id}/exports/history/${country.id}`}
+            data-test="export-status-country-of-interest-link"
+          >
+            {country.name}
+          </StyledLink>
+        </div>
+      ))}
+    </StyledTD>
+  )
 }
 
 const FutureInterestCountries = ({
@@ -93,6 +119,8 @@ const ExportStatus = ({
   company,
   queryString,
   exportCountriesInformation,
+  numberOfCurrentExportCountries,
+  maximumTenCurrentExportCountries,
   numberOfFutureInterestCountries,
   maximumTenFutureInterestCountries,
   ...props
@@ -141,39 +169,44 @@ const ExportStatus = ({
             )}
           </SummaryTable.Row>
           <SummaryTable.Row heading="Currently exporting to">
-            {company.export_to_countries?.length > 0 ? (
-              <StyledTD>
-                {company.export_to_countries.map((country) => (
-                  <span>
-                    <StyledLink
-                      href={`/companies/${company.id}/exports/history/${country.id}`}
-                      data-test="export-status-currently-exporting-to-link"
-                    >
-                      {country.name}
-                    </StyledLink>
-                    &nbsp;
-                  </span>
-                ))}
-              </StyledTD>
+            {numberOfCurrentExportCountries ? (
+              <CurrentExportingCountries
+                maximumTenCurrentExportCountries={
+                  maximumTenCurrentExportCountries
+                }
+                company={company}
+              />
             ) : (
               <StyledSpan>Not set</StyledSpan>
             )}
+            {numberOfCurrentExportCountries > 10 && (
+              <StyledViewMoreLink
+                href={`/companies/${company.id}/exports`}
+                data-test="export-status-currently-exporting-to-link"
+              >
+                {`View ${numberOfCurrentExportCountries - 10} more`}
+              </StyledViewMoreLink>
+            )}
           </SummaryTable.Row>
           <SummaryTable.Row heading="Future countries of interest">
-            <FutureInterestCountries
-              maximumTenFutureInterestCountries={
-                maximumTenFutureInterestCountries
-              }
-              company={company}
-            />
-            <StyledLink
-              href={`/companies/${company.id}/exports`}
-              data-test="export-status-future-exporting-to-link"
-            >
-              {numberOfFutureInterestCountries > 10
-                ? `View ${numberOfFutureInterestCountries - 10} more`
-                : 'View exports'}
-            </StyledLink>
+            {numberOfFutureInterestCountries ? (
+              <FutureInterestCountries
+                maximumTenFutureInterestCountries={
+                  maximumTenFutureInterestCountries
+                }
+                company={company}
+              />
+            ) : (
+              <StyledSpan>Not set</StyledSpan>
+            )}
+            {numberOfFutureInterestCountries > 10 && (
+              <StyledViewMoreLink
+                href={`/companies/${company.id}/exports`}
+                data-test="export-status-future-exporting-to-link"
+              >
+                {`View ${numberOfFutureInterestCountries - 10} more`}
+              </StyledViewMoreLink>
+            )}
           </SummaryTable.Row>
           <SummaryTable.Row heading="Last export win">
             {props.latestExportWin
@@ -185,7 +218,6 @@ const ExportStatus = ({
           <SummaryTable.Row heading="Total exports won">
             {props.count}
           </SummaryTable.Row>
-
           <StyledTableRow>
             <StyledLastTableCell colSpan={2}>
               <Link

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -67,7 +67,14 @@ export const SUBSEGMENT = {
   challenge: 'Challenge',
 }
 
-const ExportStatus = ({ activePage, company, queryString, ...props }) => {
+const ExportStatus = ({
+  activePage,
+  company,
+  queryString,
+  exportCountriesInformation,
+  futureInterestCountries,
+  ...props
+}) => {
   return (
     <Task.Status
       name={TASK_GET_LATEST_EXPORT_WINS}

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -13,6 +13,7 @@ import {
 import { connect } from 'react-redux'
 import { OVERVIEW__EXPORT_WINS_SUMMARY } from '../../../../../client/actions'
 import { format } from '../../../../../client/utils/date'
+import { kebabCase } from 'lodash'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin: 0;
@@ -47,12 +48,10 @@ const StyledSpan = styled('span')`
 `
 
 const StyledLink = styled(Link)`
-  color: grey;
   margin-right: 5px;
 `
 const StyledViewMoreLink = styled(Link)`
   font-size: 12px;
-  color: grey;
   margin-right: 5px;
 `
 
@@ -81,37 +80,14 @@ export const SUBSEGMENT = {
   challenge: 'Challenge',
 }
 
-const CurrentExportingCountries = ({
-  maximumTenCurrentExportCountries,
-  company,
-}) => {
+const Countries = ({ countries, company, divDataTest, linkDataTest }) => {
   return (
-    <StyledDiv data-test="current-export-list">
-      {maximumTenCurrentExportCountries.map((country) => (
+    <StyledDiv data-test={divDataTest}>
+      {countries.map((country) => (
         <div key={country.id}>
           <StyledLink
             href={`/companies/${company.id}/exports/history/${country.id}`}
-            data-test={`current-export-country-link ${country.name}`}
-          >
-            {country.name}
-          </StyledLink>
-        </div>
-      ))}
-    </StyledDiv>
-  )
-}
-
-const FutureInterestCountries = ({
-  maximumTenFutureInterestCountries,
-  company,
-}) => {
-  return (
-    <StyledDiv data-test="future-interest-list">
-      {maximumTenFutureInterestCountries.map((country) => (
-        <div key={country.id}>
-          <StyledLink
-            href={`/companies/${company.id}/exports/history/${country.id}`}
-            data-test={`export-future-country-of-interest-link ${country.name}`}
+            data-test={`${linkDataTest}-${kebabCase(country.name)}-link`}
           >
             {country.name}
           </StyledLink>
@@ -176,11 +152,11 @@ const ExportStatus = ({
           </SummaryTable.Row>
           <SummaryTable.Row heading="Currently exporting to">
             {numberOfCurrentExportCountries ? (
-              <CurrentExportingCountries
-                maximumTenCurrentExportCountries={
-                  maximumTenCurrentExportCountries
-                }
+              <Countries
                 company={company}
+                countries={maximumTenCurrentExportCountries}
+                divDataTest={'current-export-list'}
+                linkDataTest={'current-export-country'}
               />
             ) : (
               <StyledSpan>Not set</StyledSpan>
@@ -196,16 +172,16 @@ const ExportStatus = ({
           </SummaryTable.Row>
           <SummaryTable.Row heading="Future countries of interest">
             {numberOfFutureInterestCountries ? (
-              <FutureInterestCountries
-                maximumTenFutureInterestCountries={
-                  maximumTenFutureInterestCountries
-                }
+              <Countries
                 company={company}
+                countries={maximumTenFutureInterestCountries}
+                divDataTest={'future-export-list'}
+                linkDataTest={'future-export-country'}
               />
             ) : (
               <StyledSpan>Not set</StyledSpan>
             )}
-            {numberOfFutureInterestCountries > 10 && (
+            {numberOfCurrentExportCountries > 10 && (
               <StyledViewMoreLink
                 href={`/companies/${company.id}/exports`}
                 data-test="export-status-future-exporting-to-link"

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -41,6 +41,7 @@ const StyledSpan = styled('span')`
 
 const StyledLink = styled(Link)`
   color: grey;
+  margin-right: 5px;
 `
 const GreenLabel = styled('span')`
   background-color: #cce2d9;
@@ -67,12 +68,33 @@ export const SUBSEGMENT = {
   challenge: 'Challenge',
 }
 
+const FutureInterestCountries = ({
+  maximumTenFutureInterestCountries,
+  company,
+}) => {
+  return (
+    <StyledTD>
+      {maximumTenFutureInterestCountries.map((country) => (
+        <div key={country.id}>
+          <StyledLink
+            href={`/companies/${company.id}/exports/history/${country.id}`}
+            data-test="export-status-country-of-interest-link"
+          >
+            {country.name}
+          </StyledLink>
+        </div>
+      ))}
+    </StyledTD>
+  )
+}
+
 const ExportStatus = ({
   activePage,
   company,
   queryString,
   exportCountriesInformation,
-  futureInterestCountries,
+  numberOfFutureInterestCountries,
+  maximumTenFutureInterestCountries,
   ...props
 }) => {
   return (
@@ -138,23 +160,20 @@ const ExportStatus = ({
             )}
           </SummaryTable.Row>
           <SummaryTable.Row heading="Future countries of interest">
-            {company.future_interest_countries?.length > 0 ? (
-              <StyledTD>
-                {company.future_interest_countries.map((country) => (
-                  <span>
-                    <StyledLink
-                      href={`/companies/${company.id}/exports/history/${country.id}`}
-                      data-test="export-status-country-of-interest-link"
-                    >
-                      {country.name}
-                    </StyledLink>
-                    &nbsp;
-                  </span>
-                ))}
-              </StyledTD>
-            ) : (
-              <StyledSpan>Not set</StyledSpan>
-            )}
+            <FutureInterestCountries
+              maximumTenFutureInterestCountries={
+                maximumTenFutureInterestCountries
+              }
+              company={company}
+            />
+            <StyledLink
+              href={`/companies/${company.id}/exports`}
+              data-test="export-status-future-exporting-to-link"
+            >
+              {numberOfFutureInterestCountries > 10
+                ? `View ${numberOfFutureInterestCountries - 10} more`
+                : 'View exports'}
+            </StyledLink>
           </SummaryTable.Row>
           <SummaryTable.Row heading="Last export win">
             {props.latestExportWin

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -355,10 +355,15 @@ describe('Company overview page', () => {
           .contains('Export sub-segment')
           .siblings()
           .contains('td', 'Sustain: Nurture & grow')
-        cy.get('th')
-          .contains('Currently exporting to')
-          .siblings()
-          .contains('td', 'Western Sahara')
+        cy.get('[data-test="current-export-list"]')
+          .children()
+          .should('have.length.of.at.most', 10)
+        cy.get('[data-test="export-status-currently-exporting-to-link"]')
+          .contains('View 2 more')
+          .click()
+        cy.location('pathname').should('eq', companyExportsAllOverview)
+        cy.go('back')
+        cy.get('[data-test="exportStatusContainer"]').children()
         cy.get('th')
           .contains('Last export win')
           .siblings()
@@ -370,7 +375,12 @@ describe('Company overview page', () => {
         cy.get('th')
           .contains('Future countries of interest')
           .siblings()
-          .contains('td', 'Yemen')
+          .contains('td', 'Saint Helena')
+        cy.get('[data-test="export-status-future-exporting-to-link"]')
+          .contains('View 4 more')
+          .click()
+        cy.location('pathname').should('eq', companyExportsAllOverview)
+        cy.go('back')
       })
 
       it('the card should link to the export status overview page', () => {
@@ -381,22 +391,24 @@ describe('Company overview page', () => {
         cy.go('back')
       })
       it('the card should link to the export history page of the specific country', () => {
-        cy.get('[data-test="export-status-currently-exporting-to-link"]')
-          .contains('Western Sahara')
+        cy.get('[data-test="current-export-country-link Algeria"]')
+          .contains('Algeria')
           .click()
         cy.location('pathname').should(
           'eq',
-          `${companyExportsAllOverview}/history/36afd8d0-5d95-e211-a939-e4115bead28a`
+          `${companyExportsAllOverview}/history/955f66a0-5d95-e211-a939-e4115bead28a`
         )
         cy.go('back')
       })
       it('the card should link to the future countries of interest', () => {
-        cy.get('[data-test="export-status-country-of-interest-link"]')
-          .contains('Yemen')
+        cy.get(
+          '[data-test="export-future-country-of-interest-link Saint Helena"]'
+        )
+          .contains('Saint Helena')
           .click()
         cy.location('pathname').should(
           'eq',
-          `${companyExportsAllOverview}/history/37afd8d0-5d95-e211-a939-e4115bead28a`
+          `${companyExportsAllOverview}/history/dec8d80f-efe5-4190-a8e9-c8ccc38e7724`
         )
         cy.go('back')
       })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -391,7 +391,7 @@ describe('Company overview page', () => {
         cy.go('back')
       })
       it('the card should link to the export history page of the specific country', () => {
-        cy.get('[data-test="current-export-country-link Algeria"]')
+        cy.get('[data-test="current-export-country-algeria-link"]')
           .contains('Algeria')
           .click()
         cy.location('pathname').should(
@@ -401,9 +401,7 @@ describe('Company overview page', () => {
         cy.go('back')
       })
       it('the card should link to the future countries of interest', () => {
-        cy.get(
-          '[data-test="export-future-country-of-interest-link Saint Helena"]'
-        )
+        cy.get('[data-test="future-export-country-saint-helena-link"]')
           .contains('Saint Helena')
           .click()
         cy.location('pathname').should(

--- a/test/sandbox/fixtures/v4/company/company-all-overview-details.json
+++ b/test/sandbox/fixtures/v4/company/company-all-overview-details.json
@@ -224,25 +224,199 @@
   "duns_number": "121212121",
   "employee_range": null,
   "export_experience_category": null,
-  "export_to_countries": [
+  "export_countries": [
     {
-      "name": "Occupied Palestinian Territories",
-      "id": "35afd8d0-5d95-e211-a939-e4115bead28a"
+      "country": {
+        "id": "12341",
+        "name": "France"
+      },
+      "status": "currently_exporting"
     },
     {
-      "name": "Western Sahara",
-      "id": "36afd8d0-5d95-e211-a939-e4115bead28a"
+      "country": {
+        "id": "12342",
+        "name": "Germany"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12343",
+        "name": "Netherlands"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12344",
+        "name": "Canada"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12345",
+        "name": "Argentina"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12346",
+        "name": "Brazil"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12347",
+        "name": "Iceland"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "955f66a0-5d95-e211-a939-e4115bead28a",
+        "name": "Algeria"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12349",
+        "name": "Vietnam"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12340",
+        "name": "Australia"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "id": "12350",
+        "name": "Moldova"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "name": "Western Sahara",
+        "id": "36afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "currently_exporting"
+    },
+    {
+      "country": {
+        "name": "Saint Helena",
+        "id": "dec8d80f-efe5-4190-a8e9-c8ccc38e7724"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Samoa",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "San Marino",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Saudi Arabia",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Senegal",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Serbia",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Seychelles",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Sharjah",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Singapore",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Slovakia",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Slovenia",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Somalia",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Spain",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "name": "Sri Lanka",
+        "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
+      },
+      "status": "future_interest"
+    },
+    {
+      "country": {
+        "id": "4123",
+        "name": "Sweden"
+      },
+      "status": "not_interested"
     }
   ],
-
   "export_potential" : "High",
   "export_sub_segment":"sustain_nurture_and_grow",
-  "future_interest_countries": [
-    {
-      "name": "Yemen",
-      "id": "37afd8d0-5d95-e211-a939-e4115bead28a"
-    }
-  ],  "global_headquarters": null,
   "headquarter_type": null,
   "id": "ba8fae21-2895-47cf-90ba-9273c94dab88",
   "is_number_of_employees_estimated": true,


### PR DESCRIPTION
## Description of change

Refactor the overview page so that the exports card is using the same currently exporting and future countries of interest module as the Exports page. Also set the card to display a maximum of 10 countries per category.

## Test instructions

View a company with more than 10 companies currently exporting to or future countries of interest and the number over 10 will be displayed in a "View" link. This link does not appear where the number is 10 or less 

## Screenshots

![Screenshot 2023-04-19 at 09 38 09](https://user-images.githubusercontent.com/72826129/233018764-0d3251f1-cc33-4d5b-8a3d-27ff7d30a75f.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
