### PR TITLE
Add line height so tags wrap with margin

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -90,6 +90,10 @@ export const HierarchyItemContents = styled.div`
 
 export const HierarchyItemHeading = styled.div`
   padding: 15px;
+
+  :first-child {
+    line-height: 30px;
+  }
 `
 
 export const SubsidiaryList = styled.ul`
@@ -184,6 +188,7 @@ export const HierarchyTag = styled(Tag)`
   float: right;
   margin-left: 15px;
 `
+
 export const InlineDescriptionList = styled.dl`
   padding: 15px;
   background-color: ${GREY_4};


### PR DESCRIPTION
## Description of change

Add line-height to header of each company on company tree so that the tags have a reasonable margin when they wrap

## Test instructions

_What should I see?_

## Screenshots

### Before
![Screenshot 2023-07-04 at 15 23 06](https://github.com/uktrade/data-hub-frontend/assets/54268863/5d0e7c00-268e-444d-9d1d-14e65235ceea)

### After
![Screenshot 2023-07-04 at 15 23 22](https://github.com/uktrade/data-hub-frontend/assets/54268863/9d57bee8-2e0b-48fb-846c-5858f1c97051)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
