### PR TITLE
feature/CLS2-196-interactions-page-multi-select-stay-open

### DIFF
--- a/src/client/company.js
+++ b/src/client/company.js
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import { apiProxyAxios } from './components/Task/utils'
 import { castArray } from 'lodash'
 
@@ -9,15 +8,7 @@ export const getCompanyNames = (company) => {
 
   const companies = castArray(company)
 
-  return axios
-    .all(
-      companies.map((company) => apiProxyAxios.get(`/v4/company/${company}`))
-    )
-    .then(
-      axios.spread((...responses) =>
-        responses.map(({ data }) => ({
-          companies: data,
-        }))
-      )
-    )
+  return apiProxyAxios
+    .post('/v4/search/company', { id: companies })
+    .then(({ data }) => data.results)
 }

--- a/src/client/components/ActivityFeed/CollectionList/filters.js
+++ b/src/client/components/ActivityFeed/CollectionList/filters.js
@@ -46,9 +46,9 @@ export const buildSelectedFilters = (
   },
   company: {
     queryParam: 'company',
-    options: selectedCompanies.map(({ companies }) => ({
-      label: companies.name,
-      value: companies.id,
+    options: selectedCompanies.map((company) => ({
+      label: company.name,
+      value: company.id,
       categoryLabel: LABELS.company,
     })),
   },

--- a/src/client/modules/Interactions/CollectionList/filters.js
+++ b/src/client/modules/Interactions/CollectionList/filters.js
@@ -31,9 +31,9 @@ export const buildSelectedFilters = (
   },
   company: {
     queryParam: 'company',
-    options: selectedCompanies.map(({ companies }) => ({
-      label: companies.name,
-      value: companies.id,
+    options: selectedCompanies.map((company) => ({
+      label: company.name,
+      value: company.id,
       categoryLabel: LABELS.company,
     })),
   },

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -63,7 +63,7 @@ const adviser = {
 }
 
 const myCompanyId = '0fb3379c-341c-4da4-b825-bf8d47b26baa'
-const myCompanyEndpoint = `/api-proxy/v4/company/${myCompanyId}`
+const searchCompanyEndpoint = `/api-proxy/v4/search/company`
 
 const companiesFilter = '[data-test="company-filter"]'
 
@@ -209,7 +209,9 @@ describe('Interactions Collections Filter', () => {
         count: 1,
         results: [company],
       }).as('companyListApiRequest')
-      cy.intercept('GET', myCompanyEndpoint, company).as('companyApiRequest')
+      cy.intercept('POST', searchCompanyEndpoint, { results: [company] }).as(
+        'companyApiRequest'
+      )
       cy.visit(`/interactions?${queryParams}`)
       assertPayload('@apiRequest', expectedPayload)
       assertTypeaheadOptionSelected({
@@ -226,7 +228,9 @@ describe('Interactions Collections Filter', () => {
         count: 1,
         results: [company],
       }).as('companyListApiRequest')
-      cy.intercept('GET', myCompanyEndpoint, company).as('companyApiRequest')
+      cy.intercept('POST', searchCompanyEndpoint, { results: [company] }).as(
+        'companyApiRequest'
+      )
 
       cy.visit(`/interactions?${queryString}`)
       cy.wait('@apiRequest')


### PR DESCRIPTION
## Description of change

Call the company search endpoint with all company ids, instead of calling the `v4/company` for each company id. This is much faster as it uses a single opensearch query, instead of querying the company id's one at a time

## Test instructions

Open chrome dev tools Network tab, go to http://localhost:3000/interactions?page=1. Using the Company filter, add as many companies as you want. In the network tab you can see the http://localhost:3000/api-proxy/v4/search/company endpoint is being called once with the payload containing each company id selected

Perform the same test on the main branch. You will see an individual network request for every company selected

## Screenshots

No visible changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
