### PR TITLE
bugfix/assert-breadcrumbs-fails-with-single-breadcrumb

### DIFF
--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -61,7 +61,7 @@ const LocalHeader = ({
     role="region"
   >
     <StyledMain>
-      <BreadcrumbsWrapper>
+      <BreadcrumbsWrapper data-test="breadcrumbs">
         {breadcrumbs?.map((breadcrumb) =>
           breadcrumb.link ? (
             useReactRouter && breadcrumb.text !== 'Home' ? (

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -84,7 +84,7 @@ const assertSummaryTable = ({ dataTest, heading, showEditLink, content }) => {
  */
 const assertBreadcrumbs = (specs) => {
   const entries = Object.entries(specs)
-  cy.contains(Object.keys(specs).join(''))
+  cy.get('[data-test=breadcrumbs] > ol')
     .children('li')
     .should('have.length', entries.length)
     .each((x, i) => {


### PR DESCRIPTION
## Description of change

When a page only has a single breadcrumb, the `assertBreadcrumbs` function fails. This PR refactors the `assertBreadcrumbs` function so it works with a single breadcrumb as required in https://github.com/uktrade/data-hub-frontend/pull/5565

## Test instructions

Nothing to test in this PR, only that nothing is broken in the functional tests



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
