### PR TITLE
Cls2 180 link to company tree from company page

### DIFF
--- a/src/apps/companies/apps/dnb-hierarchy/__test__/middleware.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/middleware.test.js
@@ -180,4 +180,38 @@ describe('#setDnbHierarchyDetails', async () => {
       ).to.equal(0)
     })
   })
+
+  context('when the api call fails to get related companies', async () => {
+    let middlewareParameters
+
+    before(async () => {
+      middlewareParameters = buildSubsidiaryMiddlewareParameters({
+        company: {
+          id: 1,
+          duns_number: DUNS_NUMBER,
+        },
+      })
+
+      mockGetDnbHierarchy({
+        companyId: 1,
+        responseCode: 502,
+      })
+
+      await setDnbHierarchyDetails(
+        middlewareParameters.reqMock,
+        middlewareParameters.resMock,
+        middlewareParameters.nextSpy
+      )
+    })
+
+    it('should  swallow exception and return empty response', async () => {
+      expect(middlewareParameters.resMock.locals.globalUltimate).to.be.undefined
+      expect(middlewareParameters.resMock.locals.dnbHierarchyCount).to.be.equal(
+        0
+      )
+      expect(
+        middlewareParameters.resMock.locals.dnbRelatedCompaniesCount
+      ).to.be.equal(0)
+    })
+  })
 })

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
@@ -23,7 +23,8 @@ function mockGetDnbHierarchy({
     .reply(responseCode, relatedCompaniesCount)
 
   nock(config.apiRoot)
-    .post(`/v4/search/company?limit=1`)
+    .post(`/v4/search/company`)
+    .query(true)
     .reply(responseCode, responseBody)
 }
 

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
@@ -18,7 +18,7 @@ function mockGetDnbHierarchy({
 
   nock(config.apiRoot)
     .get(
-      `/v4/dnb/${companyId}/related-companies/count?include_subsidiary_companies=true`
+      `/v4/dnb/${companyId}/related-companies/count?include_manually_linked_companies=true`
     )
     .reply(responseCode, relatedCompaniesCount)
 

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
@@ -20,7 +20,10 @@ function mockGetDnbHierarchy({
     .get(
       `/v4/dnb/${companyId}/related-companies/count?include_manually_linked_companies=true`
     )
-    .reply(responseCode, relatedCompaniesCount)
+    .reply(responseCode, {
+      related_companies_count: relatedCompaniesCount,
+      total: relatedCompaniesCount,
+    })
 
   nock(config.apiRoot)
     .post(`/v4/search/company`)

--- a/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/utils.js
@@ -4,6 +4,8 @@ const config = require('../../../../../config')
 function mockGetDnbHierarchy({
   globalUltimateDunsNumber,
   responseBody,
+  companyId,
+  relatedCompaniesCount,
   responseCode = 200,
   offset = 0,
   limit = 10,
@@ -12,6 +14,16 @@ function mockGetDnbHierarchy({
     .get(
       `/v4/company?limit=${limit}&offset=${offset}&sortby=name&global_ultimate_duns_number=${globalUltimateDunsNumber}`
     )
+    .reply(responseCode, responseBody)
+
+  nock(config.apiRoot)
+    .get(
+      `/v4/dnb/${companyId}/related-companies/count?include_subsidiary_companies=true`
+    )
+    .reply(responseCode, relatedCompaniesCount)
+
+  nock(config.apiRoot)
+    .post(`/v4/search/company?limit=1`)
     .reply(responseCode, responseBody)
 }
 

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -57,8 +57,7 @@ async function setDnbHierarchyDetails(req, res, next) {
   )
   res.locals.globalUltimate = globalUltimate
   res.locals.dnbHierarchyCount = dnbHierarchyCount
-  res.locals.dnbRelatedCompaniesCount =
-    dnbHierarchyCount > 1 ? dnbHierarchyCount - 1 : 0
+  res.locals.dnbRelatedCompaniesCount = dnbHierarchyCount
   next()
 }
 

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -48,8 +48,8 @@ async function getDnbHierarchyDetails(req, company) {
           ...globalUltimateResult,
           url: urls.companies.detail(globalUltimateResult.id),
         },
-        dnbRelatedCompaniesCount: dnbRelatedCompaniesCount,
-        dnbHierarchyCount: dnbRelatedCompaniesCount + 1,
+        dnbRelatedCompaniesCount: dnbRelatedCompaniesCount.total,
+        dnbHierarchyCount: dnbRelatedCompaniesCount.related_companies_count + 1,
       }
     } catch (err) {
       return { dnbHierarchyCount: 0, dnbRelatedCompaniesCount: 0 }

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -38,16 +38,19 @@ async function getDnbHierarchyDetails(req, company) {
       company.global_ultimate_duns_number
     )
     const globalUltimateResult = get(globalUltimate, 'results[0]')
+
     return {
       globalUltimate: globalUltimateResult && {
         ...globalUltimateResult,
         url: urls.companies.detail(globalUltimateResult.id),
       },
       dnbRelatedCompaniesCount: dnbRelatedCompaniesCount,
+      dnbHierarchyCount: dnbRelatedCompaniesCount + 1,
     }
   }
 
   return {
+    dnbHierarchyCount: 0,
     dnbRelatedCompaniesCount: 0,
   }
 }
@@ -55,10 +58,11 @@ async function getDnbHierarchyDetails(req, company) {
 async function setDnbHierarchyDetails(req, res, next) {
   const { company } = res.locals
 
-  const { globalUltimate, dnbRelatedCompaniesCount } =
+  const { globalUltimate, dnbHierarchyCount, dnbRelatedCompaniesCount } =
     await getDnbHierarchyDetails(req, company)
+
   res.locals.globalUltimate = globalUltimate
-  res.locals.dnbHierarchyCount = dnbRelatedCompaniesCount + 1 //TODO these 2 variables can be refactored into a single but they are used across many components so a lot of files will change
+  res.locals.dnbHierarchyCount = dnbHierarchyCount
   res.locals.dnbRelatedCompaniesCount = dnbRelatedCompaniesCount
   next()
 }

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -29,27 +29,30 @@ function setCompanyHierarchyLocalNav(req, res, next) {
 
 async function getDnbHierarchyDetails(req, company) {
   if (company.duns_number) {
-    const dnbRelatedCompaniesCount = await getRelatedCompaniesCount(
-      req,
-      company.id
-    )
-
-    let globalUltimateResult
-    if (company.global_ultimate_duns_number) {
-      const globalUltimate = await getGlobalUltimate(
+    try {
+      const dnbRelatedCompaniesCount = await getRelatedCompaniesCount(
         req,
-        company.global_ultimate_duns_number
+        company.id
       )
-      globalUltimateResult = get(globalUltimate, 'results[0]')
-    }
+      let globalUltimateResult
+      if (company.global_ultimate_duns_number) {
+        const globalUltimate = await getGlobalUltimate(
+          req,
+          company.global_ultimate_duns_number
+        )
+        globalUltimateResult = get(globalUltimate, 'results[0]')
+      }
 
-    return {
-      globalUltimate: globalUltimateResult && {
-        ...globalUltimateResult,
-        url: urls.companies.detail(globalUltimateResult.id),
-      },
-      dnbRelatedCompaniesCount: dnbRelatedCompaniesCount,
-      dnbHierarchyCount: dnbRelatedCompaniesCount + 1,
+      return {
+        globalUltimate: globalUltimateResult && {
+          ...globalUltimateResult,
+          url: urls.companies.detail(globalUltimateResult.id),
+        },
+        dnbRelatedCompaniesCount: dnbRelatedCompaniesCount,
+        dnbHierarchyCount: dnbRelatedCompaniesCount + 1,
+      }
+    } catch (err) {
+      return { dnbHierarchyCount: 0, dnbRelatedCompaniesCount: 0 }
     }
   }
 

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -28,16 +28,20 @@ function setCompanyHierarchyLocalNav(req, res, next) {
 }
 
 async function getDnbHierarchyDetails(req, company) {
-  if (company.duns_number && company.global_ultimate_duns_number) {
+  if (company.duns_number) {
     const dnbRelatedCompaniesCount = await getRelatedCompaniesCount(
       req,
       company.id
     )
-    const globalUltimate = await getGlobalUltimate(
-      req,
-      company.global_ultimate_duns_number
-    )
-    const globalUltimateResult = get(globalUltimate, 'results[0]')
+
+    let globalUltimateResult
+    if (company.global_ultimate_duns_number) {
+      const globalUltimate = await getGlobalUltimate(
+        req,
+        company.global_ultimate_duns_number
+      )
+      globalUltimateResult = get(globalUltimate, 'results[0]')
+    }
 
     return {
       globalUltimate: globalUltimateResult && {

--- a/src/apps/companies/apps/dnb-hierarchy/middleware.js
+++ b/src/apps/companies/apps/dnb-hierarchy/middleware.js
@@ -27,37 +27,39 @@ function setCompanyHierarchyLocalNav(req, res, next) {
   }
 }
 
-async function getDnbHierarchyDetails(req, dunsNumber, companyId) {
-  if (dunsNumber) {
-    const dnbHierarchyCount = await getRelatedCompaniesCount(req, companyId)
-    const globalUltimate = await getGlobalUltimate(req, dunsNumber)
+async function getDnbHierarchyDetails(req, company) {
+  if (company.duns_number && company.global_ultimate_duns_number) {
+    const dnbRelatedCompaniesCount = await getRelatedCompaniesCount(
+      req,
+      company.id
+    )
+    const globalUltimate = await getGlobalUltimate(
+      req,
+      company.global_ultimate_duns_number
+    )
     const globalUltimateResult = get(globalUltimate, 'results[0]')
-
     return {
       globalUltimate: globalUltimateResult && {
         ...globalUltimateResult,
         url: urls.companies.detail(globalUltimateResult.id),
       },
-      dnbHierarchyCount,
+      dnbRelatedCompaniesCount: dnbRelatedCompaniesCount,
     }
   }
 
   return {
-    dnbHierarchyCount: 0,
+    dnbRelatedCompaniesCount: 0,
   }
 }
 
 async function setDnbHierarchyDetails(req, res, next) {
   const { company } = res.locals
 
-  const { globalUltimate, dnbHierarchyCount } = await getDnbHierarchyDetails(
-    req,
-    company.global_ultimate_duns_number,
-    company.id
-  )
+  const { globalUltimate, dnbRelatedCompaniesCount } =
+    await getDnbHierarchyDetails(req, company)
   res.locals.globalUltimate = globalUltimate
-  res.locals.dnbHierarchyCount = dnbHierarchyCount
-  res.locals.dnbRelatedCompaniesCount = dnbHierarchyCount
+  res.locals.dnbHierarchyCount = dnbRelatedCompaniesCount + 1 //TODO these 2 variables can be refactored into a single but they are used across many components so a lot of files will change
+  res.locals.dnbRelatedCompaniesCount = dnbRelatedCompaniesCount
   next()
 }
 

--- a/src/apps/companies/apps/dnb-hierarchy/repos.js
+++ b/src/apps/companies/apps/dnb-hierarchy/repos.js
@@ -15,6 +15,25 @@ function getDnbHierarchy(req, globalUltimateDunsNumber, limit, page = 1) {
   })
 }
 
+async function getRelatedCompaniesCount(req, companyId) {
+  return authorisedRequest(req, {
+    url: `${config.apiRoot}/v4/dnb/${companyId}/related-companies/count?include_subsidiary_companies=true`,
+  })
+}
+
+async function getGlobalUltimate(req, globalUltimateDunsNumber) {
+  return authorisedRequest(req, {
+    method: 'POST',
+    url: `${config.apiRoot}/v4/search/company`,
+    qs: {
+      limit: 1,
+    },
+    body: { duns_number: globalUltimateDunsNumber },
+  })
+}
+
 module.exports = {
   getDnbHierarchy,
+  getGlobalUltimate,
+  getRelatedCompaniesCount,
 }

--- a/src/apps/companies/apps/dnb-hierarchy/repos.js
+++ b/src/apps/companies/apps/dnb-hierarchy/repos.js
@@ -16,13 +16,13 @@ function getDnbHierarchy(req, globalUltimateDunsNumber, limit, page = 1) {
 }
 
 async function getRelatedCompaniesCount(req, companyId) {
-  return authorisedRequest(req, {
+  return await authorisedRequest(req, {
     url: `${config.apiRoot}/v4/dnb/${companyId}/related-companies/count?include_subsidiary_companies=true`,
   })
 }
 
 async function getGlobalUltimate(req, globalUltimateDunsNumber) {
-  return authorisedRequest(req, {
+  return await authorisedRequest(req, {
     method: 'POST',
     url: `${config.apiRoot}/v4/search/company`,
     qs: {

--- a/src/apps/companies/apps/dnb-hierarchy/repos.js
+++ b/src/apps/companies/apps/dnb-hierarchy/repos.js
@@ -17,7 +17,7 @@ function getDnbHierarchy(req, globalUltimateDunsNumber, limit, page = 1) {
 
 async function getRelatedCompaniesCount(req, companyId) {
   return await authorisedRequest(req, {
-    url: `${config.apiRoot}/v4/dnb/${companyId}/related-companies/count?include_subsidiary_companies=true`,
+    url: `${config.apiRoot}/v4/dnb/${companyId}/related-companies/count?include_manually_linked_companies=true`,
   })
 }
 

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -144,7 +144,9 @@ const CompanyLocalHeader = ({
                   href={urls.companies.dnbHierarchy.tree(company.id)}
                   data-test="company-tree-link"
                 >
-                  {`View ${dnbRelatedCompaniesCount + 1} related companies`}
+                  {`View company tree: ${
+                    dnbRelatedCompaniesCount + 1
+                  } companies`}
                 </Link>
               </StyledRelatedCompaniesWrapper>
             )}

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -144,7 +144,7 @@ const CompanyLocalHeader = ({
                   href={urls.companies.dnbHierarchy.tree(company.id)}
                   data-test="company-tree-link"
                 >
-                  {`View ${dnbRelatedCompaniesCount} related companies`}
+                  {`View ${dnbRelatedCompaniesCount + 1} related companies`}
                 </Link>
               </StyledRelatedCompaniesWrapper>
             )}

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -144,7 +144,7 @@ const CompanyLocalHeader = ({
                   href={urls.companies.dnbHierarchy.tree(company.id)}
                   data-test="company-tree-link"
                 >
-                  View related companies
+                  {`View ${dnbRelatedCompaniesCount} related companies`}
                 </Link>
               </StyledRelatedCompaniesWrapper>
             )}

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -551,6 +551,6 @@ const assertDescription = () => {
 
 const assertRelatedCompaniesLink = () => {
   cy.get(companyLocalHeader.relatedCompaniesLink)
-    .contains('View related companies')
+    .contains('View 5 related companies')
     .should('have.attr', 'href', companyTreeUrl)
 }

--- a/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
+++ b/test/functional/cypress/specs/companies/local-header/global-ultimate-spec.js
@@ -551,6 +551,6 @@ const assertDescription = () => {
 
 const assertRelatedCompaniesLink = () => {
   cy.get(companyLocalHeader.relatedCompaniesLink)
-    .contains('View 5 related companies')
+    .contains('View company tree: 6 companies')
     .should('have.attr', 'href', companyTreeUrl)
 }

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -7,6 +7,7 @@ var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-n
 var companySearchNotMatchedNoCountry = require('../../../fixtures/v4/dnb/company-search-not-matched-no-country.json')
 var companySearchNotMatchedUS = require('../../../fixtures/v4/dnb/company-search-not-matched-us.json')
 var companyInvestigation = require('../../../fixtures/v4/dnb/company-investigation.json')
+var dnbGlobalUltimate = require('../../../fixtures/v4/company/company-dnb-global-ultimate.json')
 
 const { fakerCompanyFamilyTree } = require('./company-tree')
 
@@ -57,5 +58,5 @@ exports.companyFamilyTree = function (req, res) {
 }
 
 exports.relatedCompaniesCount = function (req, res) {
-  res.json(1)
+  res.json(req.params.companyId === dnbGlobalUltimate.id ? 5 : 0)
 }

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -55,3 +55,7 @@ exports.companyFamilyTree = function (req, res) {
     })
   )
 }
+
+exports.relatedCompaniesCount = function (req, res) {
+  res.json(1)
+}

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -58,5 +58,19 @@ exports.companyFamilyTree = function (req, res) {
 }
 
 exports.relatedCompaniesCount = function (req, res) {
-  res.json(req.params.companyId === dnbGlobalUltimate.id ? 5 : 0)
+  res.json(
+    req.params.companyId === dnbGlobalUltimate.id
+      ? {
+          total: 5,
+          related_companies_count: 3,
+          manually_linked_subsidiaries_count: 2,
+          reduced_tree: false,
+        }
+      : {
+          total: 0,
+          related_companies_count: 0,
+          manually_linked_subsidiaries_count: 0,
+          reduced_tree: false,
+        }
+  )
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -465,6 +465,10 @@ app.post('/v4/dnb/company-link', v4Dnb.companyLink)
 app.post('/v4/dnb/company-change-request', v4Dnb.companyChangeRequest)
 app.get('/v4/dnb/company-change-request', v4Dnb.companyChangeRequest)
 app.get('/v4/dnb/:companyId/family-tree', v4Dnb.companyFamilyTree)
+app.get(
+  '/v4/dnb/:companyId/related-companies/count',
+  v4Dnb.relatedCompaniesCount
+)
 
 // V4 legacy company list
 app.get('/v4/user/company-list/:companyId', v4Company.getCompanyList)


### PR DESCRIPTION
## Description of change

Add the count of related companies to the view related companies link. This value is returned from a new api endpoint released in https://github.com/uktrade/data-hub-api/pull/4720

Ideally this would all take place in react and not be added to a nunjucks controller, but that is a large refactoring exercise outside the scope of this ticket

## Test instructions

Using any company that is part of a hierarchy, for example http://localhost:3000/companies/bb2c85cf-c44a-4d9e-ba20-f1a8a3c94125/overview, in the company header the link will now contain the number of related companies

## Screenshots

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/fbffc333-1a3c-4c6d-897d-fd0841e122b4)

_Add a screenshot_

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/f0a93d92-40b1-4ede-b25d-a14278326489)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
