### PR TITLE
User friendly message when no related records.

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -175,7 +175,9 @@ const HierarchyItem = ({
         }
       >
         <span>
-          {company.id ? (
+          {Object.keys(company).length === 0 ? (
+            `No related companies found`
+          ) : company?.id ? (
             <Link
               href={urls.companies.overview.index(company.id)}
               aria-label={`Go to ${company.name} details`}


### PR DESCRIPTION
## Description of change

On the company hierarchy page when a company has no related records a user friendly message should be shown.

## Test instructions

When viewing a [company without related records](http://localhost:3000/companies/dd89e209-18d6-432e-aad0-093b0f0e1422/company-tree) a friendly message should be shown. 

## Screenshots

### Before

<img width="980" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/f750a0f9-1d2f-47be-bba7-21fa0b525f60">

### After

<img width="986" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/d1d28bb5-f628-4486-a6eb-8456ea344111">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
