### PR TITLE
Add currency form field validation to the export pipeline form

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { isEmpty } from 'lodash'
 
 import Form from '../../../components/Form'
 import {
@@ -24,7 +25,7 @@ import {
 import { FORM_LAYOUT } from '../../../../common/constants'
 import { TASK_SAVE_EXPORT, ID as STATE_ID } from './state'
 import Task from '../../../components/Task'
-import { ERROR_MESSAGES } from './constants'
+import { ERROR_MESSAGES, POSITIVE_INT_REGEX } from './constants'
 import { validateTeamMembers } from './validation'
 import { SECTOR_LABELS, STATUS_LABELS } from './labels'
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
@@ -34,6 +35,8 @@ import { FONT_WEIGHTS } from '@govuk-react/constants'
 
 import { transformArrayIdNameToValueLabel } from '../../../transformers'
 import { TASK_REDIRECT_TO_CONTACT_FORM } from '../../../components/ContactForm/state'
+
+export const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
 
 const ExportFormFields = ({
   analyticsFormName,
@@ -103,8 +106,19 @@ const ExportFormFields = ({
                   <FieldCurrency
                     name="estimated_export_value_amount"
                     label="Estimated value in GBP"
-                    required={ERROR_MESSAGES.estimated_export_value_amount}
                     boldLabel={false}
+                    validate={(value) => {
+                      if (isPositiveInteger(value)) {
+                        const formValue = parseInt(value, 10)
+                        return formValue > 0
+                          ? null
+                          : ERROR_MESSAGES.estimated_export_value_amount
+                      } else if (isEmpty(value)) {
+                        return ERROR_MESSAGES.estimated_export_value_empty
+                      } else {
+                        return ERROR_MESSAGES.estimated_export_value_amount
+                      }
+                    }}
                   />
                 </div>
                 <FieldDate

--- a/src/client/modules/ExportPipeline/ExportForm/constants.js
+++ b/src/client/modules/ExportPipeline/ExportForm/constants.js
@@ -1,9 +1,13 @@
+export const POSITIVE_INT_REGEX = /^[0-9]{1,19}$/
+
 export const ERROR_MESSAGES = {
   title: 'Enter an export title',
   owner: 'Enter an owner',
   team_members: 'You can only add 5 team members',
   estimated_export_value_years: 'Select an estimated years',
-  estimated_export_value_amount: 'Estimated value cannot be blank',
+  estimated_export_value_empty: 'Enter the estimated value in GBP',
+  estimated_export_value_amount:
+    'Enter the estimated value in GBP (max 19 digits)',
   estimated_win_date: {
     required: 'Enter an estimated date for win',
     invalid: 'Enter a valid date',

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -155,6 +155,56 @@ describe('Export pipeline create', () => {
       })
     })
 
+    context('when the currency field has form validation errors', () => {
+      const fieldElement = '[data-test="field-estimated_export_value_amount"]'
+      const currencyInput = '[data-test="estimated-export-value-amount-input"]'
+      const saveButton = '[data-test=submit-button]'
+
+      before(() => {
+        cy.visit(addPageUrl)
+      })
+
+      it('should display an error when the field is empty', () => {
+        cy.get(saveButton).click()
+        assertFieldError(
+          cy.get(fieldElement),
+          ERROR_MESSAGES.estimated_export_value_empty,
+          false
+        )
+      })
+      it('should display an error when the field value is negative', () => {
+        cy.get(currencyInput).type('-5000')
+        cy.get(saveButton).click()
+        assertFieldError(
+          cy.get(fieldElement),
+          ERROR_MESSAGES.estimated_export_value_amount,
+          false
+        )
+      })
+
+      it('should display an error when the field value is greater than 19 digits', () => {
+        cy.get(currencyInput).clear()
+        cy.get(currencyInput).type('12345678912345678912')
+        cy.get(saveButton).click()
+        assertFieldError(
+          cy.get(fieldElement),
+          ERROR_MESSAGES.estimated_export_value_amount,
+          false
+        )
+      })
+
+      it('should display an error when the field value is non numerical', () => {
+        cy.get(currencyInput).clear()
+        cy.get(currencyInput).type('ABC')
+        cy.get(saveButton).click()
+        assertFieldError(
+          cy.get(fieldElement),
+          ERROR_MESSAGES.estimated_export_value_amount,
+          false
+        )
+      })
+    })
+
     context('when the form contains invalid data and is submitted', () => {
       before(() => {
         cy.visit(addPageUrl)
@@ -177,11 +227,6 @@ describe('Export pipeline create', () => {
         assertFieldError(
           cy.get('[data-test="field-estimated_export_value_years"]'),
           ERROR_MESSAGES.estimated_export_value_years
-        )
-        assertFieldError(
-          cy.get('[data-test="field-estimated_export_value_amount"]'),
-          ERROR_MESSAGES.estimated_export_value_amount,
-          false
         )
         assertFieldError(
           cy.get('[data-test="field-destination_country"]'),

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -240,7 +240,7 @@ describe('Export pipeline edit', () => {
         )
         assertFieldError(
           cy.get('[data-test="field-estimated_export_value_amount"]'),
-          ERROR_MESSAGES.estimated_export_value_amount,
+          ERROR_MESSAGES.estimated_export_value_empty,
           false
         )
         assertFieldError(


### PR DESCRIPTION
## Description of change
Does what is says on the tin.

The content will need updating, this can be done when we look at the form overall. 

**We only want two error messages:**
1. A generic error message (we probably don't want the 'max 19 digits' part)
2. An empty error message 

## Screenshots
**Empty**
<img width="707" alt="empty" src="https://user-images.githubusercontent.com/964268/233649061-2643a94d-cd50-49b1-9395-01bb8792aa92.png">
**Negative**
<img width="707" alt="negative" src="https://user-images.githubusercontent.com/964268/233649156-ce56efe0-0737-48c1-8adf-4fe8753135ab.png">
**> 19 digits**
<img width="707" alt="19 digits" src="https://user-images.githubusercontent.com/964268/233649191-e0832035-d43f-4cce-a39c-518c081ea02b.png">
**Non numeric values**
<img width="707" alt="letters" src="https://user-images.githubusercontent.com/964268/233649322-99a622cb-2d1f-4cb0-83af-72b47e5aac81.png">
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
