### PR TITLE
Change messaging on Create new company list page

### DIFF
--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -22,6 +22,7 @@ const CreateListForm = ({
       flashMessage={() => 'Company list created'}
       submitButtonLabel="Create list"
       cancelRedirectTo={() => cancelUrl}
+      cancelButtonLabel="Back"
       transformPayload={(values) => ({
         id,
         values,
@@ -37,7 +38,7 @@ const CreateListForm = ({
           hint={hint}
           validate={(value) =>
             value && value.length > maxLength
-              ? `Enter list name which is no longer than ${maxLength} characters`
+              ? `Enter list name which is no longer than ${maxLength} characters long`
               : null
           }
         />

--- a/src/apps/company-lists/controllers/__test__/create.test.js
+++ b/src/apps/company-lists/controllers/__test__/create.test.js
@@ -92,10 +92,11 @@ describe('Creating company lists', () => {
       expect(
         global.middlewareParameters.resMock.render
       ).to.have.been.calledWith('company-lists/views/create-list-container', {
+        heading: 'Add Company to list',
         props: {
           id: '1',
           name: 'listName',
-          label: 'List name',
+          label: 'What do you want to name your new list?',
           hint: 'This is a name only you see, and can be up to 30 characters long',
           cancelUrl: `/companies/1/lists/add-remove`,
           maxLength: 30,

--- a/src/apps/company-lists/controllers/__test__/create.test.js
+++ b/src/apps/company-lists/controllers/__test__/create.test.js
@@ -85,7 +85,7 @@ describe('Creating company lists', () => {
       ).to.have.been.calledWith('Company')
       expect(
         global.middlewareParameters.resMock.breadcrumb
-      ).to.have.been.calledWith('Create a list')
+      ).to.have.been.calledWith('Create new list')
     })
 
     it('should render to the view with props', () => {
@@ -96,7 +96,7 @@ describe('Creating company lists', () => {
           id: '1',
           name: 'listName',
           label: 'List name',
-          hint: 'This is a name only you see, and can be up to 30 characters',
+          hint: 'This is a name only you see, and can be up to 30 characters long',
           cancelUrl: `/companies/1/lists/add-remove`,
           maxLength: 30,
         },

--- a/src/apps/company-lists/controllers/create.js
+++ b/src/apps/company-lists/controllers/create.js
@@ -16,13 +16,14 @@ async function renderCreateListForm(req, res, next) {
   try {
     res
       .breadcrumb(company.name, `/companies/${company.id}`)
-      .breadcrumb('Create a list')
+      .breadcrumb('Create new list')
       .render('company-lists/views/create-list-container', {
+        heading: `Add ${company.name} to list`,
         props: {
           id: company.id,
           name: 'listName',
-          label: 'List name',
-          hint: 'This is a name only you see, and can be up to 30 characters',
+          label: 'What do you wat to name your new list?',
+          hint: 'This is a name only you see, and can be up to 30 characters long',
           cancelUrl: `/companies/${company.id}/lists/add-remove`,
           maxLength: 30,
         },

--- a/src/apps/company-lists/controllers/create.js
+++ b/src/apps/company-lists/controllers/create.js
@@ -22,7 +22,7 @@ async function renderCreateListForm(req, res, next) {
         props: {
           id: company.id,
           name: 'listName',
-          label: 'What do you wat to name your new list?',
+          label: 'What do you want to name your new list?',
           hint: 'This is a name only you see, and can be up to 30 characters long',
           cancelUrl: `/companies/${company.id}/lists/add-remove`,
           maxLength: 30,

--- a/test/functional/cypress/specs/company-lists/create-spec.js
+++ b/test/functional/cypress/specs/company-lists/create-spec.js
@@ -14,27 +14,27 @@ describe('Create a company list', () => {
       Companies: urls.companies.index(),
       'Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978':
         '/companies/4cd4128b-1bad-4f1e-9146-5d4678c6a018',
-      'Create a list': undefined,
+      'Create new list': undefined,
     })
 
     it('displays the "Create list" heading', () => {
       cy.get(selectors.localHeader().heading).should(
         'have.text',
-        'Create a list'
+        'Add Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978 to list'
       )
     })
 
     it('displays the list name', () => {
       cy.get(selectors.companyList.create.label).should(
         'have.text',
-        'List name'
+        'What do you wat to name your new list?'
       )
     })
 
     it('displays the hint', () => {
       cy.get(selectors.companyList.create.hint).should(
         'have.text',
-        'This is a name only you see, and can be up to 30 characters'
+        'This is a name only you see, and can be up to 30 characters long'
       )
     })
 
@@ -49,8 +49,8 @@ describe('Create a company list', () => {
       )
     })
 
-    it('displays a cancel link', () => {
-      cy.get(selectors.companyList.create.cancel).should('have.text', 'Cancel')
+    it('displays a back link', () => {
+      cy.get(selectors.companyList.create.cancel).should('have.text', 'Back')
     })
   })
 

--- a/test/functional/cypress/specs/company-lists/create-spec.js
+++ b/test/functional/cypress/specs/company-lists/create-spec.js
@@ -27,7 +27,7 @@ describe('Create a company list', () => {
     it('displays the list name', () => {
       cy.get(selectors.companyList.create.label).should(
         'have.text',
-        'What do you wat to name your new list?'
+        'What do you want to name your new list?'
       )
     })
 


### PR DESCRIPTION
## Description of change
Update the messaging when adding a company to a new list. 

## Test instructions

Go to a company and add it to a new list. 
- [View options >]
- [Add to or remove from lists]

![image](https://user-images.githubusercontent.com/699259/234254476-430313ad-d2a8-4972-8528-e03e3fee3e2c.png)
_What should I see?_

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/699259/234253427-2ce1e0fa-692a-4483-bcb0-d79969011651.png)

### After

![image](https://user-images.githubusercontent.com/699259/234253453-3a065a40-eebe-4d3b-ab79-0fd1ff86ee6a.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
