### PR TITLE
bugfix/CLS2-195-edit-business-details-error

### DIFF
--- a/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
+++ b/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
@@ -30,7 +30,9 @@ const CompanyMatched = ({
       name="turnover"
       data-test="company-matched-annual-turnover"
     >
-      {company.turnover
+      {!company.turnover_gbp && !company.turnover_range
+        ? 'Not set'
+        : company.turnover
         ? currencyGBP(company.turnover_gbp, {
             maximumSignificantDigits: 2,
           })

--- a/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
+++ b/src/apps/companies/apps/edit-company/client/CompanyMatched.jsx
@@ -32,7 +32,7 @@ const CompanyMatched = ({
     >
       {!company.turnover_gbp && !company.turnover_range
         ? 'Not set'
-        : company.turnover
+        : company.turnover_gbp
         ? currencyGBP(company.turnover_gbp, {
             maximumSignificantDigits: 2,
           })

--- a/test/component/cypress/specs/EditCompany/EditCompanyForm.cy.jsx
+++ b/test/component/cypress/specs/EditCompany/EditCompanyForm.cy.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+import DataHubProvider from '../provider'
+import EditCompanyForm from '../../../../../src/apps/companies/apps/edit-company/client/EditCompanyForm'
+
+describe('EditCompanyForm', () => {
+  const base_company = { duns_number: 1, address: {}, number_of_employees: 1 }
+
+  const Component = (props) => (
+    <DataHubProvider>
+      <EditCompanyForm formInitialValues={{}} {...props} />
+    </DataHubProvider>
+  )
+
+  context('When turnover_gbp and turnover_range is null', () => {
+    it('should render a "Not set" message', () => {
+      cy.mount(
+        <Component
+          company={{
+            ...base_company,
+            turnover_gbp: null,
+            turnover_range: null,
+          }}
+        />
+      )
+      cy.get('[data-test="field-turnover"]').contains('Not set')
+    })
+  })
+
+  context('When turnover_gbp is populated and turnover_range is null', () => {
+    it('should render the value as a currency', () => {
+      cy.mount(
+        <Component
+          company={{
+            ...base_company,
+            turnover_gbp: 50,
+            turnover_range: null,
+          }}
+        />
+      )
+      cy.get('[data-test="field-turnover"]').contains('£50')
+    })
+  })
+
+  context('When turnover_gbp is null and turnover_range is null', () => {
+    it('should render the turnover range value', () => {
+      cy.mount(
+        <Component
+          company={{
+            ...base_company,
+            turnover_gbp: null,
+            turnover_range: { name: 'abc' },
+          }}
+        />
+      )
+      cy.get('[data-test="field-turnover"]').contains('abc')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Show not set message when the turnover range data is missing

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/d456d10e-aeb0-4683-88b9-a7107678d5ea)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/929e9453-847e-4443-9a72-8ab867b26574)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
