### PR TITLE
feature/RR-926-update-error-messaging-on-interaction-page

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -37,7 +37,7 @@ const StepInteractionType = () => {
       <FieldRadios
         label="What would you like to record?"
         name="kind"
-        required="Select what you would like to record"
+        required="Select interaction type"
         options={[
           {
             label: 'A standard interaction',
@@ -73,7 +73,7 @@ const StepInteractionType = () => {
       <FieldRadios
         label="What would you like to record?"
         name="kind"
-        required="Select what you would like to record"
+        required="Select interaction type"
         onChange={getOnChangeHandler('kind', setFieldValue)}
         options={[
           {
@@ -116,7 +116,7 @@ const StepInteractionType = () => {
       <FieldRadios
         name="theme"
         label="What is this regarding?"
-        required="Select what you would like to record"
+        required="Select interaction type"
         options={configuredFieldRadiosOptions}
       />
     </>

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -1,6 +1,7 @@
 const { reduce, isEqual } = require('lodash')
 
 import {
+  assertFieldError,
   assertFieldInput,
   assertFieldRadiosWithLegend,
   assertFieldSelect,
@@ -1257,6 +1258,40 @@ describe('Editing an interaction without a theme', () => {
     cy.get('[data-test="status-message"]').should(
       'have.text',
       'Interaction updated'
+    )
+  })
+})
+
+describe('Interaction landing page error checking', () => {
+  beforeEach(() => {
+    cy.visit(urls.companies.interactions.create(company.id))
+  })
+  it('should display an error when no interaction types are selected', () => {
+    cy.contains('button', 'Continue').click()
+
+    assertFieldError(
+      cy.get('[data-test="field-theme"]'),
+      'Select interaction type'
+    )
+  })
+
+  it('should display an error when no export interaction types are selected', () => {
+    cy.contains('label', 'Export').click()
+    cy.contains('button', 'Continue').click()
+
+    assertFieldError(
+      cy.get('[data-test="field-kind"]'),
+      'Select interaction type'
+    )
+  })
+
+  it('should display an error when no other interaction types are selected', () => {
+    cy.contains('label', 'Other').click()
+    cy.contains('button', 'Continue').click()
+
+    assertFieldError(
+      cy.get('[data-test="field-kind"]'),
+      'Select interaction type'
     )
   })
 })


### PR DESCRIPTION
## Description of change

Updated error message on the add interaction page, and added some additional tests for checking these errors

## Test instructions

Go to http://localhost:3000/companies/0f5b780d-d917-4e14-86c3-04ba0e145155/interactions/create?step=interaction_type, don't click any options and submit the form

## Screenshots

![image](https://user-images.githubusercontent.com/102232401/236208996-e852b8b3-211c-48aa-a013-09a3c38e6fef.png)

_Add a screenshot_

### After

![image](https://user-images.githubusercontent.com/102232401/236208837-f9ef5ba3-9cb7-4f00-94f7-1e159cc09d8f.png)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
