### PR TITLE
feature/CLS2-271-additional-faker-data

### DIFF
--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -95,6 +95,20 @@ const createSubsidiary = (
   company.subsidiaries = subsidiaryCompanies
 }
 
+const manuallyLinkedCompanyFaker = () => {
+  return {
+    id: faker.string.uuid(),
+    name: faker.company.name(),
+    employee_range: faker.helpers.arrayElement(EMPLOYEE_RANGE),
+    headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
+    address: addressFaker(),
+    uk_region: ukRegionFaker(),
+    one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
+    archived: false,
+    hierarchy: 0,
+  }
+}
+
 const companyTreeFaker = ({
   treeDepth = 2,
   minCompaniesPerLevel = 1,
@@ -106,17 +120,9 @@ const companyTreeFaker = ({
   ),
 }) => ({
   ...globalCompany,
-  manually_verified_subsidiaries: [
-    {
-      id: faker.string.uuid(),
-      name: faker.company.name(),
-      employee_range: faker.helpers.arrayElement(EMPLOYEE_RANGE),
-      headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
-      address: addressFaker(),
-      uk_region: ukRegionFaker(),
-      archived: false,
-    },
-  ],
+  manually_verified_subsidiaries: [...new Array(5)].map(
+    manuallyLinkedCompanyFaker
+  ),
 })
 
 export { companyTreeFaker, companyTreeItemFaker, companyTreeItemListFaker }

--- a/test/sandbox/routes/v4/dnb/company-tree.js
+++ b/test/sandbox/routes/v4/dnb/company-tree.js
@@ -106,21 +106,27 @@ const createSubsidiary = (
   company.subsidiaries = subsidiaryCompanies
 }
 
+const manuallyLinkedCompanyFaker = () => {
+  return {
+    id: faker.string.uuid(),
+    name: faker.company.name(),
+    employee_range: faker.helpers.arrayElement(employeeRange),
+    headquarter_type: faker.helpers.arrayElement(headquarterType),
+    address: address,
+    uk_region: faker.helpers.arrayElement(ukRegion),
+    one_list_tier: faker.helpers.arrayElement(oneListTier),
+    archived: false,
+    hierarchy: 0,
+  }
+}
+
 exports.fakerCompanyFamilyTree = ({
   treeDepth = 2,
   minCompaniesPerLevel = 1,
   maxCompaniesPerLevel = 1,
 }) => ({
   ...createCompanyTree(treeDepth, minCompaniesPerLevel, maxCompaniesPerLevel),
-  manually_verified_subsidiaries: [
-    {
-      id: faker.string.uuid(),
-      name: faker.company.name(),
-      employee_range: faker.helpers.arrayElement(employeeRange),
-      headquarter_type: faker.helpers.arrayElement(headquarterType),
-      address: address,
-      uk_region: faker.helpers.arrayElement(ukRegion),
-      archived: false,
-    },
-  ],
+  manually_verified_subsidiaries: [...new Array(5)].map(
+    manuallyLinkedCompanyFaker
+  ),
 })


### PR DESCRIPTION
## Description of change

Added extra fields to the faker api response for the family tree endpoint

## Test instructions

Start the sandbox and go to url http://localhost:8000/v4/dnb/0418f79f-154b-4f55-85a6-8ddad559663e/family-tree, you will see the new fields in the response

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/0f540632-b9d0-4bd7-8dba-3645e64a9cd7)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
