### PR TITLE
Mark interaction questions to be optional

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -294,7 +294,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="has_related_trade_agreements"
-            legend="Does this interaction relate to a named trade agreement? (Optional)"
+            legend="Does this interaction relate to a named trade agreement? (optional)"
             options={OPTIONS_YES_NO}
           />
 
@@ -439,7 +439,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="were_countries_discussed"
-            legend="Were any countries discussed? (Optional)"
+            legend="Were any countries discussed? (optional)"
             options={OPTIONS_YES_NO}
           />
           {values.were_countries_discussed === OPTION_YES && (
@@ -489,7 +489,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="has_related_opportunity"
-            legend="Does this interaction relate to a large capital opportunity? (Optional)"
+            legend="Does this interaction relate to a large capital opportunity? (optional)"
             options={OPTIONS_YES_NO}
           />
 
@@ -525,7 +525,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="helped_remove_export_barrier"
-            legend="Did the interaction help remove an export barrier? (Optional)"
+            legend="Did the interaction help remove an export barrier? (optional)"
             options={OPTIONS_YES_NO}
           />
 

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -294,8 +294,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="has_related_trade_agreements"
-            legend="Does this interaction relate to a named trade agreement?"
-            required="Select if this relates to a named trade agreement"
+            legend="Does this interaction relate to a named trade agreement? (Optional)"
             options={OPTIONS_YES_NO}
           />
 
@@ -440,8 +439,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="were_countries_discussed"
-            legend="Were any countries discussed?"
-            required="Select if any countries were discussed"
+            legend="Were any countries discussed? (Optional)"
             options={OPTIONS_YES_NO}
           />
           {values.were_countries_discussed === OPTION_YES && (
@@ -491,8 +489,7 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="has_related_opportunity"
-            legend="Does this interaction relate to a large capital opportunity?"
-            required="Answer if this interaction relates to a large capital opportunity"
+            legend="Does this interaction relate to a large capital opportunity? (Optional)"
             options={OPTIONS_YES_NO}
           />
 
@@ -528,9 +525,8 @@ const StepInteractionDetails = ({
           <FieldRadios
             inline={true}
             name="helped_remove_export_barrier"
-            legend="Did the interaction help remove an export barrier?"
+            legend="Did the interaction help remove an export barrier? (Optional)"
             options={OPTIONS_YES_NO}
-            required="Select if the interaction helped remove an export barrier"
           />
 
           {values.helped_remove_export_barrier === OPTION_YES && (

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -59,7 +59,7 @@ const ELEMENT_SERVICE_NET_RECEIPT = {
   label: 'Net receipt (optional)',
 }
 const ELEMENT_RELATED_TRADE_AGREEMENT = {
-  legend: 'Does this interaction relate to a named trade agreement?',
+  legend: 'Does this interaction relate to a named trade agreement? (optional)',
   assert: assertFieldRadiosWithLegend,
   optionsCount: 2,
 }
@@ -68,7 +68,8 @@ const ELEMENT_TRADE_AGREEMENTS = {
   placeholder: '-- Select named trade agreement --',
 }
 const ELEMENT_RELATED_OPPORTUNITY = {
-  legend: 'Does this interaction relate to a large capital opportunity?',
+  legend:
+    'Does this interaction relate to a large capital opportunity? (optional)',
   assert: assertFieldRadiosWithLegend,
   optionsCount: 2,
 }
@@ -139,7 +140,7 @@ const ELEMENT_FEEDBACK_POLICY = {
 }
 
 const ELEMENT_EXPORT_BARRIER = {
-  legend: 'Did the interaction help remove an export barrier?',
+  legend: 'Did the interaction help remove an export barrier? (optional)',
   assert: assertFieldRadiosWithLegend,
   optionsCount: 2,
 }
@@ -151,7 +152,7 @@ const ELEMENT_POLICY_FEEDBACK_NOTES = {
   label: 'Business intelligence',
 }
 const ELEMENT_COUNTRIES = {
-  legend: 'Were any countries discussed?',
+  legend: 'Were any countries discussed? (optional)',
   assert: assertFieldRadiosWithLegend,
   optionsCount: 2,
 }
@@ -414,7 +415,7 @@ const selectInteractionType = (theme, kind) => {
 
 const company = fixtures.company.venusLtd
 
-describe('Interaction theme', () => {
+describe('Export theme - standard interaction', () => {
   context('when viewing the form', () => {
     beforeEach(() => {
       spyOnRequest()
@@ -447,7 +448,7 @@ describe('Interaction theme', () => {
     })
   })
 
-  context('when creating an interaction', () => {
+  context('when creating an export interaction', () => {
     beforeEach(() => {
       spyOnRequest()
       cy.visit(urls.companies.interactions.create(company.id))
@@ -491,26 +492,23 @@ describe('Interaction theme', () => {
         .should('have.text', 'Johnny Cakeman')
     })
 
-    const interaction_error_messages = [
+    const export_standard_theme_error_messages = [
       'Select a service',
-      'Select if this relates to a named trade agreement',
       'Select at least one contact',
       'Select a communication channel',
       'Enter a summary',
       'Select if the contact provided business intelligence',
-      'Select if any countries were discussed',
-      'Select if the interaction helped remove an export barrier',
     ]
 
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(interaction_error_messages)
+      assertErrorSummary(export_standard_theme_error_messages)
     })
 
     it('should validate the second tier service form field', () => {
       fillSelect('[data-test=field-service]', 'DBT export service or funding')
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(interaction_error_messages)
+      assertErrorSummary(export_standard_theme_error_messages)
     })
 
     it('should save the interaction', () => {
@@ -576,7 +574,7 @@ describe('Interaction theme', () => {
   })
 })
 
-describe('Service delivery theme', () => {
+describe('Export theme - service delivery', () => {
   context('when creating a service delivery', () => {
     beforeEach(() => {
       spyOnRequest()
@@ -611,26 +609,23 @@ describe('Service delivery theme', () => {
       ])
     })
 
-    const service_delivery_errors = [
+    const export_service_delivery_theme_error_messages = [
       'Select a service',
-      'Select if this relates to a named trade agreement',
       'Select at least one contact',
       'Select if this was an event',
       'Enter a summary',
       'Select if the contact provided business intelligence',
-      'Select if any countries were discussed',
-      'Select if the interaction helped remove an export barrier',
     ]
 
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(service_delivery_errors)
+      assertErrorSummary(export_service_delivery_theme_error_messages)
     })
 
     it('should validate the second tier service form field', () => {
       fillSelect('[data-test=field-service]', 'DBT export service or funding')
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(service_delivery_errors)
+      assertErrorSummary(export_service_delivery_theme_error_messages)
     })
 
     it('should save the service delivery', () => {
@@ -714,24 +709,23 @@ describe('Investment theme', () => {
       ])
     })
 
-    const investment_error_messages = [
+    const investment_theme_error_messages = [
       'Select a service',
       'Select at least one contact',
       'Select a communication channel',
       'Enter a summary',
       'Select if the contact provided business intelligence',
-      'Answer if this interaction relates to a large capital opportunity',
     ]
 
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(investment_error_messages)
+      assertErrorSummary(investment_theme_error_messages)
     })
 
     it('should validate the second tier service form field', () => {
       fillSelect('[data-test=field-service]', 'Enquiry received')
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(investment_error_messages)
+      assertErrorSummary(investment_theme_error_messages)
     })
 
     it('should save the interaction', () => {
@@ -835,25 +829,23 @@ describe('Trade Agreement theme', () => {
       ])
     })
 
-    const trade_agreement_error_messages = [
+    const trade_agreement_theme_error_messages = [
       'Select a service',
-      'Select if this relates to a named trade agreement',
       'Select at least one contact',
       'Select a communication channel',
       'Enter a summary',
       'Select if the contact provided business intelligence',
-      'Select if any countries were discussed',
     ]
 
     it('should validate the form', () => {
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(trade_agreement_error_messages)
+      assertErrorSummary(trade_agreement_theme_error_messages)
     })
 
     it('should validate the second tier service form field', () => {
       fillSelect('[data-test=field-service]', 'Specific service')
       cy.contains('button', 'Add interaction').click()
-      assertErrorSummary(trade_agreement_error_messages)
+      assertErrorSummary(trade_agreement_theme_error_messages)
     })
 
     it('should save the interaction for a specific service', () => {


### PR DESCRIPTION
## Description of change

The yes - no questions on the “Add interaction” form are, the vast majority of the time, answered “no”.

The aim of this ticket is to mark some of the questions as optional so that users don’t have to click no every single time. These questions are:

Related named trade agreement

Countries discussed (only displays for Export-type interactions)

Help to remove an export barrier (only displays for Export-type interactions)

Relate to Large Capital Opportunity (only displays for Investment-type interactions)

Note: Business intelligence and comms channel will remain compulsory for the time being.

## Test instructions

From Datahub, navigate into company list -> details -> add interaction -> [Investment theme] then continue (marking some interaction questions to be `optional`)

Interaction theme

Export, Investment and Other

- Does this interaction relate to a named trade agreement? (optional)
- Were any countries discussed? (optional)
- Did the interaction help remove an export barrier? (optional)
- Does this interaction relate to a large capital opportunity? (optional)

Trade Agreement

- Does this interaction relate to a named trade agreement? (optional)
- Were any countries discussed? (optional)

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/d66cfcd2-5fe5-48f7-b7a4-ac45fe027af9)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/a93b07dd-54e2-46bf-aeac-492734d28258)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
