### PR TITLE
Feature/cls2 275 overview page activity show only internal and company specific activity

### DIFF
--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -258,7 +258,10 @@ async function fetchActivityFeedHandler(req, res, next) {
       activityType = [],
     } = req.query
     let dnbHierarchyIds = []
-    if (company.is_global_ultimate && showDnbHierarchy) {
+    if (
+      company.is_global_ultimate &&
+      (showDnbHierarchy === true || showDnbHierarchy[0] === 'true')
+    ) {
       const { results } = await getGlobalUltimateHierarchy(
         req,
         company.global_ultimate_duns_number

--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActivityCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActivityCard.jsx
@@ -8,6 +8,7 @@ import { ActivityFeedApp, SummaryTable } from '../../../../../client/components'
 import { companies } from '../../../../../lib/urls'
 import CompanyActivityFeed from '../../activity-feed/client/CompanyActivityFeed'
 import { StyledLastTableCell, StyledTableRow } from './components'
+import { FILTER_KEYS } from '../../activity-feed/constants'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin: 0;
@@ -51,6 +52,7 @@ const ActivityCard = (props) => {
               isOverview={true}
               numberOfItems={numberOfItems}
               feedType={feedType}
+              activityType={[FILTER_KEYS.dataHubActivity]}
             />
           </StyledLastTableCell>
         </StyledTableRow>

--- a/src/client/components/ActivityFeed/ActivityFeedApp.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedApp.jsx
@@ -7,7 +7,7 @@ import { FILTER_FEED_TYPE } from '../../../apps/companies/apps/activity-feed/con
 export default class ActivityFeedApp extends React.Component {
   static propTypes = {
     actions: PropTypes.node,
-    activityTypeFilter: PropTypes.array.isRequired,
+    activityType: PropTypes.array.isRequired,
     apiEndpoint: PropTypes.string.isRequired,
     isGlobalUltimate: PropTypes.bool,
     dnbHierarchyCount: PropTypes.number,
@@ -17,7 +17,7 @@ export default class ActivityFeedApp extends React.Component {
   }
 
   static defaultProps = {
-    activityTypeFilter: [],
+    activityType: [],
     actions: null,
     isGlobalUltimate: false,
     dnbHierarchyCount: null,
@@ -28,7 +28,7 @@ export default class ActivityFeedApp extends React.Component {
   constructor(props) {
     super(props)
 
-    const { activityTypeFilter, feedType } = props
+    const { activityType, feedType } = props
 
     this.state = {
       activities: [],
@@ -38,7 +38,7 @@ export default class ActivityFeedApp extends React.Component {
       from: 0,
       total: 0,
       queryParams: {
-        activityTypeFilter,
+        activityType,
         showDnbHierarchy: false,
         feedType: feedType,
       },
@@ -99,12 +99,12 @@ export default class ActivityFeedApp extends React.Component {
   }
 
   static async fetchActivities(apiEndpoint, from, numberOfItems, queryParams) {
-    const { activityTypeFilter, showDnbHierarchy, feedType } = queryParams
+    const { activityType, showDnbHierarchy, feedType } = queryParams
 
     const params = {
       from,
       size: numberOfItems,
-      activityTypeFilter,
+      activityType,
       showDnbHierarchy,
       feedType,
     }
@@ -128,6 +128,7 @@ export default class ActivityFeedApp extends React.Component {
       companyIsArchived,
       isOverview,
       feedType,
+      activityType,
     } = this.props
 
     const isEmptyFeed = activities.length === 0 && !hasMore
@@ -146,6 +147,7 @@ export default class ActivityFeedApp extends React.Component {
         companyIsArchived={companyIsArchived}
         isOverview={isOverview}
         feedType={feedType}
+        activityType={activityType}
       >
         {isEmptyFeed && !error && (
           <div data-test="noActivities">There are no activities to show.</div>

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -899,6 +899,9 @@ describe('Company overview page', () => {
       })
 
       it('the card should contain a message outling three active investments', () => {
+        cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]', {
+          timeout: 1000,
+        }).should('be.visible')
         cy.get('[data-test="activeInvestmentProjectsContainer"]')
           .children()
           .first()

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -80,6 +80,7 @@ const COMPANY_WITH_MANY_CONTACTS =
 const MAX_EMAIL_CAMPAIGN =
   'dit:DataHubCompany:6df487c5-7c75-4672-8907-f74b49e6c635'
 exports.activityFeed = function (req, res) {
+  const size = get(req.body, 'size')
   // Activities by contact
   var isContactActivityQuery = get(
     req.body,
@@ -153,7 +154,7 @@ exports.activityFeed = function (req, res) {
     get(req.body, "query.bool.must[0].term['object.type']") ===
     'dit:aventri:Event'
 
-  if (isAventriEventQuery) {
+  if (size == 10 && isAventriEventQuery) {
     var aventriEventIdQuery = req.body.query.bool.must[1]
     var aventriId = aventriEventIdQuery.terms.id[0]
 
@@ -271,7 +272,6 @@ exports.activityFeed = function (req, res) {
     "query.bool.filter.bool.should[0].bool.must[0].terms['object.type']"
   )
 
-  const size = get(req.body, 'size')
   var company = get(
     req.body,
     "query.bool.filter.bool.should[0].bool.must[1].terms['object.attributedTo.id'][0]"
@@ -281,6 +281,7 @@ exports.activityFeed = function (req, res) {
   }
   if (
     (size != 10 && isEqual(dataHubTypes, DATA_HUB_AND_EXTERNAL_ACTIVITY)) ||
+    isEqual(dataHubTypes, DATA_HUB_ACTIVITY) ||
     company == COMPANY_WITH_MANY_CONTACTS
   ) {
     const filteredSortHits = dataHubActivities.hits.hits

--- a/test/sandbox/routes/v4/activity-feed/activity-feed.js
+++ b/test/sandbox/routes/v4/activity-feed/activity-feed.js
@@ -154,7 +154,7 @@ exports.activityFeed = function (req, res) {
     get(req.body, "query.bool.must[0].term['object.type']") ===
     'dit:aventri:Event'
 
-  if (size == 10 && isAventriEventQuery) {
+  if ((size === undefined || size == 10) && isAventriEventQuery) {
     var aventriEventIdQuery = req.body.query.bool.must[1]
     var aventriId = aventriEventIdQuery.terms.id[0]
 


### PR DESCRIPTION
## Description of change

Company Overview page should only include Internal (Data Hub) Upcoming and Recent activities for current company not all companies in the tree and External activities should not be included.

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
