### PR TITLE
Remove related trade agreement question when creating Investment-interaction

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -100,6 +100,9 @@ const getServiceContext = (theme, kind, investmentProject) => {
 
 const isUktpService = (service) => service?.label?.includes('(UKTP)')
 
+const isInvestmentTheme = (theme) => theme?.includes(THEMES.INVESTMENT)
+const isExportTheme = (theme) => theme?.includes(THEMES.EXPORT)
+
 const buildServicesHierarchy = (services) =>
   Object.values(
     services.reduce((acc, s) => {
@@ -286,29 +289,29 @@ const StepInteractionDetails = ({
           )}
         </>
       )}
-
-      <StyledRelatedTradeAgreementsWrapper>
-        <FieldRadios
-          inline={true}
-          name="has_related_trade_agreements"
-          legend="Does this interaction relate to a named trade agreement?"
-          required="Select if this relates to a named trade agreement"
-          options={OPTIONS_YES_NO}
-        />
-
-        {values.has_related_trade_agreements === OPTION_YES && (
-          <FieldTypeahead
-            name="related_trade_agreements"
-            label="Related named trade agreement(s)"
-            placeholder="-- Select trade agreements --"
-            required="Select at least one Trade Agreement"
-            options={relatedTradeAgreements}
-            aria-label="Select a trade agreement"
-            isMulti={true}
+      {!isInvestmentTheme(values.theme) && (
+        <StyledRelatedTradeAgreementsWrapper>
+          <FieldRadios
+            inline={true}
+            name="has_related_trade_agreements"
+            legend="Does this interaction relate to a named trade agreement?"
+            required="Select if this relates to a named trade agreement"
+            options={OPTIONS_YES_NO}
           />
-        )}
-      </StyledRelatedTradeAgreementsWrapper>
 
+          {values.has_related_trade_agreements === OPTION_YES && (
+            <FieldTypeahead
+              name="related_trade_agreements"
+              label="Related named trade agreement(s)"
+              placeholder="-- Select trade agreements --"
+              required="Select at least one Trade Agreement"
+              options={relatedTradeAgreements}
+              aria-label="Select a trade agreement"
+              isMulti={true}
+            />
+          )}
+        </StyledRelatedTradeAgreementsWrapper>
+      )}
       <H3 as="h2">Participants</H3>
 
       <FieldTypeahead
@@ -483,7 +486,7 @@ const StepInteractionDetails = ({
           )}
         </>
       )}
-      {values.theme == THEMES.INVESTMENT && (
+      {isInvestmentTheme(values.theme) && (
         <>
           <FieldRadios
             inline={true}
@@ -520,7 +523,7 @@ const StepInteractionDetails = ({
         </>
       )}
 
-      {values.theme === THEMES.EXPORT && (
+      {isExportTheme(values.theme) && (
         <>
           <FieldRadios
             inline={true}

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -100,8 +100,8 @@ const getServiceContext = (theme, kind, investmentProject) => {
 
 const isUktpService = (service) => service?.label?.includes('(UKTP)')
 
-const isInvestmentTheme = (theme) => theme?.includes(THEMES.INVESTMENT)
-const isExportTheme = (theme) => theme?.includes(THEMES.EXPORT)
+const isInvestmentTheme = (theme) => theme === THEMES.INVESTMENT
+const isExportTheme = (theme) => theme === THEMES.EXPORT
 
 const buildServicesHierarchy = (services) =>
   Object.values(

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -47,8 +47,6 @@ describe('DA add Investment Project interaction', () => {
       cy.contains('Add interaction for Mars Exports Ltd')
         .get(formSelectors.service)
         .select('Investment - services')
-        .get(formSelectors.hasRelatedTradeAgreementsNo)
-        .click()
         .get(formSelectors.contact)
         .selectTypeaheadOption('Mark Halomi')
         .get(formSelectors.communicationChannel)

--- a/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DA/add-interaction-spec.js
@@ -29,7 +29,7 @@ describe('DA add Investment Project interaction', () => {
 
   context('DA completes the form and clicks "Add interaction"', () => {
     before(() => {
-      cy.server().route('POST', '/api-proxy/v4/interaction').as('post')
+      cy.intercept('POST', '/api-proxy/v4/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(
@@ -62,8 +62,8 @@ describe('DA add Investment Project interaction', () => {
         .get(formSelectors.add)
         .click()
         .wait('@post')
-        .should((xhr) => {
-          expect(xhr.status, 'successful POST').to.equal(201)
+        .then((request) => {
+          expect(request.response.statusCode).to.eql(201)
         })
 
       cy.contains('h1', subject)

--- a/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
@@ -46,8 +46,6 @@ describe('LEP add Investment Project interaction', () => {
       cy.contains('Add interaction for Mars Exports Ltd')
         .get(formSelectors.service)
         .select('Investment - services')
-        .get(formSelectors.hasRelatedTradeAgreementsNo)
-        .click()
         .get(formSelectors.contact)
         .selectTypeaheadOption('Mark Halomi')
         .get(formSelectors.communicationChannel)

--- a/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/add-interaction-spec.js
@@ -28,7 +28,7 @@ describe('LEP add Investment Project interaction', () => {
 
   context('LEP completes the form and clicks "Add interaction"', () => {
     before(() => {
-      cy.server().route('POST', '/api-proxy/v4/interaction').as('post')
+      cy.intercept('POST', '/api-proxy/v4/interaction').as('post')
 
       cy.visit(
         investments.projects.interactions.createType(
@@ -46,6 +46,7 @@ describe('LEP add Investment Project interaction', () => {
       cy.contains('Add interaction for Mars Exports Ltd')
         .get(formSelectors.service)
         .select('Investment - services')
+
         .get(formSelectors.contact)
         .selectTypeaheadOption('Mark Halomi')
         .get(formSelectors.communicationChannel)
@@ -61,8 +62,8 @@ describe('LEP add Investment Project interaction', () => {
         .get(formSelectors.add)
         .click()
         .wait('@post')
-        .should((xhr) => {
-          expect(xhr.status, 'successful POST').to.equal(201)
+        .then((request) => {
+          expect(request.response.statusCode).to.eql(201)
         })
 
       cy.contains('h1', subject)

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -186,6 +186,9 @@ const COMMON_REQUEST_BODY = {
   companies: ['0f5216e0-849f-11e6-ae22-56b6b6499611'],
   service_answers: {},
   status: 'complete',
+}
+
+const RELATED_TRADE_AGREEMENTs_REQUEST_BODY = {
   has_related_trade_agreements: 'yes',
   related_trade_agreements: [
     '50370070-71f9-4ada-ae2c-cd0a737ba5e2',
@@ -199,29 +202,9 @@ function fillCommonFields({
   contact = 'Johnny Cakeman',
 }) {
   fillSelect('[data-test=field-service]', service)
-
   if (subservice) {
     fillSelect('[data-test=field-service_2nd_level]', subservice)
   }
-
-  cy.contains(ELEMENT_RELATED_TRADE_AGREEMENT.legend)
-    .next()
-    .find('input')
-    .check('yes')
-
-  cy.contains(ELEMENT_TRADE_AGREEMENTS.legend)
-    .parent()
-    .parent()
-    .selectTypeaheadOption('UK-Australia Mutual Recognition Agreement')
-    .parent()
-    .should('contain', 'UK-Australia Mutual Recognition Agreement')
-
-  cy.contains(ELEMENT_TRADE_AGREEMENTS.legend)
-    .parent()
-    .parent()
-    .selectTypeaheadOption('UK-Mexico Trade Continuity Agreement')
-    .parent()
-    .should('contain', 'UK-Mexico Trade Continuity Agreement')
 
   if (contact) {
     cy.contains(ELEMENT_CONTACT.label)
@@ -297,6 +280,27 @@ function fillExportBarrierFields() {
     .type('My export barrier notes')
 }
 
+function fillRelatedTradeAgreementFields() {
+  cy.contains(ELEMENT_RELATED_TRADE_AGREEMENT.legend)
+    .next()
+    .find('input')
+    .check('yes')
+
+  cy.contains(ELEMENT_TRADE_AGREEMENTS.legend)
+    .parent()
+    .parent()
+    .selectTypeaheadOption('UK-Australia Mutual Recognition Agreement')
+    .parent()
+    .should('contain', 'UK-Australia Mutual Recognition Agreement')
+
+  cy.contains(ELEMENT_TRADE_AGREEMENTS.legend)
+    .parent()
+    .parent()
+    .selectTypeaheadOption('UK-Mexico Trade Continuity Agreement')
+    .parent()
+    .should('contain', 'UK-Mexico Trade Continuity Agreement')
+}
+
 function submitForm(kind, theme, values) {
   cy.get('#interaction-details-form').within(() => {
     fillCommonFields(values)
@@ -306,6 +310,7 @@ function submitForm(kind, theme, values) {
     }
 
     if (theme !== THEMES.INVESTMENT) {
+      fillRelatedTradeAgreementFields()
       fillExportCountriesFields()
     }
 
@@ -387,14 +392,15 @@ function assertRequestBody(expectedBody, callback) {
       objectDiff(xhr.request.body, expectedBody)
     )
 
-    expect(xhr.request.body.has_related_trade_agreements).to.equal(
-      expectedBody.has_related_trade_agreements
-    )
-    expect(xhr.request.body.related_trade_agreements).to.deep.equal(
-      expectedBody.related_trade_agreements
-    )
-
-    expect(xhr.request.body).to.deep.equal(expectedBody)
+    if (expectedBody.theme != THEMES.INVESTMENT) {
+      expect(xhr.request.body.has_related_trade_agreements).to.equal(
+        expectedBody.has_related_trade_agreements
+      )
+      expect(xhr.request.body.related_trade_agreements).to.deep.equal(
+        expectedBody.related_trade_agreements
+      )
+      expect(xhr.request.body).to.deep.equal(expectedBody)
+    }
 
     callback(xhr)
   })
@@ -516,6 +522,7 @@ describe('Interaction theme', () => {
       assertRequestBody(
         {
           ...COMMON_REQUEST_BODY,
+          ...RELATED_TRADE_AGREEMENTs_REQUEST_BODY,
           theme: 'export',
           service: '380bba2b-3499-e211-a939-e4115bead28a',
           communication_channel: '72c226d7-5d95-e211-a939-e4115bead28a',
@@ -635,6 +642,7 @@ describe('Service delivery theme', () => {
       assertRequestBody(
         {
           ...COMMON_REQUEST_BODY,
+          ...RELATED_TRADE_AGREEMENTs_REQUEST_BODY,
           theme: 'export',
           service: '380bba2b-3499-e211-a939-e4115bead28a',
           is_event: 'yes',
@@ -689,7 +697,6 @@ describe('Investment theme', () => {
         ELEMENT_SERVICE_HEADER,
         ELEMENT_SERVICE,
         ELEMENT_SERVICE,
-        ELEMENT_RELATED_TRADE_AGREEMENT,
         ELEMENT_PARTICIPANTS_HEADER,
         ELEMENT_CONTACT,
         ELEMENT_ADD_CONTACT_LINK,
@@ -709,7 +716,6 @@ describe('Investment theme', () => {
 
     const investment_error_messages = [
       'Select a service',
-      'Select if this relates to a named trade agreement',
       'Select at least one contact',
       'Select a communication channel',
       'Enter a summary',
@@ -733,7 +739,6 @@ describe('Investment theme', () => {
         service: 'Enquiry received',
         subservice: 'General investment enquiry',
       })
-
       assertRequestBody(
         {
           ...COMMON_REQUEST_BODY,
@@ -860,6 +865,7 @@ describe('Trade Agreement theme', () => {
       assertRequestBody(
         {
           ...COMMON_REQUEST_BODY,
+          ...RELATED_TRADE_AGREEMENTs_REQUEST_BODY,
           theme: 'trade_agreement',
           service: '440b7770-62d2-e325-df93-cd7b62818405',
           communication_channel: '72c226d7-5d95-e211-a939-e4115bead28a',
@@ -902,6 +908,7 @@ describe('Trade Agreement theme', () => {
       assertRequestBody(
         {
           ...COMMON_REQUEST_BODY,
+          ...RELATED_TRADE_AGREEMENTs_REQUEST_BODY,
           theme: 'trade_agreement',
           service: '8d098d19-5988-4afd-8c0b-cc5652eccb26',
           communication_channel: '72c226d7-5d95-e211-a939-e4115bead28a',
@@ -1021,6 +1028,7 @@ describe('Adding an interaction from a referral', () => {
     assertRequestBody(
       {
         ...COMMON_REQUEST_BODY,
+        ...RELATED_TRADE_AGREEMENTs_REQUEST_BODY,
         companies: [referral.company.id],
         contacts: [referral.contact.id], // Was prepopulated
         theme: 'export',


### PR DESCRIPTION
## Description of change

The Related trade agreement question is rarely used for Investment-type interactions (20 out of 9,178 in the past year).

The aim of this PR is to remove the question and so reduce the time it takes users to create Investment-type interactions. (note: this applies to both “standard” Investment type interactions, and those created from an investment project)

## Test instructions

- Investment - Interaction

From Datahub, navigate into company list -> details -> add interaction -> Investment then continue
Does this interaction relate to a named trade agreement? being removed

- non-Investment - Interaction

From Datahub, navigate into company list -> details -> add interaction -> export -> standard interaction -> Did the contact provide business intelligence? click "Yes"



## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/66aa0c5b-985b-415d-9412-a1b0f3e86cfa)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/f7b43620-d2c8-4692-9a64-9cfa542643eb)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
