### PR TITLE
Export pipeline sort

### DIFF
--- a/src/client/modules/ExportPipeline/ExportList/ExportSelect.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ExportSelect.jsx
@@ -7,7 +7,7 @@ import qs from 'qs'
 
 import { Select } from '../../../components'
 
-const StyledSelect = styled(Select)(({ maxWidth }) => ({
+const StyledSelect = styled(Select)(() => ({
   alignItems: 'flex-start',
   flexDirection: 'column',
   flex: '1 1',
@@ -15,7 +15,6 @@ const StyledSelect = styled(Select)(({ maxWidth }) => ({
     width: '100%',
     minWidth: 170,
     maxHeight: 36,
-    ...(maxWidth ? { maxWidth: `${maxWidth}px` } : {}),
   },
   marginBottom: SPACING.SCALE_1,
   [MEDIA_QUERIES.DESKTOP]: {
@@ -23,7 +22,7 @@ const StyledSelect = styled(Select)(({ maxWidth }) => ({
   },
 }))
 
-const ExportSelect = ({ label, options = [], qsParam, maxWidth }) => {
+const ExportSelect = ({ label, options = [], qsParam }) => {
   const history = useHistory()
   const location = useLocation()
 
@@ -44,7 +43,6 @@ const ExportSelect = ({ label, options = [], qsParam, maxWidth }) => {
     <StyledSelect
       label={label}
       data-test={kebabCase(`${qsParam}-select`)}
-      maxWidth={maxWidth}
       input={{
         onChange,
         initialValue,

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -148,6 +148,11 @@ const ExportList = ({
                   qsParam="owner"
                   options={filters.owner.options}
                 />
+                <ExportSelect
+                  label="Sort by"
+                  qsParam="sortby"
+                  options={filters.sortby.options}
+                />
               </FiltersContainer>
             )}
           </Task.Status>

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -146,7 +146,6 @@ const ExportList = ({
                 <ExportSelect
                   label="Owner"
                   qsParam="owner"
-                  maxWidth="173"
                   options={filters.owner.options}
                 />
               </FiltersContainer>

--- a/src/client/modules/ExportPipeline/ExportList/state.js
+++ b/src/client/modules/ExportPipeline/ExportList/state.js
@@ -9,6 +9,7 @@ export const TASK_GET_EXPORT_PIPELINE_METADATA =
 export const ID = 'exportPipelineList'
 
 import {
+  SORT_OPTIONS,
   STATUS_LIST_OPTIONS,
   EXPORT_POTENTIAL_LIST_OPTIONS,
 } from '../constants'
@@ -48,6 +49,9 @@ export const state2props = ({ router, ...state }) => {
       },
       owner: {
         options: ownerOptions,
+      },
+      sortby: {
+        options: SORT_OPTIONS,
       },
     },
   }

--- a/src/client/modules/ExportPipeline/ExportList/task.js
+++ b/src/client/modules/ExportPipeline/ExportList/task.js
@@ -13,6 +13,7 @@ export const getExportPipelineList = ({
   limit = 10,
   page = 1,
   archived = false,
+  sortby = 'created_on:desc',
   status,
   export_potential,
   sector,
@@ -20,7 +21,6 @@ export const getExportPipelineList = ({
   estimated_win_date_after, // from
   estimated_win_date_before, // to
   owner,
-  sortby = 'created_on:desc',
 }) => {
   const offset = getPageOffset({ limit, page })
   const payload = omitBy(
@@ -29,12 +29,12 @@ export const getExportPipelineList = ({
       page,
       offset,
       archived,
+      sortby,
       status,
       export_potential,
       sector,
       destination_country,
       owner,
-      sortby,
     },
     (fieldValue) =>
       fieldValue === SHOW_ALL_OPTION.value || isUndefined(fieldValue)

--- a/src/client/modules/ExportPipeline/ExportList/task.js
+++ b/src/client/modules/ExportPipeline/ExportList/task.js
@@ -20,6 +20,7 @@ export const getExportPipelineList = ({
   estimated_win_date_after, // from
   estimated_win_date_before, // to
   owner,
+  sortby = 'created_on:desc',
 }) => {
   const offset = getPageOffset({ limit, page })
   const payload = omitBy(
@@ -33,6 +34,7 @@ export const getExportPipelineList = ({
       sector,
       destination_country,
       owner,
+      sortby,
     },
     (fieldValue) =>
       fieldValue === SHOW_ALL_OPTION.value || isUndefined(fieldValue)

--- a/src/client/modules/ExportPipeline/constants.js
+++ b/src/client/modules/ExportPipeline/constants.js
@@ -1,3 +1,18 @@
+export const SORT_OPTIONS = [
+  {
+    label: 'Recently created',
+    value: 'created_on:desc',
+  },
+  {
+    label: 'Export title A-Z',
+    value: 'title',
+  },
+  {
+    label: 'Export title Z-A',
+    value: '-title',
+  },
+]
+
 export const EXPORT_POTENTIAL_OPTIONS = [
   { label: 'High', value: 'high' },
   { label: 'Medium', value: 'medium' },

--- a/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/export-pipeline-spec.js
@@ -25,7 +25,7 @@ describe('Export pipeline', () => {
       cy.intercept('POST', '/api-proxy/v4/export').as('createExport')
       cy.intercept(
         'GET',
-        '/api-proxy/v4/export?limit=10&page=1&offset=0&archived=false'
+        '/api-proxy/v4/export?limit=10&page=1&offset=0&archived=false&sortby=created_on%3Adesc'
       ).as('listExport')
     })
 

--- a/test/functional/cypress/specs/export-pipeline/filter-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/filter-spec.js
@@ -19,8 +19,14 @@ const assertListItems = ({ length }) => {
 
 describe('Export filters', () => {
   const endpoint = '/api-proxy/v4/export'
-  const queryParams = 'limit=10&page=1&offset=0&archived=false'
-  const requestUrl = `${endpoint}?${queryParams}`
+  const defaultQueryParams = qs.stringify({
+    limit: 10,
+    page: 1,
+    offset: 0,
+    archived: false,
+    sortby: 'created_on:desc',
+  })
+  const requestUrl = `${endpoint}?${defaultQueryParams}`
   const exportTab = urls.exportPipeline.index()
 
   const exportList = [
@@ -108,9 +114,10 @@ describe('Export filters', () => {
 
   context('Status', () => {
     const element = '[data-test="status-select"]'
+    const url = `${requestUrl}&status=won`
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}&status=won`, {
+      cy.intercept('GET', url, {
         body: {
           count: exportList.length,
           results: exportList.filter((exp) => exp.status === 'won'),
@@ -134,7 +141,7 @@ describe('Export filters', () => {
 
     it('should filter from the url', () => {
       cy.visit(`${exportTab}?status=won`)
-      assertRequestUrl('@apiRequestStatus', `${requestUrl}&status=won`)
+      assertRequestUrl('@apiRequestStatus', url)
       assertListItems({ length: 1 })
       cy.get(`${element} select`).find(':selected').contains('Won')
     })
@@ -143,16 +150,17 @@ describe('Export filters', () => {
       cy.visit(exportTab)
       cy.wait('@apiRequestList')
       cy.get(`${element} select`).select('won')
-      assertRequestUrl('@apiRequestStatus', `${requestUrl}&status=won`)
+      assertRequestUrl('@apiRequestStatus', url)
       assertListItems({ length: 1 })
     })
   })
 
   context('Export potential', () => {
     const element = '[data-test="export-potential-select"]'
+    const url = `${requestUrl}&export_potential=high`
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}&export_potential=high`, {
+      cy.intercept('GET', url, {
         body: {
           count: exportList.length,
           results: exportList.filter((exp) => exp.export_potential === 'high'),
@@ -176,10 +184,7 @@ describe('Export filters', () => {
 
     it('should filter from the url', () => {
       cy.visit(`${exportTab}?export_potential=high`)
-      assertRequestUrl(
-        '@apiRequestExportPotential',
-        `${requestUrl}&export_potential=high`
-      )
+      assertRequestUrl('@apiRequestExportPotential', url)
       assertListItems({ length: 1 })
       cy.get(`${element} select`).find(':selected').contains('High')
     })
@@ -188,16 +193,15 @@ describe('Export filters', () => {
       cy.visit(exportTab)
       cy.wait('@apiRequestList')
       cy.get(`${element} select`).select('High')
-      assertRequestUrl(
-        '@apiRequestExportPotential',
-        `${requestUrl}&export_potential=high`
-      )
+      assertRequestUrl('@apiRequestExportPotential', url)
       assertListItems({ length: 1 })
     })
   })
 
   context('Sector', () => {
     const element = '[data-test="sector-select"]'
+    const url = `${requestUrl}&sector=1`
+
     const sectors = [
       sectorFaker({
         id: 1,
@@ -214,7 +218,7 @@ describe('Export filters', () => {
     ]
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}&sector=1`, {
+      cy.intercept('GET', url, {
         body: {
           count: exportList.length,
           results: exportList.filter((exp) => exp.sector.id === '1'), // Advanced Engineering
@@ -242,7 +246,7 @@ describe('Export filters', () => {
 
     it('should filter from the url', () => {
       cy.visit(`${exportTab}?sector=1`)
-      assertRequestUrl('@apiRequestSector', `${requestUrl}&sector=1`)
+      assertRequestUrl('@apiRequestSector', url)
       assertListItems({ length: 1 })
       cy.get(`${element} select`)
         .find(':selected')
@@ -254,13 +258,15 @@ describe('Export filters', () => {
       cy.wait('@apiRequestList')
       cy.wait('@apiRequestMetadataSector')
       cy.get(`${element} select`).select('Advanced Engineering')
-      assertRequestUrl('@apiRequestSector', `${requestUrl}&sector=1`)
+      assertRequestUrl('@apiRequestSector', url)
       assertListItems({ length: 1 })
     })
   })
 
   context('Country', () => {
     const element = '[data-test="destination-country-select"]'
+    const url = `${requestUrl}&destination_country=3`
+
     const countries = [
       countryFaker({
         id: 1,
@@ -277,7 +283,7 @@ describe('Export filters', () => {
     ]
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}&destination_country=3`, {
+      cy.intercept('GET', url, {
         body: {
           count: exportList.length,
           results: exportList.filter(
@@ -307,10 +313,7 @@ describe('Export filters', () => {
 
     it('should filter from the url', () => {
       cy.visit(`${exportTab}?destination_country=3`)
-      assertRequestUrl(
-        '@apiRequestCountry',
-        `${requestUrl}&destination_country=3`
-      )
+      assertRequestUrl('@apiRequestCountry', url)
       assertListItems({ length: 1 })
       cy.get(`${element} select`).find(':selected').contains('St Lucia')
     })
@@ -320,10 +323,7 @@ describe('Export filters', () => {
       cy.wait('@apiRequestList')
       cy.wait('@apiRequestMetadataCountry')
       cy.get(`${element} select`).select('St Lucia')
-      assertRequestUrl(
-        '@apiRequestCountry',
-        `${requestUrl}&destination_country=3`
-      )
+      assertRequestUrl('@apiRequestCountry', url)
       assertListItems({ length: 1 })
     })
   })
@@ -410,9 +410,10 @@ describe('Export filters', () => {
 
   context('Owner', () => {
     const element = '[data-test="owner-select"]'
+    const url = `${requestUrl}&owner=1`
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}&owner=1`, {
+      cy.intercept('GET', url, {
         body: {
           count: 2,
           results: exportList.slice(0, 2),
@@ -436,7 +437,7 @@ describe('Export filters', () => {
 
     it('should filter from the url', () => {
       cy.visit(`${exportTab}?owner=1`)
-      assertRequestUrl('@apiRequestListOwners', `${requestUrl}&owner=1`)
+      assertRequestUrl('@apiRequestListOwners', url)
       assertListItems({ length: 2 })
       cy.get(`${element} select`).find(':selected').contains('Warren Buffet')
     })
@@ -447,7 +448,7 @@ describe('Export filters', () => {
       cy.wait('@apiRequestOwnersSelect')
       cy.get(`${element} select`).select('Warren Buffet')
       assertListItems({ length: 2 })
-      assertRequestUrl('@apiRequestListOwners', `${requestUrl}&owner=1`)
+      assertRequestUrl('@apiRequestListOwners', url)
     })
   })
 })

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -1,3 +1,5 @@
+import qs from 'qs'
+
 import { exportFaker, exportListFaker } from '../../fakers/export'
 import urls from '../../../../../src/lib/urls'
 
@@ -42,18 +44,23 @@ const assertTitleLink = (element, href, text) => {
 }
 
 describe('Export pipeline list', () => {
+  const endpoint = '/api-proxy/v4/export'
+  const queryString = qs.stringify({
+    limit: 10,
+    page: 1,
+    offset: 0,
+    archived: false,
+    sortby: 'created_on:desc',
+  })
+
   context('When the api returns no export items', () => {
     before(() => {
-      cy.intercept(
-        'GET',
-        '/api-proxy/v4/export?limit=10&page=1&offset=0&archived=false',
-        {
-          body: {
-            count: 0,
-            results: [],
-          },
-        }
-      ).as('apiRequest')
+      cy.intercept('GET', `${endpoint}?${queryString}`, {
+        body: {
+          count: 0,
+          results: [],
+        },
+      }).as('apiRequest')
       cy.visit(urls.exportPipeline.index())
       cy.wait('@apiRequest')
     })
@@ -171,16 +178,12 @@ describe('Export pipeline list', () => {
     const notArchivedExports = exportList.filter((e) => e.archived == false)
 
     before(() => {
-      cy.intercept(
-        'GET',
-        '/api-proxy/v4/export?limit=10&page=1&offset=0&archived=false',
-        {
-          body: {
-            count: notArchivedExports.length,
-            results: notArchivedExports,
-          },
-        }
-      ).as('apiRequest')
+      cy.intercept('GET', `${endpoint}?${queryString}`, {
+        body: {
+          count: notArchivedExports.length,
+          results: notArchivedExports,
+        },
+      }).as('apiRequest')
       cy.visit(urls.exportPipeline.index())
       cy.wait('@apiRequest')
     })

--- a/test/functional/cypress/specs/export-pipeline/sort-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/sort-spec.js
@@ -1,0 +1,99 @@
+import { assertRequestUrl } from '../../support/assertions'
+import { exportListFaker } from '../../fakers/export'
+import urls from '../../../../../src/lib/urls'
+
+const transformOptions = (options) =>
+  [...options].map((o) => ({
+    value: o.value,
+    label: o.label,
+  }))
+
+const endpoint = '/api-proxy/v4/export'
+const queryParams = 'limit=10&page=1&offset=0&archived=false'
+const requestUrl = `${endpoint}?${queryParams}`
+const exportTab = urls.exportPipeline.index()
+
+describe('Export pipeline sort', () => {
+  context('Default sort', () => {
+    const element = '[data-test="sortby-select"] option'
+    const exports = exportListFaker(3)
+
+    before(() => {
+      cy.intercept('GET', `${requestUrl}&sortby=created_on%3Adesc`, {
+        body: {
+          count: exports.length,
+          results: exports,
+        },
+      }).as('apiReqList')
+      cy.intercept('GET', '/api-proxy/v4/export/owner', [])
+      cy.visit(exportTab)
+    })
+
+    it('should apply the default sort', () => {
+      assertRequestUrl('@apiReqList', `${requestUrl}&sortby=created_on%3Adesc`)
+    })
+
+    it('should have all sort options', () => {
+      cy.get(element).then((options) => {
+        expect(transformOptions(options)).to.deep.eq([
+          { value: 'created_on:desc', label: 'Recently created' },
+          { value: 'title', label: 'Export title A-Z' },
+          { value: '-title', label: 'Export title Z-A' },
+        ])
+      })
+    })
+  })
+
+  context('User sort', () => {
+    const element = '[data-test="sortby-select"] select'
+    const exports = exportListFaker(3)
+
+    beforeEach(() => {
+      // sortby=created_on:desc
+      cy.intercept('GET', `${requestUrl}&sortby=created_on%3Adesc`, {
+        body: {
+          count: exports.length,
+          results: exports,
+        },
+      }).as('apiReqSortbyCreatedOn')
+      // sortby=title (A-Z)
+      cy.intercept('GET', `${requestUrl}&sortby=title`, {
+        body: {
+          count: exports.length,
+          results: exports,
+        },
+      }).as('apiReqSortbyTitleA-Z')
+      // sortby=-title (Z-A)
+      cy.intercept('GET', `${requestUrl}&sortby=-title`, {
+        body: {
+          count: exports.length,
+          results: exports,
+        },
+      }).as('apiReqSortbyTitleZ-A')
+      cy.intercept('GET', '/api-proxy/v4/export/owner', [])
+      cy.visit(exportTab)
+    })
+
+    it('should sort by "Recently created"', () => {
+      // As "Recently created" is the default sort
+      // we need to select another option first
+      cy.get(element).select('Export title A-Z')
+      cy.wait('@apiReqSortbyTitleA-Z')
+      cy.get(element).select('Recently created')
+      assertRequestUrl(
+        '@apiReqSortbyCreatedOn',
+        `${requestUrl}&sortby=created_on%3Adesc`
+      )
+    })
+
+    it('should sort by "Export title A-Z"', () => {
+      cy.get(element).select('Export title A-Z')
+      assertRequestUrl('@apiReqSortbyTitleA-Z', `${requestUrl}&sortby=title`)
+    })
+
+    it('should sort by "Export title Z-A"', () => {
+      cy.get(element).select('Export title Z-A')
+      assertRequestUrl('@apiReqSortbyTitleZ-A', `${requestUrl}&sortby=-title`)
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Export pipeline sort options:
1. Recently created (the default)
2. Export title A-Z
3. Export title Z-A

## Test instructions
**Sort by**
* Go to `/export` and apply any of the three sort options. 

**Book marking**
* Copy and paste the url into a separate browser tab to see the list maintain the sort.

## Screenshots
### Dashboard
<img width="981" alt="dashboard" src="https://github.com/uktrade/data-hub-frontend/assets/964268/673ea929-452a-469c-a529-cadb37d31bfd">

### Personalised Dashboard
<img width="794" alt="personalised-dashboard" src="https://github.com/uktrade/data-hub-frontend/assets/964268/041935e5-8472-4b03-a83a-3f1ded1de199">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
