### PR TITLE
Add an interaction kind to investment and trade agreement

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -20,7 +20,6 @@ const getKindHandler = (setFieldValue) => (e) => {
 const getNoKindHandler = (setFieldValue) => (e) => {
   setFieldValue('service', '')
   setFieldValue('theme', e.target.value)
-  setFieldValue('kind', KINDS.INTERACTION)
 }
 
 const StepInteractionType = () => {

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -284,9 +284,16 @@ export function saveInteraction({ values, companyIds, referralId }) {
           ? values.large_capital_opportunity.value
           : null,
     }),
-    // If the user has selected investment the API still requires a kind.
-    ...(values.theme === THEMES.INVESTMENT &&
-      !values.kind && { kind: KINDS.INTERACTION }),
+    // If the user has selected Investment the
+    // API endpoint still requires a kind.
+    ...(values.theme == THEMES.INVESTMENT && {
+      kind: KINDS.INTERACTION,
+    }),
+    // If the user has selected Trade agreement
+    // the API endpoint still requires a kind.
+    ...(values.theme == THEMES.TRADE_AGREEMENT && {
+      kind: KINDS.INTERACTION,
+    }),
   }
 
   const payload = values.id
@@ -298,6 +305,7 @@ export function saveInteraction({ values, companyIds, referralId }) {
         ...commonPayload,
         export_countries: transformExportCountries(values),
       }
+
   return request(
     values.id ? `${endpoint}/${values.id}` : endpoint,
     omit(payload, FIELDS_TO_OMIT)


### PR DESCRIPTION
## Description of change
When a user creates an interaction and they choose a `theme` (Interaction or Trade agreement) the API expects a `kind` to be set as "interaction". Previously, this was done in the `onChange` event handlers, but the value set was quickly removed in subsequent form updates. Now we perform a check just before saving the form, and if applicable, set the `kind` there.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
