### PR TITLE
bugfix/RR-981-export-form-button-text

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormAdd.jsx
@@ -71,6 +71,7 @@ const ExportFormAdd = ({ exportItem }) => {
         cancelRedirectUrl={urls.companies.activity.index(companyId)}
         redirectToUrl={urls.exportPipeline.index()}
         flashMessage={({ data }) => `'${data.title}' created`}
+        formSubmitButtonLabel="Add export"
       />
     </DefaultLayout>
   )

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -44,6 +44,7 @@ const ExportFormFields = ({
   cancelRedirectUrl,
   redirectToUrl,
   exportItem,
+  formSubmitButtonLabel,
   taskProps = {},
 }) => (
   <Task.Status {...taskProps}>
@@ -59,6 +60,7 @@ const ExportFormFields = ({
             initialValues={exportItem}
             transformPayload={(values) => ({ exportId: values.id, values })}
             flashMessage={flashMessage}
+            submitButtonLabel={formSubmitButtonLabel}
           >
             {({ values }) => (
               <>
@@ -222,10 +224,12 @@ ExportFormFields.propTypes = {
   redirectToUrl: PropTypes.string.isRequired,
   taskProps: PropTypes.object,
   formDataLoaded: PropTypes.bool,
+  formSubmitButtonLabel: PropTypes.string,
 }
 
 ExportFormFields.defaultProps = {
   formDataLoaded: false,
+  formSubmitButtonLabel: 'Save',
 }
 
 export default ExportFormFields

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -91,7 +91,7 @@ describe('Export pipeline create', () => {
       })
 
       it('should render a form with display a save button', () => {
-        cy.get('[data-test=submit-button]').should('have.text', 'Save')
+        cy.get('[data-test=submit-button]').should('have.text', 'Add export')
       })
 
       it('should render a form with a cancel link', () => {


### PR DESCRIPTION
## Description of change

Changed the test for the add export form submit button to be Add export instead of Save

## Test instructions

Go to the add export form for a company, for example http://localhost:3000/export/create?companyId=c1ea5ee7-c6f5-4dd1-8c5e-785c5a115719. The green submit button will display the text "Add export"

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/234891214-df0a452c-2d6b-45bb-ba19-f646393f9f13.png)


### After

![image](https://user-images.githubusercontent.com/102232401/234887839-bb21d671-6e8c-4192-9191-3b327501a92d.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
