### PR TITLE
bugfix/RR-980-dropdown-sizing

### DIFF
--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -13,6 +13,7 @@ import {
 } from '../../../../client/utils/date.js'
 import { currencyGBP } from '../../../../client/utils/number-utils'
 import { get } from 'lodash'
+import { ToggleButton } from '../../../components/ToggleSection/BaseToggleSection'
 
 const ListItem = styled('li')({
   paddingTop: SPACING.SCALE_4,
@@ -59,6 +60,12 @@ const StyledDD = styled('dd')({
   ...lineHeightMixin,
 })
 
+const DashboardToggleSection = styled(ToggleSection)({
+  [ToggleButton]: {
+    fontSize: FONT_SIZE.SIZE_16,
+  },
+})
+
 const statusToColourMap = {
   WON: 'green',
   ACTIVE: 'blue',
@@ -98,7 +105,7 @@ const ItemRenderer = (item) => {
       </TagContainer>
       <Header>{item.company.name}</Header>
       <Link href={`/export/${item.id}/details`}>{item.title}</Link>
-      <ToggleSection
+      <DashboardToggleSection
         onOpen={(open) =>
           open ? setToggleLabel('Hide') : setToggleLabel('Show')
         }
@@ -130,7 +137,7 @@ const ItemRenderer = (item) => {
           <StyledDT>Created on:</StyledDT>
           <StyledDD>{formatMediumDateTime(item.created_on)}</StyledDD>
         </StyledDL>
-      </ToggleSection>
+      </DashboardToggleSection>
     </ListItem>
   )
 }


### PR DESCRIPTION
## Description of change

Lower the font size for toggle button on the export dashboard

## Test instructions

Go to the export dashboard at http://localhost:3000/export, the show and hide buttons are now a smaller font

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/235190782-9d98ec0d-7479-446d-be2b-57e2cd019b7c.png)

### After

![image](https://user-images.githubusercontent.com/102232401/235190644-06015556-d142-49c3-9d6a-7e179374cf29.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
