### PR TITLE
feature/CLS2-182-add-breadcrumbs-to-access-denied

### DIFF
--- a/src/client/components/AccessDenied/index.jsx
+++ b/src/client/components/AccessDenied/index.jsx
@@ -1,23 +1,26 @@
 import React from 'react'
 import { DefaultLayout } from '..'
 
-const AccessDenied = () => (
+const AccessDenied = ({ breadcrumbs }) => (
   <DefaultLayout
     heading="You don't have permission to view this page"
     pageTitle="Access denied"
+    breadcrumbs={breadcrumbs}
   >
-    <p>
-      If you think you should have access or need to sign up to a DBT system
-      then <a href="/support">request access</a>.
-    </p>
-    <p>
-      You can also <a href="/">browse or search from the homepage</a> to find
-      the information you need.
-    </p>
+    <div data-test="access-denied">
+      <p>
+        If you think you should have access or need to sign up to a DBT system
+        then <a href="/support">request access</a>.
+      </p>
+      <p>
+        You can also <a href="/">browse or search from the homepage</a> to find
+        the information you need.
+      </p>
 
-    <p>
-      <strong>403</strong>
-    </p>
+      <p>
+        <strong>403</strong>
+      </p>
+    </div>
   </DefaultLayout>
 )
 

--- a/test/component/cypress/specs/AccessDenied.cy.jsx
+++ b/test/component/cypress/specs/AccessDenied.cy.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import AccessDenied from '../../../../src/client/components/AccessDenied'
+import urls from '../../../../src/lib/urls'
+import { assertBreadcrumbs } from '../../../functional/cypress/support/assertions'
+import DataHubProvider from './provider'
+
+describe('AccessDenied', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <AccessDenied {...props} />
+    </DataHubProvider>
+  )
+
+  context('When breadcrumbs are provided', () => {
+    it('they are used instead of the default', () => {
+      cy.mount(
+        <Component
+          breadcrumbs={[
+            {
+              link: urls.dashboard(),
+              text: 'Home',
+            },
+            {
+              link: urls.companies.index(),
+              text: 'Companies',
+            },
+          ]}
+        />
+      )
+      assertBreadcrumbs({
+        Home: urls.dashboard(),
+        Companies: urls.companies.index(),
+      })
+    })
+  })
+})

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -20,6 +20,8 @@ const reducer = (state, action) =>
     ...Typeahead.reducerSpread,
     ...FieldAddAnother.reducerSpread,
     ...Form.reducerSpread,
+    activeFeatureGroups: () => [],
+    modulePermissions: () => [],
   })(action.type === 'RESET' ? undefined : state, action)
 
 export const store = legacy_createStore(


### PR DESCRIPTION
## Description of change

Allow breadcrumbs to be overridden when needed

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
