### PR TITLE
Update character limit on company name lookup to 60

### DIFF
--- a/src/client/components/Form/elements/FieldDnbCompany/index.jsx
+++ b/src/client/components/Form/elements/FieldDnbCompany/index.jsx
@@ -26,7 +26,7 @@ import FormLayout from '../../../Layout/FormLayout'
 import { FORM_LAYOUT } from '../../../../../common/constants'
 
 const COMPANY_NAME_MIN_LENGTH = 2
-const COMPANY_NAME_MAX_LENGTH = 30
+const COMPANY_NAME_MAX_LENGTH = 60
 
 const StyledUnorderedList = styled(UnorderedList)`
   list-style-type: disc;


### PR DESCRIPTION
## Description of change

Update the character limit for looking up a company name when searching for verified business details

## Test instructions

_What should I see?_

## Screenshots

### Before
Limit of 30:
![Screenshot 2023-05-18 at 12 17 26](https://github.com/uktrade/data-hub-frontend/assets/54268863/d1933791-0992-4a9e-9c6d-9894d9420b64)

### After
Limit of 60:

![Screenshot 2023-05-18 at 12 16 32](https://github.com/uktrade/data-hub-frontend/assets/54268863/6072afad-fa3c-4e6a-9125-a5ab3f7bb657)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
