### PR TITLE
bugfix/RR-948-owner-team-name

### DIFF
--- a/src/client/modules/ExportPipeline/__test__/transformers.test.js
+++ b/src/client/modules/ExportPipeline/__test__/transformers.test.js
@@ -1,6 +1,7 @@
 import {
   transformFormValuesForAPI,
   transformAPIValuesForForm,
+  transformOwnerAPIValue,
 } from '../transformers'
 
 describe('transformFormValuesForAPI', () => {
@@ -119,6 +120,30 @@ describe('transformAPIValuesForForm', () => {
         exporter_experience: undefined,
         notes: 'large amount of text',
       })
+    })
+  })
+})
+
+describe('transformOwnerAPIValue', () => {
+  context('When the owner does not belong to a team', () => {
+    const team = [null, { name: null }]
+    team.forEach((team) => {
+      it('Should return the mapped value with just the owner name', () => {
+        expect(
+          transformOwnerAPIValue({ id: 'b', name: 'c', dit_team: team })
+        ).to.deep.equal({
+          value: 'b',
+          label: 'c',
+        })
+      })
+    })
+  })
+
+  context('When the owner belongs to a team', () => {
+    it('Should return the mapped value with the team name appended to the owner name', () => {
+      expect(
+        transformOwnerAPIValue({ id: 'b', name: 'c', dit_team: { name: 'd' } })
+      ).to.deep.equal({ value: 'b', label: 'c, d' })
     })
   })
 })

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -38,6 +38,14 @@ export const transformFormValuesForAPI = ({
   notes,
 })
 
+export const transformOwnerAPIValue = (owner) => {
+  const transformed = transformIdNameToValueLabel(owner)
+  if (owner.dit_team?.name) {
+    transformed.label = `${transformed.label}, ${owner.dit_team.name}`
+  }
+  return transformed
+}
+
 export const transformAPIValuesForForm = ({
   company,
   id,
@@ -58,7 +66,7 @@ export const transformAPIValuesForForm = ({
   company: { id: company.id, name: company.name },
   id,
   title,
-  owner: owner && transformIdNameToValueLabel(owner),
+  owner: owner && transformOwnerAPIValue(owner),
   team_members: transformArrayIdNameToValueLabel(team_members),
   estimated_export_value_years: estimated_export_value_years?.id,
   estimated_export_value_amount: estimated_export_value_amount,


### PR DESCRIPTION
## Description of change

If an owner belongs to a dit team, display this team name in the field to match the functionality of the typeahead field

## Test instructions

Use any advisor who belongs to a DIT team, for example, Chloe Wong. Set this person as the owner of an export and save the form. When you go back to the form the dit team name will remain appended to the advisor name

## Screenshots

### Before

![chrome_GXzQPk129W](https://user-images.githubusercontent.com/102232401/235931655-ad516a07-5fcf-4416-9655-21244c92a65e.gif)

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
