### PR TITLE
Create company referral button

### DIFF
--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+
 import styled from 'styled-components'
 import { GREY_3, GREY_3_LEGACY } from '../../../client/utils/colours'
 import { FONT_SIZE } from '@govuk-react/constants'
@@ -22,16 +23,13 @@ const StyledButton = styled(StyledCompanyReferButton)`
   border-bottom: 3px solid ${GREY_3_LEGACY};
 `
 
-const LocalHeaderCompanyRefer = ({ company }) => {
+const LocalHeaderCompanyRefer = (companyId) => {
   const handleClickRefer = () => {
-    window.location.href = `/companies/${company.id}/referrals/send`
+    window.location.href = `/companies/${companyId}/referrals/send`
   }
   return (
     <>
-      <StyledButton
-        data-test={'refer-company-button'}
-        onClick={handleClickRefer}
-      >
+      <StyledButton data-test="refer-company-button" onClick={handleClickRefer}>
         <span>Refer this company</span>
       </StyledButton>
     </>

--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import styled from 'styled-components'
+import { GREY_3, GREY_3_LEGACY } from '../../../client/utils/colours'
+import { FONT_SIZE } from '@govuk-react/constants'
+
+const StyledCompanyReferButton = styled('button')`
+  display: inline-table;
+  padding: 4px 8px 4px 8px;
+  border: none;
+  vertical-align: middle;
+  cursor: pointer;
+  margin-right: 10px;
+  font-size: ${FONT_SIZE.SIZE_14};
+  span {
+    pointer-events: none;
+    display: inline-block;
+    font-size: ${FONT_SIZE.SIZE_16};
+  }
+`
+const StyledButton = styled(StyledCompanyReferButton)`
+  background-color: ${GREY_3};
+  border-bottom: 3px solid ${GREY_3_LEGACY};
+`
+
+const LocalHeaderCompanyRefer = ({ company }) => {
+  const handleClickRefer = () => {
+    window.location.href = `/companies/${company.id}/referrals/send`
+  }
+  return (
+    <>
+      <StyledButton onClick={handleClickRefer}>
+        <span>Refer this company</span>
+      </StyledButton>
+    </>
+  )
+}
+
+export default LocalHeaderCompanyRefer

--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { GREY_3, GREY_3_LEGACY } from '../../../client/utils/colours'
 import { FONT_SIZE } from '@govuk-react/constants'
+import urls from '../../../lib/urls'
 
 const StyledCompanyReferButton = styled('button')`
   display: inline-table;
@@ -23,9 +24,9 @@ const StyledButton = styled(StyledCompanyReferButton)`
   border-bottom: 3px solid ${GREY_3_LEGACY};
 `
 
-const LocalHeaderCompanyRefer = (companyId) => {
+const LocalHeaderCompanyRefer = ({ companyId }) => {
   const handleClickRefer = () => {
-    window.location.href = `/companies/${companyId}/referrals/send`
+    window.location.href = urls.companies.referrals.send(companyId)
   }
   return (
     <>

--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
@@ -28,7 +28,10 @@ const LocalHeaderCompanyRefer = ({ company }) => {
   }
   return (
     <>
-      <StyledButton onClick={handleClickRefer}>
+      <StyledButton
+        data-test={'refer-company-button'}
+        onClick={handleClickRefer}
+      >
         <span>Refer this company</span>
       </StyledButton>
     </>

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -17,6 +17,7 @@ import {
 import LocalHeader from '../../../client/components/LocalHeader/LocalHeader'
 import LocalHeaderHeading from '../../../client/components/LocalHeader/LocalHeaderHeading'
 import LocalHeaderCompanyLists from './LocalHeaderCompanyLists'
+import LocalHeaderCompanyRefer from './LocalHeaderCompanyRefer'
 import Badge from '../../../client/components/Badge'
 import StatusMessage from '../../../client/components/StatusMessage'
 import { addressToString } from '../../../client/utils/addresses'
@@ -46,6 +47,7 @@ const StyledButtonContainer = styled('div')`
 
 const StyledList = styled('div')`
   padding-bottom: 10px;
+  display: inline-flex;
 `
 
 const StyledButtonLink = styled.a({
@@ -164,6 +166,7 @@ const CompanyLocalHeader = ({
           </GridRow>
           <StyledList>
             <LocalHeaderCompanyLists company={company} />
+            <LocalHeaderCompanyRefer company={company} />
           </StyledList>
           {(company.isUltimate || company.isGlobalHQ) && (
             <TypeWrapper>

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -166,7 +166,7 @@ const CompanyLocalHeader = ({
           </GridRow>
           <StyledList>
             <LocalHeaderCompanyLists company={company} />
-            <LocalHeaderCompanyRefer company={company.id} />
+            <LocalHeaderCompanyRefer companyId={company.id} />
           </StyledList>
           {(company.isUltimate || company.isGlobalHQ) && (
             <TypeWrapper>

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -166,7 +166,7 @@ const CompanyLocalHeader = ({
           </GridRow>
           <StyledList>
             <LocalHeaderCompanyLists company={company} />
-            <LocalHeaderCompanyRefer company={company} />
+            <LocalHeaderCompanyRefer company={company.id} />
           </StyledList>
           {(company.isUltimate || company.isGlobalHQ) && (
             <TypeWrapper>

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -6,6 +6,7 @@ const {
   assertCompanyAddress,
   assertBadgeText,
   assertAddButton,
+  assertReferButton,
   assertExportProjectButton,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
@@ -25,6 +26,7 @@ const company = fixtures.company.archivedLtd
 const advisersUrl = urls.companies.advisers.index(company.id)
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
 const detailsUrl = urls.companies.detail(company.id)
+const referralsUrl = urls.companies.referrals.send(company.id)
 const unarchiveUrl = urls.companies.unarchive(company.id)
 const addInteractionUrl = urls.companies.interactions.create(company.id)
 const exportProjectUrl = urls.exportPipeline.create(company.id)
@@ -51,6 +53,10 @@ describe('Local header for archived company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/archived-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/archived-spec.js
@@ -103,6 +103,10 @@ describe('Local header for archived company', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
     })
 
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
+    })
+
     it('should display company list item buttons', () => {
       assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
     })
@@ -143,6 +147,10 @@ describe('Local header for archived company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -187,6 +195,10 @@ describe('Local header for archived company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -235,6 +247,10 @@ describe('Local header for archived company', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
       })
 
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })
@@ -277,6 +293,10 @@ describe('Local header for archived company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -323,6 +343,10 @@ describe('Local header for archived company', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
     })
 
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
+    })
+
     it('should display company list item buttons', () => {
       assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
     })
@@ -365,6 +389,10 @@ describe('Local header for archived company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -6,6 +6,7 @@ const {
   assertCompanyAddress,
   assertBadgeText,
   assertAddButton,
+  assertReferButton,
   assertExportProjectButton,
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
@@ -25,6 +26,7 @@ const address =
 const advisersUrl = urls.companies.advisers.index(company.id)
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
 const detailsUrl = urls.companies.detail(company.id)
+const referralsUrl = urls.companies.referrals.send(company.id)
 const dnbHierarchyUrl = urls.companies.dnbHierarchy.index(company.id)
 const addInteractionUrl = urls.companies.interactions.create(company.id)
 const exportProjectUrl = urls.exportPipeline.create(company.id)
@@ -55,6 +57,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -110,6 +110,10 @@ describe('Local header for global ultimate company', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
     })
 
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
+    })
+
     it('should display company list item buttons', () => {
       assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
     })
@@ -151,6 +155,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -200,6 +208,10 @@ describe('Local header for global ultimate company', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
     })
 
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
+    })
+
     it('should display company list item buttons', () => {
       assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
     })
@@ -247,6 +259,10 @@ describe('Local header for global ultimate company', () => {
 
       it('should display the add to list button', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
+      })
+
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
       })
 
       it('should display company list item buttons', () => {
@@ -299,6 +315,10 @@ describe('Local header for global ultimate company', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
       })
 
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })
@@ -345,6 +365,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -394,6 +418,10 @@ describe('Local header for global ultimate company', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
     })
 
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
+    })
+
     it('should display company list item buttons', () => {
       assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
     })
@@ -439,6 +467,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -7,6 +7,7 @@ const {
   assertBreadcrumbs,
   assertExportCountryHistoryBreadcrumbs,
   assertAddButton,
+  assertReferButton,
   assertExportProjectButton,
   assertArchivePanelNotVisible,
   assertAddInteractionButton,
@@ -20,6 +21,7 @@ const company = fixtures.company.investigationLimited
 
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
 const detailsUrl = urls.companies.detail(company.id)
+const referralsUrl = urls.companies.referrals.send(company.id)
 const addInteractionUrl = urls.companies.interactions.create(company.id)
 const exportProjectUrl = urls.exportPipeline.create(company.id)
 
@@ -51,6 +53,10 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the add to list button', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
+      })
+
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
       })
 
       it('should display company list item buttons', () => {
@@ -101,6 +107,10 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the add to list button', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
+      })
+
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
       })
 
       it('should display company list item buttons', () => {
@@ -157,6 +167,14 @@ describe('Local header for company under dnb investigation', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
       })
 
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })
@@ -211,6 +229,10 @@ describe('Local header for company under dnb investigation', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
       })
 
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })
@@ -259,6 +281,10 @@ describe('Local header for company under dnb investigation', () => {
 
       it('should display the add to list button', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
+      })
+
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
       })
 
       it('should display company list item buttons', () => {
@@ -311,6 +337,10 @@ describe('Local header for company under dnb investigation', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {
@@ -366,6 +396,10 @@ describe('Local header for company under dnb investigation', () => {
         assertAddButton(addRemoveFromListUrl, detailsUrl)
       })
 
+      it('should display the refer this company button', () => {
+        assertReferButton(referralsUrl)
+      })
+
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })
@@ -416,6 +450,10 @@ describe('Local header for company under dnb investigation', () => {
 
     it('should display the add to list button', () => {
       assertAddButton(addRemoveFromListUrl, detailsUrl)
+    })
+
+    it('should display the refer this company button', () => {
+      assertReferButton(referralsUrl)
     })
 
     it('should display company list item buttons', () => {

--- a/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/under-dnb-investigation-spec.js
@@ -171,10 +171,6 @@ describe('Local header for company under dnb investigation', () => {
         assertReferButton(referralsUrl)
       })
 
-      it('should display the refer this company button', () => {
-        assertReferButton(referralsUrl)
-      })
-
       it('should display company list item buttons', () => {
         assertCompanyListItemButton(addRemoveFromListUrl, detailsUrl)
       })

--- a/test/functional/cypress/support/company-local-header-assertions.js
+++ b/test/functional/cypress/support/company-local-header-assertions.js
@@ -41,6 +41,18 @@ const assertAddButton = (addRemoveFromListUrl, detailsUrl) => {
 }
 
 /**
+ * Asserts that the refer this compnay button has the correct URL
+ */
+const assertReferButton = (referralUrl) => {
+  cy.get('[data-test="refer-company-button"]').contains('Refer this company')
+  cy.get('[data-test="refer-company-button"]').click()
+  cy.location().should((loc) => {
+    expect(loc.pathname).to.eq(referralUrl)
+  })
+  cy.go('back')
+}
+
+/**
  * Asserts that the company list item button has the correct URL
  */
 const assertCompanyListItemButton = (addRemoveFromListUrl, detailsUrl) => {
@@ -118,6 +130,7 @@ module.exports = {
   assertCompanyAddress,
   assertBadgeText,
   assertAddButton,
+  assertReferButton,
   assertExportProjectButton,
   assertAddInteractionButton,
   assertBreadcrumbs,


### PR DESCRIPTION
## Description of change

Create a ‘Refer this company’ button on company pages. 

## Test instructions

When viewing a company header, you should see a button to 'Refer this company' and the button links through to the referrals form.

## Screenshots

### Before


<img width="1433" alt="Screenshot 2023-06-08 at 11 41 59" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/f907b4e0-74f9-4b30-8f17-714352fb18c9">


### After

<img width="1440" alt="Screenshot 2023-06-08 at 11 39 55" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/7e36878a-e341-4a11-b7ad-9c86e72a1377">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
