### PR TITLE
href link fix and typos

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -18,7 +18,7 @@ import {
   HierarchyContents,
   HierarchyItemContents,
   SubsidiaryList,
-  HierachyListItem,
+  HierarchyListItem,
   HierarchyHeaderContents,
 } from './styled'
 
@@ -69,11 +69,11 @@ const Subsidiaries = ({
         isOpen={isOpen}
         childCount={company.subsidiaries.length}
       >
-        {company.subsidiaries.map((subsidary, index) => (
+        {company.subsidiaries.map((subsidiary, index) => (
           <HierarchyItem
             requestedCompanyId={requestedCompanyId}
-            company={subsidary}
-            hierarchy={subsidary.hierarchy}
+            company={subsidiary}
+            hierarchy={subsidiary.hierarchy}
             fullTreeExpanded={fullTreeExpanded}
             key={`hierarchy_item_${index}`}
             isFinalItemInLevel={index + 1 === company.subsidiaries.length}
@@ -131,7 +131,7 @@ const Hierarchy = ({ requestedCompanyId, familyTree }) => {
               as={Link}
               href={urls.companies.subsidiaries.index(requestedCompanyId)}
             >
-              + Show manually linked susidiaries
+              + Show manually linked subsidiaries
             </Button>
           </ToggleSubsidiariesButtonContent>
         </li>
@@ -157,7 +157,7 @@ const HierarchyItem = ({
   }, [fullTreeExpanded])
 
   return (
-    <HierachyListItem
+    <HierarchyListItem
       globalParent={globalParent}
       isFinalItemInLevel={isFinalItemInLevel}
       data-test="hierarchy-item"
@@ -173,7 +173,7 @@ const HierarchyItem = ({
       >
         {company.id ? (
           <Link
-            href={urls.companies.details(company.id)}
+            href={urls.companies.overview.index(company.id)}
             aria-label={`Go to ${company.name} details`}
           >
             {company.name}
@@ -190,7 +190,7 @@ const HierarchyItem = ({
         fullTreeExpanded={fullTreeExpanded}
         requestedCompanyId={requestedCompanyId}
       />
-    </HierachyListItem>
+    </HierarchyListItem>
   )
 }
 
@@ -207,7 +207,7 @@ const breadcrumbs = (company) =>
           text: 'Companies',
         },
         {
-          link: urls.companies.details(company.id),
+          link: urls.companies.overview.index(company.id),
           text: company.name,
         },
         {

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -89,7 +89,7 @@ export const ToggleSubsidiariesButtonContent = styled.div`
   }
 `
 
-export const HierachyListItem = styled.li`
+export const HierarchyListItem = styled.li`
   position: relative;
   ${({ globalParent, isFinalItemInLevel }) =>
     !globalParent &&

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -36,7 +36,7 @@ const assertRelatedCompaniesPage = ({ company }) => {
     assertBreadcrumbs({
       Home: urls.dashboard(),
       Companies: urls.companies.index(),
-      [company.name]: urls.companies.details(company.id),
+      [company.name]: urls.companies.overview.index(company.id),
       'Business details': urls.companies.businessDetails(company.id),
       'Related companies': null,
     })
@@ -189,7 +189,7 @@ describe('D&B Company hierarchy tree', () => {
         .should(
           'have.attr',
           'href',
-          urls.companies.details(
+          urls.companies.overview.index(
             companyOnlyImmediateSubsidiaries.ultimate_global_company
               .subsidiaries[0].id
           )


### PR DESCRIPTION
## Description of change

The hierarchy tree company link should navigate to the overview tab not the details tab for that company

## Test instructions

Open a company page for a company with a genuine duns number. Append company-tree to the url
http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/company-tree

Click on the company name link in the hierarch box

Open's in the overview tab of that company

## Screenshots

### Before

![Screenshot 2023-06-16 at 14 46 52](https://github.com/uktrade/data-hub-frontend/assets/72826129/13bc399b-45b6-4921-86c3-ed33865d22a5)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
