### PR TITLE
bugfix/RR-950-auto-add-new-contact

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
+++ b/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
@@ -64,7 +64,7 @@ describe('overwriteObjectWithSessionStorageValues', () => {
     'when sessionState contains values and query string is populated',
     () => {
       before(() => (getItem = populatedSessionState))
-      it('should return exportItem with any field in the state overwritten by the same field in the sessionStorage', () => {
+      it('should return exportItem with any field in the state overwritten by the same field in the sessionStorage and the new contact in the list of contacts', () => {
         expect(
           overwriteObjectWithSessionStorageValues(
             {
@@ -73,11 +73,21 @@ describe('overwriteObjectWithSessionStorageValues', () => {
                 name: 'b',
               },
               team_members: [{ label: 'd', value: 3 }],
+              contact: [
+                { label: 'contact 1', value: 1 },
+                { label: 'contact 2', value: 2 },
+              ],
               notes: 'long notes',
             },
-            new URLSearchParams('?new-contact-name=abc')
+            new URLSearchParams('?new-contact-name=abc&new-contact-id=10')
           )
-        ).to.deep.equal(exportItemSessionStorage)
+        ).to.deep.equal({
+          ...exportItemSessionStorage,
+          contacts: [
+            ...exportItemSessionStorage.contacts,
+            { label: 'abc', value: '10' },
+          ],
+        })
       })
     }
   )
@@ -96,7 +106,7 @@ describe('overwriteObjectWithSessionStorageValues', () => {
             title: 'title 123',
             contacts: [{ name: 'd', id: 3 }],
           },
-          new URLSearchParams('?new-contact-name=abc')
+          new URLSearchParams('?new-contact-name=abc&new-contact-id=1')
         )
       ).to.deep.include({
         company: {

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -10,10 +10,21 @@ export const overwriteObjectWithSessionStorageValues = (
   searchParams
 ) => {
   const valuesFromStorage = JSON.parse(window.sessionStorage.getItem(ID))
-  if (valuesFromStorage && searchParams.has('new-contact-name')) {
-    return {
+  const contactLabel = searchParams.get('new-contact-name')
+  const contactValue = searchParams.get('new-contact-id')
+  const newContact =
+    contactLabel && contactValue
+      ? { value: contactValue, label: contactLabel }
+      : null
+
+  if (valuesFromStorage && newContact) {
+    const mergedValues = {
       ...transformAPIValuesForForm(exportItem),
       ...valuesFromStorage,
+    }
+    return {
+      ...mergedValues,
+      contacts: [...mergedValues.contacts, newContact],
     }
   }
   return { ...transformAPIValuesForForm(exportItem) }

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -1,4 +1,5 @@
 import { contactFaker, contactsListFaker } from '../../fakers/contacts'
+import { addNewContact } from '../../support/actions'
 
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
@@ -12,6 +13,7 @@ const {
   assertLocalHeader,
   assertBreadcrumbs,
   assertFieldEmpty,
+  assertTypeaheadOptionSelected,
 } = require('../../support/assertions')
 
 const {
@@ -68,18 +70,6 @@ describe('Export pipeline create', () => {
     const addPageUrl = `/export/create?companyId=${company.id}`
     const newExport = generateExport()
     const newContact = contactFaker()
-
-    const add_contact_and_return_to_export_form = () => {
-      cy.get('[data-test="add-a-new-contact-link"').click()
-      fill('[data-test=group-field-first_name]', newContact.first_name)
-      fill('[data-test=group-field-last_name]', newContact.last_name)
-      fill('[data-test=job-title-input]', newContact.job_title)
-      fill('[data-test=job-title-input]', newContact.job_title)
-      fill('[data-test=email-input]', newContact.email)
-      cy.get('[name="addressSameAsCompany"]').check('Yes')
-      cy.get('[name="primary"]').check('No')
-      cy.get('[data-test="submit-button"').click()
-    }
 
     context('when verifying the page', () => {
       before(() => {
@@ -146,7 +136,8 @@ describe('Export pipeline create', () => {
         fill('[data-test=title-input]', newExport.title)
         fill('[data-test=estimated_win_date-month]', '09')
         fill('[data-test=estimated_win_date-year]', '2029')
-        add_contact_and_return_to_export_form()
+        cy.get('[data-test="add-a-new-contact-link"').click()
+        addNewContact(newContact)
         cy.visit('/')
         cy.visit(addPageUrl)
         assertFieldEmpty('[data-test=title-input]')
@@ -329,12 +320,16 @@ describe('Export pipeline create', () => {
             newExport.exporter_experience.id
           )
           fill('[data-test=field-notes]', newExport.notes)
-          add_contact_and_return_to_export_form()
+          cy.get('[data-test="add-a-new-contact-link"').click()
+          addNewContact(newContact)
           assertFlashMessage(
             `You have successfully added a new contact ${newContact.name}`
           )
+          assertTypeaheadOptionSelected({
+            element: '[data-test=field-contacts]',
+            expectedOption: newContact.name,
+          })
 
-          fillTypeahead('[data-test=field-contacts]', newContact.name)
           cy.window()
             .its('sessionStorage')
             .invoke('getItem', 'exportForm')

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -1,3 +1,6 @@
+import { contactFaker } from '../../fakers/contacts'
+import { addNewContact } from '../../support/actions'
+
 const urls = require('../../../../../src/lib/urls')
 
 const {
@@ -14,6 +17,7 @@ const {
   assertTypeaheadValues,
   assertFieldDateShort,
   assertPayload,
+  assertTypeaheadOptionSelected,
 } = require('../../support/assertions')
 const { exportItems } = require('../../../../sandbox/routes/v4/export/exports')
 const {
@@ -285,6 +289,30 @@ describe('Export pipeline edit', () => {
           cy.get('[data-test="field-estimated_win_date"]'),
           ERROR_MESSAGES.estimated_win_date.invalid
         )
+      })
+    })
+
+    context('when the a new contact is added', () => {
+      const newContact = contactFaker()
+      before(() => {
+        cy.intercept('POST', `/api-proxy/v4/contact`, newContact).as(
+          'postContactApiRequest'
+        )
+      })
+
+      it('should be added to existing list of contacts', () => {
+        cy.get('[data-test="add-a-new-contact-link"').click()
+        addNewContact(newContact)
+        exportItem.contacts.map((x) =>
+          assertTypeaheadOptionSelected({
+            element: '[data-test=field-contacts]',
+            expectedOption: x.name,
+          })
+        )
+        assertTypeaheadOptionSelected({
+          element: '[data-test=field-contacts]',
+          expectedOption: newContact.name,
+        })
       })
     })
 

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -1,3 +1,5 @@
+import { fill } from './form-fillers'
+
 const adviserResult = require('../../../sandbox/fixtures/autocomplete-adviser-list.json')
 
 /**
@@ -173,4 +175,15 @@ export const omisCollectionListRequest = (
   }).as('apiRequest')
   cy.visit(link)
   cy.wait('@apiRequest')
+}
+
+export const addNewContact = (contact) => {
+  fill('[data-test=group-field-first_name]', contact.first_name)
+  fill('[data-test=group-field-last_name]', contact.last_name)
+  fill('[data-test=job-title-input]', contact.job_title)
+  fill('[data-test=job-title-input]', contact.job_title)
+  fill('[data-test=email-input]', contact.email)
+  cy.get('[name="addressSameAsCompany"]').check('Yes')
+  cy.get('[name="primary"]').check('No')
+  cy.get('[data-test="submit-button"').click()
 }


### PR DESCRIPTION
## Description of change

- Move the add contact cypress action into the actions.js file
- When adding a new contact as part of the export pipeline item, append that new contact to the list of contacts for the export after being redirected back to the export page

## Test instructions

- Edit an existing export item, or create a new one. For editing you can use this http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit
- Click the Add a new contact link, after adding that contact you will be redirected back to the export.
- The contact you added will now be a selected contact


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
