### PR TITLE
feature/cls2-184-additional-faked-fields

### DIFF
--- a/test/functional/cypress/fakers/constants.js
+++ b/test/functional/cypress/fakers/constants.js
@@ -125,3 +125,34 @@ export const EMPLOYEE_RANGE = [
     name: '500+',
   },
 ]
+
+export const ONE_LIST_TIER = [
+  {
+    id: 'b91bf800-8d53-e311-aef3-441ea13961e2',
+    name: 'Tier A - Strategic Account',
+  },
+  {
+    id: '7e0c261a-d447-e411-985c-e4115bead28a',
+    name: 'Tier A2 - Global Partners',
+  },
+  {
+    id: 'bb1bf800-8d53-e311-aef3-441ea13961e2',
+    name: 'Tier B - Global Accounts',
+  },
+  {
+    id: '23ef2218-37f7-4abf-aacb-7c49f65ee1e3',
+    name: 'Tier B - Global Accounts (Capital Investment)',
+  },
+  {
+    id: 'bd1bf800-8d53-e311-aef3-441ea13961e2',
+    name: 'Tier C - Local Accounts (UKTI Managed)',
+  },
+  {
+    id: '12798372-8eb4-e511-88b6-e4115bead28a',
+    name: 'Tier D - LEP Managed Branch (not IST)',
+  },
+  {
+    id: '572dfefe-cd1d-e611-9bdc-e4115bead28a',
+    name: 'Tier D - POST Identified/Managed',
+  },
+]

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 import { listFaker } from './utils'
 import { addressFaker } from './addresses'
 import { ukRegionFaker } from './regions'
-import { EMPLOYEE_RANGE, HEADQUARTER_TYPE } from './constants'
+import { EMPLOYEE_RANGE, HEADQUARTER_TYPE, ONE_LIST_TIER } from './constants'
 
 const companyTreeItemFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
@@ -26,6 +26,8 @@ const companyTreeItemFaker = (overrides = {}) => ({
     },
   ],
   latest_interaction_date: faker.date.past(),
+  one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
+  archived: false,
   hierarchy: 1,
   subsidiaries: [],
   ...overrides,
@@ -110,6 +112,9 @@ const companyTreeFaker = ({
       name: faker.company.name(),
       employee_range: faker.helpers.arrayElement(EMPLOYEE_RANGE),
       headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
+      address: addressFaker(),
+      uk_region: ukRegionFaker(),
+      archived: false,
     },
   ],
 })

--- a/test/sandbox/routes/v4/dnb/company-tree.js
+++ b/test/sandbox/routes/v4/dnb/company-tree.js
@@ -3,6 +3,7 @@
 var ukRegion = require('../../../fixtures/v4/metadata/uk-region.json')
 var employeeRange = require('../../../fixtures/v4/metadata/employee-range.json')
 var headquarterType = require('../../../fixtures/v4/metadata/headquarter-type.json')
+var oneListTier = require('../../../fixtures/v4/metadata/one-list-tier.json')
 
 const { faker } = require('@faker-js/faker')
 
@@ -39,6 +40,8 @@ const companyTreeItemFaker = (overrides = {}) => ({
     },
   ],
   latest_interaction_date: faker.date.past(),
+  one_list_tier: faker.helpers.arrayElement(oneListTier),
+  archived: false,
   hierarchy: 1,
   subsidiaries: [],
   ...overrides,
@@ -115,6 +118,9 @@ exports.fakerCompanyFamilyTree = ({
       name: faker.company.name(),
       employee_range: faker.helpers.arrayElement(employeeRange),
       headquarter_type: faker.helpers.arrayElement(headquarterType),
+      address: address,
+      uk_region: faker.helpers.arrayElement(ukRegion),
+      archived: false,
     },
   ],
 })


### PR DESCRIPTION
## Description of change

Added additional fields to the sandbox and faker for the company tree

## Test instructions

Run the sandbox locally, open the url http://localhost:8000/v4/dnb/0418f79f-154b-4f55-85a6-8ddad559663e/family-tree and you will see the new fields in the api response


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
