### PR TITLE
Update address to be labelled as registered when no other addresses e…

### DIFF
--- a/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionAddresses.jsx
@@ -47,29 +47,36 @@ const SectionAddresses = ({
   isDnbCompany,
   isArchived,
   urls,
-}) => (
-  <SummaryTable
-    caption="Addresses"
-    data-test="addressesDetailsContainer"
-    actions={
-      !isDnbCompany &&
-      !isArchived && (
-        <Link href={`${urls.companyEdit}#field-address`}>Edit</Link>
-      )
-    }
-  >
-    <Table.Row>
-      {businessDetails.registered_address && (
-        <Address
-          address={businessDetails.registered_address}
-          isRegistered={true}
-        />
-      )}
+}) => {
+  const hasOnlyOneAddress = businessDetails.registered_address == null
 
-      <Address address={businessDetails.address} />
-    </Table.Row>
-  </SummaryTable>
-)
+  return (
+    <SummaryTable
+      caption="Addresses"
+      data-test="addressesDetailsContainer"
+      actions={
+        !isDnbCompany &&
+        !isArchived && (
+          <Link href={`${urls.companyEdit}#field-address`}>Edit</Link>
+        )
+      }
+    >
+      <Table.Row>
+        {!hasOnlyOneAddress && (
+          <Address
+            address={businessDetails.registered_address}
+            isRegistered={true}
+          />
+        )}
+
+        <Address
+          address={businessDetails.address}
+          isRegistered={hasOnlyOneAddress}
+        />
+      </Table.Row>
+    </SummaryTable>
+  )
+}
 
 SectionAddresses.propTypes = {
   businessDetails: PropTypes.object.isRequired,

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -86,7 +86,7 @@ const assertUnarchiveLinkNotVisible = () => {
   })
 }
 
-const assertAddressesContainer = (showEdit) => {
+const assertAddressContainer = (showEdit) => {
   it('should display the "Addresses" details container', () => {
     assertSummaryTable({
       dataTest: 'addressesDetailsContainer',
@@ -222,7 +222,7 @@ describe('Companies business details', () => {
         })
       })
 
-      assertAddressesContainer(false)
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddresses({
@@ -354,7 +354,7 @@ describe('Companies business details', () => {
         })
       })
 
-      assertAddressesContainer(true)
+      assertAddressContainer(true)
 
       it('should display the address', () => {
         assertAddresses({
@@ -426,7 +426,7 @@ describe('Companies business details', () => {
         })
       })
 
-      assertAddressesContainer(false)
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddresses({
@@ -523,7 +523,7 @@ describe('Companies business details', () => {
         })
       })
 
-      assertAddressesContainer(false)
+      assertAddressContainer(false)
 
       it('should display the address', () => {
         assertAddresses({
@@ -579,7 +579,7 @@ describe('Companies business details', () => {
         })
       })
 
-      assertAddressesContainer(true)
+      assertAddressContainer(true)
 
       it('should display the address', () => {
         assertAddresses({


### PR DESCRIPTION
…xist on the company

## Description of change

When a company only has `address` filled in the database but not `registered_address` then `address` is labelled as `Registered` instead of `Trading`.  A company must have a registered address and `address` can be trading, registered or a different address

## Test instructions

_What should I see?_

## Screenshots

### Before
![Before](https://github.com/uktrade/data-hub-frontend/assets/54268863/33342cfd-d881-496e-8d34-6d653b092056)

### After
![After](https://github.com/uktrade/data-hub-frontend/assets/54268863/16bbbe36-05d7-43a2-b53f-2293aa747c7d)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
