### PR TITLE
Feature/rr 958 personalised dashboard flash messages

### DIFF
--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -38,6 +38,7 @@ import {
   CustomContainer,
   DataHubFeed,
 } from '../../components'
+import FlashMessages from '../LocalHeader/FlashMessages'
 
 const SearchBackground = styled('div')`
   background-color: ${BLUE};
@@ -97,6 +98,7 @@ const PersonalisedDashboard = ({
       </SearchContainer>
     </SearchBackground>
     <CustomContainer width="1180">
+      <FlashMessages />
       <Task.Status
         name={TASK_CHECK_FOR_INVESTMENTS}
         id={CHECK_FOR_INVESTMENTS_ID}

--- a/test/functional/cypress/specs/dashboard-new/flash-messages-spec.js
+++ b/test/functional/cypress/specs/dashboard-new/flash-messages-spec.js
@@ -1,0 +1,33 @@
+describe('Dashboard - Flash Messages', () => {
+  before(() => {
+    cy.setUserFeatures(['personalised-dashboard'])
+  })
+
+  beforeEach(() => {
+    cy.visit('/')
+  })
+
+  context('When there are no flash messages to show', () => {
+    it('should hide the flash messages component', () => {
+      cy.get('[data-test=flash]').should('not.exist')
+    })
+  })
+
+  context('When there are flash messages to show', () => {
+    before(() => {
+      cy.window().then(() => {
+        sessionStorage.setItem(
+          'flash-messages',
+          JSON.stringify({ success: ['Success flash message'] })
+        )
+      })
+    })
+    it('should show the flash messages component', () => {
+      cy.get('[data-test=flash]').should('exist')
+    })
+  })
+
+  after(() => {
+    cy.resetUser()
+  })
+})


### PR DESCRIPTION
## Description of change

The personalised dashboard doesn't have a FlashMessages component, so any messages are not seen until a user clicks away from the dashboard page.

This change adds the FlashMessages component to the personalised dashboard so any messages are seen by the user immediately

## Test instructions

Go to the http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/delete and delete the export. You will be redirected to the homepage and a flash message will appear

## Screenshots

### Before

![chrome_MZKp9XsDiV](https://user-images.githubusercontent.com/102232401/233958976-27f31a5b-c687-486f-9995-2b6b64c56e65.gif)

### After

![chrome_TlkgGL3DzZ](https://user-images.githubusercontent.com/102232401/233959038-5474a9c6-0c36-46c3-a937-cb703aa0a6f2.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
