### PR TITLE
Update Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,9 +19,6 @@ updates:
   - dependency-name: react-router-dom # TET-34
     versions:
     - "> 5.3.0"
-  - dependency-name: redis # TET-131
-    versions:
-    - "> 3.1.2"
   - dependency-name: axios # TET-354
     versions:
     - "> 0.27.2"
@@ -45,10 +42,10 @@ updates:
   - dependency-name: "@storybook/react"
     versions:
     - ">= 0"
-  - dependency-name: "@storybook/builder-webpack5"
+  - dependency-name: "@storybook/react-webpack5"
     versions:
     - ">= 0"
-  - dependency-name: "@storybook/manager-webpack5"
+  - dependency-name: "storybook"
     versions:
     - ">= 0"
   - dependency-name: "@sentry/node"


### PR DESCRIPTION
## Description of change

I've updated the Dependabot ignore list to include the new Storybook dependencies (added in #5638). I've also removed `redis` as we've already upgraded it (#5374).

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
