### PR TITLE
feature/RR-987-export-button-name-change

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -157,7 +157,7 @@ const CompanyLocalHeader = ({
                   Add to or remove from lists
                 </DropdownButton>
                 <DropdownButton href={urls.exportPipeline.create(company.id)}>
-                  Add to export list
+                  Add export project
                 </DropdownButton>
               </ConnectedDropdownMenu>
             </GridCol>

--- a/test/functional/cypress/specs/companies/local-header/options-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/options-spec.js
@@ -22,10 +22,10 @@ describe('Local header options', () => {
         )
     })
 
-    it('should display the add to export list link', () => {
+    it('should display the add export project link', () => {
       cy.get('@links')
         .last()
-        .should('have.text', 'Add to export list')
+        .should('have.text', 'Add export project')
         .should(
           'have.attr',
           'href',


### PR DESCRIPTION
## Description of change

Update the text for the Add to export list button

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/235625991-ef13afaf-c58b-4c60-9495-4be46d42326b.png)

### After

![image](https://user-images.githubusercontent.com/102232401/235625912-565057f4-966b-4a74-94c8-01b7fc4e6dd0.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
