### PR TITLE
bugfix/RR-964-cancel-delete-redirect

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDelete/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDelete/index.jsx
@@ -63,7 +63,7 @@ const ExportFormDelete = ({ exportItem }) => {
             <Form
               id="export-delete-form"
               analyticsFormName="deleteExportForm"
-              cancelRedirectTo={() => urls.exportPipeline.index()}
+              cancelRedirectTo={() => urls.exportPipeline.details(exportId)}
               redirectTo={() => urls.exportPipeline.index()}
               submissionTaskName={TASK_DELETE_EXPORT}
               initialValues={exportItem}

--- a/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
@@ -66,14 +66,18 @@ describe('Export pipeline delete', () => {
       it('should render a form with a cancel link', () => {
         cy.get('[data-test=cancel-button]')
           .should('have.text', 'Cancel')
-          .should('have.attr', 'href', urls.exportPipeline.index())
+          .should(
+            'have.attr',
+            'href',
+            urls.exportPipeline.details(exportItem.id)
+          )
       })
     })
 
     context('when the form cancel button is clicked', () => {
       it('the form should return to the export tab on the dashboard page', () => {
         cy.get('[data-test=cancel-button]').click()
-        assertUrl(urls.exportPipeline.index())
+        assertUrl(urls.exportPipeline.details(exportItem.id))
       })
     })
 


### PR DESCRIPTION
## Description of change

Redirect to correct page on cancelling the delete form

## Test instructions

Go to the delete page of any export item, for example http://localhost:3000/export/b7c55b3a-1463-4cc3-a1fa-e68424a8fafc/delete
Click the cancel button, you should be taken to the details page of that export item and not the dashboard


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
