### PR TITLE
Replace GreenLabel with Tag component on Export Status card

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -3,7 +3,7 @@ import { Link, Table } from 'govuk-react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { SummaryTable } from '../../../../../client/components'
+import { SummaryTable, Tag } from '../../../../../client/components'
 import Task from '../../../../../client/components/Task'
 import {
   TASK_GET_LATEST_EXPORT_WINS,
@@ -53,16 +53,6 @@ const StyledLink = styled(Link)`
 const StyledViewMoreLink = styled(Link)`
   font-size: 12px;
   margin-right: 5px;
-`
-
-const GreenLabel = styled('span')`
-  background-color: #cce2d9;
-  color: #005b30;
-  padding: 4px;
-  white-space: pre-line;
-  font-size: 14px;
-  text-transform: uppercase;
-  font-weight: bold;
 `
 
 export const SUBSEGMENT = {
@@ -130,7 +120,7 @@ const ExportStatus = ({
             {company.export_potential ? (
               <StyledTD>
                 <div>
-                  <GreenLabel>{company.export_potential}</GreenLabel>
+                  <Tag colour="green">{company.export_potential}</Tag>
                 </div>
               </StyledTD>
             ) : (
@@ -141,9 +131,9 @@ const ExportStatus = ({
             {company.export_sub_segment ? (
               <StyledTD>
                 <div>
-                  <GreenLabel>
+                  <Tag colour="green">
                     {SUBSEGMENT[company.export_sub_segment]}
-                  </GreenLabel>
+                  </Tag>
                 </div>
               </StyledTD>
             ) : (

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -55,6 +55,10 @@ const StyledViewMoreLink = styled(Link)`
   margin-right: 5px;
 `
 
+const StyledTag = styled(Tag)`
+  white-space: pre-wrap;
+`
+
 export const SUBSEGMENT = {
   sustain_nurture_and_grow: 'Sustain: Nurture & grow',
   sustain_develop_export_capability: 'Sustain: develop export capability',
@@ -120,7 +124,9 @@ const ExportStatus = ({
             {company.export_potential ? (
               <StyledTD>
                 <div>
-                  <Tag colour="green">{company.export_potential}</Tag>
+                  <StyledTag colour="green">
+                    {company.export_potential}
+                  </StyledTag>
                 </div>
               </StyledTD>
             ) : (
@@ -131,9 +137,9 @@ const ExportStatus = ({
             {company.export_sub_segment ? (
               <StyledTD>
                 <div>
-                  <Tag colour="green">
+                  <StyledTag colour="green">
                     {SUBSEGMENT[company.export_sub_segment]}
-                  </Tag>
+                  </StyledTag>
                 </div>
               </StyledTD>
             ) : (


### PR DESCRIPTION
## Description of change

Replace GreenLabel with Tag component on Export Status card

## Test instructions

Export potential and Export sub segment should be rendered using Tag component instead of custom CSS code.
 
## Screenshots

### Before

![image](https://user-images.githubusercontent.com/699259/234303489-89c223ee-1b6f-4bc4-8717-fc21d10ee5ae.png)

### After

![image](https://user-images.githubusercontent.com/699259/234492262-428f044b-c644-46cf-9ca7-cf740717eb51.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
