### PR TITLE
feature/CLS2-196-keep-advisor-open-after-selection

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -195,6 +195,7 @@ const ProjectsCollection = ({
               data-test="my-projects-filter"
             />
             <Filters.AdvisersTypeahead
+              closeMenuOnSelect={false}
               taskProps={adviserListTask}
               isMulti={true}
               onlyShowActiveAdvisers={false}

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -28,6 +28,7 @@ const fetchAdvisers = (onlyShowActiveAdvisers) => {
 
 const RoutedAdvisersTypeahead = ({
   taskProps,
+  closeMenuOnSelect,
   onlyShowActiveAdvisers = true,
   loadOptions = fetchAdvisers(onlyShowActiveAdvisers),
   ...props
@@ -36,7 +37,7 @@ const RoutedAdvisersTypeahead = ({
     {() => (
       <RoutedTypeahead
         loadOptions={loadOptions}
-        closeMenuOnSelect={true}
+        closeMenuOnSelect={closeMenuOnSelect}
         {...props}
       />
     )}
@@ -50,6 +51,9 @@ RoutedAdvisersTypeahead.propTypes = {
     name: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
   }).isRequired,
+  closeMenuOnSelect: PropTypes.bool,
 }
+
+RoutedAdvisersTypeahead.defaultProps = { closeMenuOnSelect: true }
 
 export default RoutedAdvisersTypeahead

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -177,6 +177,7 @@ const InteractionCollection = ({
               closeMenuOnSelect={false}
             />
             <Filters.AdvisersTypeahead
+              closeMenuOnSelect={false}
               taskProps={adviserListTask}
               isMulti={true}
               onlyShowActiveAdvisers={false}


### PR DESCRIPTION
## Description of change

Keep the advisor filter open when an option is chosen

## Test instructions

On the interactions page http://localhost:3000/interactions?page=1 and the  investments page http://localhost:3000/investments/projects?, add multiple advisers. The filter will remain open after each selection

## Screenshots

### After

![chrome_rOGJbNUGlo](https://github.com/uktrade/data-hub-frontend/assets/102232401/bdb927bb-4867-4440-9102-30c826069644)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
