### PR TITLE
Revert contact query fix.

### DIFF
--- a/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/contact-activity-query.js
@@ -70,25 +70,6 @@ const contactActivityQuery = (
                     must: [
                       {
                         term: {
-                          'object.type': 'dit:maxemail:Email:Sent',
-                        },
-                      },
-                      {
-                        term: {
-                          'object.dit:emailAddress': {
-                            value: email,
-                            case_insensitive: true,
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
-                {
-                  bool: {
-                    must: [
-                      {
-                        term: {
                           'object.attributedTo.id':
                             'dit:directoryFormsApi:SubmissionType:export-support-service',
                         },


### PR DESCRIPTION
## Description of change

This reverses the fix for Activity Stream maxemail contact query. Looks like this particular activity is actually not implemented in the ActivityFeed component (it only has maxemail campaign implemented) and because of a bug, when component gets an activity it can't render, it will crash.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
