### PR TITLE
Cls2 93 display likelihood of landing overview

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
@@ -7,7 +7,12 @@ import { FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import { companyProjectsState2props } from './state'
 import { connect } from 'react-redux'
 import urls from '../../../../../lib/urls'
-import { BLUE, GREY_2, TAG_COLOURS } from '../../../../../client/utils/colours'
+import {
+  BLUE,
+  GREY_1,
+  GREY_2,
+  TAG_COLOURS,
+} from '../../../../../client/utils/colours'
 import { kebabCase } from 'lodash'
 
 const StyledActiveInvestmentSubject = styled('h3')`
@@ -84,7 +89,7 @@ const StyledActiveInvestmentTableBottomCell = styled(Table.Cell)`
 `
 
 const StyledSpan = styled('span')`
-  color: ${GREY_2};
+  color: ${GREY_1};
 `
 const LikelihoodToLand = ({ likelihood }) => {
   if (likelihood === 'High') {

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
@@ -94,11 +94,11 @@ const StyledSpan = styled('span')`
 `
 const LikelihoodToLand = ({ likelihood }) => {
   if (likelihood === 'High') {
-    return <span style={{ color: `${GREEN}` }}>{`${likelihood} (80%)`}</span>
+    return <span style={{ color: `${GREEN}` }}>{`${likelihood}`}</span>
   } else if (likelihood === 'Medium') {
-    return <span style={{ color: `${ORANGE}` }}>{`${likelihood} (60%)`}</span>
+    return <span style={{ color: `${ORANGE}` }}>{`${likelihood}`}</span>
   } else {
-    return <span style={{ color: `${RED}` }}>{`${likelihood} (40%)`}</span>
+    return <span style={{ color: `${RED}` }}>{`${likelihood}`}</span>
   }
 }
 

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
@@ -7,7 +7,13 @@ import { FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import { companyProjectsState2props } from './state'
 import { connect } from 'react-redux'
 import urls from '../../../../../lib/urls'
-import { BLUE, GREY_2 } from '../../../../../client/utils/colours'
+import {
+  BLUE,
+  GREEN,
+  RED,
+  GREY_2,
+  ORANGE,
+} from '../../../../../client/utils/colours'
 import { kebabCase } from 'lodash'
 
 const StyledActiveInvestmentSubject = styled('h3')`
@@ -86,6 +92,15 @@ const StyledActiveInvestmentTableBottomCell = styled(Table.Cell)`
 const StyledSpan = styled('span')`
   color: ${GREY_2};
 `
+const LikelihoodToLand = ({ likelihood }) => {
+  if (likelihood === 'High') {
+    return <span style={{ color: `${GREEN}` }}>{`${likelihood} (80%)`}</span>
+  } else if (likelihood === 'Medium') {
+    return <span style={{ color: `${ORANGE}` }}>{`${likelihood} (60%)`}</span>
+  } else {
+    return <span style={{ color: `${RED}` }}>{`${likelihood} (40%)`}</span>
+  }
+}
 
 const ActiveInvestmentList = ({ upcomingActiveInvestments, queryString }) => {
   return upcomingActiveInvestments.map((activeInvestment) => {
@@ -120,6 +135,25 @@ const ActiveInvestmentList = ({ upcomingActiveInvestments, queryString }) => {
             {new Date(activeInvestment.estimated_land_date).toLocaleDateString(
               'en-GB',
               { month: 'long', year: 'numeric' }
+            )}
+          </StyledActiveInvestmentTableCell>
+        </StyledActiveInvestmentTableRow>
+        <StyledActiveInvestmentTableRow>
+          <StyledActiveInvestmentHeadingTableCellHeader
+            colSpan={1}
+            data-test={`likelihood-of-landing-${kebabCase(
+              activeInvestment.name
+            )}-header`}
+          >
+            Likelihood of landing
+          </StyledActiveInvestmentHeadingTableCellHeader>
+          <StyledActiveInvestmentTableCell colSpan={1}>
+            {activeInvestment.likelihood_to_land ? (
+              <LikelihoodToLand
+                likelihood={activeInvestment.likelihood_to_land.name}
+              />
+            ) : (
+              <StyledSpan>Not set</StyledSpan>
             )}
           </StyledActiveInvestmentTableCell>
         </StyledActiveInvestmentTableRow>

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
@@ -7,13 +7,7 @@ import { FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import { companyProjectsState2props } from './state'
 import { connect } from 'react-redux'
 import urls from '../../../../../lib/urls'
-import {
-  BLUE,
-  GREEN,
-  RED,
-  GREY_2,
-  ORANGE,
-} from '../../../../../client/utils/colours'
+import { BLUE, GREY_2, TAG_COLOURS } from '../../../../../client/utils/colours'
 import { kebabCase } from 'lodash'
 
 const StyledActiveInvestmentSubject = styled('h3')`
@@ -94,11 +88,32 @@ const StyledSpan = styled('span')`
 `
 const LikelihoodToLand = ({ likelihood }) => {
   if (likelihood === 'High') {
-    return <span style={{ color: `${GREEN}` }}>{`${likelihood}`}</span>
+    return (
+      <strong
+        className="govuk-tag"
+        Style={`background: ${TAG_COLOURS.green.background}; color: ${TAG_COLOURS.green.colour}`}
+      >
+        High
+      </strong>
+    )
   } else if (likelihood === 'Medium') {
-    return <span style={{ color: `${ORANGE}` }}>{`${likelihood}`}</span>
+    return (
+      <strong
+        className="govuk-tag"
+        Style={`background: ${TAG_COLOURS.orange.background}; color: ${TAG_COLOURS.orange.colour}`}
+      >
+        Medium
+      </strong>
+    )
   } else {
-    return <span style={{ color: `${RED}` }}>{`${likelihood}`}</span>
+    return (
+      <strong
+        className="govuk-tag"
+        Style={`background: ${TAG_COLOURS.red.background}; color: ${TAG_COLOURS.red.colour}`}
+      >
+        Low
+      </strong>
+    )
   }
 }
 

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -61,9 +61,6 @@ describe('Company overview page', () => {
       },
     },
   })
-  // const oneActiveInvestmentNoStatus = exportFaker({
-
-  // })
   context(
     'when viewing company overview the tab should display Overview',
     () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -61,6 +61,9 @@ describe('Company overview page', () => {
       },
     },
   })
+  // const oneActiveInvestmentNoStatus = exportFaker({
+
+  // })
   context(
     'when viewing company overview the tab should display Overview',
     () => {
@@ -850,6 +853,9 @@ describe('Company overview page', () => {
         cy.get('[data-test="last-interaction-date-new-rollercoaster-header"]')
           .next()
           .contains('Not set')
+        cy.get('[data-test="likelihood-of-landing-new-rollercoaster-header"]')
+          .next()
+          .contains('High')
         cy.get('[data-test="active-investment-page-new-restaurant-link"]')
           .contains('New restaurant')
           .click()
@@ -863,6 +869,9 @@ describe('Company overview page', () => {
         cy.get('[data-test="estimated-land-date-new-restaurant-header"]')
           .next()
           .contains('October 2025')
+        cy.get('[data-test="likelihood-of-landing-new-restaurant-header"]')
+          .next()
+          .contains('Medium')
         cy.get('[data-test="last-interaction-date-new-restaurant-header"]')
           .next()
           .contains('16 March 2021')
@@ -875,6 +884,9 @@ describe('Company overview page', () => {
         cy.get('[data-test="estimated-land-date-wig-factory-header"]')
           .next()
           .contains('January 2026')
+        cy.get('[data-test="likelihood-of-landing-wig-factory-header"]')
+          .next()
+          .contains('Low')
         cy.get('[data-test="active-investment-page-wig-factory-link"]')
           .contains('Wig factory')
           .click()
@@ -909,7 +921,46 @@ describe('Company overview page', () => {
       })
     }
   )
-
+  context(
+    'when viewing the active investment projects card for a business that has an investment but no status',
+    () => {
+      before(() => {
+        cy.intercept('POST', '/api-proxy/v3/search/investment_project', {
+          body: {
+            count: 1,
+            results: [
+              {
+                likelihood_to_land: null,
+                stage: {
+                  id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+                  name: 'Active',
+                },
+                estimated_land_date: '2025-10-13',
+                latest_interaction: {
+                  date: '2021-03-16T00:00:00+00:00',
+                  subject: 'A project interaction',
+                  id: '3fd90013-4bcb-4c39-b8df-df264471ea85',
+                },
+                name: 'New restaurant',
+              },
+            ],
+          },
+        }).as('apiRequest')
+        cy.visit(
+          urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
+        )
+      })
+      it('the card should contain that the status of the investment is Not set', () => {
+        cy.get('[data-test="activeInvestmentProjectsContainer"]')
+          .children()
+          .first()
+          .contains('Active investment projects')
+        cy.get('[data-test="likelihood-of-landing-new-restaurant-header"]')
+          .next()
+          .contains('Not set')
+      })
+    }
+  )
   context(
     'when viewing the active investment projects card for a business that has no investment projects',
     () => {

--- a/test/sandbox/fixtures/v3/search/investment-project.json
+++ b/test/sandbox/fixtures/v3/search/investment-project.json
@@ -441,7 +441,7 @@
       },
       "investor_type": null,
       "level_of_involvement": null,
-      "likelihood_to_land": null,
+      "likelihood_to_land": {"name": "High"},
       "project_assurance_adviser": {
         "id": "5a644146-5298-4741-91f3-d5d7558adf47",
         "first_name": "Paula",
@@ -619,7 +619,7 @@
       },
       "investor_type": null,
       "level_of_involvement": null,
-      "likelihood_to_land": null,
+      "likelihood_to_land": {"name": "Medium"},
       "project_assurance_adviser": {
         "id": "5a644146-5298-4741-91f3-d5d7558adf47",
         "first_name": "Paula",
@@ -827,7 +827,7 @@
       },
       "investor_type": null,
       "level_of_involvement": null,
-      "likelihood_to_land": null,
+      "likelihood_to_land": {"name": "Low"},
       "project_assurance_adviser": {
         "id": "5a644146-5298-4741-91f3-d5d7558adf47",
         "first_name": "Paula",


### PR DESCRIPTION
## Description of change

Add likelihood to land status to Active investment projects overview card

## Test instructions

The status of a project should be displayed using the Gov tag design. (VENUS SOLUTIONS LIMITED)

Where there is no status 'Not set' should be displayed. (De Volkskrant B.V.)

## Screenshots

![Screenshot 2023-04-24 at 11 15 23](https://user-images.githubusercontent.com/72826129/233969725-93ee3776-7ce3-4783-8a60-5da11089c04c.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
