### PR TITLE
Add headquarter location for business details card

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -15,9 +15,6 @@ import {
 
 const StyledAddressList = styled('ul')``
 
-const isGlobalHQ = (company) =>
-  company.headquarterType && company.headquarterType.name === 'ghq'
-
 const BusinessDetailsCard = ({ company }) => (
   <StyledSummaryTable
     caption="Business details"
@@ -71,21 +68,18 @@ const BusinessDetailsCard = ({ company }) => (
       {buildCellContents(company.sector, company.sector?.name)}
     </SummaryTable.Row>
     <SummaryTable.Row heading="Headquarter Location">
-      {isGlobalHQ(company)
-        ? buildCellContents(
-            company.address?.country,
-            company.address?.country?.name
-          )
-        : buildCellContents(
-            company.globalUltimateCountry,
-            company.globalUltimateCountry
-          )}
-      <Link
-        href={urls.companies.dnbHierarchy.tree(company.id)}
-        data-test="company-tree-link"
-      >
-        View company tree
-      </Link>
+      {buildCellContents(
+        company.globalUltimateCountry,
+        company.globalUltimateCountry
+      )}
+      {company.globalUltimateCountry && (
+        <Link
+          href={urls.companies.dnbHierarchy.tree(company.id)}
+          data-test="company-tree-link"
+        >
+          View company tree
+        </Link>
+      )}
     </SummaryTable.Row>
     <StyledTableRow>
       <StyledLastTableCell colSpan={2}>

--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -15,6 +15,9 @@ import {
 
 const StyledAddressList = styled('ul')``
 
+const isGlobalHQ = (company) =>
+  company.headquarterType && company.headquarterType.name === 'ghq'
+
 const BusinessDetailsCard = ({ company }) => (
   <StyledSummaryTable
     caption="Business details"
@@ -66,6 +69,23 @@ const BusinessDetailsCard = ({ company }) => (
     </SummaryTable.Row>
     <SummaryTable.Row heading="DBT Sector">
       {buildCellContents(company.sector, company.sector?.name)}
+    </SummaryTable.Row>
+    <SummaryTable.Row heading="Headquarter Location">
+      {isGlobalHQ(company)
+        ? buildCellContents(
+            company.address?.country,
+            company.address?.country?.name
+          )
+        : buildCellContents(
+            company.globalUltimateCountry,
+            company.globalUltimateCountry
+          )}
+      <Link
+        href={urls.companies.dnbHierarchy.tree(company.id)}
+        data-test="company-tree-link"
+      >
+        View company tree
+      </Link>
     </SummaryTable.Row>
     <StyledTableRow>
       <StyledLastTableCell colSpan={2}>

--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -67,20 +67,17 @@ const BusinessDetailsCard = ({ company }) => (
     <SummaryTable.Row heading="DBT Sector">
       {buildCellContents(company.sector, company.sector?.name)}
     </SummaryTable.Row>
-    <SummaryTable.Row heading="Headquarter Location">
-      {buildCellContents(
-        company.globalUltimateCountry,
-        company.globalUltimateCountry
-      )}
-      {company.globalUltimateCountry && (
+    {company.globalUltimateCountry && (
+      <SummaryTable.Row heading="Headquarter Location">
+        {company.globalUltimateCountry}
         <Link
           href={urls.companies.dnbHierarchy.tree(company.id)}
           data-test="company-tree-link"
         >
           View company tree
         </Link>
-      )}
-    </SummaryTable.Row>
+      </SummaryTable.Row>
+    )}
     <StyledTableRow>
       <StyledLastTableCell colSpan={2}>
         <Link

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -230,10 +230,7 @@ describe('Company overview page', () => {
           .siblings()
           .contains('td', 'Not set')
         cy.get('th').contains('DBT Sector').siblings().contains('td', 'Not set')
-        cy.get('th')
-          .contains('Headquarter Location')
-          .siblings()
-          .contains('td', 'Not set')
+        cy.get('th').contains('Headquarter Location').should('not.exist')
       })
 
       it('the card should not show link to the company tree page', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -161,7 +161,7 @@ describe('Company overview page', () => {
         cy.location('pathname').should(
           'eq',
           urls.companies.dnbHierarchy.tree(
-            fixtures.company.dnBGlobalUltimateAndGlobalHq.id
+            fixtures.company.dnbGlobalUltimate.id
           )
         )
         cy.go('back')
@@ -234,6 +234,10 @@ describe('Company overview page', () => {
           .contains('Headquarter Location')
           .siblings()
           .contains('td', 'Not set')
+      })
+
+      it('the card should not show link to the company tree page', () => {
+        cy.get('[data-test="company-tree-link"]').should('not.exist')
       })
     }
   )

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -235,10 +235,6 @@ describe('Company overview page', () => {
           .siblings()
           .contains('td', 'Not set')
       })
-
-      it('the card should not show link to the company tree page', () => {
-        cy.get('[data-test="company-tree-link"]').should('not.exist')
-      })
     }
   )
   context(

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -140,9 +140,7 @@ describe('Company overview page', () => {
     () => {
       before(() => {
         cy.visit(
-          urls.companies.overview.index(
-            fixtures.company.dnBGlobalUltimateAndGlobalHq.id
-          )
+          urls.companies.overview.index(fixtures.company.dnbGlobalUltimate.id)
         )
       })
       it('the card should contain Headquarter Location matching country of the company', () => {
@@ -154,7 +152,7 @@ describe('Company overview page', () => {
           .children()
           .last()
         cy.get('th').contains('Headquarter Location')
-        cy.get('td').contains('United States')
+        cy.get('td').contains('United Kingdom')
       })
       it('the card should link to the company tree page', () => {
         cy.get('[data-test="company-tree-link"]')
@@ -236,6 +234,10 @@ describe('Company overview page', () => {
           .contains('Headquarter Location')
           .siblings()
           .contains('td', 'Not set')
+      })
+
+      it('the card should not show link to the company tree page', () => {
+        cy.get('[data-test="company-tree-link"]').should('not.exist')
       })
     }
   )

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -24,7 +24,7 @@ describe('Company overview page', () => {
   const companyBusinessDetailsUrlAllOverview = urls.companies.businessDetails(
     fixtures.company.allOverviewDetails.id
   )
-  const companyAdivsersUrlAllOverview = urls.companies.advisers.index(
+  const companyAdvisersUrlAllOverview = urls.companies.advisers.index(
     fixtures.company.allOverviewDetails.id
   )
   const companyExportsAllOverview = urls.companies.exports.index(
@@ -118,7 +118,9 @@ describe('Company overview page', () => {
         cy.get('th').contains('Number of Employees')
         cy.get('td').contains('260').parent().next()
         cy.get('th').contains('DBT Sector')
-        cy.get('td').contains('Retail')
+        cy.get('td').contains('Retail').parent().next()
+        cy.get('th').contains('Headquarter Location')
+        cy.get('td').contains('United Kingdom')
       })
 
       it('the card should link to the business overview page', () => {
@@ -128,6 +130,72 @@ describe('Company overview page', () => {
         cy.location('pathname').should(
           'eq',
           companyBusinessDetailsUrlAllOverview
+        )
+        cy.go('back')
+      })
+    }
+  )
+  context(
+    'when viewing the Business details card for a global ultimate company',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.overview.index(
+            fixtures.company.dnBGlobalUltimateAndGlobalHq.id
+          )
+        )
+      })
+      it('the card should contain Headquarter Location matching country of the company', () => {
+        cy.get('[data-test="businessDetailsContainer"]')
+          .children()
+          .first()
+          .contains('Business details')
+          .next()
+          .children()
+          .last()
+        cy.get('th').contains('Headquarter Location')
+        cy.get('td').contains('United States')
+      })
+      it('the card should link to the company tree page', () => {
+        cy.get('[data-test="company-tree-link"]')
+          .contains('View company tree')
+          .click()
+        cy.location('pathname').should(
+          'eq',
+          urls.companies.dnbHierarchy.tree(
+            fixtures.company.dnBGlobalUltimateAndGlobalHq.id
+          )
+        )
+        cy.go('back')
+      })
+    }
+  )
+  context(
+    'when viewing the Business details card for a subsidiary company',
+    () => {
+      before(() => {
+        cy.visit(
+          urls.companies.overview.index(fixtures.company.dnbSubsidiary.id)
+        )
+      })
+      it('the card should contain Headquarter Location matching country of global ultimate company', () => {
+        cy.get('[data-test="businessDetailsContainer"]')
+          .children()
+          .first()
+          .contains('Business details')
+          .next()
+          .children()
+          .last()
+        cy.get('th').contains('Headquarter Location')
+        cy.get('td').contains('Canada')
+      })
+      it('the card should link to the company tree page', () => {
+        cy.get('[data-test="company-tree-link"]')
+          .contains('View company tree')
+          .click()
+        cy.location('pathname').should(
+          'eq',
+          urls.companies.dnbHierarchy.tree(fixtures.company.dnbSubsidiary.id)
         )
         cy.go('back')
       })
@@ -164,6 +232,10 @@ describe('Company overview page', () => {
           .siblings()
           .contains('td', 'Not set')
         cy.get('th').contains('DBT Sector').siblings().contains('td', 'Not set')
+        cy.get('th')
+          .contains('Headquarter Location')
+          .siblings()
+          .contains('td', 'Not set')
       })
     }
   )
@@ -222,7 +294,7 @@ describe('Company overview page', () => {
         cy.get('[data-test="account-management-page-link"]')
           .contains('View full account management')
           .click()
-        cy.location('pathname').should('eq', companyAdivsersUrlAllOverview)
+        cy.location('pathname').should('eq', companyAdvisersUrlAllOverview)
         cy.go('back')
       })
     }

--- a/test/sandbox/fixtures/v4/company/company-all-overview-details.json
+++ b/test/sandbox/fixtures/v4/company/company-all-overview-details.json
@@ -487,5 +487,6 @@
       "id": "4170d99a-02fc-46ee-8fd4-3fe786717708",
       "date": "22 May 2020"
     }
-  ]
+  ],
+  "global_ultimate_country": "United Kingdom"
 }

--- a/test/sandbox/fixtures/v4/company/company-dnb-global-ultimate.json
+++ b/test/sandbox/fixtures/v4/company/company-dnb-global-ultimate.json
@@ -76,5 +76,6 @@
   "export_potential": null,
   "great_profile_status": null,
   "is_global_ultimate": true,
-  "global_ultimate_duns_number": "079942718"
+  "global_ultimate_duns_number": "079942718",
+  "global_ultimate_country": "United Kingdom"
 }

--- a/test/sandbox/fixtures/v4/company/company-dnb-subsidiary.json
+++ b/test/sandbox/fixtures/v4/company/company-dnb-subsidiary.json
@@ -53,5 +53,6 @@
   "export_potential": null,
   "great_profile_status": null,
   "is_global_ultimate": false,
-  "global_ultimate_duns_number": "079942718"
+  "global_ultimate_duns_number": "079942718",
+  "global_ultimate_country": "Canada"
 }


### PR DESCRIPTION
## Description of change

Headquarter location displayed on business details card. If a company is has a global ultimate company or is the global ultimate then the headquarter location row is shown

## Test instructions

_What should I see?_

## Screenshots

![Screenshot 2023-07-11 at 12 28 56](https://github.com/uktrade/data-hub-frontend/assets/54268863/7d304229-4e26-4dc1-a743-5bcc093b6245)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
