### PR TITLE
Feature/cls2 273 view more details toggle

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -6,8 +6,11 @@ import {
   BLACK,
   DARK_BLUE_LEGACY,
   WHITE,
+  DARK_GREY,
 } from '../../../utils/colours'
-import { Tag } from '../../../components'
+import { Tag, ToggleSection } from '../../../components'
+import { ToggleButton } from '../../../components/ToggleSection/BaseToggleSection'
+import { FONT_SIZE } from '@govuk-react/constants'
 
 const horizontalLine = css`
   //This is the horizontal line to the left of the div
@@ -35,6 +38,24 @@ export const HierarchyContents = styled.div`
 `
 
 export const HierarchyItemContents = styled.div`
+  ${ToggleSection} {
+    margin-bottom: 0px;
+    padding-bottom: 0px;
+    svg {
+      width: ${FONT_SIZE.SIZE_16};
+      height: ${FONT_SIZE.SIZE_16};
+    }
+    > div {
+      padding: 0px;
+    }
+    ${ToggleButton} {
+      font-size: ${FONT_SIZE.SIZE_16};
+      padding: 10px 15px 15px 15px;
+      ${({ isRequestedCompanyId }) =>
+        isRequestedCompanyId ? `color: ${WHITE};` : ``}
+    }
+  }
+
   background-color: ${({ isRequestedCompanyId }) =>
     isRequestedCompanyId ? DARK_BLUE_LEGACY : GREY_4};
   border: 1px solid ${GREY_2};
@@ -61,7 +82,7 @@ export const HierarchyItemContents = styled.div`
     hierarchy != 1 &&
     `
       transform-style: preserve-3d;
-      
+
       :before {
         ${horizontalLine}
         background-color: ${GREY_2};
@@ -69,6 +90,10 @@ export const HierarchyItemContents = styled.div`
         left: -40px;
       }
   `}
+`
+
+export const HierarchyItemHeading = styled.div`
+  padding: 15px;
 `
 
 export const SubsidiaryList = styled.ul`
@@ -161,5 +186,26 @@ export const HierarchyHeaderContents = styled.div`
 
 export const HierarchyTag = styled(Tag)`
   float: right;
-  margin-left: 10px;
+  margin-left: 15px;
+`
+export const InlineDescriptionList = styled.dl`
+  padding: 15px;
+  background-color: ${GREY_4};
+  border-top: 1px solid ${GREY_2};
+  dt,
+  dd {
+    display: inline;
+    font-size: ${FONT_SIZE.SIZE_16};
+    font-height: 1;
+  }
+  dt {
+    color: ${DARK_GREY};
+  }
+  dd:before {
+    content: ' ';
+  }
+  dd:after {
+    content: ' ';
+    display: block;
+  }
 `

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -60,16 +60,12 @@ export const HierarchyItemContents = styled.div`
     isRequestedCompanyId ? DARK_BLUE_LEGACY : GREY_4};
   border: 1px solid ${GREY_2};
   min-height: 60px;
-  padding: 10px;
+
   margin-top: 20px;
   display: flex;
   flex-direction: column;
   justify-content: start;
-  ${({ isRequestedCompanyId }) =>
-    isRequestedCompanyId &&
-    `
-    color: ${WHITE};
-  `}
+
   ${Link} {
     width: fit-content;
     ${({ isRequestedCompanyId }) =>
@@ -87,7 +83,7 @@ export const HierarchyItemContents = styled.div`
         ${horizontalLine}
         background-color: ${GREY_2};
         top: 16px;
-        left: -40px;
+        left: -30px;
       }
   `}
 `
@@ -158,7 +154,7 @@ export const HierarchyListItem = styled.li`
       :before {
         ${verticalLine}
         background-color: ${GREY_2};
-        height: ${isFinalItemInLevel ? '48px' : 'calc(100% + 40px)'};
+        height: ${isFinalItemInLevel ? '40px' : 'calc(100% + 40px)'};
         top: ${isFinalItemInLevel ? '-20px' : '-18px'};
       }
   `}


### PR DESCRIPTION
## Description of change

Add a View more detail section to the company tree hierarchy that shows company details.

## Test instructions

Each company on the tree contains a View more detail link that when clicked shows address, sector, employee and last interaction date.

## Screenshots

###Before 
![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/330a166b-1f4e-40a6-9dce-a3cade024fe6)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/dbf022cf-4b54-4441-9cee-ec402ccae2e1)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
