### PR TITLE
feature/CLS2-routed-company-typeahead-close

### DIFF
--- a/src/client/components/RoutedCompanyTypeahead/index.jsx
+++ b/src/client/components/RoutedCompanyTypeahead/index.jsx
@@ -33,13 +33,14 @@ const fetchCompanies = () => {
 const RoutedCompanyTypeahead = ({
   taskProps,
   loadOptions = fetchCompanies(),
+  closeMenuOnSelect,
   ...props
 }) => (
   <Task.Status {...taskProps} progressOverlay={true}>
     {() => (
       <RoutedTypeahead
         loadOptions={loadOptions}
-        closeMenuOnSelect={true}
+        closeMenuOnSelect={closeMenuOnSelect}
         {...props}
       />
     )}
@@ -53,6 +54,9 @@ RoutedCompanyTypeahead.propTypes = {
     name: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
   }).isRequired,
+  closeMenuOnSelect: PropTypes.bool,
 }
+
+RoutedCompanyTypeahead.defaultProps = { closeMenuOnSelect: true }
 
 export default RoutedCompanyTypeahead

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -174,6 +174,7 @@ const InteractionCollection = ({
               noOptionsMessage="No companies found"
               selectedOptions={selectedFilters.company.options}
               data-test="company-filter"
+              closeMenuOnSelect={false}
             />
             <Filters.AdvisersTypeahead
               taskProps={adviserListTask}


### PR DESCRIPTION
## Description of change

Keep the company typeahead on the interactions page open when a selection is made

## Test instructions

Go to http://localhost:3000/interactions?page=1, and start typing into the Company filter. On choosing a company the dropdown will now remain open to allow multiple selections

## Screenshots


### After

![chrome_s7y0h6v2FX](https://github.com/uktrade/data-hub-frontend/assets/102232401/789b3523-c9c8-447f-a7db-54a5535ddf51)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
