### PR TITLE
Bugfix/rr 969 scroll to add contacts field

### DIFF
--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -42,6 +42,12 @@ const FieldTypeahead = ({
   autoScroll,
   ...props
 }) => {
+  const styledWrapperRef = React.useRef(null)
+  React.useEffect(() => {
+    if (autoScroll) {
+      styledWrapperRef.current.scrollIntoView()
+    }
+  }, [autoScroll])
   const { value, error, touched, onBlur } = useField({
     name,
     validate,

--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -42,12 +42,6 @@ const FieldTypeahead = ({
   autoScroll,
   ...props
 }) => {
-  const styledWrapperRef = React.useRef(null)
-  React.useEffect(() => {
-    if (autoScroll) {
-      styledWrapperRef.current.scrollIntoView()
-    }
-  }, [autoScroll])
   const { value, error, touched, onBlur } = useField({
     name,
     validate,

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -172,6 +172,7 @@ const ExportFormFields = ({
                   resultToOptions={({ results }) =>
                     transformArrayIdNameToValueLabel(results)
                   }
+                  autoScroll={values.scrollToContact}
                 />
                 <Task>
                   {(getTask) => {

--- a/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
+++ b/src/client/modules/ExportPipeline/ExportForm/__test__/state.test.js
@@ -87,6 +87,7 @@ describe('overwriteObjectWithSessionStorageValues', () => {
             ...exportItemSessionStorage.contacts,
             { label: 'abc', value: '10' },
           ],
+          scrollToContact: true,
         })
       })
     }

--- a/src/client/modules/ExportPipeline/ExportForm/state.js
+++ b/src/client/modules/ExportPipeline/ExportForm/state.js
@@ -22,9 +22,11 @@ export const overwriteObjectWithSessionStorageValues = (
       ...transformAPIValuesForForm(exportItem),
       ...valuesFromStorage,
     }
+
     return {
       ...mergedValues,
       contacts: [...mergedValues.contacts, newContact],
+      scrollToContact: true,
     }
   }
   return { ...transformAPIValuesForForm(exportItem) }


### PR DESCRIPTION
## Description of change

When navigating back to the export form from the add contact page, auto scroll to the contacts section

## Test instructions

- When adding or editing an export, click the Add a new contact link.
- Add a new contact, on returning to the export form the contact section should scroll into view

## Screenshots


### After

![chrome_akHOYJjyWN](https://user-images.githubusercontent.com/102232401/235643465-bdb83d75-3155-48aa-98bf-7f7d2d723f5b.gif)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
