### PR TITLE
bugfix/RR-966-field-ordering-differences

### DIFF
--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -156,6 +156,12 @@ const ExportDetailsForm = ({ exportItem }) => {
                       ? 'Not set'
                       : exportItem.sector.name}
                   </SummaryTable.Row>
+                  <SummaryTable.ListRow
+                    heading="Company contacts"
+                    value={exportItem.contacts.map(transformIdNameToValueLabel)}
+                    emptyValue="Not set"
+                    hideWhenEmpty={false}
+                  />
                   <SummaryTable.Row
                     heading="Exporter experience"
                     hideWhenEmpty={false}
@@ -164,12 +170,6 @@ const ExportDetailsForm = ({ exportItem }) => {
                       ? 'Not set'
                       : exportItem.exporter_experience.name}
                   </SummaryTable.Row>
-                  <SummaryTable.ListRow
-                    heading="Company contacts"
-                    value={exportItem.contacts.map(transformIdNameToValueLabel)}
-                    emptyValue="Not set"
-                    hideWhenEmpty={false}
-                  ></SummaryTable.ListRow>
                   <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
                     {isEmpty(exportItem.notes) ? 'Not set' : exportItem.notes}
                   </SummaryTable.Row>{' '}

--- a/test/functional/cypress/specs/export-pipeline/export-details-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-details-spec.js
@@ -47,8 +47,8 @@ describe('Export Details summary ', () => {
         'Export potential': capitalize(exportItem.export_potential),
         Destination: exportItem.destination_country.name,
         'Main sector': exportItem.sector.name,
-        'Exporter experience': exportItem.exporter_experience.name,
         'Company contacts': exportItem.contacts.map((obj) => obj.name).join(''),
+        'Exporter experience': exportItem.exporter_experience.name,
         Notes: exportItem.notes,
       })
     })


### PR DESCRIPTION
## Description of change

The ordering of the fields on the export details page do not match the ordering on the form. Swap the company contacts and the exporter experience fields on the details page

## Test instructions

Go to any export item details page, the ordering now will match the order on the Add / Edit form

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/235681832-40f45316-e171-408a-bd72-90cfc977d018.png)

### After

![image](https://user-images.githubusercontent.com/102232401/235681703-6da8ba84-ca22-4b75-857e-05631474ed4b.png)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
