### PR TITLE
bugfix/RR-956-redirect-to-dashboard-tab

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDelete/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDelete/index.jsx
@@ -18,7 +18,7 @@ const DISPLAY_DELETE_EXPORT = 'Delete export'
 const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
-      link: urls.dashboard(),
+      link: urls.exportPipeline.index(),
       text: 'Home',
     },
   ]
@@ -63,8 +63,8 @@ const ExportFormDelete = ({ exportItem }) => {
             <Form
               id="export-delete-form"
               analyticsFormName="deleteExportForm"
-              cancelRedirectTo={() => urls.dashboard()}
-              redirectTo={() => urls.dashboard()}
+              cancelRedirectTo={() => urls.exportPipeline.index()}
+              redirectTo={() => urls.exportPipeline.index()}
               submissionTaskName={TASK_DELETE_EXPORT}
               initialValues={exportItem}
               transformPayload={(values) => ({ exportId: values.id, values })}

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -36,7 +36,7 @@ const Container = styled('div')`
 const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
-      link: urls.dashboard(),
+      link: urls.exportPipeline.index(),
       text: 'Home',
     },
   ]

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -21,7 +21,7 @@ function useQuery() {
 const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
-      link: urls.dashboard(),
+      link: urls.exportPipeline.index(),
       text: 'Home',
     },
     {
@@ -69,7 +69,7 @@ const ExportFormAdd = ({ exportItem }) => {
         }}
         exportItem={exportItem}
         cancelRedirectUrl={urls.companies.activity.index(companyId)}
-        redirectToUrl={urls.dashboard()}
+        redirectToUrl={urls.exportPipeline.index()}
         flashMessage={({ data }) => `'${data.title}' created`}
       />
     </DefaultLayout>

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -15,7 +15,7 @@ const DISPLAY_EDIT_EXPORT = 'Edit export'
 const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
-      link: urls.dashboard(),
+      link: urls.exportPipeline.index(),
       text: 'Home',
     },
     {

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -54,7 +54,7 @@ describe('Export pipeline create', () => {
 
     it('should render add event breadcrumb', () => {
       assertBreadcrumbs({
-        Home: urls.dashboard(),
+        Home: urls.exportPipeline.index(),
         Companies: urls.companies.index(),
         'Add export': null,
       })
@@ -83,7 +83,7 @@ describe('Export pipeline create', () => {
 
       it('should render the add export breadcrumb', () => {
         assertBreadcrumbs({
-          Home: urls.dashboard(),
+          Home: urls.exportPipeline.index(),
           Companies: urls.companies.index(),
           [company.name]: urls.companies.activity.index(company.id),
           'Add export': null,
@@ -293,7 +293,7 @@ describe('Export pipeline create', () => {
           cy.visit(addPageUrl)
         })
 
-        it('the form should redirect to the dashboard page and display a success message', () => {
+        it('the form should redirect to the export tab on the dashboard page and display a success message', () => {
           const teamMember = faker.helpers.arrayElement(autoCompleteAdvisers)
 
           fill('[data-test=title-input]', newExport.title)
@@ -356,7 +356,7 @@ describe('Export pipeline create', () => {
             notes: newExport.notes,
           })
 
-          assertExactUrl('')
+          assertExactUrl(urls.exportPipeline.index())
           assertFlashMessage(`'${newExport.title}' created`)
 
           cy.window()

--- a/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
@@ -17,7 +17,7 @@ describe('Export pipeline delete', () => {
 
     it('should render edit event breadcrumb', () => {
       assertBreadcrumbs({
-        Home: urls.dashboard(),
+        Home: urls.exportPipeline.index(),
         Companies: urls.companies.index(),
       })
     })
@@ -50,7 +50,7 @@ describe('Export pipeline delete', () => {
 
       it('should render the delete export breadcrumb', () => {
         assertBreadcrumbs({
-          Home: urls.dashboard(),
+          Home: urls.exportPipeline.index(),
           [exportItem.title]: urls.exportPipeline.edit(exportItem.id),
           ['Are you sure you want to delete...']: null,
         })
@@ -66,26 +66,26 @@ describe('Export pipeline delete', () => {
       it('should render a form with a cancel link', () => {
         cy.get('[data-test=cancel-button]')
           .should('have.text', 'Cancel')
-          .should('have.attr', 'href', urls.dashboard())
+          .should('have.attr', 'href', urls.exportPipeline.index())
       })
     })
 
     context('when the form cancel button is clicked', () => {
-      it('the form should redirect to the dashboard page', () => {
+      it('the form should return to the export tab on the dashboard page', () => {
         cy.get('[data-test=cancel-button]').click()
-        assertUrl(urls.dashboard())
+        assertUrl(urls.exportPipeline.index())
       })
     })
 
     context('when the delete form is submitted', () => {
-      it('the form should return to the dashboard', () => {
+      it('the form should return to the export tab on the dashboard page', () => {
         cy.get('[data-test=submit-button]').click()
 
         cy.wait('@deleteExportItemApiRequest').then(({ request }) => {
           expect(request.url).to.contain(exportItem.id)
         })
 
-        assertUrl(urls.dashboard())
+        assertUrl(urls.exportPipeline.index())
 
         assertFlashMessage(`‘${exportItem.title}’ has been deleted`)
       })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -53,7 +53,7 @@ describe('Export pipeline edit', () => {
 
     it('should render edit event breadcrumb', () => {
       assertBreadcrumbs({
-        Home: urls.dashboard(),
+        Home: urls.exportPipeline.index(),
         Companies: urls.companies.index(),
       })
     })
@@ -87,7 +87,7 @@ describe('Export pipeline edit', () => {
 
       it('should render the edit export breadcrumb', () => {
         assertBreadcrumbs({
-          Home: urls.dashboard(),
+          Home: urls.exportPipeline.index(),
           Companies: urls.companies.index(),
           [exportItem.company.name]: urls.companies.activity.index(
             exportItem.company.id
@@ -317,7 +317,7 @@ describe('Export pipeline edit', () => {
     })
 
     context('when the form contains valid data and is submitted', () => {
-      it('the form should stay on the current page and display flash message', () => {
+      it('the form should redirect to the export details page and display flash message', () => {
         cy.get('[data-test=submit-button]').click()
 
         assertPayload('@patchExportItemApiRequest', {

--- a/test/functional/cypress/specs/export-pipeline/export-details-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-details-spec.js
@@ -23,7 +23,7 @@ describe('Export Details summary ', () => {
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
-        Home: urls.dashboard(),
+        Home: urls.exportPipeline.index(),
         [exportItem.title]: null,
       })
     })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -739,7 +739,7 @@ const assertUrl = (url) => {
  * Assert url is exactly matches the current url
  */
 const assertExactUrl = (url) => {
-  cy.url().should('eq', `${Cypress.config('baseUrl')}/${url}`)
+  cy.url().should('eq', `${Cypress.config('baseUrl')}${url}`)
 }
 
 /**


### PR DESCRIPTION
## Description of change

There is an export tab on the dashboard that has it's own route. Instead of redirecting to the dashboard route which defaults to the "My companies list" tab use the export tab route instead

## Test instructions

On any of the export pipeline pages with a breadcrumb, click the Home link and you will be taken to the /export page

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
