### PR TITLE
Consolidate all parseQueryString functions to use a single instance

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/state.js
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/state.js
@@ -1,20 +1,11 @@
-import { isEmpty, omitBy } from 'lodash'
-import qs from 'qs'
 import { SORT_OPTIONS } from '../../../../../client/modules/Contacts/CollectionList/constants'
+import { parseQueryString } from '../../../../../client/utils'
 
 export const OVERVIEW_COMPANY_PROJECTS_LIST_ID = 'overviewCompanyProjectsList'
 export const TASK_GET_PROJECT_WON_COUNT = 'TASK_GET_PROJECT_WON_COUNT'
 export const OVERVIEW_COMPANY_EXPORT_WINS_LIST_ID =
   'overviewCompanyExportWinsList'
 export const TASK_GET_LATEST_EXPORT_WINS = 'TASK_GET_LATEST_EXPORT_WINS'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const companyProjectsState2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/apps/investments/client/projects/state.js
+++ b/src/apps/investments/client/projects/state.js
@@ -1,6 +1,3 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
-
 import {
   getFinancialYearStart,
   generateFinancialYearLabel,
@@ -13,6 +10,7 @@ import {
   PROJECT_STATUS_OPTIONS,
   INVOLVEMENT_LEVEL_OPTIONS,
 } from './constants'
+import { parseQueryString } from '../../../../client/utils'
 
 export const INVESTMENT_PROJECTS_ID = 'projectsList'
 export const COMPANY_PROJECTS_LIST_ID = 'companyProjectsList'
@@ -21,14 +19,6 @@ export const TASK_GET_INVESTMENTS_PROJECTS_ADVISER_NAME =
   'TASK_GET_INVESTMENTS_PROJECTS_ADVISER_NAME'
 export const TASK_GET_INVESTMENTS_PROJECTS_METADATA =
   'TASK_GET_INVESTMENTS_PROJECTS_METADATA'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const projectsState2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/components/ActivityFeed/CollectionList/state.js
+++ b/src/client/components/ActivityFeed/CollectionList/state.js
@@ -1,5 +1,7 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
+import { buildSelectedFilters } from './filters'
+import { SORT_OPTIONS } from './constants'
+import { transformWasPolicyfeedBackProvidedToApi } from './transformers'
+import { parseQueryString } from '../../../utils'
 
 export const TASK_GET_COMPANY_ACTIVITIES_LIST =
   'TASK_GET_COMPANY_ACTIVITIES_LIST'
@@ -22,18 +24,6 @@ export const TASK_GET_INTERACTIONS_COMPANY_NAME =
   'TASK_GET_INTERACTIONS_COMPANY_NAME'
 
 export const ID = 'companyActivitiesList'
-
-import { buildSelectedFilters } from './filters'
-import { SORT_OPTIONS } from './constants'
-import { transformWasPolicyfeedBackProvidedToApi } from './transformers'
-
-const parseQueryString = (queryString) => {
-  const queryProps = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryProps,
-    page: parseInt(queryProps.page || 1, 10),
-  }
-}
 
 export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/modules/Companies/CollectionList/state.js
+++ b/src/client/modules/Companies/CollectionList/state.js
@@ -1,5 +1,7 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
+import { buildSelectedFilters } from './filters'
+import { COMPANY_STATUS_OPTIONS, SORT_OPTIONS } from './constants'
+import { transformArchivedToApi, transformPostcodeToApi } from './transformers'
+import { parseQueryString } from '../../../utils'
 
 export const TASK_GET_COMPANIES_LIST = 'TASK_GET_COMPANIES_LIST'
 export const TASK_GET_COMPANIES_METADATA = 'TASK_GET_COMPANIES_METADATA'
@@ -7,18 +9,6 @@ export const TASK_GET_COMPANIES_LEAD_ITA_OR_GLOBAL_ACCOUNT_MANAGER_NAME =
   'TASK_GET_COMPANIES_LEAD_ITA_OR_GLOBAL_ACCOUNT_MANAGER_NAME'
 
 export const ID = 'companiesList'
-
-import { buildSelectedFilters } from './filters'
-import { COMPANY_STATUS_OPTIONS, SORT_OPTIONS } from './constants'
-import { transformArchivedToApi, transformPostcodeToApi } from './transformers'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 /**
  * Convert both location and redux state to props

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/state.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/state.js
@@ -1,21 +1,11 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
-
 import { transformPostcodeToApi } from '../../CollectionList/transformers'
 import { buildSelectedFilters } from './filters'
 import { SORT_OPTIONS } from '../../CollectionList/constants'
+import { parseQueryString } from '../../../../utils'
 
 export const ID = 'linkGlobalHQ'
 
 export const TASK_GET_GLOBAL_HQ_LIST = 'TASK_GET_GLOBAL_HQ_LIST'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/state.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/state.js
@@ -1,21 +1,11 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
-
 import { transformPostcodeToApi } from '../../CollectionList/transformers'
 import { buildSelectedFilters } from './filters'
 import { SORT_OPTIONS } from '../../CollectionList/constants'
+import { parseQueryString } from '../../../../utils'
 
 export const ID = 'linkSubsidiary'
 
 export const TASK_GET_SUBSIDIARY_LIST = 'TASK_GET_SUBSIDIARY_LIST'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/modules/Events/CollectionList/state.js
+++ b/src/client/modules/Events/CollectionList/state.js
@@ -1,5 +1,6 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
+import { buildSelectedFilters } from './filters'
+import { SORT_OPTIONS } from './constants'
+import { parseQueryString } from '../../../utils'
 
 export const TASK_GET_EVENTS_LIST = 'TASK_GET_EVENTS_LIST'
 export const TASK_GET_EVENTS_METADATA = 'TASK_GET_EVENTS_METADATA'
@@ -8,17 +9,6 @@ export const TASK_GET_ALL_ACTIVITY_FEED_EVENTS =
   'TASK_GET_ALL_ACTIVITY_FEED_EVENTS'
 
 export const ID = 'eventsList'
-
-import { buildSelectedFilters } from './filters'
-import { SORT_OPTIONS } from './constants'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 /**
  * Convert both location and redux state to props

--- a/src/client/modules/Events/EventAventriRegistrationStatus/state.js
+++ b/src/client/modules/Events/EventAventriRegistrationStatus/state.js
@@ -1,19 +1,12 @@
-import { omitBy, isEmpty } from 'lodash'
 import qs from 'qs'
+
 import { EVENT_ATTENDEES_MAPPING } from '../../../../apps/companies/apps/activity-feed/constants'
+import { parseQueryString } from '../../../utils'
 
 export const TASK_GET_EVENT_AVENTRI_REGISTRATION_STATUS_ATTENDEES =
   'TASK_GET_EVENT_AVENTRI_REGISTRATION_STATUS_ATTENDEES'
 
 export const ID = 'eventAventriRegistrationStatusAttendees'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const mapUrlSlugToRegistrationStatus = (urlSlug) => {
   const status = Object.entries(EVENT_ATTENDEES_MAPPING).find(

--- a/src/client/modules/Interactions/CollectionList/state.js
+++ b/src/client/modules/Interactions/CollectionList/state.js
@@ -1,5 +1,7 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
+import { buildSelectedFilters } from './filters'
+import { SORT_OPTIONS } from './constants'
+import { transformWasPolicyfeedBackProvidedToApi } from './transformers'
+import { parseQueryString } from '../../../utils'
 
 export const TASK_GET_INTERACTIONS_LIST = 'TASK_GET_INTERACTIONS_LIST'
 export const TASK_GET_INTERACTIONS_ADVISER_NAME =
@@ -10,18 +12,6 @@ export const TASK_GET_INTERACTIONS_COMPANY_NAME =
   'TASK_GET_INTERACTIONS_COMPANY_NAME'
 
 export const ID = 'interactionsList'
-
-import { buildSelectedFilters } from './filters'
-import { SORT_OPTIONS } from './constants'
-import { transformWasPolicyfeedBackProvidedToApi } from './transformers'
-
-const parseQueryString = (queryString) => {
-  const queryProps = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryProps,
-    page: parseInt(queryProps.page || 1, 10),
-  }
-}
 
 export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/modules/Omis/CollectionList/state.js
+++ b/src/client/modules/Omis/CollectionList/state.js
@@ -1,6 +1,3 @@
-import { omitBy, isEmpty } from 'lodash'
-import qs from 'qs'
-
 import { buildSelectedFilters } from './filters'
 import {
   SORT_OPTIONS,
@@ -8,6 +5,7 @@ import {
   STATUSES,
   RECONCILIATION_STATUSES,
 } from './constants'
+import { parseQueryString } from '../../../utils'
 
 export const ORDERS_LIST_ID = 'ordersList'
 export const COMPANY_ORDERS_LIST_ID = 'companyOrdersList'
@@ -18,14 +16,6 @@ export const TASK_GET_ORDERS_METADATA = 'TASK_GET_ORDERS_METADATA'
 export const TASK_GET_ORDERS_RECONCILIATION = 'TASK_GET_ORDERS_RECONCILIATION'
 export const TASK_GET_ORDERS_RECONCILIATION_METADATA =
   'TASK_GET_ORDERS_RECONCILIATION_METADATA'
-
-const parseQueryString = (queryString) => {
-  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
-  return {
-    ...queryParams,
-    page: parseInt(queryParams.page || 1, 10),
-  }
-}
 
 export const ordersState2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)

--- a/src/client/utils/index.js
+++ b/src/client/utils/index.js
@@ -1,6 +1,17 @@
+import { isEmpty, omitBy } from 'lodash'
+import qs from 'qs'
+
 export const idNameToValueLabel = ({ id, name }) => ({
   value: id,
   label: name,
 })
 
 export const idNamesToValueLabels = (idNames) => idNames.map(idNameToValueLabel)
+
+export const parseQueryString = (queryString) => {
+  const queryParams = omitBy({ ...qs.parse(queryString) }, isEmpty)
+  return {
+    ...queryParams,
+    page: parseInt(queryParams.page || 1, 10),
+  }
+}


### PR DESCRIPTION
## Description of change

Whilst I was doing the work to reactify the link subsidiary page I noticed that there were numerous duplicate instances of the `parseQueryString` function. I have added this to the `utils` and removed all duplicates.

## Test instructions

Changed pages should work as normal.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
