### PR TITLE
Revert business intelligence guidance.

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -414,12 +414,18 @@ const StepInteractionDetails = ({
             required="Enter business intelligence"
             hint={
               <>
-                Add brief details of what business intelligence was discussed,
-                such as impacts on the company, sector, economy and any actions
-                taken. This information will be visible to other Data Hub users,
-                the Business Intelligence Unit and DBT.
+                Please summarise the information the business shared during this
+                interaction, including sufficient detail to convey the meaning
+                and significance of the topics covered.
                 <br />
                 <br />
+                Where available, include:
+                <br />• Opportunities, risks and/or anything affecting business
+                operations (company, sector or market) or investor sentiment
+                <br />• Quantify impacts and timescales (e.g. costs,
+                number/location of jobs created/lost)
+                <br />• Actions the business has or is proposing to take
+                <br />• Comments, questions or requests of HMG
               </>
             }
           />


### PR DESCRIPTION
## Description of change

This PR reverts the business intelligence guidance in the interaction form.

## Test instructions

You can go to interaction form, answer "Did the contact provide business intelligence?" as Yes and you should see the "Business intelligence summary" field with updated guidance. 

## Screenshots

### Before

<img width="766" alt="Screenshot 2023-06-08 at 16 27 10" src="https://github.com/uktrade/data-hub-frontend/assets/5889630/657c8508-78e9-48a6-9a98-3782a4190ef6">

### After

<img width="814" alt="Screenshot 2023-06-08 at 16 26 49" src="https://github.com/uktrade/data-hub-frontend/assets/5889630/8ef87e71-0b9c-4207-a21d-73171f3f3865">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
