### PR TITLE
Temporarily comment out flaky test

### DIFF
--- a/test/visual-component/cypress/specs/toggle-section/toggle-section.spec.js
+++ b/test/visual-component/cypress/specs/toggle-section/toggle-section.spec.js
@@ -35,12 +35,19 @@ describe('ToggleSection', () => {
       .should('be.visible')
       .compareSnapshot('dashboard-multi')
   })
-  it('should render the filter single toggle section correctly', () => {
-    cy.visit('/iframe.html?id=togglesection--filter-single')
-    cy.get('#storybook-root')
-      .should('be.visible')
-      .compareSnapshot('filter-single')
-  })
+
+  // Temporarily commenting out this test while Pippo looks into why it's
+  // failing remotely but passes locally. The tests are run in docker
+  // containers both locally and remotely, so in theory they should produce
+  // the same results.
+
+  // it('should render the filter single toggle section correctly', () => {
+  //   cy.visit('/iframe.html?id=togglesection--filter-single')
+  //   cy.get('#storybook-root')
+  //     .should('be.visible')
+  //     .compareSnapshot('filter-single')
+  // })
+
   it('should render the filter multiple toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--filter-multiple')
     cy.get('#storybook-root')


### PR DESCRIPTION
## Description of change
Temporarily commenting out a flaky test while Pippo looks into why it's failing remotely but passes locally. The tests are run in docker containers both locally and remotely, in theory they should produce the same results.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
