### PR TITLE
Removed Business Intelligence Policy questions

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -176,7 +176,6 @@ const StepInteractionDetails = ({
   contacts,
   services,
   serviceDeliveryStatuses,
-  policyAreas,
   policyIssueTypes,
   communicationChannels,
   countries,
@@ -417,15 +416,12 @@ const StepInteractionDetails = ({
             required="Select at least one policy issue type"
           />
 
-          <FieldTypeahead
-            isMulti={true}
-            name="policy_areas"
-            label="Policy areas"
-            placeholder="-- Select policy area --"
-            options={policyAreas}
-            required="Select at least one policy area"
+          <FieldHelp
+            helpSummary="Help with policy issue types"
+            helpText="A policy type is the broad category/categories that the information fits into."
+            footerUrl={helpUrl(2)}
+            footerUrlDescription="Learn more about policy issue types"
           />
-
           <FieldTextarea
             name="policy_feedback_notes"
             label="Business intelligence summary"

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -176,7 +176,6 @@ const StepInteractionDetails = ({
   contacts,
   services,
   serviceDeliveryStatuses,
-  policyIssueTypes,
   communicationChannels,
   countries,
   onOpenContactForm,
@@ -409,19 +408,6 @@ const StepInteractionDetails = ({
 
       {values.was_policy_feedback_provided === OPTION_YES && (
         <>
-          <FieldCheckboxes
-            name="policy_issue_types"
-            legend="Policy issue types"
-            options={policyIssueTypes}
-            required="Select at least one policy issue type"
-          />
-
-          <FieldHelp
-            helpSummary="Help with policy issue types"
-            helpText="A policy type is the broad category/categories that the information fits into."
-            footerUrl={helpUrl(2)}
-            footerUrlDescription="Learn more about policy issue types"
-          />
           <FieldTextarea
             name="policy_feedback_notes"
             label="Business intelligence summary"
@@ -576,8 +562,6 @@ StepInteractionDetails.propTypes = {
   companyId: PropTypes.string.isRequired,
   services: typeaheadOptionsListProp.isRequired,
   serviceDeliveryStatuses: typeaheadOptionsListProp.isRequired,
-  policyAreas: typeaheadOptionsListProp.isRequired,
-  policyIssueTypes: typeaheadOptionsListProp.isRequired,
   communicationChannels: typeaheadOptionsListProp.isRequired,
   countries: typeaheadOptionsListProp.isRequired,
   relatedTradeAgreements: typeaheadOptionsListProp.isRequired,

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -21,7 +21,6 @@ async function renderInteractionDetailsForm(req, res, next) {
     const [
       services,
       serviceDeliveryStatuses,
-      policyIssueTypes,
       communicationChannels,
       countries,
       relatedTradeAgreements,
@@ -31,7 +30,6 @@ async function renderInteractionDetailsForm(req, res, next) {
         transformer: transformServiceToOption,
       }),
       getOptions(req, 'service-delivery-status', { sorted: false }),
-      getOptions(req, 'policy-issue-type'),
       getOptions(req, 'communication-channel'),
       getOptions(req, 'country'),
       getOptions(req, 'trade-agreement'),
@@ -55,7 +53,6 @@ async function renderInteractionDetailsForm(req, res, next) {
             .map(transformContactToOption),
           services,
           serviceDeliveryStatuses,
-          policyIssueTypes,
           communicationChannels,
           countries,
           relatedTradeAgreements,

--- a/src/apps/interactions/apps/details-form/controllers.js
+++ b/src/apps/interactions/apps/details-form/controllers.js
@@ -21,7 +21,6 @@ async function renderInteractionDetailsForm(req, res, next) {
     const [
       services,
       serviceDeliveryStatuses,
-      policyAreas,
       policyIssueTypes,
       communicationChannels,
       countries,
@@ -32,7 +31,6 @@ async function renderInteractionDetailsForm(req, res, next) {
         transformer: transformServiceToOption,
       }),
       getOptions(req, 'service-delivery-status', { sorted: false }),
-      getOptions(req, 'policy-area'),
       getOptions(req, 'policy-issue-type'),
       getOptions(req, 'communication-channel'),
       getOptions(req, 'country'),
@@ -57,7 +55,6 @@ async function renderInteractionDetailsForm(req, res, next) {
             .map(transformContactToOption),
           services,
           serviceDeliveryStatuses,
-          policyAreas,
           policyIssueTypes,
           communicationChannels,
           countries,

--- a/src/client/modules/Interactions/InteractionDetails/index.jsx
+++ b/src/client/modules/Interactions/InteractionDetails/index.jsx
@@ -120,18 +120,6 @@ const InteractionDetails = ({ interactionId, archivedDocumentPath }) => {
                 children={interaction.communicationChannel.name}
               />
             )}
-            {interaction.policyIssueTypes.length > 0 && (
-              <SummaryTable.Row
-                heading="Policy issue types"
-                children={transformArray(interaction.policyIssueTypes)}
-              />
-            )}
-            {interaction.policyAreas.length > 0 && (
-              <SummaryTable.Row
-                heading="Policy areas"
-                children={transformArray(interaction.policyAreas)}
-              />
-            )}
             {interaction.policyFeedbackNotes && (
               <SummaryTable.Row
                 heading="Business intelligence"

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -151,9 +151,6 @@ const ELEMENT_EXPORT_BARRIER_HOW = {
 const ELEMENT_POLICY_ISSUE_TYPES = {
   label: 'Policy issue types',
 }
-const ELEMENT_POLICY_AREAS = {
-  label: 'Policy areas',
-}
 const ELEMENT_POLICY_FEEDBACK_NOTES = {
   label: 'Business intelligence',
 }
@@ -258,12 +255,6 @@ function fillCommonFields({
     .next()
     .contains('Domestic')
     .click()
-
-  cy.contains(ELEMENT_POLICY_AREAS.label)
-    .parent()
-    .next()
-    .selectTypeaheadOption('State Aid')
-    .should('contain', 'State Aid')
 
   cy.contains(ELEMENT_POLICY_FEEDBACK_NOTES.label)
     .parent()

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -147,10 +147,6 @@ const ELEMENT_EXPORT_BARRIER = {
 const ELEMENT_EXPORT_BARRIER_HOW = {
   legend: 'Tell us how the interaction helped remove an export barrier',
 }
-
-const ELEMENT_POLICY_ISSUE_TYPES = {
-  label: 'Policy issue types',
-}
 const ELEMENT_POLICY_FEEDBACK_NOTES = {
   label: 'Business intelligence',
 }
@@ -185,8 +181,7 @@ const COMMON_REQUEST_BODY = {
   subject: 'Some summary',
   notes: 'Some notes',
   was_policy_feedback_provided: 'yes',
-  policy_issue_types: ['688ac22e-89d4-4d1f-bf0b-013588bf63a7'],
-  policy_areas: ['583c0bb6-d3c5-4e4b-8f25-e861c1e8d9c9'],
+  policy_areas: [],
   policy_feedback_notes: 'Some policy feedback notes',
   companies: ['0f5216e0-849f-11e6-ae22-56b6b6499611'],
   service_answers: {},
@@ -250,11 +245,6 @@ function fillCommonFields({
     .type('Some notes')
 
   cy.contains(ELEMENT_FEEDBACK_POLICY.legend).next().find('input').check('yes')
-
-  cy.contains(ELEMENT_POLICY_ISSUE_TYPES.label)
-    .next()
-    .contains('Domestic')
-    .click()
 
   cy.contains(ELEMENT_POLICY_FEEDBACK_NOTES.label)
     .parent()

--- a/test/functional/cypress/specs/interaction/details-spec.js
+++ b/test/functional/cypress/specs/interaction/details-spec.js
@@ -441,10 +441,6 @@ describe('Interaction details', () => {
           'Date of service delivery': '22 April 2022',
           'Adviser(s)': 'Brendan Smith, Aberdeen City Council',
           Event: 'No',
-          'Policy issue types':
-            'Domestic, EU exit, Non-EU trade priority, Economic opportunity, Economic risk, International Climate',
-          'Policy areas':
-            'Access to Finance, Access to Public Funding (inc. EU funding), Agriculture (Regulation/Support), Announcement Feedback, Government Communications, Health and Social Care (NHS), Imports, Inclusive Economy, Standards, State Aid, Supply Chains and Raw Materials, Tariffs and Trade Policy, COP26 Energy transitions, including RE100 and EP100, COP26 Finance, including TCFD, COP26 Nature, including supply chains',
           'Business intelligence':
             'Any comments the company made to you on areas such as issues impacting them or feedback on government policy. This information will be visible to other Data Hub users, the Business Intelligence Unit and may also be shared within DBT.',
           'Named trade agreement(s)':


### PR DESCRIPTION
## Description of change

When adding Business Intelligence to an interaction, there are two compulsory questions around policy (issue type and area). The Business Intelligence team do not trust this data - users' answers not reliable.

The purpose of this ticket is to remove those questions - Policy issue types area and Policy areas


## Test instructions

From Datahub, navigate into company list -> details -> add interaction -> export -> standard interaction -> Did the contact provide business intelligence? click "Yes"

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/7b614dba-a8db-4156-8b85-18d1ae4d6974)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/7ae2535a-fe50-431f-9cc4-473bf7a3f0b2)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
