### PR TITLE
bugfix/RR-982-button-spacing

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -26,7 +26,7 @@ const Container = styled('div')`
   align-items: baseline;
   margin-bottom: 30px;
   ${Link} {
-    margin-right: 40px;
+    margin-right: 20px;
   }
   @media (max-width: ${BREAKPOINTS.TABLET}) {
     flex-direction: column;


### PR DESCRIPTION
## Description of change

Change width of the buttons on the export details page to 20px, to match the width on the form buttons

## Test instructions

Go to the details page for an export item, for example http://localhost:3000/export/402b4745-96fb-4c9f-aa07-111e09faa8dd/details. The buttons will be closer together

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/234898545-b72701bd-c3b7-42ce-9902-4205049c2fe0.png)

### After

![image](https://user-images.githubusercontent.com/102232401/234897451-c1ecd4c9-1401-4efa-9c02-a584703f4d2b.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
