### PR TITLE
Cls2 180 add to data hub link

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -29,6 +29,7 @@ import {
   HierarchyItemHeading,
   StyledLinkedSubsidiaryButton,
   AddCompanyLink,
+  AddCompanyLinkDiv,
 } from './styled'
 import { addressToString } from '../../../utils/addresses'
 import { GREY_4, BLACK, WHITE, BLUE } from '../../../utils/colours'
@@ -322,12 +323,15 @@ const HierarchyItem = ({
             </InlineDescriptionList>
           </ToggleSection>
         ) : (
-          <AddCompanyLink
-            href={urls.companies.create()}
-            aria-label={`Add ${company.name} to data Hub`}
-          >
-            Add {company.name} to Data Hub
-          </AddCompanyLink>
+          <AddCompanyLinkDiv>
+            <AddCompanyLink
+              href={urls.companies.createFromDNB(company.duns_number)}
+              aria-label={`Add ${company.name} to data Hub`}
+              data-test={`add-${companyName}`}
+            >
+              Add {company.name} to Data Hub
+            </AddCompanyLink>
+          </AddCompanyLinkDiv>
         )}
       </HierarchyItemContents>
       <Subsidiaries

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -28,6 +28,7 @@ import {
   InlineDescriptionList,
   HierarchyItemHeading,
   StyledLinkedSubsidiaryButton,
+  AddCompanyLink,
 } from './styled'
 import { addressToString } from '../../../utils/addresses'
 import { GREY_4, BLACK, WHITE, BLUE } from '../../../utils/colours'
@@ -286,7 +287,7 @@ const HierarchyItem = ({
             </HierarchyTag>
           )}
         </HierarchyItemHeading>
-        {isOnDataHub && (
+        {isOnDataHub ? (
           <ToggleSection
             colour={isRequestedCompanyId ? WHITE : BLUE}
             onOpen={(open) =>
@@ -320,6 +321,13 @@ const HierarchyItem = ({
               </dd>
             </InlineDescriptionList>
           </ToggleSection>
+        ) : (
+          <AddCompanyLink
+            href={urls.companies.create()}
+            aria-label={`Add ${company.name} to data Hub`}
+          >
+            Add {company.name} to Data Hub
+          </AddCompanyLink>
         )}
       </HierarchyItemContents>
       <Subsidiaries

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -210,3 +210,9 @@ export const InlineDescriptionList = styled.dl`
     display: block;
   }
 `
+
+export const AddCompanyLink = styled(Link)`
+  font-size: ${FONT_SIZE.SIZE_16};
+  margin-left: 15px;
+  padding-bottom: 15px;
+`

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -211,8 +211,10 @@ export const InlineDescriptionList = styled.dl`
   }
 `
 
+export const AddCompanyLinkDiv = styled('div')`
+  padding: 15px;
+`
+
 export const AddCompanyLink = styled(Link)`
   font-size: ${FONT_SIZE.SIZE_16};
-  margin-left: 15px;
-  padding-bottom: 15px;
 `

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -124,6 +124,7 @@ module.exports = {
   companies: {
     index: url('/companies', PRIMARY_LINK_PARAMS.companies),
     create: url('/companies', '/create'),
+    createFromDNB: url('/companies/create?duns_number=', ':dunsNumber'),
     export: url('/companies', '/export'),
     detail: url('/companies', '/:companyId'),
     edit: url('/companies', '/:companyId/edit'),


### PR DESCRIPTION
## Description of change

Add a company to data hub link added to the company hierarchy tree when the company is not currently in Data Hab

## Test instructions

Load a tree with a mix of companies on and not on Data Hub. Like should be displayed in place of 'view more details'. This should link through to the create URL nut include a duns number

## Screenshots

![Screenshot 2023-07-12 at 16 13 10](https://github.com/uktrade/data-hub-frontend/assets/72826129/94d41f42-6884-4d25-a4b6-0b4c4a8429b8)


[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
