### PR TITLE
Updated export button text

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -156,7 +156,7 @@ const CompanyLocalHeader = ({
                   Add to or remove from lists
                 </DropdownButton>
                 <DropdownButton href={urls.exportPipeline.create(company.id)}>
-                  Add to my pipeline
+                  Add to export list
                 </DropdownButton>
               </ConnectedDropdownMenu>
             </GridCol>

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -149,6 +149,7 @@ const CompanyLocalHeader = ({
                 label="View options"
                 closedLabel="Hide options"
                 id="local_header"
+                dataTest="local-header-options-dropdown"
               >
                 <DropdownButton
                   href={`/companies/${company.id}/lists/add-remove?returnUrl=${queryString}`}

--- a/src/client/components/DropdownMenu/index.jsx
+++ b/src/client/components/DropdownMenu/index.jsx
@@ -97,6 +97,7 @@ const DropdownMenu = ({
   activeIndex,
   onUpdateIndex,
   closeMenu,
+  dataTest,
 }) => {
   const buttonRef = React.useRef(null)
   const childrenGroupRef = React.useRef(null)
@@ -158,6 +159,7 @@ const DropdownMenu = ({
       ref={containerRef}
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
+      data-test={dataTest}
     >
       <DropdownButtonContainer>
         <DropdownToggleButton

--- a/test/functional/cypress/specs/companies/local-header/options-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/options-spec.js
@@ -1,0 +1,36 @@
+const fixtures = require('../../../fixtures')
+const urls = require('../../../../../../src/lib/urls')
+
+describe('Local header options', () => {
+  context('when the view options button is clicked', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.activity.index(fixtures.company.dnbCorp.id))
+      cy.get('[data-test=local-header-options-dropdown] > div > button').click()
+      cy.get('#dropDownOptionsMenu > a').as('links')
+    })
+
+    it('should display the add to list link', () => {
+      cy.get('@links')
+        .first()
+        .should('have.text', 'Add to or remove from lists')
+        .should(
+          'have.attr',
+          'href',
+          `${urls.companies.lists.addRemove(
+            fixtures.company.dnbCorp.id
+          )}?returnUrl=${urls.companies.detail(fixtures.company.dnbCorp.id)}`
+        )
+    })
+
+    it('should display the add to export list link', () => {
+      cy.get('@links')
+        .last()
+        .should('have.text', 'Add to export list')
+        .should(
+          'have.attr',
+          'href',
+          urls.exportPipeline.create(fixtures.company.dnbCorp.id)
+        )
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Update the text on the button that redirects to the add export page

## Test instructions

Go to any company, click the View Options button. The bottom button should read "Add to export list"

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/234516662-e48bdf66-be75-423a-af4b-100129c3b297.png)

### After

![image](https://user-images.githubusercontent.com/102232401/234516483-32809a04-a10b-4035-921d-e6bc45b66d0f.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
