### PR TITLE
Cls2 232 link subsidiary button

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -23,6 +23,7 @@ import {
   HierarchyHeaderContents,
   HierarchyTag,
   ManuallyLinkedHierarchyListItem,
+  StyledLinkedSubsidiaryButton,
 } from './styled'
 import pluralize from 'pluralize'
 
@@ -61,6 +62,7 @@ const Subsidiaries = ({
   fullTreeExpanded,
   requestedCompanyId,
   label,
+  isManuallyLinked = false,
 }) =>
   Array.isArray(company.subsidiaries) &&
   company.subsidiaries.length > 0 && (
@@ -87,10 +89,21 @@ const Subsidiaries = ({
             isFinalItemInLevel={
               requestedCompanyHasManuallyVerified && hierarchy === 1
                 ? false
-                : index + 1 === company.subsidiaries.length
+                : index + 1 === company.subsidiaries.length && !isManuallyLinked
             }
           />
         ))}
+        {isManuallyLinked && (
+          <li>
+            <StyledLinkedSubsidiaryButton
+              buttonColour={GREY_4}
+              buttonTextColour={BLACK}
+              data-test="link-subsidiary-button"
+            >
+              Link a new subsidiary company
+            </StyledLinkedSubsidiaryButton>
+          </li>
+        )}
       </SubsidiaryList>
     </>
   )
@@ -161,6 +174,7 @@ const ManuallyLinkedList = ({ requestedCompanyId, familyTree }) => {
         isOpen={isOpen}
         setIsOpen={setIsOpen}
         requestedCompanyId={requestedCompanyId}
+        isManuallyLinked={true}
         label="manually linked subsidiaries"
       />
     </ManuallyLinkedHierarchyListItem>

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -99,6 +99,9 @@ const Subsidiaries = ({
               buttonColour={GREY_4}
               buttonTextColour={BLACK}
               data-test="link-subsidiary-button"
+              onClick={() =>
+                (window.location = `/companies/${requestedCompanyId}/subsidiaries/link`)
+              }
             >
               Link a new subsidiary company
             </StyledLinkedSubsidiaryButton>

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { H2, Link } from 'govuk-react'
+import { H2, Link, Button } from 'govuk-react'
 import Task from '../../../components/Task'
 import { TASK_GET_COMPANY_DETAIL } from '../CompanyDetails/state'
 import { ID as COMPANY_DETAILS_ID } from '../../Companies/CompanyDetails/state'
@@ -95,15 +95,16 @@ const Subsidiaries = ({
         ))}
         {isManuallyLinked && (
           <li>
-            <StyledLinkedSubsidiaryButton
-              buttonColour={GREY_4}
-              buttonTextColour={BLACK}
-              data-test="link-subsidiary-button"
-              onClick={() =>
-                (window.location = `/companies/${requestedCompanyId}/subsidiaries/link`)
-              }
-            >
-              Link a new subsidiary company
+            <StyledLinkedSubsidiaryButton>
+              <Button
+                as={Link}
+                href={urls.companies.subsidiaries.link(requestedCompanyId)}
+                buttonColour={GREY_4}
+                buttonTextColour={BLACK}
+                data-test="link-subsidiary-button"
+              >
+                Link a new subsidiary company
+              </Button>
             </StyledLinkedSubsidiaryButton>
           </li>
         )}

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -63,31 +63,32 @@ export const SubsidiaryList = styled.ul`
 `
 export const StyledButton = styled(Button)``
 
-export const StyledLinkedSubsidiaryButton = styled(Button)`
+export const StyledLinkedSubsidiaryButton = styled.div`
   margin-top: 20px;
-  transform-style: preserve-3d;
 
-  // This is the horizontal line to the left of the button
+  transform-style: preserve-3d;
   :before {
+    //This is the horizontal line to the left of the div
     content: '';
     background-color: ${GREY_2};
     position: relative;
     width: 100px;
     height: 5px;
-    top: 16px;
-    left: -40px;
+    top: 22px;
+    left: -29px;
     display: block;
     transform: translateZ(-1px);
   }
-  // This is the vertical line that stretches between the last company and the button
+
   :after {
+    // This is the vertical line that stretches between the last company and the button
     content: '';
     background-color: ${GREY_2};
     position: absolute;
     width: 5px;
     height: 48px;
-    top: -20px;
-    left: -31px;
+    top: -21px;
+    left: -29px;
     display: block;
   }
 `

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -1,5 +1,5 @@
 import { Button, Link } from 'govuk-react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import {
   GREY_2,
   GREY_4,
@@ -8,6 +8,26 @@ import {
   WHITE,
 } from '../../../utils/colours'
 import { Tag } from '../../../components'
+
+const horizontalLine = css`
+  //This is the horizontal line to the left of the div
+  content: '';
+  background-color: ${GREY_2};
+  position: relative;
+  width: 100px;
+  height: 5px;
+  display: block;
+  transform: translateZ(-1px);
+`
+const verticalLine = css`
+  //This is the vertical line that stretches between the child companies
+  content: '';
+  background-color: ${GREY_2};
+  position: absolute;
+  width: 5px;
+  display: block;
+  transform: translateZ(-1px);
+`
 
 export const HierarchyContents = styled.div`
   padding-bottom: 10px;
@@ -40,16 +60,12 @@ export const HierarchyItemContents = styled.div`
     hierarchy != 1 &&
     `
       transform-style: preserve-3d;
-      :before { //This is the horizontal line to the left of the div
-        content: '';
+      
+      :before {
+        ${horizontalLine}
         background-color: ${GREY_2};
-        position: relative;
-        width: 100px;
-        height: 5px;
         top: 16px;
         left: -40px;
-        display: block;
-        transform: translateZ(-1px);
       }
   `}
 `
@@ -67,29 +83,18 @@ export const StyledLinkedSubsidiaryButton = styled.div`
   margin-top: 20px;
 
   transform-style: preserve-3d;
+
   :before {
-    //This is the horizontal line to the left of the div
-    content: '';
-    background-color: ${GREY_2};
-    position: relative;
-    width: 100px;
-    height: 5px;
+    ${horizontalLine}
     top: 22px;
     left: -29px;
-    display: block;
-    transform: translateZ(-1px);
   }
 
   :after {
-    // This is the vertical line that stretches between the last company and the button
-    content: '';
-    background-color: ${GREY_2};
-    position: absolute;
-    width: 5px;
+    ${verticalLine}
     height: 48px;
     top: -21px;
     left: -29px;
-    display: block;
   }
 `
 
@@ -126,16 +131,11 @@ export const HierarchyListItem = styled.li`
     !globalParent &&
     `
       :before {
-        //This is the vertical line that stretches between the child companies
-        content: '';
+        ${verticalLine}
         background-color: ${GREY_2};
-        position: absolute;
-        width: 5px;
         height: ${isFinalItemInLevel ? '48px' : 'calc(100% + 40px)'};
         top: ${isFinalItemInLevel ? '-20px' : '-18px'};
         left: -29px;
-        display: block;
-        transform: translateZ(-1px);
       }
   `}
 `

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -63,6 +63,35 @@ export const SubsidiaryList = styled.ul`
 `
 export const StyledButton = styled(Button)``
 
+export const StyledLinkedSubsidiaryButton = styled(Button)`
+  margin-top: 20px;
+  transform-style: preserve-3d;
+
+  // This is the horizontal line to the left of the button
+  :before {
+    content: '';
+    background-color: ${GREY_2};
+    position: relative;
+    width: 100px;
+    height: 5px;
+    top: 16px;
+    left: -40px;
+    display: block;
+    transform: translateZ(-1px);
+  }
+  // This is the vertical line that stretches between the last company and the button
+  :after {
+    content: '';
+    background-color: ${GREY_2};
+    position: absolute;
+    width: 5px;
+    height: 48px;
+    top: -20px;
+    left: -31px;
+    display: block;
+  }
+`
+
 export const ToggleSubsidiariesButtonContent = styled.div`
   padding-top: 20px;
   ${StyledButton} {

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -25,6 +25,7 @@ const verticalLine = css`
   background-color: ${GREY_2};
   position: absolute;
   width: 5px;
+  left: -29px;
   display: block;
   transform: translateZ(-1px);
 `
@@ -94,7 +95,6 @@ export const StyledLinkedSubsidiaryButton = styled.div`
     ${verticalLine}
     height: 48px;
     top: -21px;
-    left: -29px;
   }
 `
 
@@ -135,7 +135,6 @@ export const HierarchyListItem = styled.li`
         background-color: ${GREY_2};
         height: ${isFinalItemInLevel ? '48px' : 'calc(100% + 40px)'};
         top: ${isFinalItemInLevel ? '-20px' : '-18px'};
-        left: -29px;
       }
   `}
 `

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -382,5 +382,25 @@ describe('D&B Company hierarchy tree', () => {
         .contains('Hide 5 manually linked subsidiaries')
       cy.get('[data-test="hierarchy-item"]').eq(2).should('be.visible')
     })
+
+    it('should display a link new subsidiary company button', () => {
+      cy.get('[data-test="manually-linked-hierarchy-container"]')
+        .should('have.length', 1)
+        .click()
+      cy.get('[data-test="link-subsidiary-button"]')
+        .should('be.visible')
+        .contains('Link a new subsidiary company')
+    })
+
+    it('should go to the link new subsidiary page when button is clicked', () => {
+      cy.get('[data-test="manually-linked-hierarchy-container"]')
+        .should('have.length', 1)
+        .click()
+      cy.get('[data-test="link-subsidiary-button"]').click()
+      cy.location('pathname').should(
+        'eq',
+        urls.companies.subsidiaries.link(dnbGlobalUltimate.id)
+      )
+    })
   })
 })


### PR DESCRIPTION
## Description of change

Button to link to 'add new subsidiary' page. This will only appear if a company already has manually linked subsidiaries in the tree.

## Test instructions

_What should I see?_

## Screenshots

### After
![Screenshot 2023-06-29 at 11 23 21](https://github.com/uktrade/data-hub-frontend/assets/54268863/773d1547-5f24-4432-85ab-1aef9fe2d3f6)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
