### PR TITLE
Refactor company contact/order lists with new template

### DIFF
--- a/src/apps/companies/controllers/contacts.js
+++ b/src/apps/companies/controllers/contacts.js
@@ -1,5 +1,3 @@
-const urls = require('../../../lib/urls')
-
 function renderContacts(req, res) {
   const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
 
@@ -7,16 +5,7 @@ function renderContacts(req, res) {
 
   res.render('companies/views/contacts', {
     props: {
-      company,
-      breadcrumbs: [
-        { link: urls.dashboard(), text: 'Home' },
-        {
-          link: urls.companies.index(),
-          text: 'Companies',
-        },
-        { link: urls.companies.detail(company.id), text: company.name },
-        { text: 'Contacts' },
-      ],
+      companyId: company.id,
       returnUrl,
       dnbRelatedCompaniesCount,
       localNavItems: res.locals.localNavItems,

--- a/src/apps/companies/controllers/orders.js
+++ b/src/apps/companies/controllers/orders.js
@@ -1,5 +1,3 @@
-const urls = require('../../../lib/urls')
-
 function renderOrders(req, res) {
   const { company, returnUrl, dnbRelatedCompaniesCount } = res.locals
 
@@ -7,13 +5,7 @@ function renderOrders(req, res) {
 
   res.render('companies/views/orders', {
     props: {
-      company,
-      breadcrumbs: [
-        { link: urls.dashboard(), text: 'Home' },
-        { link: urls.companies.index(), text: 'Companies' },
-        { link: urls.companies.detail(company.id), text: company.name },
-        { text: 'Orders (OMIS)' },
-      ],
+      companyId: company.id,
       returnUrl,
       dnbRelatedCompaniesCount,
       localNavItems: res.locals.localNavItems,

--- a/src/apps/companies/views/contacts.njk
+++ b/src/apps/companies/views/contacts.njk
@@ -1,6 +1,6 @@
-{% extends "./template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'company-contacts-collection',
     props: props

--- a/src/apps/companies/views/orders.njk
+++ b/src/apps/companies/views/orders.njk
@@ -1,6 +1,6 @@
-{% extends "./template.njk" %}
+{% extends "_layouts/template-no-local-header.njk" %}
 
-{% block body_main_content %}
+{% block body %}
   {% component 'react-slot', {
     id: 'company-orders-collection',
     props: props

--- a/src/client/modules/Contacts/CollectionList/CompanyContactsCollection.jsx
+++ b/src/client/modules/Contacts/CollectionList/CompanyContactsCollection.jsx
@@ -4,6 +4,9 @@ import { Link, Details } from 'govuk-react'
 
 import { CONTACTS__LOADED } from '../../../actions'
 import { FilteredCollectionList } from '../../../components'
+import { CompanyResource } from '../../../components/Resource'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
+import urls from '../../../../lib/urls'
 
 import {
   TASK_GET_CONTACTS_LIST,
@@ -12,10 +15,13 @@ import {
 } from './state'
 
 const CompanyContactsCollection = ({
-  company,
+  companyId,
   payload,
   optionMetadata,
   selectedFilters,
+  dnbRelatedCompaniesCount,
+  returnUrl,
+  localNavItems,
   ...props
 }) => {
   const collectionListTask = {
@@ -25,42 +31,60 @@ const CompanyContactsCollection = ({
     startOnRender: {
       payload: {
         ...payload,
-        companyId: company.id,
+        companyId: companyId,
       },
       onSuccessDispatch: CONTACTS__LOADED,
     },
   }
 
   return (
-    <>
-      {company.archived && (
-        <Details
-          summary="Why can I not add a contact?"
-          data-test="archived-details"
+    <CompanyResource id={companyId}>
+      {(company) => (
+        <CompanyLayout
+          company={company}
+          breadcrumbs={[
+            { link: urls.dashboard(), text: 'Home' },
+            {
+              link: urls.companies.index(),
+              text: 'Companies',
+            },
+            { link: urls.companies.detail(company.id), text: company.name },
+            { text: 'Contacts' },
+          ]}
+          dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+          returnUrl={returnUrl}
+          localNavItems={localNavItems}
         >
-          Contacts cannot be added to an archived company.{' '}
-          <Link href={`/companies/${company.id}/unarchive`}>
-            Click here to unarchive
-          </Link>
-        </Details>
+          {company.archived && (
+            <Details
+              summary="Why can I not add a contact?"
+              data-test="archived-details"
+            >
+              Contacts cannot be added to an archived company.{' '}
+              <Link href={`/companies/${company.id}/unarchive`}>
+                Click here to unarchive
+              </Link>
+            </Details>
+          )}
+          <FilteredCollectionList
+            {...props}
+            collectionName="contact"
+            sortOptions={optionMetadata.sortOptions}
+            taskProps={collectionListTask}
+            selectedFilters={selectedFilters}
+            addItemUrl={
+              company.archived ? null : `/contacts/create?company=${company.id}`
+            }
+            entityName="contact"
+            defaultQueryParams={{
+              archived: ['false'],
+              sortby: 'modified_on:desc',
+              page: 1,
+            }}
+          />
+        </CompanyLayout>
       )}
-      <FilteredCollectionList
-        {...props}
-        collectionName="contact"
-        sortOptions={optionMetadata.sortOptions}
-        taskProps={collectionListTask}
-        selectedFilters={selectedFilters}
-        addItemUrl={
-          company.archived ? null : `/contacts/create?company=${company.id}`
-        }
-        entityName="contact"
-        defaultQueryParams={{
-          archived: ['false'],
-          sortby: 'modified_on:desc',
-          page: 1,
-        }}
-      ></FilteredCollectionList>
-    </>
+    </CompanyResource>
   )
 }
 

--- a/src/client/modules/Omis/CollectionList/CompanyOrdersCollection.jsx
+++ b/src/client/modules/Omis/CollectionList/CompanyOrdersCollection.jsx
@@ -10,6 +10,9 @@ import { ORDERS__LOADED } from '../../../actions'
 
 import { FilteredCollectionList } from '../../../components'
 import { listSkeletonPlaceholder } from '../../../components/SkeletonPlaceholder'
+import { CompanyResource } from '../../../components/Resource'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
+import urls from '../../../../lib/urls'
 
 import {
   companyOrdersState2props,
@@ -31,10 +34,13 @@ const StyledLinkHeader = styled(StyledHeader)`
 `
 
 const CompanyOrdersCollection = ({
-  company,
+  companyId,
   payload,
   optionMetadata,
   selectedFilters,
+  dnbRelatedCompaniesCount,
+  returnUrl,
+  localNavItems,
   ...props
 }) => {
   const collectionListTask = {
@@ -45,7 +51,7 @@ const CompanyOrdersCollection = ({
     startOnRender: {
       payload: {
         ...payload,
-        companyId: company.id,
+        companyId: companyId,
       },
       onSuccessDispatch: ORDERS__LOADED,
     },
@@ -60,38 +66,56 @@ const CompanyOrdersCollection = ({
   )
 
   return (
-    <>
-      {company.archived && (
-        <Details
-          summary="Why can I not add an order?"
-          data-test="archived-details"
+    <CompanyResource id={companyId}>
+      {(company) => (
+        <CompanyLayout
+          company={company}
+          breadcrumbs={[
+            { link: urls.dashboard(), text: 'Home' },
+            {
+              link: urls.companies.index(),
+              text: 'Companies',
+            },
+            { link: urls.companies.detail(company.id), text: company.name },
+            { text: 'Orders (OMIS)' },
+          ]}
+          dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+          returnUrl={returnUrl}
+          localNavItems={localNavItems}
         >
-          Orders cannot be added to an archived company.{' '}
-          <Link href={`/companies/${company.id}/unarchive`}>
-            Click here to unarchive
-          </Link>
-        </Details>
+          {company.archived && (
+            <Details
+              summary="Why can I not add an order?"
+              data-test="archived-details"
+            >
+              Orders cannot be added to an archived company.{' '}
+              <Link href={`/companies/${company.id}/unarchive`}>
+                Click here to unarchive
+              </Link>
+            </Details>
+          )}
+          <FilteredCollectionList
+            {...props}
+            collectionName="order"
+            sortOptions={optionMetadata.sortOptions}
+            taskProps={collectionListTask}
+            selectedFilters={selectedFilters}
+            addItemUrl={
+              company.archived
+                ? null
+                : `/omis/create?company=${company.id}&skip-company=true`
+            }
+            entityName="order"
+            entityNamePlural="orders"
+            titleRenderer={TitleRenderer}
+            defaultQueryParams={{
+              page: 1,
+              sortby: 'created_on:desc',
+            }}
+          />
+        </CompanyLayout>
       )}
-      <FilteredCollectionList
-        {...props}
-        collectionName="order"
-        sortOptions={optionMetadata.sortOptions}
-        taskProps={collectionListTask}
-        selectedFilters={selectedFilters}
-        addItemUrl={
-          company.archived
-            ? null
-            : `/omis/create?company=${company.id}&skip-company=true`
-        }
-        entityName="order"
-        entityNamePlural="orders"
-        titleRenderer={TitleRenderer}
-        defaultQueryParams={{
-          page: 1,
-          sortby: 'created_on:desc',
-        }}
-      ></FilteredCollectionList>
-    </>
+    </CompanyResource>
   )
 }
 


### PR DESCRIPTION
## Description of change
The company contact and OMIS order pages have been refactored to use the new layout introduced in https://github.com/uktrade/data-hub-frontend/pull/5682.

## Test instructions

Go to the contact or OMIS order pages for a company. Everything should work as before.

## Screenshots

See screenshots in https://github.com/uktrade/data-hub-frontend/pull/5682. There are no visual changes to the pages themselves.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
