### PR TITLE
Cls2 142 single link for last project won 

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
@@ -60,8 +60,9 @@ const InvestmentStatusCard = ({
                   href={`/investments/projects/${summary.won.last_won_project.id}`}
                   data-test="latest-won-project-link"
                 >
-                  {format(summary.won.last_won_project.last_changed)} -{' '}
-                  {summary.won.last_won_project.name}
+                  {`${format(summary.won.last_won_project.last_changed)} - ${
+                    summary.won.last_won_project.name
+                  }`}
                 </Link>
               ) : (
                 <StyledSpan>None</StyledSpan>

--- a/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
@@ -56,20 +56,13 @@ const InvestmentStatusCard = ({
           >
             <SummaryTable.Row heading="Last Project won">
               {summary?.won?.last_won_project?.id != null ? (
-                <div>
-                  <Link
-                    href={`/investments/projects/${summary.won.last_won_project.id}`}
-                    data-test="latest-won-project-link"
-                  >
-                    {format(summary.won.last_won_project.last_changed)}
-                  </Link>
-                  <br />
-                  <Link
-                    href={`/investments/projects/${summary.won.last_won_project.id}`}
-                  >
-                    {summary.won.last_won_project.name}
-                  </Link>
-                </div>
+                <Link
+                  href={`/investments/projects/${summary.won.last_won_project.id}`}
+                  data-test="latest-won-project-link"
+                >
+                  {format(summary.won.last_won_project.last_changed)} -{' '}
+                  {summary.won.last_won_project.name}
+                </Link>
               ) : (
                 <StyledSpan>None</StyledSpan>
               )}

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -483,6 +483,15 @@ describe('Company overview page', () => {
           .contains('Last Project won')
           .siblings()
           .contains('td', '07 Jun 2022')
+        cy.get('[data-test="latest-won-project-link"]').click()
+        cy.location('pathname').should(
+          'eq',
+          urls.investments.projects.details(
+            '945ea6d1-eee3-4f5b-9144-84a75b71b8e6'
+          )
+        )
+        cy.go('back')
+        cy.get('[data-test="investmentsStatusContainer"]')
         cy.get('th')
           .contains('Total projects won')
           .siblings()

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -516,7 +516,9 @@ describe('Company overview page', () => {
           .click()
         cy.location('pathname').should(
           'eq',
-          '/companies/ba8fae21-2895-47cf-90ba-9273c94dab88/investments/projects'
+          urls.companies.investments.companyInvestmentProjects(
+            'ba8fae21-2895-47cf-90ba-9273c94dab88'
+          )
         )
         cy.go('back')
       })
@@ -538,7 +540,9 @@ describe('Company overview page', () => {
           .click()
         cy.location('pathname').should(
           'eq',
-          '/investments/projects/945ea6d1-eee3-4f5b-9144-84a75b71b8e6/details'
+          urls.investments.projects.details(
+            '945ea6d1-eee3-4f5b-9144-84a75b71b8e6'
+          )
         )
         cy.go('back')
       })
@@ -583,7 +587,9 @@ describe('Company overview page', () => {
       it('should take us to create investment page', () => {
         cy.location('pathname').should(
           'eq',
-          `/investments/projects/create/b2c34b41-1d5a-4b4b-9249-7c53ff2868ab`
+          urls.investments.projects.create(
+            'b2c34b41-1d5a-4b4b-9249-7c53ff2868ab'
+          )
         )
       })
     }


### PR DESCRIPTION
## Description of change

Create a single link for last project won using {date} - {name} as opposed to two separate links

## Test instructions

A single link for any company that has a last won project

## Screenshots

![Screenshot 2023-04-25 at 16 44 38](https://user-images.githubusercontent.com/72826129/234331447-f35ace88-fcad-4e1d-b274-6e06c8e1b53a.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
