### PR TITLE
Cls2-88 registered trading address labels

### DIFF
--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -7,7 +7,7 @@ import { Badge, SummaryTable } from '../../../../../client/components/'
 import { SPACING_POINTS } from '@govuk-react/constants'
 
 const StyledAddressList = styled('ul')`
-  ${({ isRegistered }) => isRegistered && `margin-top: ${SPACING_POINTS[2]}px;`}
+  margin-top: ${SPACING_POINTS[2]}px;
 `
 
 const Address = ({ address, isRegistered }) => {
@@ -18,8 +18,8 @@ const Address = ({ address, isRegistered }) => {
   }
   return (
     <Table.Cell>
-      {isRegistered && <Badge>Registered</Badge>}
-      <StyledAddressList isRegistered={isRegistered}>
+      {isRegistered ? <Badge>Registered</Badge> : <Badge>Trading</Badge>}
+      <StyledAddressList>
         {address.line_1 && <li>{address.line_1}</li>}
         {address.line_2 && <li>{address.line_2}</li>}
         {address.town && <li>{address.town}</li>}

--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -19,7 +19,7 @@ const Address = ({ address, isRegistered }) => {
   const addressType = isRegistered ? 'Registered' : 'Trading'
   return (
     <Table.Cell>
-      {<Badge>${addressType}</Badge>}
+      {<Badge>{addressType}</Badge>}
       <StyledAddressList data-test={`addresses${addressType}`}>
         {address.line_1 && <li>{address.line_1}</li>}
         {address.line_2 && <li>{address.line_2}</li>}

--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -16,10 +16,11 @@ const Address = ({ address, isRegistered }) => {
       return <li>{address.area.name}</li>
     }
   }
+  const addressType = isRegistered ? 'Registered' : 'Trading'
   return (
     <Table.Cell>
-      {isRegistered ? <Badge>Registered</Badge> : <Badge>Trading</Badge>}
-      <StyledAddressList>
+      {<Badge>${addressType}</Badge>}
+      <StyledAddressList data-test={`addresses${addressType}`}>
         {address.line_1 && <li>{address.line_1}</li>}
         {address.line_2 && <li>{address.line_2}</li>}
         {address.town && <li>{address.town}</li>}
@@ -58,14 +59,14 @@ const SectionAddresses = ({
     }
   >
     <Table.Row>
-      <Address address={businessDetails.address} />
-
       {businessDetails.registered_address && (
         <Address
           address={businessDetails.registered_address}
           isRegistered={true}
         />
       )}
+
+      <Address address={businessDetails.address} />
     </Table.Row>
   </SummaryTable>
 )

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -15,15 +15,13 @@ const HIERARCHY_STRINGS = {
 }
 
 const assertAddress = ({ address, registeredAddress }) => {
-  const addressSelector1 =
-    '[data-test="addressesDetailsContainer"] td:nth-child(1)'
-  const addressSelector2 =
-    '[data-test="addressesDetailsContainer"] td:nth-child(2)'
+  const trading = '[data-test="addressesTrading"]'
+  const registered = '[data-test="addressesRegistered"]'
 
   if (address) {
-    cy.get(addressSelector1).contains('Registered').should('not.exist')
+    cy.get(trading).parent().contains('Trading').should('exist')
     address.map((line, index) => {
-      cy.get(addressSelector1)
+      cy.get(trading)
         .find(`li:nth-child(${index + 1})`)
         .should('have.text', line)
     })
@@ -32,14 +30,14 @@ const assertAddress = ({ address, registeredAddress }) => {
   }
 
   if (registeredAddress) {
-    cy.get(addressSelector2).contains('Registered').should('exist')
+    cy.get(registered).parent().contains('Registered').should('exist')
     registeredAddress.map((line, index) => {
-      cy.get(addressSelector2)
+      cy.get(registered)
         .find(`li:nth-child(${index + 1})`)
         .should('have.text', line)
     })
   } else if (registeredAddress === null) {
-    cy.get(addressSelector2).should('not.exist')
+    cy.get(registered).should('not.exist')
   }
 }
 


### PR DESCRIPTION
## Description of change
On business details tab:
Update the trading address to have a label, both trading and registered addresses now have a label regardless of the presence of the other address
Reorder addresses so that the registered address always appears first

## Test instructions

_What should I see?_

## Screenshots

### Before
![Before1](https://github.com/uktrade/data-hub-frontend/assets/54268863/4dfc7ae9-9d5e-466b-b70d-d462f1c17103)
![Before2](https://github.com/uktrade/data-hub-frontend/assets/54268863/f4e31094-25ef-4ea1-a184-f082ba36ac84)

### After
![After1](https://github.com/uktrade/data-hub-frontend/assets/54268863/6ee23845-c845-48a8-9940-bfd1644076f9)
![After2](https://github.com/uktrade/data-hub-frontend/assets/54268863/6f942582-cc76-4198-82eb-b85428b9e9aa)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
