### PR TITLE
Bugfix/rr 952 save and cancel export form redirects

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -60,8 +60,8 @@ const ExportFormEdit = ({ exportItem }) => {
           },
         }}
         exportItem={exportItem}
-        cancelRedirectUrl={urls.dashboard()}
-        redirectToUrl={urls.exportPipeline.edit(exportId)}
+        cancelRedirectUrl={urls.exportPipeline.details(exportId)}
+        redirectToUrl={urls.exportPipeline.details(exportId)}
         flashMessage={({ data }) => `Changes saved to '${data.title}'`}
       />
     </DefaultLayout>

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -99,7 +99,11 @@ describe('Export pipeline edit', () => {
       it('should render a form with a cancel link', () => {
         cy.get('[data-test=cancel-button]')
           .should('have.text', 'Cancel')
-          .should('have.attr', 'href', urls.dashboard())
+          .should(
+            'have.attr',
+            'href',
+            urls.exportPipeline.details(exportItem.id)
+          )
       })
 
       it('should render a form with saved values in the form fields', () => {
@@ -206,9 +210,9 @@ describe('Export pipeline edit', () => {
     })
 
     context('when the form cancel button is clicked', () => {
-      it('the form should redirect to the dashboard page', () => {
+      it('the form should redirect to the details page', () => {
         cy.get('[data-test=cancel-button]').click()
-        assertUrl(urls.dashboard())
+        assertUrl(urls.exportPipeline.details(exportItem.id))
       })
     })
 
@@ -310,7 +314,7 @@ describe('Export pipeline edit', () => {
           notes: exportItem.notes,
         })
 
-        assertUrl(urls.exportPipeline.edit(exportItem.id))
+        assertUrl(urls.exportPipeline.details(exportItem.id))
 
         assertFlashMessage(`Changes saved to '${exportItem.title}'`)
       })


### PR DESCRIPTION
## Description of change

Current functionality for the edit export form is cancel button takes the user to the dashboard and the save button keeps the user on the edit page.
Expected functionality for the edit export form is both the cancel button and the save button take the user to the export details page.

## Test instructions

- Go to the edit page for an export item, for example, http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit
- Click the Save button and you should be taken to http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/details
- Go back to the edit page, click the Cancel button and you should be taken to http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/details

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
