### PR TITLE
bugfix/RR-931-interaction-error-message-order

### DIFF
--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -1,6 +1,7 @@
 const { reduce, isEqual } = require('lodash')
 
 import {
+  assertErrorSummary,
   assertFieldError,
   assertFieldInput,
   assertFieldRadiosWithLegend,
@@ -508,23 +509,29 @@ describe('Interaction theme', () => {
         .should('have.text', 'Johnny Cakeman')
     })
 
+    const interaction_error_messages = [
+      'Select a service',
+      'Select if this relates to a named trade agreement',
+      'Select at least one contact',
+      'Select a communication channel',
+      'Enter a summary',
+      'Select if the contact provided business intelligence',
+      'Select if any countries were discussed',
+      'Select if the interaction helped remove an export barrier',
+    ]
+
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      cy.contains('h2', 'There is a problem')
-        .next()
-        .should(
-          'have.text',
-          [
-            'Select a service',
-            'Select if this relates to a named trade agreement',
-            'Select at least one contact',
-            'Select a communication channel',
-            'Enter a summary',
-            'Select if the contact provided business intelligence',
-            'Select if any countries were discussed',
-            'Select if the interaction helped remove an export barrier',
-          ].join('')
-        )
+      assertErrorSummary(interaction_error_messages)
+    })
+
+    it('should validate the second tier service form field', () => {
+      fillSelect(
+        '[data-test=field-service]',
+        'A Specific DBT Export Service or Funding'
+      )
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(interaction_error_messages)
     })
 
     it('should save the interaction', () => {
@@ -625,23 +632,29 @@ describe('Service delivery theme', () => {
       ])
     })
 
+    const service_delivery_errors = [
+      'Select a service',
+      'Select if this relates to a named trade agreement',
+      'Select at least one contact',
+      'Select if this was an event',
+      'Enter a summary',
+      'Select if the contact provided business intelligence',
+      'Select if any countries were discussed',
+      'Select if the interaction helped remove an export barrier',
+    ]
+
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      cy.contains('h2', 'There is a problem')
-        .next()
-        .should(
-          'have.text',
-          [
-            'Select a service',
-            'Select if this relates to a named trade agreement',
-            'Select at least one contact',
-            'Select if this was an event',
-            'Enter a summary',
-            'Select if the contact provided business intelligence',
-            'Select if any countries were discussed',
-            'Select if the interaction helped remove an export barrier',
-          ].join('')
-        )
+      assertErrorSummary(service_delivery_errors)
+    })
+
+    it('should validate the second tier service form field', () => {
+      fillSelect(
+        '[data-test=field-service]',
+        'A Specific DBT Export Service or Funding'
+      )
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(service_delivery_errors)
     })
 
     it('should save the service delivery', () => {
@@ -726,22 +739,25 @@ describe('Investment theme', () => {
       ])
     })
 
+    const investment_error_messages = [
+      'Select a service',
+      'Select if this relates to a named trade agreement',
+      'Select at least one contact',
+      'Select a communication channel',
+      'Enter a summary',
+      'Select if the contact provided business intelligence',
+      'Answer if this interaction relates to a large capital opportunity',
+    ]
+
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      cy.contains('h2', 'There is a problem')
-        .next()
-        .should(
-          'have.text',
-          [
-            'Select a service',
-            'Select if this relates to a named trade agreement',
-            'Select at least one contact',
-            'Select a communication channel',
-            'Enter a summary',
-            'Select if the contact provided business intelligence',
-            'Answer if this interaction relates to a large capital opportunity',
-          ].join('')
-        )
+      assertErrorSummary(investment_error_messages)
+    })
+
+    it('should validate the second tier service form field', () => {
+      fillSelect('[data-test=field-service]', 'Enquiry received')
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(investment_error_messages)
     })
 
     it('should save the interaction', () => {
@@ -847,22 +863,25 @@ describe('Trade Agreement theme', () => {
       ])
     })
 
+    const trade_agreement_error_messages = [
+      'Select a service',
+      'Select if this relates to a named trade agreement',
+      'Select at least one contact',
+      'Select a communication channel',
+      'Enter a summary',
+      'Select if the contact provided business intelligence',
+      'Select if any countries were discussed',
+    ]
+
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      cy.contains('h2', 'There is a problem')
-        .next()
-        .should(
-          'have.text',
-          [
-            'Select a service',
-            'Select if this relates to a named trade agreement',
-            'Select at least one contact',
-            'Select a communication channel',
-            'Enter a summary',
-            'Select if the contact provided business intelligence',
-            'Select if any countries were discussed',
-          ].join('')
-        )
+      assertErrorSummary(trade_agreement_error_messages)
+    })
+
+    it('should validate the second tier service form field', () => {
+      fillSelect('[data-test=field-service]', 'A Specific Service')
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(trade_agreement_error_messages)
     })
 
     it('should save the interaction for a specific service', () => {

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -7,6 +7,7 @@ import {
   assertFieldSelect,
   testBreadcrumbs,
 } from '../../support/assertions'
+import { fillSelect } from '../../support/form-fillers'
 
 const urls = require('../../../../../src/lib/urls')
 const fixtures = require('../../fixtures')
@@ -208,15 +209,10 @@ function fillCommonFields({
   subservice = null,
   contact = 'Johnny Cakeman',
 }) {
-  cy.contains('Service').next().next().find('select').select(service)
+  fillSelect('[data-test=field-service]', service)
 
   if (subservice) {
-    cy.contains('Service')
-      .next()
-      .next()
-      .find('select')
-      .last()
-      .select(subservice)
+    fillSelect('[data-test=field-service_2nd_level]', subservice)
   }
 
   cy.contains(ELEMENT_RELATED_TRADE_AGREEMENT.legend)
@@ -482,6 +478,7 @@ describe('Interaction theme', () => {
         ELEMENT_SERVICE_HEADER,
         ELEMENT_BUSINESS_INTELLIGENCE_INFO,
         ELEMENT_SERVICE,
+        ELEMENT_SERVICE,
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
@@ -608,6 +605,7 @@ describe('Service delivery theme', () => {
         ELEMENT_SERVICE_HEADER,
         ELEMENT_BUSINESS_INTELLIGENCE_INFO,
         ELEMENT_SERVICE,
+        ELEMENT_SERVICE,
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
@@ -708,6 +706,7 @@ describe('Investment theme', () => {
       assertFormFields(cy.get('#interaction-details-form form'), [
         ELEMENT_SERVICE_HEADER,
         ELEMENT_BUSINESS_INTELLIGENCE_INFO,
+        ELEMENT_SERVICE,
         ELEMENT_SERVICE,
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
@@ -828,6 +827,7 @@ describe('Trade Agreement theme', () => {
       assertFormFields(cy.get('#interaction-details-form form'), [
         ELEMENT_SERVICE_HEADER,
         ELEMENT_BUSINESS_INTELLIGENCE_INFO,
+        ELEMENT_SERVICE,
         ELEMENT_SERVICE,
         ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,


### PR DESCRIPTION
## Description of change

The form error messages display in the order they are added to the page. The 2nd tier service `<FieldSelect />` component is only added after a selection is made to the top tier service list, which makes the error message for this field appear at the end of the list of errors.
This PR adds the 2nd tier service field to the page at the same time as all the other fields so the message appears in the correct order, however hides it with CSS until a selection is made on the top tier service list

## Test instructions

Add an interaction to any company, select an option in the first Service dropdown and then press the Add interaction button.
The second tier service error will now show first in the error messages

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/9796406e-d339-41c7-8018-e14e1dad4897)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/e0c3d4c5-b0c1-4521-baec-41d8942bcb34)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
