### PR TITLE
feature/CLS2-279-skip-add-company-tree-wizard

### DIFF
--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -20,6 +20,7 @@ import InformationList from './InformationList'
 import { ISO_CODE } from './constants'
 
 import Form from '../../../../../client/components/Form'
+import { CompanyDunsKnownStep } from './CompanyDunsKnownStep'
 
 function AddCompanyForm({
   csrfToken,
@@ -28,6 +29,7 @@ function AddCompanyForm({
   regions,
   sectors,
   features,
+  dunsNumber,
 }) {
   const optionCountryUK = countries.find(({ value }) => value === ISO_CODE.UK)
   const overseasCountries = countries.filter(
@@ -89,33 +91,53 @@ function AddCompanyForm({
         const countryIsoCode = get(country, 'value')
         const postcode = get(values.dnbCompany, 'address_postcode')
         const manualPostcode = values.postcode
+        const companyLocationUnknown = values.companyLocationUnknown
 
         // eslint-disable-next-line react-hooks/rules-of-hooks
         useEffect(() => {
           setFieldValue('country', countryID)
+          setFieldValue('countryName', countryName)
         }, [countryID])
 
         return (
           <>
-            <Step name="companyLocation">
-              <FieldRadios
-                name="companyLocation"
-                legend="Where is this company located?"
-                required="Specify location of the company"
-                options={Object.values(COMPANY_LOCATION_OPTIONS)}
-                bigLegend={true}
+            {dunsNumber && (
+              <CompanyDunsKnownStep
+                csrfToken={csrfToken}
+                features={features}
+                dunsNumber={dunsNumber}
+                countries={countries}
               />
-            </Step>
+            )}
 
-            <CompanySearchStep
-              countryName={countryName}
-              countryIsoCode={countryIsoCode}
-              csrfToken={csrfToken}
-              features={features}
-            />
+            {!dunsNumber && (
+              <Step name="companyLocation">
+                <FieldRadios
+                  name="companyLocation"
+                  legend="Where is this company located?"
+                  required="Specify location of the company"
+                  options={Object.values(COMPANY_LOCATION_OPTIONS)}
+                  bigLegend={true}
+                />
+              </Step>
+            )}
+
+            {!dunsNumber && (
+              <CompanySearchStep
+                countryName={countryName}
+                countryIsoCode={countryIsoCode}
+                csrfToken={csrfToken}
+                features={features}
+              />
+            )}
 
             {!values.cannotFind && (
-              <CompanyFoundStep countryName={countryName} features={features} />
+              <CompanyFoundStep
+                countryOptions={COMPANY_LOCATION_OPTIONS}
+                features={features}
+                allowBackButton={dunsNumber ? true : undefined}
+                showCountry={companyLocationUnknown}
+              />
             )}
 
             {!values.cannotFind && (
@@ -132,6 +154,7 @@ function AddCompanyForm({
                 organisationTypes={organisationTypes}
                 country={country}
                 features={features}
+                allowBackButton={dunsNumber ? true : undefined}
               />
             )}
             {values.cannotFind && (

--- a/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
+++ b/src/apps/companies/apps/add-company/client/AddCompanyForm.jsx
@@ -60,7 +60,6 @@ function AddCompanyForm({
     ) {
       return COMPANY_LOCATION_OPTIONS.uk
     }
-
     if (companyOverseasCountry) {
       return overseasCountries.find((c) => c.value === companyOverseasCountry)
     }

--- a/src/apps/companies/apps/add-company/client/CompanyDunsKnownStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyDunsKnownStep.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react'
+import useDnbSearch from '../../../../../client/components/EntityList/useDnbSearch'
+import useEntitySearch from '../../../../../client/components/EntityList/useEntitySearch'
+import { Step } from '../../../../../client/components'
+import { useFormContext } from '../../../../../client/components/Form/hooks'
+import ProgressIndicator from '../../../../../client/components/ProgressIndicator'
+import { get } from 'lodash'
+import { getDnbEntityText } from './CompanySearchStep'
+
+export const CompanyDunsKnownStep = ({
+  dunsNumber,
+  csrfToken,
+  features,
+  countries,
+}) => {
+  const { setFieldValue, goForward } = useFormContext()
+  const apiEndpoint = `/companies/create/dnb/company-search?_csrf=${csrfToken}`
+  const { findCompany } = useDnbSearch(apiEndpoint, features)
+  const { onEntitySearch, searching, searched, entities } =
+    useEntitySearch(findCompany)
+
+  const [alreadyExists, setAlreadyExists] = useState(undefined)
+
+  useEffect(() => onEntitySearch({ duns_number: dunsNumber }), [dunsNumber])
+  useEffect(() => {
+    if (searched) {
+      if (entities.length === 1) {
+        const dnb_company = get(entities, '[0].data.dnb_company')
+        const datahub_company_id = get(entities, '[0].data.datahub_company.id')
+
+        //if this company is already on datahub don't allow to add
+        if (datahub_company_id && dnb_company) {
+          setAlreadyExists({ ...dnb_company, company_id: datahub_company_id })
+        } else {
+          if (dnb_company) {
+            const matchingCountry = countries.find(
+              ({ value }) => value === dnb_company.address_country
+            )
+            setFieldValue('dnbCompany', dnb_company)
+            if (matchingCountry) {
+              setFieldValue('companyLocation', matchingCountry.value)
+            } else {
+              setFieldValue('companyLocationUnknown', true)
+            }
+          } else {
+            setFieldValue('cannotFind', true)
+          }
+          goForward()
+        }
+      } else {
+        setFieldValue('cannotFind', true)
+        goForward()
+      }
+    }
+  }, [searched])
+
+  return (
+    <Step name="preload-dnb" forwardButton={false} backButton={false}>
+      {searching && <ProgressIndicator message="Searching for company" />}
+      {searched && alreadyExists && (
+        <>
+          {getDnbEntityText(
+            alreadyExists.company_id,
+            alreadyExists.is_out_of_business,
+            alreadyExists.primary_name
+          )}
+        </>
+      )}
+    </Step>
+  )
+}

--- a/src/apps/companies/apps/add-company/client/CompanyDunsKnownStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyDunsKnownStep.jsx
@@ -6,6 +6,7 @@ import { useFormContext } from '../../../../../client/components/Form/hooks'
 import ProgressIndicator from '../../../../../client/components/ProgressIndicator'
 import { get } from 'lodash'
 import { getDnbEntityText } from './CompanySearchStep'
+import { ISO_CODE } from './constants'
 
 export const CompanyDunsKnownStep = ({
   dunsNumber,
@@ -38,7 +39,12 @@ export const CompanyDunsKnownStep = ({
             )
             setFieldValue('dnbCompany', dnb_company)
             if (matchingCountry) {
-              setFieldValue('companyLocation', matchingCountry.value)
+              if (matchingCountry.value === ISO_CODE.UK) {
+                setFieldValue('companyLocation', matchingCountry.value)
+              } else {
+                setFieldValue('companyLocation', 'overseas')
+                setFieldValue('companyOverseasCountry', matchingCountry.value)
+              }
             } else {
               setFieldValue('companyLocationUnknown', true)
             }

--- a/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyFoundStep.jsx
@@ -6,7 +6,11 @@ import PropTypes from 'prop-types'
 import { H3 } from '@govuk-react/heading'
 import InsetText from '@govuk-react/inset-text'
 
-import { Step, SummaryList } from '../../../../../client/components'
+import {
+  FieldRadios,
+  Step,
+  SummaryList,
+} from '../../../../../client/components'
 import { getCompanyAddress } from '../../../../../client/utils/addresses'
 import { useFormContext } from '../../../../../client/components/Form/hooks'
 
@@ -23,16 +27,22 @@ function getCompaniesHouseNumber(dnbCompany) {
   }
 }
 
-function CompanyFoundStep({ countryName, features }) {
+function CompanyFoundStep({
+  features,
+  allowBackButton,
+  countryOptions,
+  showCountry,
+}) {
   const { values } = useFormContext()
 
   const dnbCompany = get(values, 'dnbCompany')
   const companyName = get(dnbCompany, 'primary_name')
   const companyAddress = getCompanyAddress(dnbCompany, features)
   const companiesHouseNumber = getCompaniesHouseNumber(dnbCompany)
+  const countryName = get(values, 'countryName')
 
   return (
-    <Step name="companyDetails">
+    <Step name="companyDetails" backButton={allowBackButton}>
       <H3>Confirm you want to add this company to Data Hub</H3>
 
       <InsetText>
@@ -57,6 +67,20 @@ function CompanyFoundStep({ countryName, features }) {
           ]}
         />
       </InsetText>
+
+      {showCountry && (
+        <>
+          <FieldRadios
+            legend={
+              'We were unable to determine the country of this company, please select the correct value below'
+            }
+            name="companyLocation"
+            required="Specify location of the company"
+            options={Object.values(countryOptions)}
+            bigLegend={false}
+          />
+        </>
+      )}
     </Step>
   )
 }

--- a/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanyNotFoundStep.jsx
@@ -50,10 +50,15 @@ const telephoneValidator = (
   return null
 }
 
-function CompanyNotFoundStep({ organisationTypes, country, features }) {
+function CompanyNotFoundStep({
+  organisationTypes,
+  country,
+  features,
+  allowBackButton,
+}) {
   return (
     <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
-      <Step name="unhappy">
+      <Step name="unhappy" backButton={allowBackButton}>
         <Details summary="Why am I seeing this?">
           The company you want to add to Data Hub cannot be found in the
           external databases Data Hub checks. You will need to provide

--- a/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
+++ b/src/apps/companies/apps/add-company/client/CompanySearchStep.jsx
@@ -34,14 +34,18 @@ function DnbCompanyRenderer(props) {
   )
 }
 
-function getDnbEntityText(companyId, isOutOfBusiness, companyName) {
+export const getDnbEntityText = (companyId, isOutOfBusiness, companyName) => {
   if (isOutOfBusiness) {
-    return 'This company has stopped trading and is no longer in business.'
+    return (
+      <span data-test="company-out-of-business">
+        This company has stopped trading and is no longer in business.
+      </span>
+    )
   }
 
   if (companyId) {
     return (
-      <>
+      <div data-test="company-already-on-datahub">
         This company is already on Data Hub. You can record activity{' '}
         <Link
           href={`/companies/${companyId}`}
@@ -49,7 +53,7 @@ function getDnbEntityText(companyId, isOutOfBusiness, companyName) {
         >
           on the company page.
         </Link>
-      </>
+      </div>
     )
   }
 

--- a/src/apps/companies/apps/add-company/controllers.js
+++ b/src/apps/companies/apps/add-company/controllers.js
@@ -34,6 +34,7 @@ async function renderAddCompanyForm(req, res, next) {
           organisationTypes,
           regions,
           sectors,
+          dunsNumber: req.query.duns_number,
         },
       })
   } catch (error) {

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -3,6 +3,7 @@ module.exports = {
     mercuryTradingLtd: require('./ch-company/mercury-trading-ltd'),
   },
   company: {
+    default: require('../../../../test/sandbox/fixtures/v4/company/company.json'),
     noOverviewDetails: require('../../../../test/sandbox/fixtures/v4/company/company-no-overview-details.json'),
     allOverviewDetails: require('../../../../test/sandbox/fixtures/v4/company/company-all-overview-details.json'),
     archivedLtd: require('../../../../test/sandbox/fixtures/v4/company/company-archived.json'),

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -1000,7 +1000,25 @@ describe('Add company form', () => {
       'and a single company is found that is not on datahub with a matching datahub country',
       () => {
         before(() => {
-          cy.visit(`${urls.companies.create()}?duns_number=111111111`)
+          cy.intercept('POST', '/companies/create/dnb/company-search?_csrf=*', {
+            results: [
+              {
+                dnb_company: {
+                  primary_name: 'US company',
+                  duns_number: '111111111',
+                  address_line_1: '256 Square Street',
+                  address_line_2: '',
+                  address_town: 'Austin',
+                  address_county: '',
+                  address_postcode: '765413',
+                  address_area: 'Texas',
+                  address_country: 'US',
+                  registration_numbers: [],
+                },
+              },
+            ],
+          })
+          cy.visit(`${urls.companies.create()}?duns_number=268435455`)
         })
 
         it('should display a confirmation summary without the option to select a country', () => {
@@ -1012,19 +1030,18 @@ describe('Add company form', () => {
             'contain',
             'Registered company name'
           )
+          cy.get(selectors.companyAdd.summary).should('contain', 'US company')
+
+          cy.get(selectors.companyAdd.summary).should('contain', 'Country')
           cy.get(selectors.companyAdd.summary).should(
             'contain',
-            'Some unmatched company'
+            'United States'
           )
-          cy.get(selectors.companyAdd.summary).should(
-            'contain',
-            'Companies House number'
-          )
-          cy.get(selectors.companyAdd.summary).should('contain', '00016033')
+
           cy.get(selectors.companyAdd.summary).should('contain', 'Address')
           cy.get(selectors.companyAdd.summary).should(
             'contain',
-            '123 ABC Road, Brighton, BN2 9QB'
+            '256 Square Street, Austin, 765413'
           )
 
           cy.get(
@@ -1037,11 +1054,11 @@ describe('Add company form', () => {
           cy.get(selectors.companyAdd.continueButton).should('be.visible')
         })
 
-        it('should display both dbt region and sector', () => {
+        it('should display only the dbt sector', () => {
           cy.get(selectors.companyAdd.continueButton).click()
 
           cy.get(selectors.companyAdd.newCompanyRecordForm.dbtRegion).should(
-            'exist'
+            'not.exist'
           )
           cy.get(selectors.companyAdd.newCompanyRecordForm.dbtSector).should(
             'exist'
@@ -1049,9 +1066,6 @@ describe('Add company form', () => {
         })
 
         it('should submit the form', () => {
-          cy.get(selectors.companyAdd.newCompanyRecordForm.region).select(
-            'London'
-          )
           cy.get(selectors.companyAdd.newCompanyRecordForm.sector).select(
             'Advanced Engineering'
           )

--- a/test/sandbox/fixtures/v4/dnb/company-search-not-matched-no-country.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search-not-matched-no-country.json
@@ -1,0 +1,50 @@
+{
+  "total_matches": 1,
+  "total_returned": 1,
+  "page_size": 1,
+  "page_number": 1,
+  "results": [
+    {
+      "dnb_company": {
+        "duns_number": "333333333",
+        "primary_name": "Some unmatched company",
+        "trading_names": ["Some unmatched company trading name"],
+        "registration_numbers": [
+          {
+            "registration_type": "uk_companies_house_number",
+            "registration_number": "00016033"
+          }
+        ],
+        "global_ultimate_duns_number": "319999999",
+        "global_ultimate_primary_name": "Some other company parent",
+        "domain": "example.co.uk",
+        "is_out_of_business": false,
+        "address_line_1": "123 ABC Road",
+        "address_line_2": "",
+        "address_town": "Brighton",
+        "address_county": "",
+        "address_postcode": "BN2 9QB",
+        "address_country": "ABCDEF",
+        "registered_address_line_1": "",
+        "registered_address_line_2": "",
+        "registered_address_town": "Brighton",
+        "registered_address_county": "",
+        "registered_address_postcode": "BN2 9QB",
+        "registered_address_country": "GB",
+        "annual_sales": 1999999999,
+        "annual_sales_currency": "USD",
+        "is_annual_sales_estimated": null,
+        "employee_number": 300,
+        "is_employees_number_estimated": true,
+        "industry_codes": [
+          {
+            "usSicV4": "3799",
+            "usSicV4Description": "Mfg transportation equipment"
+          }
+        ],
+        "legal_status": "corporation"
+      },
+      "datahub_company": null
+    }
+  ]
+}

--- a/test/sandbox/fixtures/v4/dnb/company-search.json
+++ b/test/sandbox/fixtures/v4/dnb/company-search.json
@@ -8,9 +8,7 @@
       "dnb_company": {
         "duns_number": "111111111",
         "primary_name": "Some unmatched company",
-        "trading_names": [
-          "Some unmatched company trading name"
-        ],
+        "trading_names": ["Some unmatched company trading name"],
         "registration_numbers": [
           {
             "registration_type": "uk_companies_house_number",
@@ -53,9 +51,7 @@
       "dnb_company": {
         "duns_number": "222222222",
         "primary_name": "Some matched company",
-        "trading_names": [
-          "Some matched company trading name"
-        ],
+        "trading_names": ["Some matched company trading name"],
         "registration_numbers": [
           {
             "registration_type": "uk_companies_house_number",
@@ -147,9 +143,7 @@
       "dnb_company": {
         "duns_number": "268435455",
         "primary_name": "Some unmatched US company",
-        "trading_names": [
-          "Some unmatched company trading name"
-        ],
+        "trading_names": ["Some unmatched company trading name"],
         "registration_numbers": [
           {
             "registration_type": "uk_companies_house_number",

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -4,6 +4,7 @@ var companyLink = require('../../../fixtures/v4/dnb/company-link.json')
 var companyChangeRequest = require('../../../fixtures/v4/dnb/company-change-request.json')
 var companySearchMatched = require('../../../fixtures/v4/dnb/company-search-matched.json')
 var companySearchNotMatched = require('../../../fixtures/v4/dnb/company-search-not-matched.json')
+var companySearchNotMatchedNoCountry = require('../../../fixtures/v4/dnb/company-search-not-matched-no-country.json')
 var companySearchNotMatchedUS = require('../../../fixtures/v4/dnb/company-search-not-matched-us.json')
 var companyInvestigation = require('../../../fixtures/v4/dnb/company-investigation.json')
 
@@ -26,6 +27,8 @@ exports.companySearch = function (req, res) {
     return res.json(companySearchNotMatched)
   } else if (req.body.duns_number === '222222222') {
     return res.json(companySearchMatched)
+  } else if (req.body.duns_number === '333333333') {
+    return res.json(companySearchNotMatchedNoCountry)
   }
 
   return res.json(companySearch)

--- a/test/selectors/company/add-company.js
+++ b/test/selectors/company/add-company.js
@@ -9,6 +9,7 @@ module.exports = {
   summary: 'form dl',
   regionSelect: 'form select#uk_region',
   sectorSelect: 'form select#sector',
+
   entitySearch: {
     companyNameField: 'input[name="dnbCompanyName"]',
     postalCodeField: 'input[name="dnbPostalCode"]',
@@ -22,6 +23,8 @@ module.exports = {
       summary: 'details summary span',
       stillCannotFind: `button:contains("I still can't find what I'm looking for")`,
     },
+    outOfBusiness: '[data-test="company-out-of-business"]',
+    alreadyOnDatahub: '[data-test="company-already-on-datahub"]',
   },
   newCompanyRecordForm: {
     whyAmISeeingThis: {
@@ -52,6 +55,9 @@ module.exports = {
     sector: 'select#sector',
     areaUS: 'select#area',
     areaCanada: 'select#areaCanada',
+    companyLocation: '[data-test="field-companyLocation"]',
+    dbtRegion: '[data-test="field-uk_region"]',
+    dbtSector: '[data-test="field-sector"]',
   },
   companyDetails: {
     subheader: 'form h2',


### PR DESCRIPTION
## Description of change

The new company tree has the option to import an unknown dnb company into datahub via a link to the add company page. This page however is a multi step wizard form, but we can skip the first couple of steps as we already know the exact duns number we want to import. 

This change will skip straight to the 3rd step when a duns number is provided


## Test instructions

Using the sandbox api, these 2 duns numbers can be used to test both scenarios when skipping.:

- http://localhost:3000/companies/create?duns_number=333333333
- http://localhost:3000/companies/create?duns_number=111111111

111111111 is for a company where the dnb country code matches a datahub company code, and so we can auto assign a country id. 333333333 is for a company where the dnb country code does not match a datahub country code, and we need to prompt a user to tell us what country this company belongs to.

## Screenshots

### After

#### When the company is known
![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/f8a2d764-00e4-420e-8f24-5957e8110de9)

#### When the company country is unknown
![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/42b7acc3-3b41-4423-a503-7e4cd44f85a6)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
