### PR TITLE
Bugfix/rr 978 invalid date fix

### DIFF
--- a/src/client/components/Form/elements/FieldDate/index.jsx
+++ b/src/client/components/Form/elements/FieldDate/index.jsx
@@ -67,6 +67,10 @@ const getValidator =
     if (!isValid && !isDateEmpty) {
       return invalid || 'Enter a valid date'
     }
+
+    if (year.toString().length != 4) {
+      return 'Enter a year as 4 digits'
+    }
   }
 
 const getDefaultInitialValue = (format) => {
@@ -124,7 +128,9 @@ const FieldDate = ({
   return (
     <FieldWrapper {...{ name, label, legend, hint, error, reduced }}>
       <StyledInputWrapper error={error}>
-        {error && <ErrorText>{error}</ErrorText>}
+        {error && (
+          <ErrorText data-test={`field-${name}-error`}>{error}</ErrorText>
+        )}
         {reduced ? (
           <Input
             id={name}

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -125,7 +125,7 @@ const ExportFormFields = ({
                   name="estimated_win_date"
                   format="short"
                   label="Estimated date for win"
-                  hint="For example 11 2023."
+                  hint="For example 06 2023"
                   required={ERROR_MESSAGES.estimated_win_date.required}
                   invalid={ERROR_MESSAGES.estimated_win_date.invalid}
                 />

--- a/test/component/cypress/specs/Form/FieldDate.cy.jsx
+++ b/test/component/cypress/specs/Form/FieldDate.cy.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import { Form } from '../../../../../src/client/components'
+
+import FieldDate from '../../../../../src/client/components/Form/elements/FieldDate'
+import DataHubProvider from '../provider'
+import {
+  assertFieldError,
+  assertNotExists,
+} from '../../../../functional/cypress/support/assertions'
+
+describe('FieldDate', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form
+        id="export-form"
+        analyticsFormName="export-form"
+        cancelRedirectTo={() => '/'}
+        submissionTaskName="EMPTY"
+      >
+        <FieldDate name="test-date" {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+
+  beforeEach(() => {
+    cy.mount(<Component />)
+  })
+
+  context('when entering a 2 digit value for year', () => {
+    it('should display a validation message', () => {
+      cy.get('[data-test=test_date-day]').type('01').blur()
+      cy.get('[data-test=test_date-month]').type('01').blur()
+      cy.get('[data-test=test_date-year]').type('25').blur()
+
+      cy.get('[data-test=submit-button]').click()
+
+      assertFieldError(
+        cy.get('[data-test=field-test-date]'),
+        'Enter a year as 4 digits',
+        false
+      )
+    })
+  })
+
+  context('when entering a 4 digit value for year', () => {
+    it('should not display a validation message', () => {
+      cy.get('[data-test=test_date-day]').type('04').blur()
+      cy.get('[data-test=test_date-month]').type('09').blur()
+      cy.get('[data-test=test_date-year]').type('2028').blur()
+
+      cy.get('[data-test=submit-button]').click()
+
+      assertNotExists('[data-test=field-test-date-error]')
+    })
+  })
+})

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -6,6 +6,7 @@ import createSagaMiddleware from 'redux-saga'
 
 import rootSaga from '../../../../src/client/root-saga'
 import tasks from '../../../../src/client/components/Task/reducer'
+import Form from '../../../../src/client/components/Form'
 import Typeahead from '../../../../src/client/components/Typeahead/Typeahead'
 import FieldAddAnother from '../../../../src/client/components/Form/elements/FieldAddAnother/FieldAddAnother'
 import Resource from '../../../../src/client/components/Resource/Resource'
@@ -18,6 +19,7 @@ const reducer = (state, action) =>
     ...Resource.reducerSpread,
     ...Typeahead.reducerSpread,
     ...FieldAddAnother.reducerSpread,
+    ...Form.reducerSpread,
   })(action.type === 'RESET' ? undefined : state, action)
 
 export const store = legacy_createStore(

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -210,28 +210,35 @@ describe('Export pipeline create', () => {
           ERROR_MESSAGES.team_members
         )
       })
+      context(
+        'when the estimated dates field has form validation errors',
+        () => {
+          it('the form should display validation error message for invalid estimated dates', () => {
+            fill('[data-test=estimated_win_date-month]', '65')
+            fill('[data-test=estimated_win_date-year]', '-54')
+            cy.get('[data-test=submit-button]').click()
 
-      it('the form should display validation error message for invalid estimated dates', () => {
-        fill('[data-test=estimated_win_date-month]', '65')
-        fill('[data-test=estimated_win_date-year]', '-54')
-        cy.get('[data-test=submit-button]').click()
+            assertFieldError(
+              cy.get('[data-test="field-estimated_win_date"]'),
+              ERROR_MESSAGES.estimated_win_date.invalid
+            )
+          })
 
-        assertFieldError(
-          cy.get('[data-test="field-estimated_win_date"]'),
-          ERROR_MESSAGES.estimated_win_date.invalid
-        )
-      })
+          it('the form should display validation error message 2 digit estimated date', () => {
+            cy.get('[data-test=estimated_win_date-month]').clear()
+            cy.get('[data-test=estimated_win_date-year]').clear()
 
-      it('the form should display validation error message 2 digit estimated date', () => {
-        fill('[data-test=estimated_win_date-month]', '10')
-        fill('[data-test=estimated_win_date-year]', '23')
-        cy.get('[data-test=submit-button]').click()
+            fill('[data-test=estimated_win_date-month]', '10')
+            fill('[data-test=estimated_win_date-year]', '23')
+            cy.get('[data-test=submit-button]').click()
 
-        assertFieldError(
-          cy.get('[data-test="field-estimated_win_date"]'),
-          'Enter a year as 4 digits'
-        )
-      })
+            assertFieldError(
+              cy.get('[data-test="field-estimated_win_date"]'),
+              'Enter a year as 4 digits'
+            )
+          })
+        }
+      )
 
       context('when the currency field has form validation errors', () => {
         const fieldElement = '[data-test="field-estimated_export_value_amount"]'

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -146,56 +146,6 @@ describe('Export pipeline create', () => {
       })
     })
 
-    context('when the currency field has form validation errors', () => {
-      const fieldElement = '[data-test="field-estimated_export_value_amount"]'
-      const currencyInput = '[data-test="estimated-export-value-amount-input"]'
-      const saveButton = '[data-test=submit-button]'
-
-      before(() => {
-        cy.visit(addPageUrl)
-      })
-
-      it('should display an error when the field is empty', () => {
-        cy.get(saveButton).click()
-        assertFieldError(
-          cy.get(fieldElement),
-          ERROR_MESSAGES.estimated_export_value_empty,
-          false
-        )
-      })
-      it('should display an error when the field value is negative', () => {
-        cy.get(currencyInput).type('-5000')
-        cy.get(saveButton).click()
-        assertFieldError(
-          cy.get(fieldElement),
-          ERROR_MESSAGES.estimated_export_value_amount,
-          false
-        )
-      })
-
-      it('should display an error when the field value is greater than 19 digits', () => {
-        cy.get(currencyInput).clear()
-        cy.get(currencyInput).type('12345678912345678912')
-        cy.get(saveButton).click()
-        assertFieldError(
-          cy.get(fieldElement),
-          ERROR_MESSAGES.estimated_export_value_amount,
-          false
-        )
-      })
-
-      it('should display an error when the field value is non numerical', () => {
-        cy.get(currencyInput).clear()
-        cy.get(currencyInput).type('ABC')
-        cy.get(saveButton).click()
-        assertFieldError(
-          cy.get(fieldElement),
-          ERROR_MESSAGES.estimated_export_value_amount,
-          false
-        )
-      })
-    })
-
     context('when the form contains invalid data and is submitted', () => {
       before(() => {
         cy.visit(addPageUrl)
@@ -270,6 +220,64 @@ describe('Export pipeline create', () => {
           cy.get('[data-test="field-estimated_win_date"]'),
           ERROR_MESSAGES.estimated_win_date.invalid
         )
+      })
+
+      it('the form should display validation error message 2 digit estimated date', () => {
+        fill('[data-test=estimated_win_date-month]', '10')
+        fill('[data-test=estimated_win_date-year]', '23')
+        cy.get('[data-test=submit-button]').click()
+
+        assertFieldError(
+          cy.get('[data-test="field-estimated_win_date"]'),
+          'Enter a year as 4 digits'
+        )
+      })
+
+      context('when the currency field has form validation errors', () => {
+        const fieldElement = '[data-test="field-estimated_export_value_amount"]'
+        const currencyInput =
+          '[data-test="estimated-export-value-amount-input"]'
+        const saveButton = '[data-test=submit-button]'
+
+        it('should display an error when the field is empty', () => {
+          cy.get(saveButton).click()
+          assertFieldError(
+            cy.get(fieldElement),
+            ERROR_MESSAGES.estimated_export_value_empty,
+            false
+          )
+        })
+        it('should display an error when the field value is negative', () => {
+          cy.get(currencyInput).type('-5000')
+          cy.get(saveButton).click()
+          assertFieldError(
+            cy.get(fieldElement),
+            ERROR_MESSAGES.estimated_export_value_amount,
+            false
+          )
+        })
+
+        it('should display an error when the field value is greater than 19 digits', () => {
+          cy.get(currencyInput).clear()
+          cy.get(currencyInput).type('12345678912345678912')
+          cy.get(saveButton).click()
+          assertFieldError(
+            cy.get(fieldElement),
+            ERROR_MESSAGES.estimated_export_value_amount,
+            false
+          )
+        })
+
+        it('should display an error when the field value is non numerical', () => {
+          cy.get(currencyInput).clear()
+          cy.get(currencyInput).type('ABC')
+          cy.get(saveButton).click()
+          assertFieldError(
+            cy.get(fieldElement),
+            ERROR_MESSAGES.estimated_export_value_amount,
+            false
+          )
+        })
       })
     })
 

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -150,7 +150,7 @@ describe('Export pipeline edit', () => {
           assertFieldDateShort({
             element,
             label: 'Estimated date for win',
-            hint: 'For example 11 2023.',
+            hint: 'For example 06 2023',
             value: exportItem.estimated_win_date,
           })
         })

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -395,6 +395,7 @@ describe('Validation error messages', () => {
     "Select yes if you're the referral source for this project",
     'Choose a referral source activity',
     'Enter an estimated land date',
+    'Enter a year as 4 digits',
     'Choose a client contact',
   ]
 


### PR DESCRIPTION
## Description of change

- Added validation to block entry of 2 digit years when adding a date
- Updated the hint text for the estimated win date field on the export form 

## Test instructions

Edit an export, for example http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/edit. Try entering a 2 digit year and saving. You will see the validation error message

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/234842552-62d6074c-0c03-497a-8444-73c719e4f3f9.png)

### After

![image](https://user-images.githubusercontent.com/102232401/234842459-63c45a13-41c1-40d8-9baf-e3295950c471.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
