### PR TITLE
Reduce VM size in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,9 +69,9 @@ jobs:
   functional_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     parallelism: 9
-    resource_class: 2xlarge
+    resource_class: xlarge
     steps:
       - checkout
       - run_make:
@@ -92,7 +92,7 @@ jobs:
   a11y_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     resource_class: xlarge
     steps:
       - checkout
@@ -105,7 +105,7 @@ jobs:
   visual_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     resource_class: xlarge
     steps:
       - checkout
@@ -120,7 +120,7 @@ jobs:
   visual_component_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     resource_class: xlarge
     steps:
       - checkout
@@ -135,7 +135,7 @@ jobs:
   e2e_tests_dit:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     parallelism: 3
     resource_class: xlarge
     parameters:
@@ -151,7 +151,7 @@ jobs:
   e2e_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     parallelism: 1
     resource_class: xlarge
     parameters:
@@ -167,7 +167,7 @@ jobs:
   component_tests:
     machine:
       image: ubuntu-2004:2022.07.1
-      docker_layer_caching: false
+      docker_layer_caching: true
     steps:
       - checkout
       - run_make:


### PR DESCRIPTION
## Description of change

Reduce the circleci VM size to drop credit spend given it doesn't impact the performance nor reliability of the test suite (it might have in the past, but after a few tests it doesn't seem to be the case).

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
