### PR TITLE
Bugfix/rr 963 export details breadcrumbs

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDelete/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDelete/index.jsx
@@ -27,7 +27,7 @@ const getBreadcrumbs = (exportItem) => {
     return [
       ...defaultBreadcrumbs,
       {
-        link: urls.exportPipeline.edit(exportItem.id),
+        link: urls.exportPipeline.details(exportItem.id),
         text: exportItem.title,
       },
       { text: 'Are you sure you want to delete...' },

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormEdit.jsx
@@ -18,20 +18,16 @@ const getBreadcrumbs = (exportItem) => {
       link: urls.exportPipeline.index(),
       text: 'Home',
     },
-    {
-      link: urls.companies.index(),
-      text: 'Companies',
-    },
   ]
 
   if (exportItem) {
     return [
       ...defaultBreadcrumbs,
       {
-        link: urls.companies.activity.index(exportItem.company.id),
-        text: exportItem.company.name,
+        link: urls.exportPipeline.details(exportItem.id),
+        text: exportItem.title,
       },
-      { text: exportItem.title },
+      { text: 'Edit export' },
     ]
   }
 

--- a/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/delete-export-spec.js
@@ -18,7 +18,6 @@ describe('Export pipeline delete', () => {
     it('should render edit event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.exportPipeline.index(),
-        Companies: urls.companies.index(),
       })
     })
 
@@ -51,7 +50,7 @@ describe('Export pipeline delete', () => {
       it('should render the delete export breadcrumb', () => {
         assertBreadcrumbs({
           Home: urls.exportPipeline.index(),
-          [exportItem.title]: urls.exportPipeline.edit(exportItem.id),
+          [exportItem.title]: urls.exportPipeline.details(exportItem.id),
           ['Are you sure you want to delete...']: null,
         })
       })

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -54,7 +54,6 @@ describe('Export pipeline edit', () => {
     it('should render edit event breadcrumb', () => {
       assertBreadcrumbs({
         Home: urls.exportPipeline.index(),
-        Companies: urls.companies.index(),
       })
     })
 
@@ -88,11 +87,8 @@ describe('Export pipeline edit', () => {
       it('should render the edit export breadcrumb', () => {
         assertBreadcrumbs({
           Home: urls.exportPipeline.index(),
-          Companies: urls.companies.index(),
-          [exportItem.company.name]: urls.companies.activity.index(
-            exportItem.company.id
-          ),
-          [exportItem.title]: null,
+          [exportItem.title]: urls.exportPipeline.details(exportItem.id),
+          'Edit export': null,
         })
       })
 


### PR DESCRIPTION
## Description of change

Some of the export page breadcrumbs do not exactly match the designs, this PR fixes the incorrect links



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
