### PR TITLE
bugfix/RR-938-ess-integration

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -28,6 +28,7 @@ const {
   filterContactListOnEmail,
 } = require('../controllers')
 const { has, get } = require('lodash')
+const { sortCriteria } = require('../es-queries/sortCriteria')
 
 describe('Activity feed controllers', () => {
   let fetchActivityFeedStub,
@@ -132,21 +133,7 @@ describe('Activity feed controllers', () => {
             const expectedEsQuery = {
               from: 0,
               size: 20,
-              sort: {
-                _script: {
-                  type: 'number',
-                  script: {
-                    lang: 'painless',
-                    // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-                    // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-                    // in the list of activities, as opposed to when that activity was created.
-                    source:
-                      "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                      ": doc['published'].value.toInstant().toEpochMilli()",
-                  },
-                  order: 'desc',
-                },
-              },
+              sort: sortCriteria('desc'),
               query: {
                 bool: {
                   filter: {
@@ -285,21 +272,7 @@ describe('Activity feed controllers', () => {
         const expectedEsQuery = {
           from: 0,
           size: 20,
-          sort: {
-            _script: {
-              type: 'number',
-              script: {
-                lang: 'painless',
-                // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-                // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-                // in the list of activities, as opposed to when that activity was created.
-                source:
-                  "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                  ": doc['published'].value.toInstant().toEpochMilli()",
-              },
-              order: 'desc',
-            },
-          },
+          sort: sortCriteria('desc'),
           query: {
             bool: {
               must: [
@@ -356,21 +329,7 @@ describe('Activity feed controllers', () => {
         const expectedEsQuery = {
           from: 0,
           size: 20,
-          sort: {
-            _script: {
-              type: 'number',
-              script: {
-                lang: 'painless',
-                // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-                // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-                // in the list of activities, as opposed to when that activity was created.
-                source:
-                  "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                  ": doc['published'].value.toInstant().toEpochMilli()",
-              },
-              order: 'desc',
-            },
-          },
+          sort: sortCriteria('desc'),
           query: {
             bool: {
               filter: {
@@ -473,21 +432,7 @@ describe('Activity feed controllers', () => {
         const expectedEsQuery = {
           from: 0,
           size: 20,
-          sort: {
-            _script: {
-              type: 'number',
-              script: {
-                lang: 'painless',
-                // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-                // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-                // in the list of activities, as opposed to when that activity was created.
-                source:
-                  "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                  ": doc['published'].value.toInstant().toEpochMilli()",
-              },
-              order: 'desc',
-            },
-          },
+          sort: sortCriteria('desc'),
           query: {
             bool: {
               filter: {
@@ -605,21 +550,7 @@ describe('Activity feed controllers', () => {
           const expectedEsQuery = {
             from: 0,
             size: 20,
-            sort: {
-              _script: {
-                type: 'number',
-                script: {
-                  lang: 'painless',
-                  // Using the logic below to perform sorting, as we want to sort on published time, apart from events, which
-                  // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
-                  // in the list of activities, as opposed to when that activity was created.
-                  source:
-                    "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                    ": doc['published'].value.toInstant().toEpochMilli()",
-                },
-                order: 'desc',
-              },
-            },
+            sort: sortCriteria('desc'),
             query: {
               bool: {
                 filter: {
@@ -725,18 +656,7 @@ describe('Activity feed controllers', () => {
         const expectedEsQuery = {
           from: 0,
           size: 20,
-          sort: {
-            _script: {
-              type: 'number',
-              script: {
-                lang: 'painless',
-                source:
-                  "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-                  ": doc['published'].value.toInstant().toEpochMilli()",
-              },
-              order: 'desc',
-            },
-          },
+          sort: sortCriteria('desc'),
           query: {
             bool: {
               filter: {

--- a/src/apps/companies/apps/activity-feed/es-queries/sortCriteria.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/sortCriteria.js
@@ -8,8 +8,8 @@ const sortCriteria = (sortOrder) => {
         // have a startTime set. The sort order needs to reflect their startTime (i.e. when the event is happening)
         // in the list of activities, as opposed to when that activity was created.
         source:
-          "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() " +
-          ": doc['published'].value.toInstant().toEpochMilli()",
+          "if (doc['object.startTime'].size() > 0) return doc['object.startTime'].value" +
+          ".toInstant().toEpochMilli(); return doc['published'].value.toInstant().toEpochMilli();",
       },
       order: sortOrder,
     },


### PR DESCRIPTION
## Description of change

Using the sort criteria `doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() : doc['published'].value.toInstant().toEpochMilli()` is generating an open search error:

```
{
        "shard" : 2,
        "index" : "activities__feed_id_forms-api__date_2023-05-05__timestamp_1683270005__batch_id_fljy4hwk__",
        "node" : "qPtv06v5Rnai_FEjJrSh9A",
        "reason" : {
          "type" : "script_exception",
          "reason" : "runtime error",
          "script_stack" : [
            "org.opensearch.index.fielddata.ScriptDocValues$Dates.get(ScriptDocValues.java:173)",
            "org.opensearch.index.fielddata.ScriptDocValues$Dates.getValue(ScriptDocValues.java:167)",
            "doc['object.startTime'].size()==0 ? doc['object.startTime'].value.toInstant().toEpochMilli() : doc['published'].value.toInstant().toEpochMilli()",
            "                                                           ^---- HERE"
          ],
         "script" : "doc.containsKey('object.startTime') ? doc['object.startTime'].value.toInstant().toEpochMilli() : doc['published'].value.toInstant().toEpochMilli()",
          "lang" : "painless",
          "position" : {
            "offset" : 59,
            "start" : 0,
            "end" : 144
          },
          "caused_by" : {
            "type" : "illegal_state_exception",
            "reason" : "A document doesn't have a value for a field! Use doc[<field>].size()==0 to check if a document is missing a field!"
          }
        }
      }
```

This PR changes the sort criteria to use the way of checking a field exists as suggested in the error message, by comparing the size>0
 
## Test instructions

Go to the url http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity, scroll down and you will now see Export Support Service entries in the list

## Screenshots

### Before

![image](https://user-images.githubusercontent.com/102232401/236437596-215d59fd-b5d2-43fe-9a98-af3dcce1745c.png)

### After

![image](https://user-images.githubusercontent.com/102232401/236437901-f9e819ab-4010-4191-ae63-f23c2e8c42ee.png)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
