### PR TITLE
bugfix/RR-979-currency-field-height

### DIFF
--- a/src/client/components/Form/elements/FieldCurrency/index.jsx
+++ b/src/client/components/Form/elements/FieldCurrency/index.jsx
@@ -42,18 +42,18 @@ const StyledCurrencyPrefix = styled('div')`
   border: ${BORDER_WIDTH_FORM_ELEMENT} solid ${BLACK};
   border-right: 0px;
   display: inline-block;
-  height: 40px;
   padding: ${BORDER_WIDTH};
-  min-width: 40px;
+  min-width: 47px;
   box-sizing: border-box;
   text-align: center;
   flex: 0 0 auto;
   cursor: default;
   font-size: ${FONT_SIZE.SIZE_19};
   background-color: ${LIGHT_GREY};
+  line-height: 1.8;
 
   @media (max-width: ${BREAKPOINTS.TABLET}) {
-    line-height: 1.6;
+    line-height: 2.1;
     font-size: ${FONT_SIZE.SIZE_16};
   }
   ${(props) =>
@@ -61,11 +61,17 @@ const StyledCurrencyPrefix = styled('div')`
     `
     border: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
     border-right: 0px;
+    line-height: 1.6;
     `}
 `
 
 const StyledCurrencyWrapper = styled('div')`
   display: flex;
+  align-items: stretch;
+  height: 47px;
+  > * {
+    height: 100%;
+  }
 `
 
 /**


### PR DESCRIPTION
## Description of change

Set the currency field height to match other field components

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
