### PR TITLE
Fix/hint text

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -46,8 +46,8 @@ const StepInteractionType = () => {
             onChange: getOnChangeHandler('kind', setFieldValue),
           },
           {
-            label: 'A service that you have provided',
-            hint: 'For example, a significant assist or an event',
+            label: 'A service you have provided',
+            hint: 'For example, a significant assist or event',
             value: KINDS.SERVICE_DELIVERY,
             onChange: getOnChangeHandler('kind', setFieldValue),
           },
@@ -83,8 +83,8 @@ const StepInteractionType = () => {
             onChange: getOnChangeHandler('kind', setFieldValue),
           },
           {
-            label: 'A service that you have provided',
-            hint: 'For example, a significant assist or an event',
+            label: 'A service you have provided',
+            hint: 'For example, a significant assist or event',
             value: KINDS.SERVICE_DELIVERY,
             onChange: getOnChangeHandler('kind', setFieldValue),
           },
@@ -106,11 +106,11 @@ const StepInteractionType = () => {
         agreement.
         <br />
         <br />
-        Read more{' '}
+        For more information see{' '}
         <NewWindowLink href={urls.external.helpCentre.tradeagreementGuidance()}>
           recording trade agreement activity
         </NewWindowLink>
-        {'. '}
+        .{' '}
       </InsetText>
 
       <FieldRadios

--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -102,15 +102,15 @@ const StepInteractionType = () => {
   return (
     <>
       <InsetText data-test="trade-agreement-guide">
-        Select ‘Trade agreement’ if your interaction was set up to focus on, or
-        contributes to, implementing a trade agreement.
+        Select 'trade agreement' if your interaction deals with a named trade
+        agreement.
         <br />
         <br />
         Read more{' '}
         <NewWindowLink href={urls.external.helpCentre.tradeagreementGuidance()}>
-          information and guidance
-        </NewWindowLink>{' '}
-        on this section.
+          recording trade agreement activity
+        </NewWindowLink>
+        {'. '}
       </InsetText>
 
       <FieldRadios

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -180,7 +180,7 @@ describe('Service delivery', () => {
 
   beforeEach(() => {
     cy.visit(companies.interactions.create(company.pk))
-    selectInteractionType('Export', 'A service that you have provided')
+    selectInteractionType('Export', 'A service you have provided')
   })
 
   it('should create the service delivery', () => {

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -455,7 +455,7 @@ describe('Interaction theme', () => {
 
     it('should always have a see more guidance link', () => {
       cy.get('div [data-test="trade-agreement-guide"]>a')
-        .should('contain', 'information and guidance')
+        .should('contain', 'recording trade agreement activity')
         .should(
           'have.attr',
           'href',
@@ -603,7 +603,7 @@ describe('Service delivery theme', () => {
       cy.visit(urls.companies.interactions.create(company.id))
 
       cy.contains('label', 'Export').click()
-      cy.contains('label', 'A service that you have provided').click()
+      cy.contains('label', 'A service you have provided').click()
       cy.contains('button', 'Continue').click()
     })
 
@@ -1186,7 +1186,7 @@ describe('Filtering services based on theme & kind', () => {
   })
 
   it('should show filtered services for Export => Service delivery', () => {
-    selectInteractionType('Export', 'A service that you have provided')
+    selectInteractionType('Export', 'A service you have provided')
     cy.get('#field-service').should(
       'have.text',
       [
@@ -1247,7 +1247,7 @@ describe('Filtering services based on theme & kind', () => {
   })
 
   it('should show filtered services for Other => Service delivery', () => {
-    selectInteractionType('Other', 'A service that you have provided')
+    selectInteractionType('Other', 'A service you have provided')
 
     cy.get('#field-service').should(
       'have.text',

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -449,7 +449,7 @@ describe('Interaction theme', () => {
     it('should permanently show a description about when to select trade agreement', () => {
       cy.get('div [data-test="trade-agreement-guide"]').should(
         'contain',
-        `Select ‘Trade agreement’ if your interaction was set up to focus on, or contributes to, implementing a trade agreement.Read more information and guidance (opens in a new window or tab) on this section.`
+        `Select 'trade agreement' if your interaction deals with a named trade agreement.For more information see recording trade agreement activity (opens in a new window or tab).`
       )
     })
 


### PR DESCRIPTION
## Description of change

Update the hint text service for interaction and service delivery text.

## Test instructions

From Datahub, navigate into company list -> details -> add interaction -> export -> standard you have provided

## Screenshots

### Before

<img width="776" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/28296624/df0c88e8-d6ed-4a25-964a-f0634c8e1b80">

### After

<img width="795" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/28296624/96970f2d-dad8-4d01-ad0f-da2a50e9af82">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
