### PR TITLE
Error message added

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -432,6 +432,13 @@ const CompanyTree = ({ company, familyTree }) => {
           payload: { companyId: companyId },
           onSuccessDispatch: DNB_FAMILY_TREE_LOADED,
         }}
+        renderError={() => (
+          <div data-test="company-tree-loaded-error">
+            <h1>
+              This company contains too many records to display the Company Tree
+            </h1>
+          </div>
+        )}
       />
     </DefaultLayout>
   )

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -130,7 +130,7 @@ describe('D&B Company hierarchy tree', () => {
 
         it('should display the error message', () => {
           cy.wait('@familyTreeApi')
-          assertErrorDialog('TASK_GET_DNB_FAMILY_TREE', 'Not Found')
+          cy.get('[data-test="company-tree-loaded-error"]').should('be.visible')
         })
       }
     )


### PR DESCRIPTION
## Description of change

Company with extremely large hierarchies are timing out (circa 10K+ companies). This PR is to add a lass intrusive error page.

## Test instructions

Try to view:
China Engineering: https://www.datahub.trade.gov.uk/companies/d8936be3-6068-47d6-9099-089a0155fb51/company-tree

or

EDF: https://www.datahub.trade.gov.uk/companies/6668732e-819f-e711-ba5d-e4115bead28a/company-tree

And once the call has times out the error page below should display

![Screenshot 2023-07-04 at 14 50 44](https://github.com/uktrade/data-hub-frontend/assets/72826129/6488c734-cb7f-462b-980f-412e36016ee6)

## Screenshots

### Before

![4dcb58f2-a694-4753-a74a-6b2a4971e7c9](https://github.com/uktrade/data-hub-frontend/assets/72826129/dfdedb29-b616-43f2-be40-2f75c95ba8c6)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
