### PR TITLE
Fix fetchOptions redis expiration

### DIFF
--- a/src/lib/options.js
+++ b/src/lib/options.js
@@ -17,12 +17,9 @@ async function fetchOptions(req, url) {
   metaData = await hawkRequest(url)
 
   if (!config.isTest) {
-    await client.set(
-      url,
-      JSON.stringify(metaData),
-      'EX',
-      config.cacheDurationLong
-    )
+    await client.set(url, JSON.stringify(metaData), {
+      EX: config.cacheDurationLong,
+    })
   }
 
   return metaData


### PR DESCRIPTION
## Description of change

The redis client set function changed since v4, so to set expiration date for they key, a dictionary has to be passed.
Check https://github.com/redis/node-redis

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
