### PR TITLE
Fix validation for actual land date in investments

### DIFF
--- a/src/client/components/Form/elements/FieldDate/index.jsx
+++ b/src/client/components/Form/elements/FieldDate/index.jsx
@@ -63,6 +63,10 @@ const getValidator =
 
     const isDateEmpty = isLong ? !day && !month && !year : !month && !year
 
+    if (isDateEmpty && !required) {
+      return null
+    }
+
     if (required && isDateEmpty) {
       return required
     }

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -395,7 +395,6 @@ describe('Validation error messages', () => {
     "Select yes if you're the referral source for this project",
     'Choose a referral source activity',
     'Enter an estimated land date',
-    // 'Enter a year as 4 digits',
     'Choose a client contact',
   ]
 

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -395,7 +395,7 @@ describe('Validation error messages', () => {
     "Select yes if you're the referral source for this project",
     'Choose a referral source activity',
     'Enter an estimated land date',
-    'Enter a year as 4 digits',
+    // 'Enter a year as 4 digits',
     'Choose a client contact',
   ]
 


### PR DESCRIPTION
## Description of change

when creating a DBT involved investment project the record will not save as the form requires you to add the Actual Land Date which you may not know at the time of creating the project record. Form is marked as 'Optional' so a check was added to check if the date is not required and is empty it should return nothing instead of an error.

## Test instructions

_What should I see?_

## Screenshots

### Before

<img width="723" alt="Screenshot 2023-05-12 at 12 54 54" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/f836e5b1-afbf-4214-a830-def19563b65d">

### After

<img width="1377" alt="Screenshot 2023-05-12 at 12 56 41" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/86785701-dae5-4f93-9d79-d73e31acd2b8">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
