### PR TITLE
feature/add-autoscroll-to-typeahead

### DIFF
--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ErrorText from '@govuk-react/error-text'
@@ -39,8 +39,16 @@ const FieldTypeahead = ({
   hint,
   initialValue,
   options,
+  autoScroll,
   ...props
 }) => {
+  const styledWrapperRef = React.useRef(null)
+  useEffect(() => {
+    if (autoScroll) {
+      styledWrapperRef.current.scrollIntoView()
+    }
+  }, [autoScroll])
+
   const { value, error, touched, onBlur } = useField({
     name,
     validate,
@@ -52,7 +60,7 @@ const FieldTypeahead = ({
 
   return (
     <FieldWrapper {...{ name, label, legend, hint, error }}>
-      <StyledWrapper error={error}>
+      <StyledWrapper error={error} ref={styledWrapperRef}>
         {touched && error && <ErrorText>{error}</ErrorText>}
         <Typeahead
           name={name}
@@ -107,6 +115,10 @@ FieldTypeahead.propTypes = {
     PropTypes.object,
     PropTypes.arrayOf(PropTypes.object),
   ]),
+  /**
+   * Whether the window should auto scroll into view this component
+   */
+  autoScroll: PropTypes.bool,
 }
 
 FieldTypeahead.defaultProps = {
@@ -116,6 +128,7 @@ FieldTypeahead.defaultProps = {
   legend: null,
   hint: null,
   initialValue: null,
+  autoScroll: false,
 }
 
 export default FieldTypeahead

--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import ErrorText from '@govuk-react/error-text'
@@ -42,13 +42,6 @@ const FieldTypeahead = ({
   autoScroll,
   ...props
 }) => {
-  const styledWrapperRef = React.useRef(null)
-  useEffect(() => {
-    if (autoScroll) {
-      styledWrapperRef.current.scrollIntoView()
-    }
-  }, [autoScroll])
-
   const { value, error, touched, onBlur } = useField({
     name,
     validate,
@@ -59,8 +52,8 @@ const FieldTypeahead = ({
   const { setFieldValue } = useFormContext()
 
   return (
-    <FieldWrapper {...{ name, label, legend, hint, error }}>
-      <StyledWrapper error={error} ref={styledWrapperRef}>
+    <FieldWrapper {...{ name, label, legend, hint, error, autoScroll }}>
+      <StyledWrapper error={error}>
         {touched && error && <ErrorText>{error}</ErrorText>}
         <Typeahead
           name={name}

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import FormGroup from '@govuk-react/form-group'
 import Label from '@govuk-react/label'
@@ -166,17 +166,50 @@ const FieldWrapper = ({
   reduced,
   groupId,
   boldLabel,
+  autoScroll,
   ...rest
-}) => (
-  <StyledFormGroup
-    id={`field-${name}`}
-    data-test={`field-${name}`}
-    reduced={reduced}
-    hint={hint}
-    {...rest}
-  >
-    {!legend ? (
-      <StyledFieldsetNoStyling>
+}) => {
+  const styledWrapperRef = React.useRef(null)
+  useEffect(() => {
+    if (autoScroll) {
+      styledWrapperRef.current.scrollIntoView()
+    }
+  }, [autoScroll])
+
+  return (
+    <StyledFormGroup
+      id={`field-${name}`}
+      data-test={`field-${name}`}
+      reduced={reduced}
+      hint={hint}
+      ref={styledWrapperRef}
+      {...rest}
+    >
+      {!legend ? (
+        <StyledFieldsetNoStyling>
+          <FieldInner
+            legend={legend}
+            error={error}
+            showBorder={showBorder}
+            bigLegend={bigLegend}
+            groupId={groupId}
+          >
+            {label && (
+              <StyledLegendNoStyle>
+                <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
+                  {label}
+                </StyledLabel>
+              </StyledLegendNoStyle>
+            )}
+            {hint && (
+              <StyledHint data-test="hint-text" error={error}>
+                {hint}
+              </StyledHint>
+            )}
+            {children}
+          </FieldInner>
+        </StyledFieldsetNoStyling>
+      ) : (
         <FieldInner
           legend={legend}
           error={error}
@@ -185,11 +218,9 @@ const FieldWrapper = ({
           groupId={groupId}
         >
           {label && (
-            <StyledLegendNoStyle>
-              <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
-                {label}
-              </StyledLabel>
-            </StyledLegendNoStyle>
+            <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
+              {label}
+            </StyledLabel>
           )}
           {hint && (
             <StyledHint data-test="hint-text" error={error}>
@@ -198,30 +229,10 @@ const FieldWrapper = ({
           )}
           {children}
         </FieldInner>
-      </StyledFieldsetNoStyling>
-    ) : (
-      <FieldInner
-        legend={legend}
-        error={error}
-        showBorder={showBorder}
-        bigLegend={bigLegend}
-        groupId={groupId}
-      >
-        {label && (
-          <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
-            {label}
-          </StyledLabel>
-        )}
-        {hint && (
-          <StyledHint data-test="hint-text" error={error}>
-            {hint}
-          </StyledHint>
-        )}
-        {children}
-      </FieldInner>
-    )}
-  </StyledFormGroup>
-)
+      )}
+    </StyledFormGroup>
+  )
+}
 
 FieldInner.propTypes = {
   legend: PropTypes.node,
@@ -276,6 +287,10 @@ FieldWrapper.propTypes = {
    * Boolean for rendering the label in bold or not
    */
   boldLabel: PropTypes.bool,
+  /**
+   * Whether the window should auto scroll into view this component
+   */
+  autoScroll: PropTypes.bool,
 }
 
 FieldWrapper.defaultProps = {
@@ -286,6 +301,7 @@ FieldWrapper.defaultProps = {
   showBorder: false,
   children: null,
   boldLabel: true,
+  autoScroll: false,
 }
 
 export default FieldWrapper

--- a/test/component/cypress/specs/Form/FieldTypeahead.cy.jsx
+++ b/test/component/cypress/specs/Form/FieldTypeahead.cy.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Form } from '../../../../../src/client/components'
+
+import FieldTypeahead from '../../../../../src/client/components/Form/elements/FieldTypeahead'
+import DataHubProvider from '../provider'
+
+describe('FieldTypeahead - autoScroll', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form id="export-form">
+        {[...Array(10)].map((_, i) => (
+          <FieldTypeahead name={`typeahead-test-${i}`} />
+        ))}
+        <FieldTypeahead name="typeahead-autoscroll-test" {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+
+  context('When autoScroll is set to false', () => {
+    it('the form should stay in the default view', () => {
+      cy.mount(<Component autoScroll={false} />)
+      cy.isNotInViewport('#typeahead-autoscroll-test')
+    })
+  })
+
+  context('When autoScroll is set to true', () => {
+    it('the form should scroll to the component', () => {
+      cy.mount(<Component autoScroll={true} />)
+      cy.isInViewport('#typeahead-autoscroll-test')
+    })
+  })
+})

--- a/test/component/cypress/support/index.js
+++ b/test/component/cypress/support/index.js
@@ -1,4 +1,3 @@
 /* eslint-disable */
 import '@cypress/code-coverage/support'
-
-require('./commands')
+require('../../cypress/support/commands')

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -322,3 +322,27 @@ Cypress.Commands.add('getViewport', () => {
     return doc.documentElement.getBoundingClientRect()
   })
 })
+
+Cypress.Commands.add('isNotInViewport', (element) => {
+  cy.get(element).then(($el) => {
+    const bottom = Cypress.$(cy.state('window')).height()
+    const rect = $el[0].getBoundingClientRect()
+
+    expect(rect.top).to.be.greaterThan(bottom)
+    expect(rect.bottom).to.be.greaterThan(bottom)
+    expect(rect.top).to.be.greaterThan(bottom)
+    expect(rect.bottom).to.be.greaterThan(bottom)
+  })
+})
+
+Cypress.Commands.add('isInViewport', (element) => {
+  cy.get(element).then(($el) => {
+    const bottom = Cypress.$(cy.state('window')).height()
+    const rect = $el[0].getBoundingClientRect()
+
+    expect(rect.top).not.to.be.greaterThan(bottom)
+    expect(rect.bottom).not.to.be.greaterThan(bottom)
+    expect(rect.top).not.to.be.greaterThan(bottom)
+    expect(rect.bottom).not.to.be.greaterThan(bottom)
+  })
+})


### PR DESCRIPTION
## Description of change

Added a prop to the `<FieldWrapper/>` component to allow the component to be scrolled into view. This is needed for this bugfix ticket https://uktrade.atlassian.net/browse/RR-969

## Test instructions
This feature is not being used yet, however a component test has been added to demo this - test/component/cypress/specs/Form/FieldTypeahead.cy.jsx

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
