### PR TITLE
Improve Maxemail campaign query

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -91,17 +91,25 @@ function getContactFromEmailAddress(emailAddress, contacts) {
 
 async function getMaxemailCampaigns(req, next, contacts) {
   try {
-    // Fetch Maxemail campaigns
-    const campaignQuery = maxemailCampaignQuery()
-    const campaignsResults = await fetchActivityFeed(req, campaignQuery)
-    const campaignActivities = campaignsResults.hits.hits.map(
-      (hit) => hit._source
-    )
-
     // Fetch all Maxemail emails sent to Data Hub company contacts as part of a campaign
     const emailSentQuery = maxemailEmailSentQuery(contacts)
     const emailSentResults = await fetchActivityFeed(req, emailSentQuery)
     const emailSentActivities = emailSentResults.hits.hits.map(
+      (hit) => hit._source
+    )
+
+    const campaignIds = [
+      ...new Set(
+        emailSentActivities.map(
+          (activity) => `${activity.object.attributedTo.id}:Create`
+        )
+      ),
+    ]
+
+    // Fetch Maxemail campaigns
+    const campaignQuery = maxemailCampaignQuery(campaignIds)
+    const campaignsResults = await fetchActivityFeed(req, campaignQuery)
+    const campaignActivities = campaignsResults.hits.hits.map(
       (hit) => hit._source
     )
 

--- a/src/apps/companies/apps/activity-feed/es-queries/maxemail-campaign-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/maxemail-campaign-query.js
@@ -1,6 +1,5 @@
-const maxemailCampaignQuery = (size = 20) => {
+const maxemailCampaignQuery = (campaignIds) => {
   return {
-    size,
     sort: [
       {
         published: {
@@ -9,8 +8,19 @@ const maxemailCampaignQuery = (size = 20) => {
       },
     ],
     query: {
-      term: {
-        'object.type': 'dit:maxemail:Campaign',
+      bool: {
+        must: [
+          {
+            term: {
+              'object.type': 'dit:maxemail:Campaign',
+            },
+          },
+          {
+            terms: {
+              id: campaignIds,
+            },
+          },
+        ],
       },
     },
   }


### PR DESCRIPTION
## Description of change

The previous maxemail query would grab the latest 20 campaigns and then try to match them with any email campaign sent to given company contacts. This means the activities would only show for most recent campaigns.

This change amends that. First, it retrieves the campaign emails, extracts the campaign IDs, and then queries only for campaigns that were sent out to company contacts.

This should result in having all campaigns relevant to the company showing up in the activities.

## Test instructions

When you visit a company and open the Activity tab, you should see Maxemail campaigns, provided any were sent to the company contacts.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
