### PR TITLE
bugfix/RR-947-estimated-land-date-scrolls

### DIFF
--- a/src/client/components/Form/elements/FieldDate/index.jsx
+++ b/src/client/components/Form/elements/FieldDate/index.jsx
@@ -145,7 +145,7 @@ const FieldDate = ({
                   name={`${name}.day`}
                   data-test={`${dataTest}-day`}
                   error={touched && error}
-                  type="number"
+                  type="text"
                   value={value.day}
                   onChange={(e) => onChange(DAY, e)}
                   onBlur={onBlur}
@@ -159,7 +159,7 @@ const FieldDate = ({
                 name={`${name}.month`}
                 data-test={`${dataTest}-month`}
                 error={touched && error}
-                type="number"
+                type="text"
                 value={value.month}
                 onChange={(e) => onChange(MONTH, e)}
                 onBlur={onBlur}
@@ -172,7 +172,7 @@ const FieldDate = ({
                 name={`${name}.year`}
                 data-test={`${dataTest}-year`}
                 error={touched && error}
-                type="number"
+                type="text"
                 value={value.year}
                 onChange={(e) => onChange(YEAR, e)}
                 onBlur={onBlur}


### PR DESCRIPTION
## Description of change

The `<FieldDate />` renders inputs with type="number", which contravenes the GDS guidance:

![image](https://user-images.githubusercontent.com/102232401/234230706-eaa1aec3-c658-4703-98ae-56c7118fc5ec.png)

This is causing an issue within the `<FieldDate />`,  where the input that has focus is changing it's value when the user scrolls with their mouse


## Test instructions

- Go to any form that has a `<FieldDate />` component, for example http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit.
- Click into one of the date fields, scroll up or down and the value should not change
- Add a text value into one of the date fields and try to submit the form. An invalid message should appear

## Screenshots

### Before
![chrome_nShLZUtf4U](https://user-images.githubusercontent.com/102232401/234232579-5953e93a-3a7c-40b5-baaf-16bd6746eee8.gif)



### After

![chrome_WIWgknxQ9s](https://user-images.githubusercontent.com/102232401/234232350-c7196a62-9d90-46ba-b5ba-20b71fb8866b.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
