### PR TITLE
feature/RR-933-currency-field-formatting

### DIFF
--- a/src/client/components/Form/elements/FieldCurrency/index.jsx
+++ b/src/client/components/Form/elements/FieldCurrency/index.jsx
@@ -93,11 +93,12 @@ const FieldCurrency = ({
   })
 
   const [displayValue, setDisplayValue] = useState()
-  const [rawValue, setRawValue] = useState(value)
+  const [rawValue, setRawValue] = useState()
   const [editing, setEditing] = useState(false)
 
   useEffect(() => {
     if (!editing && value) {
+      setRawValue(value)
       setDisplayValue(decimal(value))
     }
   }, [value])

--- a/src/client/utils/__test__/number-utils.test.js
+++ b/src/client/utils/__test__/number-utils.test.js
@@ -1,0 +1,21 @@
+import { parseLocaleNumber } from '../number-utils'
+
+describe('parseLocaleNumber', () => {
+  context('when called with an empty value', () => {
+    it('should return the same value', () => {
+      expect(parseLocaleNumber('')).to.be.equal('')
+    })
+  })
+
+  context('when called with an invalid number', () => {
+    it('should return the same value', () => {
+      expect(parseLocaleNumber('123abc')).to.be.NaN
+    })
+  })
+
+  context('when called with a formatted number', () => {
+    it('should return the value with formatting removed', () => {
+      expect(parseLocaleNumber('100,00,559,6')).to.be.equal(100005596)
+    })
+  })
+})

--- a/src/client/utils/number-utils.js
+++ b/src/client/utils/number-utils.js
@@ -68,9 +68,9 @@ export const indexToOrdinal = (zeroBasedIndex) => {
 }
 
 /**
- * Parse a localized number to a float.
+ * Parse a string that has been formatted to a Number.
  * @param {string} stringNumber - the localized number
- * @param {string} locale - [optional] the locale that the number is represented in. Omit this parameter to use the current locale.
+ * @param {string} locale - [optional] the locale that the number is represented in. Omit this parameter to use the en-GB locale.
  */
 export const parseLocaleNumber = (stringNumber, locale = 'en-GB') => {
   if (!stringNumber.length) {

--- a/src/client/utils/number-utils.js
+++ b/src/client/utils/number-utils.js
@@ -66,3 +66,26 @@ export const indexToOrdinal = (zeroBasedIndex) => {
     return naturalIndex + 'rd'
   }
 }
+
+/**
+ * Parse a localized number to a float.
+ * @param {string} stringNumber - the localized number
+ * @param {string} locale - [optional] the locale that the number is represented in. Omit this parameter to use the current locale.
+ */
+export const parseLocaleNumber = (stringNumber, locale = 'en-GB') => {
+  if (!stringNumber.length) {
+    return stringNumber
+  }
+  var thousandSeparator = Intl.NumberFormat(locale)
+    .format(11111)
+    .replace(/\p{Number}/gu, '')
+  var decimalSeparator = Intl.NumberFormat(locale)
+    .format(1.1)
+    .replace(/\p{Number}/gu, '')
+
+  return Number(
+    stringNumber
+      .replace(new RegExp('\\' + thousandSeparator, 'g'), '')
+      .replace(new RegExp('\\' + decimalSeparator), '.')
+  )
+}

--- a/test/component/cypress/specs/Form/FieldCurrency.cy.jsx
+++ b/test/component/cypress/specs/Form/FieldCurrency.cy.jsx
@@ -19,6 +19,15 @@ describe('FieldCurrency', () => {
     cy.get('#currency-test').as('currencyInput')
   })
 
+  context('when a default value is provided', () => {
+    it('should set the value raw values to correct values', () => {
+      cy.mount(<Component initialValue={123456} />)
+      cy.get('@currencyInput')
+        .should('have.attr', 'value', decimal('123456'))
+        .should('have.attr', 'data-raw-value', '123456')
+    })
+  })
+
   context('when a non-numerical value is entered', () => {
     it('should not have any formatting applied', () => {
       cy.get('@currencyInput').type('abc').blur()

--- a/test/component/cypress/specs/Form/FieldCurrency.cy.jsx
+++ b/test/component/cypress/specs/Form/FieldCurrency.cy.jsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Form } from '../../../../../src/client/components'
+
+import FieldCurrency from '../../../../../src/client/components/Form/elements/FieldCurrency'
+import DataHubProvider from '../provider'
+import { decimal } from '../../../../../src/client/utils/number-utils'
+
+describe('FieldCurrency', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form id="export-form">
+        <FieldCurrency name="currency-test" {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+
+  beforeEach(() => {
+    cy.mount(<Component />)
+    cy.get('#currency-test').as('currencyInput')
+  })
+
+  context('when a non-numerical value is entered', () => {
+    it('should not have any formatting applied', () => {
+      cy.get('@currencyInput').type('abc').blur()
+      cy.get('@currencyInput')
+        .should('have.attr', 'value', 'abc')
+        .should('have.attr', 'data-raw-value', 'abc')
+    })
+  })
+
+  context('when a numerical value is entered', () => {
+    it('it should have currency formatting removed when editing the input', () => {
+      cy.get('@currencyInput').type('1000000000')
+      cy.get('@currencyInput')
+        .should('have.attr', 'value', '1000000000')
+        .should('have.attr', 'data-raw-value', '1000000000')
+    })
+
+    it('it should have currency formatting applied when leaving focus', () => {
+      cy.get('@currencyInput').type('1000000000').blur()
+      cy.get('@currencyInput')
+        .should('have.attr', 'value', decimal('1000000000'))
+        .should('have.attr', 'data-raw-value', '1000000000')
+    })
+
+    it('it should accept a user entering their own formatting', () => {
+      cy.get('@currencyInput').type('10,000').blur()
+      cy.get('@currencyInput')
+        .should('have.attr', 'value', decimal('10000'))
+        .should('have.attr', 'data-raw-value', '10000')
+    })
+
+    context(
+      'when a non numberical value is appended to a numerical value',
+      () => {
+        it('it should have currency formatting removed when leaving focus', () => {
+          cy.get('@currencyInput').type('10000').blur()
+          cy.get('@currencyInput')
+            .should('have.attr', 'value', decimal('10000'))
+            .should('have.attr', 'data-raw-value', '10000')
+
+          cy.get('@currencyInput').type('abc')
+          cy.get('@currencyInput').should(
+            'have.attr',
+            'data-raw-value',
+            '10000abc'
+          )
+          cy.get('@currencyInput').blur()
+          cy.get('@currencyInput').should('have.attr', 'value', '10000abc')
+        })
+      }
+    )
+  })
+})

--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -24,6 +24,7 @@ const {
   clearAndTypeInput,
   clearAndTypeTextArea,
 } = require('../../../support/actions')
+const { decimal } = require('../../../../../../src/client/utils/number-utils')
 
 const { oneListCorp: existingCompany, lambdaPlc: newCompany } = fixtures.company
 
@@ -66,7 +67,7 @@ describe('View large capital investor details page', () => {
           element,
           label: 'Global assets under management',
           hint: 'Enter value in US dollars',
-          value: '1000000',
+          value: decimal('1000000'),
         })
       })
     })
@@ -77,7 +78,7 @@ describe('View large capital investor details page', () => {
           element,
           label: 'Investable capital',
           hint: 'Enter value in US dollars',
-          value: '30000',
+          value: decimal('30000'),
         })
       })
     })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -1,3 +1,4 @@
+import { decimal } from '../../../../../src/client/utils/number-utils'
 import { contactFaker } from '../../fakers/contacts'
 import { addNewContact } from '../../support/actions'
 
@@ -142,7 +143,7 @@ describe('Export pipeline edit', () => {
             assertFieldInput({
               element,
               label: 'Estimated value in GBP',
-              value: exportItem.estimated_export_value_amount,
+              value: decimal(exportItem.estimated_export_value_amount),
             })
           }
         )


### PR DESCRIPTION
## Description of change

Added logic to the `<FieldCurrency />` component to display the value with currency formatting when the input does not have focus. When the input receives focus, remove any formatting to allow easier editing of the value

## Test instructions

The formatting has been added to the Total estimated export value component on the export form

## Screenshots
### Before
![chrome_LxhvO0wwWU](https://user-images.githubusercontent.com/102232401/234594833-453c15c8-6172-4953-be38-87ea5b6be6ab.gif)

### After
![chrome_1CC1E9z7J7](https://user-images.githubusercontent.com/102232401/234594813-b500704a-f2aa-40d3-b344-fcd8dc2cd183.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
