### PR TITLE
Add React template for company pages

### DIFF
--- a/src/apps/companies/apps/advisers/controllers/advisers.js
+++ b/src/apps/companies/apps/advisers/controllers/advisers.js
@@ -61,16 +61,6 @@ async function renderCoreTeamAdvisers(req, res, next) {
     res.render('companies/views/advisers', {
       props: {
         companyId,
-        company,
-        breadcrumbs: [
-          { link: urls.dashboard(), text: 'Home' },
-          {
-            link: urls.companies.index(),
-            text: 'Companies',
-          },
-          { link: urls.companies.detail(company.id), text: company.name },
-          { text: 'Core Team' },
-        ],
         returnUrl,
         dnbRelatedCompaniesCount,
         flashMessages: res.locals.getMessages(),

--- a/src/apps/companies/views/advisers.njk
+++ b/src/apps/companies/views/advisers.njk
@@ -1,6 +1,6 @@
-{% extends "./template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'core-team',
     props: props

--- a/src/client/components/CompanyLocalHeader/CompanyLocalHeader2.jsx
+++ b/src/client/components/CompanyLocalHeader/CompanyLocalHeader2.jsx
@@ -1,0 +1,271 @@
+/**
+ * This is a temporary file so that tests for pages using the old CLH component still pass.
+ * Once the refactoring process is finalised, the old CLH will be deleted and replaced with this.
+ */
+
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import pluralize from 'pluralize'
+import Main from '@govuk-react/main'
+import GridCol from '@govuk-react/grid-col'
+import GridRow from '@govuk-react/grid-row'
+import Button from '@govuk-react/button'
+import Details from '@govuk-react/details'
+import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
+
+import { GREY_3, TEXT_COLOUR } from '../../utils/colours'
+import LocalHeader from '../LocalHeader/LocalHeader'
+import LocalHeaderHeading from '../LocalHeader/LocalHeaderHeading'
+import LocalHeaderCompanyLists from './LocalHeaderCompanyLists'
+import Badge from '../Badge'
+import StatusMessage from '../StatusMessage'
+import { addressToStringResource } from '../../utils/addresses'
+import urls from '../../../lib/urls'
+import ArchivePanel from '../ArchivePanel'
+
+const StyledAddress = styled('p')`
+  margin-top: ${SPACING.SCALE_2};
+  margin-bottom: ${SPACING.SCALE_2};
+`
+
+const BadgeText = styled('span')`
+  font-weight: 600;
+  font-size: ${FONT_SIZE.SIZE_16};
+`
+
+const TypeWrapper = styled('div')`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    display: table-row;
+  }
+`
+const StyledButtonContainer = styled('div')`
+  width: 100%;
+  display: inline-block;
+`
+
+const StyledList = styled('div')`
+  padding-bottom: 10px;
+`
+
+const StyledButtonLink = styled.a({
+  marginBottom: 10,
+  float: 'right',
+})
+
+const BadgeWrapper = styled('div')`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    display: table-cell;
+  }
+`
+
+const StyledDetails = styled(Details)`
+  @media (min-width: ${BREAKPOINTS.TABLET}) {
+    margin: 0 0 0 ${SPACING.SCALE_3};
+  }
+  span,
+  div {
+    font-size: ${FONT_SIZE.SIZE_16};
+  }
+`
+
+const StyledDescription = styled('div')`
+  padding: ${SPACING.SCALE_2};
+  background-color: ${GREY_3};
+
+  * + & {
+    margin-top: ${SPACING.SCALE_3};
+  }
+
+  p {
+    margin-top: 0;
+    margin-bottom: 0;
+
+    &:not(:last-child) {
+      margin-bottom: ${SPACING.SCALE_2};
+    }
+  }
+
+  & + * {
+    margin-top: ${SPACING.SCALE_3};
+  }
+`
+
+const StyledMain = styled(Main)`
+  padding-top: ${SPACING.SCALE_1};
+  div {
+    font-size: ${FONT_SIZE.SIZE_20};
+  }
+`
+
+const isUltimate = (company) => !!company.isGlobalUltimate
+const isGlobalHQ = (company) =>
+  company.headquarterType && company.headquarterType.name === 'ghq'
+
+const hasAllocatedLeadIta = (company) =>
+  company.oneListGroupGlobalAccountManager != null
+
+const hasManagedAccountDetails = (company) =>
+  company.oneListGroupTier && hasAllocatedLeadIta(company)
+
+const isItaTierDAccount = (company) =>
+  company.oneListGroupTier &&
+  company.oneListGroupTier.id === '1929c808-99b4-4abf-a891-45f2e187b410'
+
+const CompanyLocalHeader2 = ({
+  breadcrumbs,
+  flashMessages,
+  company,
+  dnbRelatedCompaniesCount,
+  returnUrl,
+}) => {
+  return (
+    company && (
+      <>
+        <LocalHeader breadcrumbs={breadcrumbs} flashMessages={flashMessages}>
+          <GridRow>
+            <GridCol setWidth="two-thirds">
+              <LocalHeaderHeading data-test="heading">
+                {company.name}
+              </LocalHeaderHeading>
+              <StyledAddress data-test="address">
+                {addressToStringResource(company.address)}
+              </StyledAddress>
+            </GridCol>
+            <GridCol setWith="one-third">
+              <StyledButtonContainer>
+                <Button
+                  as={StyledButtonLink}
+                  data-test={'header-add-interaction'}
+                  href={urls.companies.interactions.create(company.id)}
+                  aria-label={`Add interaction with ${name}`}
+                >
+                  Add interaction
+                </Button>
+                <Button
+                  as={StyledButtonLink}
+                  data-test={'header-add-export-project'}
+                  href={urls.exportPipeline.create(company.id)}
+                  aria-label={`Add export project`}
+                  buttonColour={GREY_3}
+                  buttonTextColour={TEXT_COLOUR}
+                >
+                  Add export project
+                </Button>
+              </StyledButtonContainer>
+            </GridCol>
+          </GridRow>
+          <StyledList>
+            <LocalHeaderCompanyLists company={company} returnUrl={returnUrl} />
+          </StyledList>
+          {(isUltimate(company) || isGlobalHQ(company)) && (
+            <TypeWrapper>
+              <BadgeWrapper>
+                <Badge>
+                  <BadgeText data-test="badge">
+                    {isUltimate(company) ? 'Ultimate HQ' : 'Global HQ'}
+                  </BadgeText>
+                </Badge>
+              </BadgeWrapper>
+              {isUltimate(company) && (
+                <StyledDetails
+                  summary="What does Ultimate HQ mean?"
+                  data-test="metaList"
+                >
+                  This HQ is in control of all related company records for{' '}
+                  {company.name}.
+                </StyledDetails>
+              )}
+            </TypeWrapper>
+          )}
+          {(dnbRelatedCompaniesCount > 0 ||
+            hasManagedAccountDetails(company)) && (
+            <StyledDescription data-test="description">
+              {dnbRelatedCompaniesCount > 0 && (
+                <p>
+                  Data Hub contains{' '}
+                  <a href={urls.companies.dnbHierarchy.index(company.id)}>
+                    {dnbRelatedCompaniesCount} other company{' '}
+                    {pluralize('record', dnbRelatedCompaniesCount)}
+                  </a>{' '}
+                  related to this company
+                </p>
+              )}
+              {hasManagedAccountDetails(company) && (
+                <>
+                  <p>
+                    This is an account managed company (One List{' '}
+                    {company.oneListGroupTier.name})
+                  </p>
+                  <p>
+                    {isItaTierDAccount(company)
+                      ? 'Lead ITA'
+                      : 'Global Account Manager'}
+                    : {company.oneListGroupGlobalAccountManager.name}{' '}
+                    <a href={urls.companies.advisers.index(company.id)}>
+                      {isItaTierDAccount(company)
+                        ? 'View Lead adviser'
+                        : 'View core team'}
+                    </a>
+                  </p>
+                </>
+              )}
+            </StyledDescription>
+          )}
+        </LocalHeader>
+
+        {company.archived && (
+          <ArchivePanel
+            archivedBy={company.archivedBy}
+            archivedOn={company.archivedOn}
+            archiveReason={company.archivedReason}
+            unarchiveUrl={urls.companies.unarchive(company.id)}
+            type="company"
+          />
+        )}
+
+        {company.pendingDnbInvestigation && (
+          <StyledMain data-test="investigationMessage">
+            <StatusMessage>
+              This company record is based on information that has not yet been
+              validated. This information is currently being checked by the Data
+              Hub support team.
+            </StatusMessage>
+          </StyledMain>
+        )}
+      </>
+    )
+  )
+}
+
+CompanyLocalHeader2.propTypes = {
+  breadcrumbs: PropTypes.arrayOf(
+    PropTypes.shape({
+      link: PropTypes.string,
+      text: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  flashMessages: PropTypes.shape({
+    type: PropTypes.oneOfType([
+      PropTypes.arrayOf(
+        PropTypes.shape({
+          body: PropTypes.string.isRequired,
+          heading: PropTypes.string.isRequired,
+          id: PropTypes.string,
+        })
+      ),
+      PropTypes.arrayOf(PropTypes.string).isRequired,
+    ]),
+  }),
+  company: PropTypes.object.isRequired,
+  dnbRelatedCompaniesCount: PropTypes.number,
+  returnUrl: PropTypes.string,
+}
+
+CompanyLocalHeader2.defaultProps = {
+  flashMessages: null,
+  dnbRelatedCompaniesCount: null,
+  returnUrl: null,
+}
+
+export default CompanyLocalHeader2

--- a/src/client/components/CompanyTabbedLocalNavigation/index.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/index.jsx
@@ -52,11 +52,15 @@ const StyledLink = styled('a')`
   margin-bottom: 0;
 `
 
+const checkObjectType = (company) =>
+  company.duns_number
+    ? !company.duns_number && !company.pending_dnb_investigation
+    : !company.dunsNumber && !company.pendingDnbInvestigation
+
 const CompanyTabbedLocalNavigation = (props) => {
   const { localNavItems } = props
   const company = props.company
-  const showMatchingPrompt =
-    !company.duns_number && !company.pending_dnb_investigation
+  const showMatchingPrompt = checkObjectType(company)
 
   return (
     <StyledGridRow>

--- a/src/client/components/Layout/CompanyLayout.jsx
+++ b/src/client/components/Layout/CompanyLayout.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import GridCol from '@govuk-react/grid-col'
 import GridRow from '@govuk-react/grid-row'
 
-import { CompanyLocalHeader, CompanyTabbedLocalNavigation, Main } from '..'
+import { CompanyLocalHeader2, CompanyTabbedLocalNavigation, Main } from '..'
 
 const CompanyLayout = ({
   company,
@@ -16,7 +16,7 @@ const CompanyLayout = ({
 }) => {
   return (
     <>
-      <CompanyLocalHeader
+      <CompanyLocalHeader2
         breadcrumbs={breadcrumbs}
         flashMessages={flashMessages}
         company={company}

--- a/src/client/components/Layout/CompanyLayout.jsx
+++ b/src/client/components/Layout/CompanyLayout.jsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import GridCol from '@govuk-react/grid-col'
+import GridRow from '@govuk-react/grid-row'
+
+import { CompanyLocalHeader, CompanyTabbedLocalNavigation, Main } from '..'
+
+const CompanyLayout = ({
+  company,
+  flashMessages,
+  breadcrumbs,
+  dnbRelatedCompaniesCount,
+  children,
+  returnUrl,
+  localNavItems,
+}) => {
+  return (
+    <>
+      <CompanyLocalHeader
+        breadcrumbs={breadcrumbs}
+        flashMessages={flashMessages}
+        company={company}
+        dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+        returnUrl={returnUrl}
+      />
+      <Main>
+        <CompanyTabbedLocalNavigation
+          localNavItems={localNavItems}
+          company={company}
+        />
+        <GridRow>
+          <GridCol>{children}</GridCol>
+        </GridRow>
+      </Main>
+    </>
+  )
+}
+
+CompanyLayout.propTypes = {
+  company: PropTypes.object.isRequired,
+  permissions: PropTypes.array.isRequired,
+  children: PropTypes.element.isRequired,
+}
+
+export default CompanyLayout

--- a/src/client/components/index.jsx
+++ b/src/client/components/index.jsx
@@ -10,6 +10,7 @@ export { default as CollectionFilters } from './CollectionList/CollectionFilters
 export { default as CollectionHeaderRow } from './CollectionList/CollectionHeaderRow'
 export { default as CompanyLists } from './CompanyLists'
 export { default as CompanyLocalHeader } from './CompanyLocalHeader'
+export { default as CompanyLocalHeader2 } from './CompanyLocalHeader/CompanyLocalHeader2'
 export { default as CompanyTabbedLocalNavigation } from './CompanyTabbedLocalNavigation'
 export { default as ContactInformation } from './ContactInformation'
 export { default as DeleteCompanyListSection } from './CompanyLists/DeleteCompanyListSection'

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../../components/Resource'
 import { transformOneListCoreTeamToCollection } from './transformers'
 import { NewWindowLink } from '../../../components'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import urls from '../../../../lib/urls'
 
 const getSubheadingText = (company) => {
@@ -43,12 +44,32 @@ const buildAdviserRows = (oneListTeam) => {
   return advisers.length > 0 ? buildRow(advisers) : null
 }
 
-const CoreTeam = ({ companyId, oneListEmail }) => (
+const CoreTeam = ({
+  companyId,
+  oneListEmail,
+  dnbRelatedCompaniesCount,
+  returnUrl,
+  localNavItems,
+}) => (
   <CompanyResource id={companyId}>
     {(company) => (
       <CompanyOneListTeamResource id={companyId}>
         {(oneListTeam) => (
-          <>
+          <CompanyLayout
+            company={company}
+            breadcrumbs={[
+              { link: urls.dashboard(), text: 'Home' },
+              {
+                link: urls.companies.index(),
+                text: 'Companies',
+              },
+              { link: urls.companies.detail(company.id), text: company.name },
+              { text: 'Core Team' },
+            ]}
+            dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+            returnUrl={returnUrl}
+            localNavItems={localNavItems}
+          >
             <H2 size={LEVEL_SIZE[3]} data-test="core-team-heading">
               Advisers on the core team
             </H2>
@@ -89,7 +110,7 @@ const CoreTeam = ({ companyId, oneListEmail }) => (
               or email{' '}
               <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
             </Details>
-          </>
+          </CompanyLayout>
         )}
       </CompanyOneListTeamResource>
     )}

--- a/src/client/utils/addresses.js
+++ b/src/client/utils/addresses.js
@@ -27,4 +27,11 @@ const addressToString = (address) =>
     .filter((value) => value)
     .join(', ')
 
-module.exports = { addressToString, getCompanyAddress }
+// For company addresses retrieved via the Resource component
+const addressToStringResource = (address) =>
+  ['line1', 'line2', 'town', 'county', 'postcode', 'area.name', 'country.name']
+    .map((component) => get(address, component))
+    .filter((value) => value)
+    .join(', ')
+
+module.exports = { addressToString, addressToStringResource, getCompanyAddress }


### PR DESCRIPTION
## Description of change

Now that all company pages using the company local header have been reactified, I've written a new `CompanyLayout` component to mount the company local header and navigation (using a similar approach to #5264). This will also mean that many of the companies pages will be ascended into the `modules` directory. As there are numerous pages that need refactoring I will be merging each PR into a `feature-merge` branch so that the final transition is seamless.

To accomodate the pages that still use the company prop passed down from the controller, I've made a duplicate CompanyLocalHeader component that works with company objects obtained by a resource. This means that all tests should still pass without needing to add lots of temporary functions to check which object key to use.

This first PR sets up the company layout component and refactors a page to use it.

## Test instructions

With your local FE pointing to dev, navigate to [this company's Core Team tab](http://localhost:3000/companies/e26d3e93-67de-4c12-9d9a-1c0c190f9d92/advisers). The local header and tab navigation should work as expected.

## Screenshots

### Before
<img width="997" alt="Screenshot 2023-05-30 at 12 38 50" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/18f96bbd-497d-4a20-be0a-416757b96c29">

### After

<img width="1006" alt="Screenshot 2023-05-30 at 12 39 00" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/dfb0fcfd-9238-44dc-a5d7-2b6ccb899af5">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
