### PR TITLE
ignore missing json coverage file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,10 @@ jobs:
           command: |
             mkdir -p partial-coverage
             touch partial-coverage/.placeholder
-            cp cypress-coverage/coverage-final.json partial-coverage/cypress-coverage-$CIRCLE_WORKFLOW_JOB_ID-index-$CIRCLE_NODE_INDEX.json
+            if [ -f cypress-coverage/coverage-final.json ]; then
+              cp cypress-coverage/coverage-final.json partial-coverage/cypress-coverage-$CIRCLE_WORKFLOW_JOB_ID-index-$CIRCLE_NODE_INDEX.json
+            fi
+
       - persist_to_workspace:
           root: ~/
           paths:

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ wait-for-redis = dockerize -wait tcp://redis:6379 -timeout 5m
 
 ifdef CI
 	start-command = up --build --force-recreate -d
-	cypress-args = -- --parallel --record --key $(CYPRESS_DASHBOARD_KEY) --ci-build-id $(CIRCLE_BUILD_NUM)
+	cypress-args = -- --parallel --ci-build-id $(CIRCLE_BUILD_NUM)
 	log-command = logs --follow
 else
 	start-command = up --build --force-recreate

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ wait-for-redis = dockerize -wait tcp://redis:6379 -timeout 5m
 
 ifdef CI
 	start-command = up --build --force-recreate -d
-	cypress-args = -- --parallel --ci-build-id $(CIRCLE_BUILD_NUM)
+	cypress-args = -- --parallel --record --key $(CYPRESS_DASHBOARD_KEY) --ci-build-id $(CIRCLE_BUILD_NUM)
 	log-command = logs --follow
 else
 	start-command = up --build --force-recreate


### PR DESCRIPTION
## Description of change

Cypress VMs that don't get assigned any tests will not generate a cypress coverage file, this PR only copies that file when it exists



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
