### PR TITLE
feature/CLS2-184-add-dnb-fakers

### DIFF
--- a/test/functional/cypress/fakers/constants.js
+++ b/test/functional/cypress/fakers/constants.js
@@ -87,3 +87,41 @@ export const EXPORTER_EXPERIENCE = [
     name: 'An exported that DBT are helping maintain and grow their exports',
   },
 ]
+
+export const HEADQUARTER_TYPE = [
+  {
+    id: '43281c5e-92a4-4794-867b-b4d5f801e6f3',
+    name: 'ghq',
+  },
+  {
+    id: 'eb59eaeb-eeb8-4f54-9506-a5e08773046b',
+    name: 'ehq',
+  },
+  {
+    id: '3e6debb4-1596-40c5-aa25-f00da0e05af9',
+    name: 'ukhq',
+  },
+]
+
+export const EMPLOYEE_RANGE = [
+  {
+    id: '3dafd8d0-5d95-e211-a939-e4115bead28a',
+    name: '1 to 9',
+  },
+  {
+    id: '3eafd8d0-5d95-e211-a939-e4115bead28a',
+    name: '10 to 49',
+  },
+  {
+    id: '3fafd8d0-5d95-e211-a939-e4115bead28a',
+    name: '50 to 249',
+  },
+  {
+    id: '40afd8d0-5d95-e211-a939-e4115bead28a',
+    name: '250 to 499',
+  },
+  {
+    id: '41afd8d0-5d95-e211-a939-e4115bead28a',
+    name: '500+',
+  },
+]

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -1,22 +1,9 @@
-// TODO - the logic in this should be moved to the fakers folder once there is a real api to call
+import { faker } from '@faker-js/faker'
 
-var ukRegion = require('../../../fixtures/v4/metadata/uk-region.json')
-var employeeRange = require('../../../fixtures/v4/metadata/employee-range.json')
-var headquarterType = require('../../../fixtures/v4/metadata/headquarter-type.json')
-
-const { faker } = require('@faker-js/faker')
-
-const address = {
-  line_1: faker.location.streetAddress(),
-  line_2: faker.location.street(),
-  town: faker.location.city(),
-  county: faker.location.county(),
-  postcode: faker.location.zipCode(),
-  country: {
-    id: faker.string.uuid(),
-    name: faker.location.country(),
-  },
-}
+import { listFaker } from './utils'
+import { addressFaker } from './addresses'
+import { ukRegionFaker } from './regions'
+import { EMPLOYEE_RANGE, HEADQUARTER_TYPE } from './constants'
 
 const companyTreeItemFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
@@ -29,9 +16,9 @@ const companyTreeItemFaker = (overrides = {}) => ({
     min: 0,
     max: 15000,
   }),
-  uk_region: faker.helpers.arrayElement(ukRegion),
-  address: address, //This is called trading address on the designs
-  registered_address: address,
+  uk_region: ukRegionFaker(),
+  address: addressFaker(), //This is called trading address on the designs
+  registered_address: addressFaker(),
   sector: [
     {
       id: faker.string.uuid(),
@@ -43,6 +30,9 @@ const companyTreeItemFaker = (overrides = {}) => ({
   subsidiaries: [],
   ...overrides,
 })
+
+const companyTreeItemListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: companyTreeItemFaker, length, overrides })
 
 const createCompanyTree = (
   treeDepth,
@@ -103,18 +93,25 @@ const createSubsidiary = (
   company.subsidiaries = subsidiaryCompanies
 }
 
-exports.fakerCompanyFamilyTree = ({
+const companyTreeFaker = ({
   treeDepth = 2,
   minCompaniesPerLevel = 1,
   maxCompaniesPerLevel = 1,
+  globalCompany = createCompanyTree(
+    treeDepth,
+    minCompaniesPerLevel,
+    maxCompaniesPerLevel
+  ),
 }) => ({
-  ...createCompanyTree(treeDepth, minCompaniesPerLevel, maxCompaniesPerLevel),
+  ...globalCompany,
   manually_verified_subsidiaries: [
     {
       id: faker.string.uuid(),
       name: faker.company.name(),
-      employee_range: faker.helpers.arrayElement(employeeRange),
-      headquarter_type: faker.helpers.arrayElement(headquarterType),
+      employee_range: faker.helpers.arrayElement(EMPLOYEE_RANGE),
+      headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
     },
   ],
 })
+
+export { companyTreeFaker, companyTreeItemFaker, companyTreeItemListFaker }


### PR DESCRIPTION
## Description of change

- Start migrating from sandbox api to faker in the cypress tests for generating the dnb hierarchy
- Added a new prop to the example dnb hierarchy for the total number of companies in the tree

## Test instructions

No visible changes, but if you start the sandbox and open http://localhost:8000/v4/dnb/0418f79f-154b-4f55-85a6-8ddad559663e/family-tree you can see the new `ultimate_global_companies_count` prop



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
