### PR TITLE
Filter the export pipeline list by owner

### DIFF
--- a/src/client/modules/ExportPipeline/ExportList/ExportSelect.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ExportSelect.jsx
@@ -7,7 +7,7 @@ import qs from 'qs'
 
 import { Select } from '../../../components'
 
-const StyledSelect = styled(Select)({
+const StyledSelect = styled(Select)(({ maxWidth }) => ({
   alignItems: 'flex-start',
   flexDirection: 'column',
   flex: '1 1',
@@ -15,14 +15,15 @@ const StyledSelect = styled(Select)({
     width: '100%',
     minWidth: 170,
     maxHeight: 36,
+    ...(maxWidth ? { maxWidth: `${maxWidth}px` } : {}),
   },
   marginBottom: SPACING.SCALE_1,
   [MEDIA_QUERIES.DESKTOP]: {
     margin: SPACING.SCALE_1,
   },
-})
+}))
 
-const ExportSelect = ({ label, options = [], qsParam }) => {
+const ExportSelect = ({ label, options = [], qsParam, maxWidth }) => {
   const history = useHistory()
   const location = useLocation()
 
@@ -43,6 +44,7 @@ const ExportSelect = ({ label, options = [], qsParam }) => {
     <StyledSelect
       label={label}
       data-test={kebabCase(`${qsParam}-select`)}
+      maxWidth={maxWidth}
       input={{
         onChange,
         initialValue,

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -143,6 +143,11 @@ const ExportList = ({
                   qsParamName="estimated_win_date_before"
                   data-test="estimated-win-date-before"
                 />
+                <ExportSelect
+                  label="Owner"
+                  qsParam="owner"
+                  options={filters.owner.options}
+                />
               </FiltersContainer>
             )}
           </Task.Status>

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -146,6 +146,7 @@ const ExportList = ({
                 <ExportSelect
                   label="Owner"
                   qsParam="owner"
+                  maxWidth="173"
                   options={filters.owner.options}
                 />
               </FiltersContainer>

--- a/src/client/modules/ExportPipeline/ExportList/state.js
+++ b/src/client/modules/ExportPipeline/ExportList/state.js
@@ -25,7 +25,7 @@ const areFiltersActive = (queryParams) => {
 
 export const state2props = ({ router, ...state }) => {
   const queryParams = getQueryParamsFromLocation(router.location)
-  const { sectorOptions, countryOptions } = state[ID]
+  const { sectorOptions, countryOptions, ownerOptions } = state[ID]
   return {
     ...state[ID],
     payload: {
@@ -45,6 +45,9 @@ export const state2props = ({ router, ...state }) => {
       },
       country: {
         options: countryOptions,
+      },
+      owner: {
+        options: ownerOptions,
       },
     },
   }

--- a/src/client/modules/ExportPipeline/ExportList/task.js
+++ b/src/client/modules/ExportPipeline/ExportList/task.js
@@ -5,6 +5,7 @@ import { getPageOffset } from '../../../../client/utils/pagination.js'
 import { apiProxyAxios } from '../../../components/Task/utils'
 
 import { getMetadataOptions } from '../../../metadata'
+import { transformAPIAdvisersToOptions } from '../transformers'
 import { SHOW_ALL_OPTION } from '../constants.js'
 import urls from '../../../../lib/urls'
 
@@ -18,6 +19,7 @@ export const getExportPipelineList = ({
   destination_country,
   estimated_win_date_after, // from
   estimated_win_date_before, // to
+  owner,
 }) => {
   const offset = getPageOffset({ limit, page })
   const payload = omitBy(
@@ -30,6 +32,7 @@ export const getExportPipelineList = ({
       export_potential,
       sector,
       destination_country,
+      owner,
     },
     (fieldValue) =>
       fieldValue === SHOW_ALL_OPTION.value || isUndefined(fieldValue)
@@ -55,7 +58,9 @@ export const getExportPipelineMetadata = () =>
       },
     }),
     getMetadataOptions(urls.metadata.country()),
-  ]).then(([sectorOptions, countryOptions]) => ({
+    apiProxyAxios.get('v4/export/owner'),
+  ]).then(([sectorOptions, countryOptions, owners]) => ({
     sectorOptions: [SHOW_ALL_OPTION, ...sectorOptions],
     countryOptions: [SHOW_ALL_OPTION, ...countryOptions],
+    ownerOptions: [SHOW_ALL_OPTION, ...transformAPIAdvisersToOptions(owners)],
   }))

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -72,3 +72,9 @@ export const transformAPIValuesForForm = ({
   exporter_experience: exporter_experience?.id,
   notes,
 })
+
+export const transformAPIAdvisersToOptions = ({ data }) =>
+  data.map((adviser) => ({
+    label: adviser.name,
+    value: adviser.id,
+  }))


### PR DESCRIPTION
## Description of change
Filters the export pipeline list by owner.

The owner dropdown list includes users that own an export, if the user is a team member of an export then the owner of that export is also included in the list of owners. An owner should only appear once in the list.

## Test instructions

**Owner filter**
* Go to `/export` and apply the owner filter to view a list of exports filtered by owner.

**Book marking**
* Copy and paste the url into a separate browser tab to see the list maintain the filter selection.

## Screenshots

### Before
<img width="981" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b12eb5dd-756f-4344-8e9e-09bff1a614f2">

### After
<img width="981" alt="Screenshot 2023-06-06 at 11 18 35" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d1933689-b11b-4864-8f2b-f53f95af1a30">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
