### PR TITLE
bugfix/RR-985-handle-migration-missing-data

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -33,6 +33,28 @@ const Container = styled('div')`
   }
 `
 
+const EstimatedExport = ({
+  estimated_export_value_amount,
+  estimated_export_value_years,
+}) => {
+  if (estimated_export_value_amount && estimated_export_value_years) {
+    return (
+      <>
+        {`${estimated_export_value_years.name} / ${currencyGBP(
+          estimated_export_value_amount
+        )}`}
+      </>
+    )
+  }
+  if (estimated_export_value_amount) {
+    return <>{currencyGBP(estimated_export_value_amount)}</>
+  }
+  if (estimated_export_value_years) {
+    return <>{estimated_export_value_years.name}</>
+  }
+  return <span>Not set</span>
+}
+
 const getBreadcrumbs = (exportItem) => {
   const defaultBreadcrumbs = [
     {
@@ -94,13 +116,14 @@ const ExportDetailsForm = ({ exportItem }) => {
                     heading="Total estimated export value"
                     hideWhenEmpty={false}
                   >
-                    {isEmpty(exportItem.estimated_export_value_amount)
-                      ? 'Not set'
-                      : `${
-                          exportItem.estimated_export_value_years?.name
-                        } / ${currencyGBP(
-                          exportItem.estimated_export_value_amount
-                        )}`}
+                    <EstimatedExport
+                      estimated_export_value_amount={
+                        exportItem.estimated_export_value_amount
+                      }
+                      estimated_export_value_years={
+                        exportItem.estimated_export_value_years
+                      }
+                    />
                   </SummaryTable.Row>
                   <SummaryTable.Row
                     heading="Estimated date for Win"

--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -12,6 +12,7 @@ import {
   formatMediumDateTime,
 } from '../../../../client/utils/date.js'
 import { currencyGBP } from '../../../../client/utils/number-utils'
+import { get } from 'lodash'
 
 const ListItem = styled('li')({
   paddingTop: SPACING.SCALE_4,
@@ -64,6 +65,29 @@ const statusToColourMap = {
   INACTIVE: 'orange',
 }
 
+const EstimatedExport = ({
+  estimated_export_value_amount,
+  estimated_export_value_years,
+}) => {
+  if (estimated_export_value_amount && estimated_export_value_years) {
+    return (
+      <>
+        {currencyGBP(estimated_export_value_amount)}{' '}
+        {estimated_export_value_years && (
+          <span>({estimated_export_value_years.name})</span>
+        )}
+      </>
+    )
+  }
+  if (estimated_export_value_amount) {
+    return <>{currencyGBP(estimated_export_value_amount)}</>
+  }
+  if (estimated_export_value_years) {
+    return <>{estimated_export_value_years.name}</>
+  }
+  return <span>Not set</span>
+}
+
 const ItemRenderer = (item) => {
   const [toggleLabel, setToggleLabel] = useState('Show')
   const status = item.status.toUpperCase()
@@ -85,16 +109,24 @@ const ItemRenderer = (item) => {
       >
         <StyledDL data-test="export-details">
           <StyledDT>Destination:</StyledDT>
-          <StyledDD>{item.destination_country.name}</StyledDD>
+          <StyledDD>
+            {get(item, 'destination_country.name', 'Not set')}
+          </StyledDD>
           <StyledDT>Total estimated export value:</StyledDT>
           <StyledDD>
-            {currencyGBP(item.estimated_export_value_amount)}{' '}
-            <span>({item.estimated_export_value_years.name})</span>
+            <EstimatedExport
+              estimated_export_value_amount={item.estimated_export_value_amount}
+              estimated_export_value_years={item.estimated_export_value_years}
+            />
           </StyledDD>
           <StyledDT>Estimated date for win:</StyledDT>
-          <StyledDD>{formatShortDate(item.estimated_win_date)}</StyledDD>
+          <StyledDD>
+            {item.estimated_win_date
+              ? formatShortDate(item.estimated_win_date)
+              : 'Not set'}
+          </StyledDD>
           <StyledDT>Main sector:</StyledDT>
-          <StyledDD>{item.sector.name}</StyledDD>
+          <StyledDD>{get(item, 'sector.name', 'Not set')}</StyledDD>
           <StyledDT>Owner:</StyledDT>
           <StyledDD>{item.owner.name}</StyledDD>
           <StyledDT>Created on:</StyledDT>

--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -73,9 +73,7 @@ const EstimatedExport = ({
     return (
       <>
         {currencyGBP(estimated_export_value_amount)}{' '}
-        {estimated_export_value_years && (
-          <span>({estimated_export_value_years.name})</span>
-        )}
+        <span>({estimated_export_value_years.name})</span>
       </>
     )
   }

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -54,9 +54,7 @@ describe('Export pipeline list', () => {
       name: 'Portugal',
     },
     estimated_export_value_amount: '957485',
-    estimated_export_value_years: {
-      name: '5 years',
-    },
+    estimated_export_value_years: null,
     estimated_win_date: '2023-10-08T11:54:19Z',
     sector: {
       name: 'Energy',
@@ -77,7 +75,7 @@ describe('Export pipeline list', () => {
     destination_country: {
       name: 'Italy',
     },
-    estimated_export_value_amount: '141851',
+    estimated_export_value_amount: null,
     estimated_export_value_years: {
       name: 'Not yet known',
     },
@@ -227,8 +225,8 @@ describe('Export pipeline list', () => {
   })
 
   it('should display the total estimated export amount', () => {
-    assertEstimatedExportAmount('@firstListItem', '£957,485 (5 years)')
-    assertEstimatedExportAmount('@secondListItem', '£141,851 (Not yet known)')
+    assertEstimatedExportAmount('@firstListItem', '£957,485')
+    assertEstimatedExportAmount('@secondListItem', 'Not yet known')
     assertEstimatedExportAmount('@thirdListItem', '£858,211 (4 years)')
     assertEstimatedExportAmount('@fourthListItem', 'Not set')
   })

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -119,9 +119,34 @@ describe('Export pipeline list', () => {
     archived: true,
     title: 'Archived export',
   })
+  const missingMigratedData = exportFaker({
+    id: 5,
+    export_potential: 'low',
+    status: 'inactive',
+    company: {
+      name: 'Sony',
+    },
+    title: 'Missing Migrated Data',
+    destination_country: null,
+    estimated_export_value_amount: null,
+    estimated_export_value_years: null,
+    estimated_win_date: null,
+    sector: null,
+    owner: {
+      name: 'Ron Burgundy',
+    },
+    created_on: '2019-07-19T09:39:39.998239Z',
+  })
 
   const otherExports = exportListFaker(8)
-  const exportList = [active, won, inactive, archived, ...otherExports]
+  const exportList = [
+    active,
+    won,
+    inactive,
+    archived,
+    missingMigratedData,
+    ...otherExports,
+  ]
   const notArchivedExports = exportList.filter((e) => e.archived == false)
 
   before(() => {
@@ -145,6 +170,7 @@ describe('Export pipeline list', () => {
     cy.get('@exportItems').eq(0).as('firstListItem')
     cy.get('@exportItems').eq(1).as('secondListItem')
     cy.get('@exportItems').eq(2).as('thirdListItem')
+    cy.get('@exportItems').eq(3).as('fourthListItem')
   })
 
   it('should display a list of exports', () => {
@@ -165,60 +191,74 @@ describe('Export pipeline list', () => {
     assertExportPotentialTag('@firstListItem', 'HIGH POTENTIAL')
     assertExportPotentialTag('@secondListItem', 'MEDIUM POTENTIAL')
     assertExportPotentialTag('@thirdListItem', 'LOW POTENTIAL')
+    assertExportPotentialTag('@fourthListItem', 'LOW POTENTIAL')
   })
 
   it('should display an export active tag', () => {
     assertStatusTag('@firstListItem', 'ACTIVE')
     assertStatusTag('@secondListItem', 'WON')
     assertStatusTag('@thirdListItem', 'INACTIVE')
+    assertStatusTag('@fourthListItem', 'INACTIVE')
   })
 
   it('should display a company name header', () => {
     assertCompanyName('@firstListItem', 'Coca-Cola')
     assertCompanyName('@secondListItem', 'Alphabet')
     assertCompanyName('@thirdListItem', 'Meta')
+    assertCompanyName('@fourthListItem', 'Sony')
   })
 
   it('should display a link to the export', () => {
     assertTitleLink('@firstListItem', '/export/1/details', 'Export Coca-Cola')
     assertTitleLink('@secondListItem', '/export/2/details', 'Export Alphabet')
     assertTitleLink('@thirdListItem', '/export/3/details', 'Export Meta')
+    assertTitleLink(
+      '@fourthListItem',
+      '/export/5/details',
+      'Missing Migrated Data'
+    )
   })
 
   it('should display a destination', () => {
     assertDestination('@firstListItem', 'Portugal')
     assertDestination('@secondListItem', 'Italy')
     assertDestination('@thirdListItem', 'Greece')
+    assertDestination('@fourthListItem', 'Not set')
   })
 
   it('should display the total estimated export amount', () => {
     assertEstimatedExportAmount('@firstListItem', '£957,485 (5 years)')
     assertEstimatedExportAmount('@secondListItem', '£141,851 (Not yet known)')
     assertEstimatedExportAmount('@thirdListItem', '£858,211 (4 years)')
+    assertEstimatedExportAmount('@fourthListItem', 'Not set')
   })
 
   it('should display an estimated win date', () => {
     assertEstimatedWinDate('@firstListItem', 'October 2023')
     assertEstimatedWinDate('@secondListItem', 'May 2023')
     assertEstimatedWinDate('@thirdListItem', 'February 2023')
+    assertEstimatedWinDate('@fourthListItem', 'Not set')
   })
 
   it('should display a sector', () => {
     assertSector('@firstListItem', 'Energy')
     assertSector('@secondListItem', 'Mass Transport')
     assertSector('@thirdListItem', 'Security : Cyber Security')
+    assertSector('@fourthListItem', 'Not set')
   })
 
   it('should display an owner', () => {
     assertOwner('@firstListItem', 'Benjamin Graham')
     assertOwner('@secondListItem', 'Warren Buffet')
     assertOwner('@thirdListItem', 'Peter Lynch')
+    assertOwner('@fourthListItem', 'Ron Burgundy')
   })
 
   it('should display a created on date', () => {
     assertCreatedOnDate('@firstListItem', '20 Mar 2023, 9:19am')
     assertCreatedOnDate('@secondListItem', '19 Feb 2023, 9:29am')
     assertCreatedOnDate('@thirdListItem', '18 Jan 2023, 9:39am')
+    assertCreatedOnDate('@fourthListItem', '19 Jul 2019, 10:39am')
   })
 
   it('should show and hide the content on toggle', () => {


### PR DESCRIPTION
## Description of change

Handle null values in the DB from the data migration on the front end



## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/235171901-a11da7f1-1dc0-44f6-a742-5a215c2ed0fb.png)


### After
**Dashboard page**
![image](https://user-images.githubusercontent.com/102232401/235171840-edcd6557-5e18-4f1e-b2e2-f2065de4e1a9.png)

**Details page**
![image](https://user-images.githubusercontent.com/102232401/235172187-c9381de7-2b5f-4205-9bff-a8248dbcaef2.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
