### PR TITLE
Fix maxemail campaign date.

### DIFF
--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -25,7 +25,7 @@ export default class MaxemailCampaign extends React.PureComponent {
 
   render() {
     const { activity } = this.props
-    const published = get(activity, 'published')
+    const published = get(activity, 'object.published')
     const name = get(activity, 'actor.name')
     const from = get(activity, 'actor.dit:emailAddress')
     const emailSubject = get(activity, 'object.dit:emailSubject')


### PR DESCRIPTION
## Description of change

The Maxemail campaign component was not showing the date of the campaign. This fixes it.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
