### PR TITLE
feature/CLS2-292-reduced-company-tree-view

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -5,6 +5,7 @@ import React, { useEffect, useState } from 'react'
 import { BsFillPersonFill } from 'react-icons/bs'
 import { connect } from 'react-redux'
 import { useParams } from 'react-router-dom'
+import InsetText from '@govuk-react/inset-text'
 
 import { COMPANY_LOADED, DNB_FAMILY_TREE_LOADED } from '../../../actions'
 import { TASK_GET_COMPANY_DETAIL } from '../CompanyDetails/state'
@@ -120,18 +121,24 @@ const Subsidiaries = ({
 
 const HierarchyHeader = ({
   ultimateGlobalCount,
+  familyTreeCompaniesCount,
+  reducedTree,
   totalCount,
   fullTreeExpanded,
   onClick,
 }) => (
-  <HierarchyHeaderContents>
+  <HierarchyHeaderContents data-test="hierarchy-header">
     <H2>
       {totalCount}
-      <span> companies</span>
+      <span>
+        {' '}
+        {pluralize('company', totalCount)}
+        {reducedTree && ` out of ${ultimateGlobalCount}`}
+      </span>
     </H2>
-    {ultimateGlobalCount > 1 && (
+    {familyTreeCompaniesCount > 1 && (
       <ToggleSubsidiariesButton
-        count={ultimateGlobalCount}
+        count={familyTreeCompaniesCount}
         onClick={onClick}
         isOpen={fullTreeExpanded}
         insideTree={false}
@@ -148,20 +155,29 @@ const Hierarchy = ({ requestedCompanyId, familyTree }) => {
     familyTree.manually_verified_subsidiaries?.length
   const requestedCompanyHasManuallyVerified =
     manuallyVerifiedSubsidiariesCount > 0
+
   return isEmpty(familyTree) ? (
     <div data-test="empty-hierarchy">
       No hierarchy could be found for this company
     </div>
   ) : (
     <HierarchyContents data-test="hierarchy-contents">
+      {familyTree.reduced_tree && (
+        <InsetText data-test="reduced-tree-hierarchy">
+          Due to the large number of companies in this tree, only the immediate
+          parent companies are being shown
+        </InsetText>
+      )}
       <HierarchyHeader
         ultimateGlobalCount={familyTree.ultimate_global_companies_count}
         totalCount={
-          familyTree.ultimate_global_companies_count +
+          familyTree.family_tree_companies_count +
           manuallyVerifiedSubsidiariesCount
         }
         fullTreeExpanded={fullTreeExpanded}
         onClick={setFullTreeExpanded}
+        reducedTree={familyTree.reduced_tree}
+        familyTreeCompaniesCount={familyTree.family_tree_companies_count}
       />
       <ul>
         <HierarchyItem

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -49,12 +49,14 @@ const createCompanyTree = (
     minCompaniesPerLevel,
     maxCompaniesPerLevel
   )
-
+  const companiesCount = (
+    JSON.stringify(ultimateParent).match(/duns_number/g) || []
+  ).length
   return {
     ultimate_global_company: ultimateParent,
-    ultimate_global_companies_count: (
-      JSON.stringify(ultimateParent).match(/duns_number/g) || []
-    ).length,
+    ultimate_global_companies_count: companiesCount,
+    family_tree_companies_count: companiesCount,
+    reduced_tree: false,
   }
 }
 

--- a/test/sandbox/routes/v4/dnb/company-tree.js
+++ b/test/sandbox/routes/v4/dnb/company-tree.js
@@ -60,12 +60,14 @@ const createCompanyTree = (
     minCompaniesPerLevel,
     maxCompaniesPerLevel
   )
-
+  const companiesCount = (
+    JSON.stringify(ultimateParent).match(/duns_number/g) || []
+  ).length
   return {
     ultimate_global_company: ultimateParent,
-    ultimate_global_companies_count: (
-      JSON.stringify(ultimateParent).match(/duns_number/g) || []
-    ).length,
+    ultimate_global_companies_count: companiesCount,
+    family_tree_companies_count: companiesCount,
+    reduced_tree: false,
   }
 }
 


### PR DESCRIPTION
## Description of change

When the api returns the family tree for a company, if this tree has been reduced due to the number of companies in the tree, display the reduced tree and messaging to a user

## Test instructions

Running the api and front end locally, set a company in django to a company with a large number of companies in the tree. EDF is 767702368 and China Energy is 421297147. Viewing the company tree for one of these companies will show the reduced company tree

## Screenshots

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/a66b045d-0c5e-4567-9a83-30743cc8cb4a)

_Add a screenshot_

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/05eeda69-311f-4581-8c3f-da06d75eeb98)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
