### PR TITLE
Feature/cls2-184-temporary-company-tree-route

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -30,6 +30,7 @@ const reactRoutes = [
   '/export/:exportId/details',
   '/export/:exportId/delete',
   '/companies/:companyId/dnb-hierarchy',
+  '/companies/:companyId/company-tree',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DefaultLayout } from '../../../components'
+
+const CompanyTree = () => {
+  return (
+    <DefaultLayout
+      heading={'Company records'}
+      pageTitle={'Company records'}
+      breadcrumbs={[]}
+      useReactRouter={false}
+    >
+      <h1>Company tree</h1>
+    </DefaultLayout>
+  )
+}
+
+export default CompanyTree

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -17,6 +17,7 @@ import {
 import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
 import ExportDetails from './modules/ExportPipeline/ExportDetails'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
+import CompanyTree from './modules/Companies/CompanyHierarchy/CompanyTree'
 
 const routes = {
   companies: [
@@ -29,6 +30,11 @@ const routes = {
       path: '/companies/:companyId/dnb-hierarchy',
       module: 'datahub:companies',
       component: CompanyHierarchy,
+    },
+    {
+      path: '/companies/:companyId/company-tree',
+      module: 'datahub:companies',
+      component: CompanyTree,
     },
   ],
   contacts: [

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -171,6 +171,7 @@ module.exports = {
     dnbHierarchy: {
       index: url('/companies', '/:companyId/dnb-hierarchy'),
       data: url('/companies', '/:companyId/dnb-hierarchy/data'),
+      tree: url('/companies', '/:companyId/company-tree'),
     },
     exports: {
       index: url('/companies', '/:companyId/exports'),


### PR DESCRIPTION
## Description of change

To avoid disrupting users ability to interact with the existing dnb hierarchy page, the company tree will be deployed to a temporary url that only developers are aware of. This page is not linked to from any other pages

This url will be removed once all tickets for the company tree are completed

## Test instructions

Go to the url http://localhost:3000/companies/0418f79f-154b-4f55-85a6-8ddad559663e/company-tree. You will see an empty company tree page

## Screenshots

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/76d19194-4d92-4981-8d78-42bd6af8bd06)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
