### PR TITLE
Cls 177 company tags and headcount

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "react-app-polyfill": "^3.0.0",
         "react-dom": "^17.0.2",
         "react-error-boundary": "^4.0.9",
+        "react-icons": "^4.9.0",
         "react-lines-ellipsis": "^0.15.3",
         "react-markdown": "^8.0.7",
         "react-redux": "^7.2.6",
@@ -26575,6 +26576,14 @@
       },
       "peerDependencies": {
         "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.9.0.tgz",
+      "integrity": "sha512-ijUnFr//ycebOqujtqtV9PFS7JjhWg0QU6ykURVHuL4cbofvRCf3f6GMn9+fBktEFQOIVZnuAYLZdiyadRQRFg==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-inspector": {

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "react-app-polyfill": "^3.0.0",
     "react-dom": "^17.0.2",
     "react-error-boundary": "^4.0.9",
+    "react-icons": "^4.9.0",
     "react-lines-ellipsis": "^0.15.3",
     "react-markdown": "^8.0.7",
     "react-redux": "^7.2.6",

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -11,7 +11,8 @@ import urls from '../../../../lib/urls'
 import { DefaultLayout } from '../../../components'
 import AccessDenied from '../../../components/AccessDenied'
 import { GREY_4, BLACK } from '../../../utils/colours'
-import { isEmpty } from 'lodash'
+import { BsFillPersonFill } from 'react-icons/bs'
+import { isEmpty, kebabCase } from 'lodash'
 import {
   StyledButton,
   ToggleSubsidiariesButtonContent,
@@ -20,6 +21,7 @@ import {
   SubsidiaryList,
   HierarchyListItem,
   HierarchyHeaderContents,
+  HierarchyTag,
 } from './styled'
 
 const ToggleSubsidiariesButton = ({
@@ -172,12 +174,50 @@ const HierarchyItem = ({
         }
       >
         {company.id ? (
-          <Link
-            href={urls.companies.overview.index(company.id)}
-            aria-label={`Go to ${company.name} details`}
-          >
-            {company.name}
-          </Link>
+          <span>
+            <Link
+              href={urls.companies.overview.index(company.id)}
+              aria-label={`Go to ${company.name} details`}
+            >
+              {company.name}
+            </Link>
+            {company.one_list_tier.name && (
+              <HierarchyTag
+                colour="grey"
+                data-test={`${kebabCase(company.name)}-one-list-tag`}
+              >
+                One List {company.one_list_tier.name.slice(0, 6)}
+              </HierarchyTag>
+            )}
+            {company.address.country.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${kebabCase(company.name)}-country-tag`}
+              >
+                {company.address.country.name}
+              </HierarchyTag>
+            )}
+            {company.uk_region.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${kebabCase(company.name)}-uk-region-tag`}
+              >
+                {company.uk_region.name}
+              </HierarchyTag>
+            )}
+            {company.number_of_employees && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${kebabCase(company.name)}-number-of-employees-tag`}
+              >
+                <BsFillPersonFill
+                  size={'12'}
+                  style={{ verticalAlign: 'top', paddingTop: '1px' }}
+                />
+                {` ${company.number_of_employees}`}
+              </HierarchyTag>
+            )}
+          </span>
         ) : (
           <span>{`${company.name} (not on Data Hub)`}</span>
         )}

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -186,7 +186,7 @@ const HierarchyItem = ({
             `${company.name} (not on Data Hub)`
           )}
 
-          {company.one_list_tier.name && (
+          {company.one_list_tier?.name && (
             <HierarchyTag
               colour="grey"
               data-test={`${companyName}-one-list-tag`}
@@ -194,7 +194,7 @@ const HierarchyItem = ({
               One List {company.one_list_tier.name.slice(0, 6)}
             </HierarchyTag>
           )}
-          {company.address.country.name && (
+          {company.address?.country.name && (
             <HierarchyTag
               colour="blue"
               data-test={`${companyName}-country-tag`}
@@ -202,7 +202,7 @@ const HierarchyItem = ({
               {company.address.country.name}
             </HierarchyTag>
           )}
-          {company.uk_region.name && (
+          {company.uk_region?.name && (
             <HierarchyTag
               colour="blue"
               data-test={`${companyName}-uk-region-tag`}

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -158,6 +158,7 @@ const HierarchyItem = ({
     }
   }, [fullTreeExpanded])
 
+  const companyName = kebabCase(company.name)
   return (
     <HierarchyListItem
       globalParent={globalParent}
@@ -184,7 +185,7 @@ const HierarchyItem = ({
             {company.one_list_tier.name && (
               <HierarchyTag
                 colour="grey"
-                data-test={`${kebabCase(company.name)}-one-list-tag`}
+                data-test={`${companyName}-one-list-tag`}
               >
                 One List {company.one_list_tier.name.slice(0, 6)}
               </HierarchyTag>
@@ -192,7 +193,7 @@ const HierarchyItem = ({
             {company.address.country.name && (
               <HierarchyTag
                 colour="blue"
-                data-test={`${kebabCase(company.name)}-country-tag`}
+                data-test={`${companyName}-country-tag`}
               >
                 {company.address.country.name}
               </HierarchyTag>
@@ -200,7 +201,7 @@ const HierarchyItem = ({
             {company.uk_region.name && (
               <HierarchyTag
                 colour="blue"
-                data-test={`${kebabCase(company.name)}-uk-region-tag`}
+                data-test={`${companyName}-uk-region-tag`}
               >
                 {company.uk_region.name}
               </HierarchyTag>
@@ -208,7 +209,7 @@ const HierarchyItem = ({
             {company.number_of_employees && (
               <HierarchyTag
                 colour="blue"
-                data-test={`${kebabCase(company.name)}-number-of-employees-tag`}
+                data-test={`${companyName}-number-of-employees-tag`}
               >
                 <BsFillPersonFill
                   size={'12'}
@@ -219,7 +220,29 @@ const HierarchyItem = ({
             )}
           </span>
         ) : (
-          <span>{`${company.name} (not on Data Hub)`}</span>
+          <span>
+            {`${company.name} (not on Data Hub)`}
+            {company.address.country.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-country-tag`}
+              >
+                {company.address.country.name}
+              </HierarchyTag>
+            )}
+            {company.number_of_employees && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-number-of-employees-tag`}
+              >
+                <BsFillPersonFill
+                  size={'12'}
+                  style={{ verticalAlign: 'top', paddingTop: '1px' }}
+                />
+                {` ${company.number_of_employees}`}
+              </HierarchyTag>
+            )}
+          </span>
         )}
       </HierarchyItemContents>
       <Subsidiaries

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -174,76 +174,55 @@ const HierarchyItem = ({
             : 'related-company'
         }
       >
-        {company.id ? (
-          <span>
+        <span>
+          {company.id ? (
             <Link
               href={urls.companies.overview.index(company.id)}
               aria-label={`Go to ${company.name} details`}
             >
               {company.name}
             </Link>
-            {company.one_list_tier.name && (
-              <HierarchyTag
-                colour="grey"
-                data-test={`${companyName}-one-list-tag`}
-              >
-                One List {company.one_list_tier.name.slice(0, 6)}
-              </HierarchyTag>
-            )}
-            {company.address.country.name && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-country-tag`}
-              >
-                {company.address.country.name}
-              </HierarchyTag>
-            )}
-            {company.uk_region.name && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-uk-region-tag`}
-              >
-                {company.uk_region.name}
-              </HierarchyTag>
-            )}
-            {company.number_of_employees && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-number-of-employees-tag`}
-              >
-                <BsFillPersonFill
-                  size={'12'}
-                  style={{ verticalAlign: 'top', paddingTop: '1px' }}
-                />
-                {` ${company.number_of_employees}`}
-              </HierarchyTag>
-            )}
-          </span>
-        ) : (
-          <span>
-            {`${company.name} (not on Data Hub)`}
-            {company.address.country.name && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-country-tag`}
-              >
-                {company.address.country.name}
-              </HierarchyTag>
-            )}
-            {company.number_of_employees && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-number-of-employees-tag`}
-              >
-                <BsFillPersonFill
-                  size={'12'}
-                  style={{ verticalAlign: 'top', paddingTop: '1px' }}
-                />
-                {` ${company.number_of_employees}`}
-              </HierarchyTag>
-            )}
-          </span>
-        )}
+          ) : (
+            `${company.name} (not on Data Hub)`
+          )}
+
+          {company.one_list_tier.name && (
+            <HierarchyTag
+              colour="grey"
+              data-test={`${companyName}-one-list-tag`}
+            >
+              One List {company.one_list_tier.name.slice(0, 6)}
+            </HierarchyTag>
+          )}
+          {company.address.country.name && (
+            <HierarchyTag
+              colour="blue"
+              data-test={`${companyName}-country-tag`}
+            >
+              {company.address.country.name}
+            </HierarchyTag>
+          )}
+          {company.uk_region.name && (
+            <HierarchyTag
+              colour="blue"
+              data-test={`${companyName}-uk-region-tag`}
+            >
+              {company.uk_region.name}
+            </HierarchyTag>
+          )}
+          {company.number_of_employees && (
+            <HierarchyTag
+              colour="blue"
+              data-test={`${companyName}-number-of-employees-tag`}
+            >
+              <BsFillPersonFill
+                size={'12'}
+                style={{ verticalAlign: 'top', paddingTop: '1px' }}
+              />
+              {` ${company.number_of_employees}`}
+            </HierarchyTag>
+          )}
+        </span>
       </HierarchyItemContents>
       <Subsidiaries
         company={company}

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -7,6 +7,7 @@ import {
   DARK_BLUE_LEGACY,
   WHITE,
 } from '../../../utils/colours'
+import { Tag } from '../../../components'
 
 export const HierarchyContents = styled.div`
   padding-bottom: 10px;
@@ -123,4 +124,9 @@ export const HierarchyHeaderContents = styled.div`
       font-size: 24px;
     }
   }
+`
+
+export const HierarchyTag = styled(Tag)`
+  float: right;
+  margin-left: 10px;
 `

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -33,6 +33,18 @@ const companyName = kebabCase(
 const tagContent =
   companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
 
+const companyNoAdditionalTagData = companyTreeFaker({
+  globalCompany: {
+    ultimate_global_company: companyTreeItemFaker({
+      id: dnbGlobalUltimate.id,
+      number_of_employees: null,
+      one_list_tier: [],
+      uk_region: {},
+    }),
+    ultimate_global_companies_count: 1,
+  },
+})
+
 const assertRelatedCompaniesPage = ({ company }) => {
   it('should render the header', () => {
     assertLocalHeader(`Company records related to ${company.name}`)
@@ -225,6 +237,24 @@ describe('D&B Company hierarchy tree', () => {
         'contain.text',
         tagContent.one_list_tier.name.slice(0, 6)
       )
+    })
+  })
+
+  context('When a company has no additional company information', () => {
+    before(() => {
+      cy.intercept(
+        `api-proxy/v4/dnb/${dnbGlobalUltimate.id}/family-tree`,
+        companyNoAdditionalTagData
+      ).as('treeApi')
+      cy.visit(urls.companies.dnbHierarchy.tree(dnbGlobalUltimate.id))
+      cy.wait('@treeApi')
+    })
+
+    it('should not show any tag information', () => {
+      cy.get(`[data-test=requested-company`)
+        .children()
+        .find('strong')
+        .should('have.length', 0)
     })
   })
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -40,6 +40,9 @@ const companyNoAdditionalTagData = companyTreeFaker({
       number_of_employees: null,
       one_list_tier: [],
       uk_region: {},
+      address: {
+        country: '',
+      },
     }),
     ultimate_global_companies_count: 1,
   },
@@ -254,7 +257,7 @@ describe('D&B Company hierarchy tree', () => {
       cy.get(`[data-test=requested-company`)
         .children()
         .find('strong')
-        .should('have.length', 0)
+        .should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -39,10 +39,8 @@ const companyNoAdditionalTagData = companyTreeFaker({
       id: dnbGlobalUltimate.id,
       number_of_employees: null,
       one_list_tier: [],
-      uk_region: {},
-      address: {
-        country: '',
-      },
+      uk_region: null,
+      address: null,
     }),
     ultimate_global_companies_count: 1,
   },
@@ -258,6 +256,13 @@ describe('D&B Company hierarchy tree', () => {
         .children()
         .find('strong')
         .should('not.exist')
+
+      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
+        'not.exist'
+      )
+      cy.get(`[data-test=${companyName}-uk-region-tag]`).should('not.exist')
+      cy.get(`[data-test=${companyName}-country-tag]`).should('not.exist')
+      cy.get(`[data-test=${companyName}-one-list-tag]`).should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -27,6 +27,11 @@ const companyNoSubsidiaries = companyTreeFaker({
 
 const companyOnlyImmediateSubsidiaries = companyTreeFaker({})
 const companyWith5LevelsOfSubsidiaries = companyTreeFaker({ treeDepth: 5 })
+const companyName = kebabCase(
+  companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0].name
+)
+const tagContent =
+  companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
 
 const assertRelatedCompaniesPage = ({ company }) => {
   it('should render the header', () => {
@@ -172,9 +177,17 @@ describe('D&B Company hierarchy tree', () => {
         .find('span')
         .first()
         .should(
-          'have.text',
+          'contain.text',
           `${companyOnlyImmediateSubsidiaries.ultimate_global_company.name} (not on Data Hub)`
         )
+      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
+        'contain.text',
+        tagContent.number_of_employees
+      )
+      cy.get(`[data-test=${companyName}-uk-region-tag]`).should(
+        'contain.text',
+        tagContent.uk_region.name
+      )
     })
 
     it('should click the show subsidiaries button and check the subsidiary company displays with the correct company details', () => {
@@ -195,47 +208,22 @@ describe('D&B Company hierarchy tree', () => {
               .subsidiaries[0].id
           )
         )
-      cy.get(
-        `[data-test=${kebabCase(
-          companyOnlyImmediateSubsidiaries.ultimate_global_company
-            .subsidiaries[0].name
-        )}-number-of-employees-tag]`
-      ).should(
+
+      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
         'contain.text',
-        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
-          .number_of_employees
+        tagContent.number_of_employees
       )
-      cy.get(
-        `[data-test=${kebabCase(
-          companyOnlyImmediateSubsidiaries.ultimate_global_company
-            .subsidiaries[0].name
-        )}-uk-region-tag]`
-      ).should(
+      cy.get(`[data-test=${companyName}-uk-region-tag]`).should(
         'contain.text',
-        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
-          .uk_region.name
+        tagContent.uk_region.name
       )
-      cy.get(
-        `[data-test=${kebabCase(
-          companyOnlyImmediateSubsidiaries.ultimate_global_company
-            .subsidiaries[0].name
-        )}-country-tag]`
-      ).should(
+      cy.get(`[data-test=${companyName}-country-tag]`).should(
         'contain.text',
-        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
-          .address.country.name
+        tagContent.address.country.name
       )
-      cy.get(
-        `[data-test=${kebabCase(
-          companyOnlyImmediateSubsidiaries.ultimate_global_company
-            .subsidiaries[0].name
-        )}-one-list-tag]`
-      ).should(
+      cy.get(`[data-test=${companyName}-one-list-tag]`).should(
         'contain.text',
-        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0].one_list_tier.name.slice(
-          0,
-          6
-        )
+        tagContent.one_list_tier.name.slice(0, 6)
       )
     })
   })

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -2,6 +2,7 @@ import {
   companyTreeFaker,
   companyTreeItemFaker,
 } from '../../fakers/dnb-hierarchy'
+import { kebabCase } from 'lodash'
 
 const {
   assertErrorDialog,
@@ -194,6 +195,48 @@ describe('D&B Company hierarchy tree', () => {
               .subsidiaries[0].id
           )
         )
+      cy.get(
+        `[data-test=${kebabCase(
+          companyOnlyImmediateSubsidiaries.ultimate_global_company
+            .subsidiaries[0].name
+        )}-number-of-employees-tag]`
+      ).should(
+        'contain.text',
+        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
+          .number_of_employees
+      )
+      cy.get(
+        `[data-test=${kebabCase(
+          companyOnlyImmediateSubsidiaries.ultimate_global_company
+            .subsidiaries[0].name
+        )}-uk-region-tag]`
+      ).should(
+        'contain.text',
+        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
+          .uk_region.name
+      )
+      cy.get(
+        `[data-test=${kebabCase(
+          companyOnlyImmediateSubsidiaries.ultimate_global_company
+            .subsidiaries[0].name
+        )}-country-tag]`
+      ).should(
+        'contain.text',
+        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
+          .address.country.name
+      )
+      cy.get(
+        `[data-test=${kebabCase(
+          companyOnlyImmediateSubsidiaries.ultimate_global_company
+            .subsidiaries[0].name
+        )}-one-list-tag]`
+      ).should(
+        'contain.text',
+        companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0].one_list_tier.name.slice(
+          0,
+          6
+        )
+      )
     })
   })
 


### PR DESCRIPTION
## Description of change

Added tags for the company tree to display number of employees, uk region, country and tier status

## Test instructions

_What should I see?_

## Screenshots

### Before
![Screenshot 2023-06-20 at 11 54 30](https://github.com/uktrade/data-hub-frontend/assets/54268863/010b131f-9235-43c2-ab0b-92a0e723fd7d)

### After
![Screenshot 2023-06-20 at 11 53 31](https://github.com/uktrade/data-hub-frontend/assets/54268863/f01cc0b7-3b99-428f-a327-44737893d8a2)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
