### PR TITLE
feature/CLS2-196-adviser-filter-typeahead-close

### DIFF
--- a/src/apps/investments/client/projects/filters.js
+++ b/src/apps/investments/client/projects/filters.js
@@ -26,9 +26,9 @@ export const buildSelectedFilters = (
   },
   advisers: {
     queryParam: 'adviser',
-    options: selectedAdvisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedAdvisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.adviser,
     })),
   },

--- a/src/client/advisers.js
+++ b/src/client/advisers.js
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 import { apiProxyAxios } from './components/Task/utils'
 import { castArray } from 'lodash'
 
@@ -10,13 +8,7 @@ export const getAdviserNames = (adviser) => {
 
   const advisers = castArray(adviser)
 
-  return axios
-    .all(advisers.map((adviser) => apiProxyAxios.get(`/adviser/${adviser}/`)))
-    .then(
-      axios.spread((...responses) =>
-        responses.map(({ data }) => ({
-          advisers: data,
-        }))
-      )
-    )
+  return apiProxyAxios
+    .post('/v4/search/adviser', { id: advisers })
+    .then(({ data }) => data.results)
 }

--- a/src/client/components/ActivityFeed/CollectionList/filters.js
+++ b/src/client/components/ActivityFeed/CollectionList/filters.js
@@ -25,9 +25,9 @@ export const buildSelectedFilters = (
   },
   advisers: {
     queryParam: 'ditParticipantsAdviser',
-    options: selectedAdvisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedAdvisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.advisers,
     })),
   },

--- a/src/client/modules/Companies/CollectionList/filters.js
+++ b/src/client/modules/Companies/CollectionList/filters.js
@@ -117,9 +117,9 @@ export const buildSelectedFilters = (
   },
   leadItaOrGlobalAccountManagers: {
     queryParam: 'one_list_group_global_account_manager',
-    options: selectedLeadItaOrGlobalAccountManagers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedLeadItaOrGlobalAccountManagers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.leadItaOrGlobalAccountManager,
     })),
   },

--- a/src/client/modules/Events/CollectionList/filters.js
+++ b/src/client/modules/Events/CollectionList/filters.js
@@ -19,9 +19,9 @@ export const buildSelectedFilters = (
   },
   organisers: {
     queryParam: 'organiser',
-    options: selectedOrganisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedOrganisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.organiser,
     })),
   },

--- a/src/client/modules/Interactions/CollectionList/filters.js
+++ b/src/client/modules/Interactions/CollectionList/filters.js
@@ -23,9 +23,9 @@ export const buildSelectedFilters = (
   },
   advisers: {
     queryParam: 'dit_participants__adviser',
-    options: selectedAdvisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedAdvisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.advisers,
     })),
   },

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -67,6 +67,7 @@ const ALLOWLIST = [
   '/v4/export',
   '/v4/export/:exportId',
   '/v4/dnb/:companyId/family-tree',
+  '/v4/search/adviser',
 ]
 
 module.exports = (app) => {

--- a/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
@@ -20,7 +20,7 @@ const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
-const myAdviserEndpoint = `/api-proxy/adviser/${myAdviserId}`
+const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 
 const advisersFilter = '[data-test="adviser-filter"]'
 const myInteractionsFilter = '[data-test="my-interactions-filter"]'
@@ -72,13 +72,15 @@ describe('Company Activity Feed Filter', () => {
           ditParticipantsAdviser: [adviser.id],
         })
         cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
-        cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+        cy.intercept('POST', adviserSearchEndpoint, {
+          results: [adviser],
+        }).as('adviserSearchApiRequest')
         cy.visit(
           `${urls.companies.activity.index(
             fixtures.company.allActivitiesCompany.id
           )}?${queryString}`
         )
-        cy.wait('@adviserApiRequest')
+        cy.wait('@adviserSearchApiRequest')
         cy.wait('@apiRequest')
         assertRequestUrl('@apiRequest', expectedRequestAdviserUrl)
         /*
@@ -100,7 +102,9 @@ describe('Company Activity Feed Filter', () => {
       it('should filter from user input and remove chips', () => {
         const queryString = buildQueryString()
         cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
-        cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+        cy.intercept('POST', adviserSearchEndpoint, {
+          results: [adviser],
+        }).as('adviserSearchApiRequest')
         cy.visit(
           `${urls.companies.activity.index(
             fixtures.company.allActivitiesCompany.id
@@ -111,7 +115,7 @@ describe('Company Activity Feed Filter', () => {
           element: myInteractionsFilter,
           value: adviser.id,
         })
-        cy.wait('@adviserApiRequest')
+        cy.wait('@adviserSearchApiRequest')
         assertRequestUrl('@apiRequest', expectedRequestAdviserUrl)
 
         assertQueryParams('ditParticipantsAdviser', [adviser.id])

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -41,7 +41,7 @@ const minimumPayload = {
 
 const activeStatusFlag = 'false'
 const inactiveStatusFlag = 'true'
-const searchEndpoint = '/api-proxy/v4/search/company'
+const companySearchEndpoint = '/api-proxy/v4/search/company'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
 const usaCountryId = '81756b9a-5d95-e211-a939-e4115bead28a'
 const canadaCountryId = '5daf72a6-5d95-e211-a939-e4115bead28a'
@@ -51,7 +51,7 @@ const canadianProvincesEndpoint = `/api-proxy/v4/metadata/administrative-area?co
 describe('Companies Collections Filter', () => {
   context('Default Params', () => {
     it('should set the default params', () => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
 
       cy.visit(urls.companies.index())
 
@@ -64,7 +64,7 @@ describe('Companies Collections Filter', () => {
 
   context('Toggle groups', () => {
     it('should show company details filters and hide them on toggle', () => {
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit('/companies')
       cy.wait('@apiRequest')
       cy.get('[data-test="company-name-filter"]').should('be.visible')
@@ -88,7 +88,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from the url', () => {
       const queryString = buildQueryString({ headquarter_type: [globalHqId] })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       assertCheckboxGroupOption({
@@ -101,7 +101,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -136,7 +136,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from the url', () => {
       const queryString = buildQueryString({ name: companyNameQuery })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('have.value', companyNameQuery)
@@ -145,7 +145,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -179,7 +179,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         sector_descends: [aerospaceSectorId],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'Aerospace')
@@ -188,7 +188,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -227,7 +227,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         country: [brazilCountryId],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'Brazil')
@@ -236,7 +236,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -281,7 +281,7 @@ describe('Companies Collections Filter', () => {
         us_state: [state.id],
       })
       cy.intercept('GET', usStatesEndpoint, usStates).as('usStatesApiRequest')
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@usStatesApiRequest')
       assertPayload('@apiRequest', expectedPayload)
@@ -292,7 +292,7 @@ describe('Companies Collections Filter', () => {
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
       cy.intercept('GET', usStatesEndpoint, usStates).as('usStatesApiRequest')
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@usStatesApiRequest')
       cy.wait('@apiRequest')
@@ -340,7 +340,7 @@ describe('Companies Collections Filter', () => {
       cy.intercept('GET', canadianProvincesEndpoint, provinces).as(
         'canadianProvincesApiRequest'
       )
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@canadianProvincesApiRequest')
       assertPayload('@apiRequest', expectedPayload)
@@ -356,7 +356,7 @@ describe('Companies Collections Filter', () => {
       cy.intercept('GET', canadianProvincesEndpoint, provinces).as(
         'canadianProvincesApiRequest'
       )
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@canadianProvincesApiRequest')
       cy.wait('@apiRequest')
@@ -407,7 +407,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         uk_region: [ukRegion.id],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
 
       cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
         'ukRegionsApiRequest'
@@ -421,7 +421,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
         'ukRegionsApiRequest'
       )
@@ -461,7 +461,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         archived: [activeStatusFlag],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest').then(({ request }) => {
         expect(request.body).to.deep.equal({
@@ -479,7 +479,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -543,7 +543,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         export_to_countries: [brazilCountryId],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'Brazil')
@@ -553,7 +553,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -595,7 +595,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         future_interest_countries: [brazilCountryId],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'Brazil')
@@ -605,7 +605,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -646,7 +646,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         export_segment: [segmentValue],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'High export potential')
@@ -656,7 +656,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -697,7 +697,7 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         export_sub_segment: [subSegmentValue],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', 'Sustain: nurture & grow')
@@ -707,7 +707,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -753,7 +753,7 @@ describe('Companies Collections Filter', () => {
         latest_interaction_date_after: fromDate,
         latest_interaction_date_before: toDate,
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       assertChipExists({
@@ -778,7 +778,7 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove the chip', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -854,7 +854,10 @@ describe('Companies Collections Filter', () => {
       const queryString = buildQueryString({
         one_list_group_global_account_manager: [adviserId],
       })
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [{ id: adviserId, name: adviserName }],
+      }).as('adviserSearchApiRequest')
       cy.visit(`/companies?${queryString}`)
       assertPayload('@apiRequest', expectedPayload)
       cy.get(element).should('contain', adviserName)
@@ -863,7 +866,10 @@ describe('Companies Collections Filter', () => {
 
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [{ id: adviserId, name: adviserName }],
+      }).as('adviserSearchApiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@apiRequest')
 
@@ -889,6 +895,7 @@ describe('Companies Collections Filter', () => {
       const globalHqTypeId = '43281c5e-92a4-4794-867b-b4d5f801e6f3'
       const ukCountryId = '80756b9a-5d95-e211-a939-e4115bead28a'
       const adviserId = 'e83a608e-84a4-11e6-ae22-56b6b6499611'
+      const adviserName = 'Puck Head'
       const advancedEngineeringSectorId = 'af959812-6095-e211-a939-e4115bead28a'
       const ukRegions = ukRegionListFaker(10)
       const usStates = administrativeAreaListFaker(20)
@@ -917,7 +924,10 @@ describe('Companies Collections Filter', () => {
       cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
         'ukRegionsApiRequest'
       )
-      cy.intercept('POST', searchEndpoint).as('apiRequest')
+      cy.intercept('POST', companySearchEndpoint).as('apiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [{ id: adviserId, name: adviserName }],
+      }).as('adviserSearchApiRequest')
       cy.visit(`/companies?${queryString}`)
       cy.wait('@usStatesApiRequest')
       cy.wait('@canadianProvincesApiRequest')

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -42,6 +42,7 @@ const minimumPayload = {
 const activeStatusFlag = 'false'
 const inactiveStatusFlag = 'true'
 const companySearchEndpoint = '/api-proxy/v4/search/company'
+const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
 const usaCountryId = '81756b9a-5d95-e211-a939-e4115bead28a'
 const canadaCountryId = '5daf72a6-5d95-e211-a939-e4115bead28a'

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -43,6 +43,7 @@ const minimumPayload = {
 
 const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
+const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 const companyAutocompleteEndpoint = '/api-proxy/v4/company?autocomplete=*'
 const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service'
 const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area'
@@ -52,7 +53,6 @@ const companyOneListTierGroupMetadataEndpoint =
   '/api-proxy/v4/metadata/one-list-tier'
 
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
-const myAdviserEndpoint = `/api-proxy/adviser/${myAdviserId}`
 
 const advisersFilter = '[data-test="adviser-filter"]'
 const myInteractionsFilter = '[data-test="my-interactions-filter"]'
@@ -274,11 +274,14 @@ describe('Interactions Collections Filter', () => {
       })
 
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [adviser],
+      }).as('adviserSearchApiRequest')
       cy.intercept('GET', adviserAutocompleteEndpoint, {
         count: 1,
         results: [adviser],
       }).as('adviserListApiRequest')
-      cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+
       cy.visit(`/interactions?${queryParams}`)
       assertPayload('@apiRequest', expectedPayload)
       assertTypeaheadOptionSelected({
@@ -304,7 +307,9 @@ describe('Interactions Collections Filter', () => {
         count: 1,
         results: [adviser],
       }).as('adviserListApiRequest')
-      cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [adviser],
+      }).as('adviserSearchApiRequest')
 
       cy.visit(`/interactions?${queryString}`)
       cy.wait('@apiRequest')
@@ -315,7 +320,7 @@ describe('Interactions Collections Filter', () => {
         mockAdviserResponse: false,
       })
       cy.wait('@adviserListApiRequest')
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       assertQueryParams('dit_participants__adviser', [adviser.id])
       assertTypeaheadOptionSelected({
@@ -354,9 +359,11 @@ describe('Interactions Collections Filter', () => {
         dit_participants__adviser: [adviser.id],
       })
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
-      cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [adviser],
+      }).as('adviserSearchApiRequest')
       cy.visit(`/interactions?${queryString}`)
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       /*
       Asserts the "Adviser typeahead" filter is selected with the
@@ -377,14 +384,16 @@ describe('Interactions Collections Filter', () => {
     it('should filter from user input and remove chips', () => {
       const queryString = buildQueryString()
       cy.intercept('POST', interactionsSearchEndpoint).as('apiRequest')
-      cy.intercept('GET', myAdviserEndpoint, adviser).as('adviserApiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [adviser],
+      }).as('adviserSearchApiRequest')
       cy.visit(`/interactions?${queryString}`)
       cy.wait('@apiRequest')
       clickCheckboxGroupOption({
         element: myInteractionsFilter,
         value: adviser.id,
       })
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       assertQueryParams('adviser', [adviser.id])
       assertChipExists({ label: adviser.name, position: 1 })

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -49,7 +49,7 @@ const myAdviser = {
 }
 
 const searchEndpoint = '/api-proxy/v3/search/investment_project'
-const myAdviserEndpoint = `/api-proxy/adviser/${myAdviser.id}`
+const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
 const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
 
@@ -126,9 +126,12 @@ describe('Investments Collections Filter', () => {
         adviser: [myAdviser.id],
       })
       cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', myAdviserEndpoint, myAdviser).as('adviserApiRequest')
+
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [myAdviser],
+      }).as('adviserSearchApiRequest')
       cy.visit(`${urls.investments.projects.index()}?${queryString}`)
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       /*
       Asserts the "Adviser typeahead" filter is selected with the
@@ -149,7 +152,9 @@ describe('Investments Collections Filter', () => {
     it('should filter from "my projects" input and remove chips', () => {
       const queryString = buildQueryString()
       cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', myAdviserEndpoint, myAdviser).as('adviserApiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [myAdviser],
+      }).as('adviserSearchApiRequest')
       cy.visit(`${urls.investments.projects.index()}?${queryString}`)
       cy.wait('@apiRequest')
       cy.get('[data-test="toggle-section-button"]')
@@ -159,7 +164,7 @@ describe('Investments Collections Filter', () => {
         element: myProjectsFilter,
         value: myAdviser.id,
       })
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       assertQueryParams('adviser', [myAdviser.id])
       assertChipExists({ label: myAdviser.name, position: 1 })
@@ -172,7 +177,9 @@ describe('Investments Collections Filter', () => {
     it('should filter from "advisers" input and remove chips', () => {
       const queryString = buildQueryString()
       cy.intercept('POST', searchEndpoint).as('apiRequest')
-      cy.intercept('GET', myAdviserEndpoint, myAdviser).as('adviserApiRequest')
+      cy.intercept('POST', adviserSearchEndpoint, {
+        results: [myAdviser],
+      }).as('adviserSearchApiRequest')
       cy.intercept('GET', adviserAutocompleteEndpoint, {
         count: 1,
         results: [myAdviser],
@@ -188,7 +195,7 @@ describe('Investments Collections Filter', () => {
         mockAdviserResponse: false,
       })
       cy.wait('@adviserListApiRequest')
-      cy.wait('@adviserApiRequest')
+      cy.wait('@adviserSearchApiRequest')
       assertPayload('@apiRequest', expectedPayload)
       assertQueryParams('adviser', [myAdviser.id])
       assertTypeaheadOptionSelected({

--- a/test/sandbox/fixtures/v4/search/advisers.json
+++ b/test/sandbox/fixtures/v4/search/advisers.json
@@ -1,0 +1,1 @@
+{ "count": 1, "results": [] }

--- a/test/sandbox/routes/v4/search/adviser.js
+++ b/test/sandbox/routes/v4/search/adviser.js
@@ -1,0 +1,5 @@
+var advisers = require('../../../fixtures/v4/search/advisers.json')
+
+exports.advisers = function (req, res) {
+  return res.json(advisers)
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -58,6 +58,7 @@ var v4referralList = require('./routes/v4/referrals/list.js')
 var v4Proposition = require('./routes/v4/proposition/proposition.js')
 var v4Reminders = require('./routes/v4/reminders/index.js')
 var v4Reminder = require('./routes/v4/reminder/reminder.js')
+var v4SearchAdviser = require('./routes/v4/search/adviser.js')
 
 // Datahub API 3rd party dependencies
 var consentService = require('./routes/api/consentService.js')
@@ -600,6 +601,7 @@ app.post(
   '/v4/search/export-country-history',
   v4SearchExports.fetchExportHistory
 )
+app.post('/v4/search/adviser', v4SearchAdviser.advisers)
 
 // Whoami endpoint
 app.get('/whoami', user.whoami)


### PR DESCRIPTION
## Description of change

Call the adviser search endpoint with all adviser ids, instead of calling the `/adviser` for each adviser id. This is much faster as it uses a single opensearch query, instead of querying the adviser id's one at a time

## Test instructions

Open chrome dev tools Network tab, go to http://localhost:3000/interactions?page=1. Using the Adviser filter, add as many advisers as you want. In the network tab you can see the http://localhost:3000/api-proxy/v4/search/adviser endpoint is being called once with the payload containing each adviser id selected

Perform the same test on the main branch. You will see an individual network request for every adviser selected

This test can be repeated on the following pages, as they all use the new filter
- http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/activity
- http://localhost:3000/companies
- http://localhost:3000/events
- http://localhost:3000/investments/projects


## Screenshots
No visible changes




## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
