### PR TITLE
bugfix/CLS2-83-e2e-collection-test-fix

### DIFF
--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -16,7 +16,7 @@ describe('Collection', () => {
     })
 
     it('should return the results summary for a company collection', () => {
-      cy.get('[data-test="collectionCount"]').should('have.text', '1')
+      cy.get('[data-test="collectionCount"]').should('have.text', '2')
     })
   })
 

--- a/test/end-to-end/cypress/specs/LEP/collection-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/collection-spec.js
@@ -19,7 +19,7 @@ describe('Collection', () => {
     })
 
     it('should return the results summary for a company collection', () => {
-      cy.get('[data-test="collectionCount"]').should('have.text', '1')
+      cy.get('[data-test="collectionCount"]').should('have.text', '2')
     })
   })
 


### PR DESCRIPTION
## Description of change

Update the e2e test to check for 2 items in the filtered results, now an extra motorleaf HQ company has been added to the test data in the api


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
