### PR TITLE
Replaced all 'not set' items with the correct use of GREY_1

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/AccountManagementCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/AccountManagementCard.jsx
@@ -3,6 +3,7 @@ import { Link, Table } from 'govuk-react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
+import { GREY_1 } from '../../../../../client/utils/colours'
 
 import { SummaryTable } from '../../../../../client/components'
 
@@ -38,7 +39,7 @@ const StyledAddressList = styled('ol')`
 `
 
 const StyledSpan = styled('span')`
-  color: grey;
+  color: ${GREY_1};
 `
 
 const MAX_PRIMARY_CONTACTS = 4

--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { NewWindowLink, SummaryTable } from '../../../../../client/components'
 import { currencyGBP } from '../../../../../client/utils/number-utils'
+import { GREY_1 } from '../../../../../client/utils/colours'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin: 0;
@@ -19,6 +20,10 @@ const StyledLastTableCell = styled(Table.Cell)`
   padding-bottom: 0;
 `
 
+const StyledSpan = styled('span')`
+  color: ${GREY_1};
+`
+
 const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
   const StyledAddressList = styled('ul')``
   return (
@@ -29,7 +34,7 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
       >
         <SummaryTable.Row heading="Companies House">
           {!company.company_number ? (
-            'Not set'
+            <StyledSpan>Not set</StyledSpan>
           ) : (
             <NewWindowLink
               href={companiesHouseLink}
@@ -43,7 +48,7 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
 
         <SummaryTable.Row heading="Trading Address">
           {!company.address ? (
-            'Not set'
+            <StyledSpan>Not set</StyledSpan>
           ) : (
             <StyledAddressList>
               {company.address?.line_1 && <li>{company.address.line_1}</li>}
@@ -61,7 +66,7 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
         </SummaryTable.Row>
         <SummaryTable.Row heading="Website">
           {!company.website ? (
-            'Not set'
+            <StyledSpan>Not set</StyledSpan>
           ) : (
             <NewWindowLink href={company.website}>
               {company.website}
@@ -69,18 +74,22 @@ const BusinessDetailsCard = ({ company, queryString, companiesHouseLink }) => {
           )}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Turnover">
-          {!company.turnover_gbp && !company.turnover_range
-            ? 'Not set'
-            : company.turnover_gbp
-            ? currencyGBP(company.turnover_gbp, {
-                maximumSignificantDigits: 2,
-              })
-            : company.turnover_range?.name}
+          {!company.turnover_gbp && !company.turnover_range ? (
+            <StyledSpan>Not set</StyledSpan>
+          ) : company.turnover_gbp ? (
+            currencyGBP(company.turnover_gbp, {
+              maximumSignificantDigits: 2,
+            })
+          ) : (
+            company.turnover_range?.name
+          )}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Number of Employees">
-          {!company.number_of_employees
-            ? 'Not set'
-            : company.number_of_employees}
+          {!company.number_of_employees ? (
+            <StyledSpan>Not set</StyledSpan>
+          ) : (
+            company.number_of_employees
+          )}
         </SummaryTable.Row>
         <SummaryTable.Row heading="DBT Sector">
           {!company.sector ? 'Not set' : company.sector.name}

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ExportStatus.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link, Table } from 'govuk-react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-
+import { GREY_1 } from '../../../../../client/utils/colours'
 import { SummaryTable, Tag } from '../../../../../client/components'
 import Task from '../../../../../client/components/Task'
 import {
@@ -44,7 +44,7 @@ const StyledLastTableCell = styled(Table.Cell)`
   padding-bottom: 0;
 `
 const StyledSpan = styled('span')`
-  color: grey;
+  color: ${GREY_1};
 `
 
 const StyledLink = styled(Link)`

--- a/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
@@ -14,6 +14,7 @@ const { format } = require('../../../../../client/utils/date')
 
 import Task from '../../../../../client/components/Task'
 import { connect } from 'react-redux'
+import { GREY_1 } from '../../../../../client/utils/colours'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin: 0;
@@ -29,7 +30,7 @@ const StyledLastTableCell = styled(Table.Cell)`
   padding-bottom: 0;
 `
 const StyledSpan = styled('span')`
-  color: grey;
+  color: ${GREY_1};
 `
 const InvestmentStatusCard = ({
   queryString,


### PR DESCRIPTION
## Description of change

Ensure correct secondary text colouring throughout Overview page. The secondary text colour is GREY_1 (#505a5f). Also that "Not set" or "None" is applied consistently using a span

## Test instructions

Any values that return "Not set" or "None" within the Overview page have the colour value of #505a5f


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
