### PR TITLE
Add explicit wait for visual component test

### DIFF
--- a/test/visual-component/cypress/specs/toggle-section/toggle-section.spec.js
+++ b/test/visual-component/cypress/specs/toggle-section/toggle-section.spec.js
@@ -1,57 +1,66 @@
 describe('ToggleSection', () => {
+  const retryOptions = {
+    limit: 3,
+    delay: 1000,
+  }
+
   it('should render the default single toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--default-single')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('default-single')
+      .compareSnapshot('default-single', 0, retryOptions)
   })
   it('should render the default multiple toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--default-multiple')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('default-multi')
+      .compareSnapshot('default-multi', 0, retryOptions)
   })
   it('should render the no highlight single toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--no-highlight-single')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('no-highlight-single')
+      .compareSnapshot('no-highlight-single', 0, retryOptions)
   })
   it('should render the no highlight multiple toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--no-highlight-multiple')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('no-highlight-multi')
+      .compareSnapshot('no-highlight-multi', 0, retryOptions)
   })
   it('should render the dashboard single toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--dashboard-single-with-badge')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('dashboard-single')
+      .compareSnapshot('dashboard-single', 0, retryOptions)
   })
   it('should render the dashboard multiple toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--dashboard-multiple')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('dashboard-multi')
+      .compareSnapshot('dashboard-multi', 0, retryOptions)
   })
 
-  // Temporarily commenting out this test while Pippo looks into why it's
-  // failing remotely but passes locally. The tests are run in docker
-  // containers both locally and remotely, so in theory they should produce
-  // the same results.
+  it('should render the filter single toggle section correctly', () => {
+    cy.visit('/iframe.html?id=togglesection--filter-single')
 
-  // it('should render the filter single toggle section correctly', () => {
-  //   cy.visit('/iframe.html?id=togglesection--filter-single')
-  //   cy.get('#storybook-root')
-  //     .should('be.visible')
-  //     .compareSnapshot('filter-single')
-  // })
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
+    cy.get('#storybook-root')
+      .should('be.visible')
+      .compareSnapshot('filter-single', 0, retryOptions)
+  })
 
   it('should render the filter multiple toggle section correctly', () => {
     cy.visit('/iframe.html?id=togglesection--filter-multiple')
+    cy.get('[data-test="toggle-section-button"] > img').should('be.visible')
     cy.get('#storybook-root')
       .should('be.visible')
-      .compareSnapshot('filter-multi')
+      .compareSnapshot('filter-multi', 0, retryOptions)
   })
 })


### PR DESCRIPTION
## Description of change

Adding explicit waits and retry to make visual tests more robust to prevent flakyness

## Test instructions

make visual-component-test

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
