### PR TITLE
Add a related companies link to the company tree

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -8,6 +8,7 @@ import GridRow from '@govuk-react/grid-row'
 import Button from '@govuk-react/button'
 import Details from '@govuk-react/details'
 import { SPACING, FONT_SIZE, BREAKPOINTS } from '@govuk-react/constants'
+import { Link } from 'govuk-react'
 
 import { GREY_3, TEXT_COLOUR } from '../../utils/colours'
 import LocalHeader from '../LocalHeader/LocalHeader'
@@ -98,6 +99,9 @@ const StyledMain = styled(Main)`
     font-size: ${FONT_SIZE.SIZE_20};
   }
 `
+const StyledDiv = styled('div')`
+  padding-bottom: 8px;
+`
 
 const isUltimate = (company) => !!company.isGlobalUltimate
 const isGlobalHQ = (company) =>
@@ -135,6 +139,14 @@ const CompanyLocalHeader = ({
             <StyledAddress data-test="address">
               {addressToStringResource(company.address)}
             </StyledAddress>
+            <StyledDiv>
+              <Link
+                href={urls.companies.dnbHierarchy.tree(company.id)}
+                data-test="company-tree-link"
+              >
+                View related companies
+              </Link>
+            </StyledDiv>
           </GridCol>
           <GridCol setWith="one-third">
             <StyledButtonContainer>

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import pluralize from 'pluralize'
 import Main from '@govuk-react/main'
 import GridCol from '@govuk-react/grid-col'
 import GridRow from '@govuk-react/grid-row'
@@ -99,8 +98,8 @@ const StyledMain = styled(Main)`
     font-size: ${FONT_SIZE.SIZE_20};
   }
 `
-const StyledDiv = styled('div')`
-  padding-bottom: 8px;
+const StyledRelatedCompaniesWrapper = styled('div')`
+  padding-bottom: 20px;
 `
 
 const isUltimate = (company) => !!company.isGlobalUltimate
@@ -139,14 +138,16 @@ const CompanyLocalHeader = ({
             <StyledAddress data-test="address">
               {addressToStringResource(company.address)}
             </StyledAddress>
-            <StyledDiv>
-              <Link
-                href={urls.companies.dnbHierarchy.tree(company.id)}
-                data-test="company-tree-link"
-              >
-                View related companies
-              </Link>
-            </StyledDiv>
+            {dnbRelatedCompaniesCount > 0 && (
+              <StyledRelatedCompaniesWrapper>
+                <Link
+                  href={urls.companies.dnbHierarchy.tree(company.id)}
+                  data-test="company-tree-link"
+                >
+                  View related companies
+                </Link>
+              </StyledRelatedCompaniesWrapper>
+            )}
           </GridCol>
           <GridCol setWith="one-third">
             <StyledButtonContainer>
@@ -195,19 +196,8 @@ const CompanyLocalHeader = ({
             )}
           </TypeWrapper>
         )}
-        {(dnbRelatedCompaniesCount > 0 ||
-          hasManagedAccountDetails(company)) && (
+        {hasManagedAccountDetails(company) && (
           <StyledDescription data-test="description">
-            {dnbRelatedCompaniesCount > 0 && (
-              <p>
-                Data Hub contains{' '}
-                <a href={urls.companies.dnbHierarchy.index(company.id)}>
-                  {dnbRelatedCompaniesCount} other company{' '}
-                  {pluralize('record', dnbRelatedCompaniesCount)}
-                </a>{' '}
-                related to this company
-              </p>
-            )}
             {hasManagedAccountDetails(company) && (
               <>
                 <p>

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -27,9 +27,9 @@ const advisersUrl = urls.companies.advisers.index(company.id)
 const addRemoveFromListUrl = urls.companies.lists.addRemove(company.id)
 const detailsUrl = urls.companies.detail(company.id)
 const referralsUrl = urls.companies.referrals.send(company.id)
-const dnbHierarchyUrl = urls.companies.dnbHierarchy.index(company.id)
 const addInteractionUrl = urls.companies.interactions.create(company.id)
 const exportProjectUrl = urls.exportPipeline.create(company.id)
+const companyTreeUrl = urls.companies.dnbHierarchy.tree(company.id)
 
 describe('Local header for global ultimate company', () => {
   context('when visting a global ultimate company activity page', () => {
@@ -51,6 +51,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -83,7 +87,8 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
-  context('when visting a global ultimate company activity page', () => {
+
+  context('when visting a global ultimate business details page', () => {
     before(() => {
       cy.visit(urls.companies.businessDetails(company.id))
     })
@@ -102,6 +107,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -134,6 +143,7 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
+
   context('when visting a global ultimate company contacts page', () => {
     before(() => {
       cy.visit(urls.companies.contacts(company.id))
@@ -149,6 +159,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -181,6 +195,7 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
+
   context('when visting a global ultimate company core team page', () => {
     before(() => {
       cy.visit(advisersUrl)
@@ -200,6 +215,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -232,6 +251,7 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
+
   context(
     'when visting a global ultimate company investment projects page',
     () => {
@@ -249,8 +269,8 @@ describe('Local header for global ultimate company', () => {
         assertCompanyName(company.name)
       })
 
-      it('should display the company address', () => {
-        assertCompanyAddress(address)
+      it('should display the view related companies link', () => {
+        assertRelatedCompaniesLink(address)
       })
 
       it('should display the correct add interaction button', () => {
@@ -286,6 +306,7 @@ describe('Local header for global ultimate company', () => {
       })
     }
   )
+
   context(
     'when visting a global ultimate company investment large capital page',
     () => {
@@ -307,6 +328,10 @@ describe('Local header for global ultimate company', () => {
         assertCompanyAddress(address)
       })
 
+      it('should display the view related companies link', () => {
+        assertRelatedCompaniesLink(address)
+      })
+
       it('should display the correct add interaction button', () => {
         assertAddInteractionButton(addInteractionUrl)
       })
@@ -340,6 +365,7 @@ describe('Local header for global ultimate company', () => {
       })
     }
   )
+
   context('when visting a global ultimate company export page', () => {
     before(() => {
       cy.visit(urls.companies.exports.index(company.id))
@@ -359,6 +385,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -391,6 +421,7 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
+
   context('when visting a global ultimate company export history page', () => {
     before(() => {
       cy.visit(urls.companies.exports.history.index(company.id))
@@ -410,6 +441,10 @@ describe('Local header for global ultimate company', () => {
       assertCompanyAddress(address)
     })
 
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
+    })
+
     it('should display the correct add interaction button', () => {
       assertAddInteractionButton(addInteractionUrl)
     })
@@ -442,6 +477,7 @@ describe('Local header for global ultimate company', () => {
       assertDescription()
     })
   })
+
   context('when visting a global ultimate company orders page', () => {
     before(() => {
       cy.visit(urls.companies.orders(company.id))
@@ -459,6 +495,10 @@ describe('Local header for global ultimate company', () => {
 
     it('should display the company address', () => {
       assertCompanyAddress(address)
+    })
+
+    it('should display the view related companies link', () => {
+      assertRelatedCompaniesLink(address)
     })
 
     it('should display the correct add interaction button', () => {
@@ -505,12 +545,12 @@ const assertMetaList = () => {
 }
 
 const assertDescription = () => {
-  cy.get(companyLocalHeader.description.paragraph(1))
-    .contains(
-      'Data Hub contains 2 other company records related to this company'
-    )
-    .contains('2 other company records')
-    .should('have.attr', 'href', dnbHierarchyUrl)
-  assertOneListTierA(2)
-  assertCoreTeam(3, advisersUrl)
+  assertOneListTierA(1)
+  assertCoreTeam(2, advisersUrl)
+}
+
+const assertRelatedCompaniesLink = () => {
+  cy.get(companyLocalHeader.relatedCompaniesLink)
+    .contains('View related companies')
+    .should('have.attr', 'href', companyTreeUrl)
 }

--- a/test/selectors/company-local-header.js
+++ b/test/selectors/company-local-header.js
@@ -3,6 +3,7 @@ module.exports = () => {
     metaList: '[data-test="metaList"]',
     companyName: '[data-test="heading"]',
     address: '[data-test="address"]',
+    relatedCompaniesLink: '[data-test="company-tree-link"]',
     badge: '[data-test="badge"]',
     description: {
       paragraph: (number) => `[data-test="description"] p:nth-child(${number})`,


### PR DESCRIPTION
## Description of change

Add a new link to the company hierarchy tree, replacing the description bar in the current header. The next PR will include the number of related companies in the link, however that requires additional API work

## Test instructions

Go to any company that is part of a hierarchy, for example diageo http://localhost:3000/companies/bb2c85cf-c44a-4d9e-ba20-f1a8a3c94125/overview. The link for the related companies will now be under the address

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/56318c25-a132-4e6f-9f45-16f3583496a3)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/45118f39-5e02-4583-ba8b-4d831c6c184a)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
