### PR TITLE
Feature/cls2 233  change link from activity tab to navigate to only internal activities

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -34,6 +34,7 @@ const LOCAL_NAV = [
   {
     path: 'activity',
     label: 'Activity',
+    search: '?activityType%5B0%5D=dataHubActivity&page=1',
     permissions: ['interaction.view_all_interaction'],
   },
   {

--- a/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
@@ -73,7 +73,7 @@ const CompanyLocalTab = (props) => {
     <StyledListItem key={`tab-${index}`}>
       <StyledAnchorTag
         selected={navItem.isActive}
-        href={navItem.url}
+        href={`${navItem.url}${navItem.search ? navItem.search : ''}`}
         id={`tab-${navItem.path}`}
         key={`tab-link-${navItem.path}`}
         aria-label={navItem.ariaDescription}

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -55,8 +55,8 @@ describe('DBT Permission', () => {
       ])
     })
     it('when on the activity tab, internal activity should be selected', () => {
-      // I'd recommend targeting [id="tab-activity"] for better future proofing.
-      assertActivitytab('[data-test="tabbedLocalNavList"] > :nth-child(2)')
+      cy.get('[data-test="tabbedLocalNavList"]').contains('Activity').click()
+      assertActivitytab('#field-activityType-1')
     })
   })
 

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -3,6 +3,7 @@ const selectors = require('../../../../selectors')
 const {
   assertLocalNav,
   assertLocalReactNav,
+  assertActivitytab,
 } = require('../../support/assertions')
 
 const {
@@ -52,6 +53,10 @@ describe('DBT Permission', () => {
         'Export',
         'Orders',
       ])
+    })
+    it('when on the activity tab, internal activity should be selected', () => {
+      // I'd recommend targeting [id="tab-activity"] for better future proofing.
+      assertActivitytab('[data-test="tabbedLocalNavList"] > :nth-child(2)')
     })
   })
 

--- a/test/end-to-end/cypress/support/assertions.js
+++ b/test/end-to-end/cypress/support/assertions.js
@@ -1,12 +1,8 @@
 const { keys, forEach } = require('lodash')
 
 const selectors = require('../../../selectors')
-const urls = require('../../../../src/lib/urls')
 
 const PAGE_SIZE = 10
-
-const activityUrl = urls.companies.activity.index
-// ?activityType%5B0%5D=dataHubActivity&page=1
 
 const assertError = (message) => {
   cy.get('body').should('contain', message)
@@ -84,12 +80,7 @@ const assertLocalNav = (selector, navList) => {
 
 const assertActivitytab = (selector) => {
   const navElement = cy.get(selector)
-  navElement.click()
-  navElement.should((loc) => {
-    expect(loc.pathname).to.eq()
-    expect(loc.search).contains(activityUrl)
-    cy.get('[type="checkbox"]').first().check()
-  })
+  navElement.should('be.checked')
 }
 
 const assertLocalReactNav = (selector, navList) => {

--- a/test/end-to-end/cypress/support/assertions.js
+++ b/test/end-to-end/cypress/support/assertions.js
@@ -1,8 +1,12 @@
 const { keys, forEach } = require('lodash')
 
 const selectors = require('../../../selectors')
+const urls = require('../../../../src/lib/urls')
 
 const PAGE_SIZE = 10
+
+const activityUrl = urls.companies.activity.index
+// ?activityType%5B0%5D=dataHubActivity&page=1
 
 const assertError = (message) => {
   cy.get('body').should('contain', message)
@@ -78,6 +82,16 @@ const assertLocalNav = (selector, navList) => {
   })
 }
 
+const assertActivitytab = (selector) => {
+  const navElement = cy.get(selector)
+  navElement.click()
+  navElement.should((loc) => {
+    expect(loc.pathname).to.eq()
+    expect(loc.search).contains(activityUrl)
+    cy.get('[type="checkbox"]').first().check()
+  })
+}
+
 const assertLocalReactNav = (selector, navList) => {
   cy.get(selector).as('navElements')
   cy.get('@navElements').should(
@@ -98,4 +112,5 @@ module.exports = {
   assertLocalNav,
   assertKeyValueTable,
   assertLocalReactNav,
+  assertActivitytab,
 }


### PR DESCRIPTION
## Description of change

Change the link so Activity type > Internal activity checkbox is pre-checked as default when visiting the Activity page from the local nav menu. 

## Test instructions

_What should I see?_

## Screenshots

### Before
<img width="971" alt="Screenshot 2023-06-15 at 09 41 04" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/b40a46aa-df96-4ffa-9b76-fc94105bb2f5">

### After
<img width="987" alt="Screenshot 2023-06-15 at 10 33 39" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/764e14f0-a86d-4ee1-8dea-77acde72eb5a">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
