### PR TITLE
Feature/rr 951 add e2e test for export pipeline

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
@@ -1,0 +1,81 @@
+const fixtures = require('../../fixtures')
+const { exportFaker } = require('../../../../functional/cypress/fakers/export')
+const { exportPipeline } = require('../../../../../src/lib/urls')
+const {
+  fill,
+  fillTypeahead,
+  fillSelect,
+} = require('../../../../functional/cypress/support/form-fillers')
+
+describe('Export pipeline', () => {
+  const company = fixtures.company.create.defaultCompany(
+    'export pipeline testing'
+  )
+  const contact = fixtures.contact.create(company.pk)
+  const newExport = exportFaker({ destination_country: { name: 'Greece' } })
+  let createdExportId
+
+  context('Happy path export pipeline item', () => {
+    before(() => {
+      cy.loadFixture([company])
+      cy.loadFixture([contact])
+    })
+
+    beforeEach(() => {
+      cy.intercept('POST', '/api-proxy/v4/export').as('createExport')
+      cy.intercept('GET', '/api-proxy/v4/export?limit=10&page=1&offset=0').as(
+        'listExport'
+      )
+    })
+
+    it('should successfully create an export', () => {
+      cy.visit(exportPipeline.create(company.pk))
+      fill('[data-test=title-input]', newExport.title)
+      fillSelect(
+        '[data-test=field-estimated_export_value_years]',
+        newExport.estimated_export_value_years.id
+      )
+      fill(
+        '[data-test=estimated-export-value-amount-input]',
+        newExport.estimated_export_value_amount
+      )
+      fill('[data-test=estimated_win_date-month]', '03')
+      fill('[data-test=estimated_win_date-year]', '2035')
+      fillTypeahead(
+        '[data-test=field-destination_country]',
+        newExport.destination_country.name
+      )
+      fillTypeahead('[data-test=field-sector]', newExport.sector.name)
+      cy.get('[name="status"]').check(newExport.status)
+      cy.get('[name="export_potential"]').check(newExport.export_potential)
+
+      fillTypeahead('[data-test=field-contacts]', 'Johnny Cakeman')
+
+      cy.get('[data-test=submit-button]').click()
+
+      cy.wait('@createExport').then(
+        ({ response }) => (createdExportId = response.body.id)
+      )
+    })
+
+    it('should successfully edit an export', () => {
+      cy.visit(exportPipeline.edit(createdExportId))
+      cy.get('[data-test=title-input]').type('edited title')
+      cy.get('[data-test=field-notes]').type('edited notes')
+      cy.get('[data-test=submit-button]').click()
+
+      cy.visit(exportPipeline.edit(createdExportId))
+    })
+
+    it('should successfully delete an export', () => {
+      cy.visit(exportPipeline.delete(createdExportId))
+      cy.get('[data-test=submit-button]').click()
+
+      cy.visit(exportPipeline.index())
+      cy.wait('@listExport')
+      cy.get(`a[href="${exportPipeline.details(createdExportId)}"]`).should(
+        'not.exist'
+      )
+    })
+  })
+})

--- a/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
@@ -23,9 +23,10 @@ describe('Export pipeline', () => {
 
     beforeEach(() => {
       cy.intercept('POST', '/api-proxy/v4/export').as('createExport')
-      cy.intercept('GET', '/api-proxy/v4/export?limit=10&page=1&offset=0').as(
-        'listExport'
-      )
+      cy.intercept(
+        'GET',
+        '/api-proxy/v4/export?limit=10&page=1&offset=0&archived=false'
+      ).as('listExport')
     })
 
     it('should successfully create an export', () => {

--- a/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
@@ -58,6 +58,14 @@ describe('Export pipeline', () => {
       )
     })
 
+    it('should successfully display the new export', () => {
+      cy.visit(exportPipeline.index())
+      cy.wait('@listExport')
+      cy.get(`a[href="${exportPipeline.details(createdExportId)}"]`).should(
+        'exist'
+      )
+    })
+
     it('should successfully edit an export', () => {
       cy.visit(exportPipeline.edit(createdExportId))
       cy.get('[data-test=title-input]').type('edited title')
@@ -70,7 +78,9 @@ describe('Export pipeline', () => {
     it('should successfully delete an export', () => {
       cy.visit(exportPipeline.delete(createdExportId))
       cy.get('[data-test=submit-button]').click()
+    })
 
+    it('should not display the deleted export in the list', () => {
       cy.visit(exportPipeline.index())
       cy.wait('@listExport')
       cy.get(`a[href="${exportPipeline.details(createdExportId)}"]`).should(


### PR DESCRIPTION
## Description of change

Add a new e2e test that performs the following steps and assertions:

- Adds a new export pipeline item
- Check the new export pipeline item appears in the list of export pipeline items
- Edit the new export pipeline and change some field values
- Delete the new export pipeline item
- Check the deleted item no longer appears in the list of export pipeline items

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
