### PR TITLE
feature/CLS2-82-activity-feed-show-related-companies

### DIFF
--- a/src/apps/investments/client/projects/constants.js
+++ b/src/apps/investments/client/projects/constants.js
@@ -48,21 +48,3 @@ export const PROJECT_STATUS_OPTIONS = [
   { label: 'Lost', value: 'lost' },
   { label: 'Dormant', value: 'dormant' },
 ]
-
-export const INCLUDE_RELATED_COMPANIES = [
-  {
-    label: 'Parent companies',
-    value: 'include_parent_companies',
-  },
-  {
-    label: 'Subsidiary companies',
-    value: 'include_subsidiary_companies',
-  },
-]
-
-export const INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY =
-  INCLUDE_RELATED_COMPANIES.map((option) =>
-    option.value === 'include_subsidiary_companies'
-      ? { ...option, disabled: 'disabled' }
-      : option
-  )

--- a/src/apps/investments/client/projects/filters.js
+++ b/src/apps/investments/client/projects/filters.js
@@ -26,9 +26,9 @@ export const buildSelectedFilters = (
   },
   advisers: {
     queryParam: 'adviser',
-    options: selectedAdvisers.map(({ advisers }) => ({
-      label: advisers.name,
-      value: advisers.id,
+    options: selectedAdvisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
       categoryLabel: LABELS.adviser,
     })),
   },

--- a/src/apps/investments/client/projects/filters.js
+++ b/src/apps/investments/client/projects/filters.js
@@ -1,3 +1,4 @@
+import { INCLUDE_RELATED_COMPANIES } from '../../../../client/components/RoutedRelatedCompaniesCheckboxGroup/constants'
 import {
   buildOptionsFilter,
   buildDatesFilter,
@@ -7,7 +8,6 @@ import {
   LABELS,
   PROJECT_STATUS_OPTIONS,
   INVOLVEMENT_LEVEL_OPTIONS,
-  INCLUDE_RELATED_COMPANIES,
 } from './constants'
 
 export const buildSelectedFilters = (
@@ -26,9 +26,9 @@ export const buildSelectedFilters = (
   },
   advisers: {
     queryParam: 'adviser',
-    options: selectedAdvisers.map((adviser) => ({
-      label: adviser.name,
-      value: adviser.id,
+    options: selectedAdvisers.map(({ advisers }) => ({
+      label: advisers.name,
+      value: advisers.id,
       categoryLabel: LABELS.adviser,
     })),
   },

--- a/src/client/components/ActivityFeed/CollectionList/filters.js
+++ b/src/client/components/ActivityFeed/CollectionList/filters.js
@@ -9,6 +9,7 @@ import {
   buildDatesFilter,
   buildInputFieldFilter,
 } from '../../../filters'
+import { INCLUDE_RELATED_COMPANIES } from '../../RoutedRelatedCompaniesCheckboxGroup/constants'
 
 export const buildSelectedFilters = (
   queryParams,
@@ -87,6 +88,14 @@ export const buildSelectedFilters = (
       options: BUSINESS_INTELLIGENCE_OPTION,
       value: queryParams.was_policy_feedback_provided,
       categoryLabel: LABELS.businessIntelligence,
+    }),
+  },
+  includeRelatedCompanies: {
+    queryParam: 'include_related_companies',
+    options: buildOptionsFilter({
+      options: INCLUDE_RELATED_COMPANIES,
+      value: queryParams.include_related_companies,
+      categoryLabel: LABELS.includeRelatedCompanies,
     }),
   },
 })

--- a/src/client/components/ActivityFeed/CollectionList/index.jsx
+++ b/src/client/components/ActivityFeed/CollectionList/index.jsx
@@ -125,11 +125,6 @@ const CompanyActivityCollection = ({
     value: currentAdviserId,
   }
 
-  const dnbHierarchyCountOption = {
-    label: `Activity across all ${dnbHierarchyCount} companies`,
-    value: true,
-  }
-
   return (
     <CompanyResource id={companyId}>
       {(company) => (
@@ -185,15 +180,11 @@ const CompanyActivityCollection = ({
                 data-test="date-before-filter"
               />
               {dnbHierarchyCount > 0 && (
-                <Filters.CheckboxGroup
-                  legend={LABELS.showDNBHierarchy}
-                  name="showDnbHierarchy"
-                  qsParam="showDnbHierarchy"
-                  options={[dnbHierarchyCountOption]}
+                <Filters.RelatedCompaniesCheckboxGroup
+                  company={company}
                   selectedOptions={
-                    payload.showDnbHierarchy ? [dnbHierarchyCountOption] : []
+                    selectedFilters.includeRelatedCompanies.options
                   }
-                  data-test="show-dnb-hierarchy-filter"
                 />
               )}
               <FilterToggleSection

--- a/src/client/components/ActivityFeed/CollectionList/state.js
+++ b/src/client/components/ActivityFeed/CollectionList/state.js
@@ -44,6 +44,15 @@ export const state2props = ({ router, ...state }) => {
     currentAdviserId
   )
 
+  queryParams.include_parent_companies =
+    selectedFilters.includeRelatedCompanies.options.some(
+      (f) => f.value === 'include_parent_companies'
+    )
+  queryParams.include_subsidiary_companies =
+    selectedFilters.includeRelatedCompanies.options.some(
+      (f) => f.value === 'include_subsidiary_companies'
+    )
+
   return {
     ...state[ID],
     payload: {

--- a/src/client/components/ActivityFeed/CollectionList/tasks.js
+++ b/src/client/components/ActivityFeed/CollectionList/tasks.js
@@ -64,6 +64,8 @@ const getCompanyActivities = ({
   policy_issue_types,
   company_one_list_group_tier,
   dit_participants__team,
+  include_parent_companies,
+  include_subsidiary_companies,
 }) =>
   axios
     .get(`/companies/${company?.id}/activity/data`, {
@@ -86,6 +88,8 @@ const getCompanyActivities = ({
         policy_issue_types,
         company_one_list_group_tier,
         dit_participants__team,
+        include_parent_companies,
+        include_subsidiary_companies,
       },
     })
     .then(({ data }) => transformResponseToCollection(data))

--- a/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
+++ b/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
@@ -2,14 +2,14 @@ import React from 'react'
 import { Details, Paragraph } from 'govuk-react'
 import { FONT_SIZE } from '@govuk-react/constants'
 import styled from 'styled-components'
-import {
-  INCLUDE_RELATED_COMPANIES,
-  INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY,
-} from '../../../apps/investments/client/projects/constants'
 import { RelatedCompaniesCountResource } from '../Resource'
 import { FilterToggleSection } from '../ToggleSection'
 
 import RoutedCheckboxGroupField from '../RoutedCheckboxGroupField'
+import {
+  INCLUDE_RELATED_COMPANIES,
+  INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY,
+} from './constants'
 
 const SUBSIDIARIES_LIMITED_LABEL =
   'Due to the large number of related companies in this  tree, we can only show projects from parent companies.'

--- a/src/client/components/RoutedRelatedCompaniesCheckboxGroup/constants.js
+++ b/src/client/components/RoutedRelatedCompaniesCheckboxGroup/constants.js
@@ -1,0 +1,17 @@
+export const INCLUDE_RELATED_COMPANIES = [
+  {
+    label: 'Parent companies',
+    value: 'include_parent_companies',
+  },
+  {
+    label: 'Subsidiary companies',
+    value: 'include_subsidiary_companies',
+  },
+]
+
+export const INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY =
+  INCLUDE_RELATED_COMPANIES.map((option) =>
+    option.value === 'include_subsidiary_companies'
+      ? { ...option, disabled: 'disabled' }
+      : option
+  )

--- a/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
@@ -25,7 +25,8 @@ const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 const advisersFilter = '[data-test="adviser-filter"]'
 const myInteractionsFilter = '[data-test="my-interactions-filter"]'
 const createdByOthersFilter = '[data-test="created-by-others-filter"]'
-const showDnBHierarchyFilter = '[data-test="show-dnb-hierarchy-filter"]'
+const relatedCompaniesFilter =
+  '[data-test="checkbox-include_related_companies"]'
 
 const adviser = {
   id: myAdviserId,
@@ -240,28 +241,84 @@ describe('Company Activity Feed Filter', () => {
       const companyActivitiesEndPoint =
         urls.companies.activity.index(fixtures.company.dnbGlobalUltimate.id) +
         '/data**'
-
-      const expectedRequestUrl = `?size=10&from=0&showDnbHierarchy[]=true&sortby=date:desc`
-
-      it('Activity across all companies option should be shown for related companies', () => {
+      const urlQuery = `?size=10&from=0&sortby=date:desc&include_related_companies[0]=include_parent_companies&include_related_companies[1]=include_subsidiary_companies`
+      const expectedRequestUrl = `?size=10&from=0&sortby=date:desc&include_parent_companies=true&include_subsidiary_companies=true`
+      it('Should render the subsidiary companies option disabled when related companies large', () => {
+        cy.intercept(
+          'GET',
+          `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?include_manually_linked_companies=true`,
+          { reduced_tree: true }
+        ).as('relatedCompaniesApiRequest')
         cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
         cy.visit(
           urls.companies.activity.index(fixtures.company.dnbGlobalUltimate.id)
         )
+        cy.wait('@apiRequest')
+
+        cy.get(relatedCompaniesFilter).eq(0).should('not.be.disabled')
+        cy.get(relatedCompaniesFilter).eq(1).should('be.disabled')
+      })
+
+      it('Should render the subsidiary companies option enabled when related companies small', () => {
+        cy.intercept(
+          'GET',
+          `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?include_manually_linked_companies=true`,
+          { reduced_tree: false }
+        ).as('relatedCompaniesApiRequest')
+        cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
+        cy.visit(
+          urls.companies.activity.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+        cy.wait('@apiRequest')
+
+        cy.wait('@relatedCompaniesApiRequest')
+        cy.get(relatedCompaniesFilter).eq(0).should('not.be.disabled')
+        cy.get(relatedCompaniesFilter).eq(1).should('not.be.disabled')
+      })
+
+      it('Activity across all companies option should be shown for related companies', () => {
+        cy.intercept(
+          'GET',
+          `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?include_manually_linked_companies=true`,
+          { reduced_tree: false }
+        ).as('relatedCompaniesApiRequest')
+        cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
+        cy.visit(
+          urls.companies.activity.index(fixtures.company.dnbGlobalUltimate.id)
+        )
+
         assertRequestUrl('@apiRequest', minimumRequest)
-        cy.get(showDnBHierarchyFilter).find(`input`).parent().click()
+
+        cy.get(relatedCompaniesFilter).click({
+          multiple: true,
+        })
+        cy.wait('@apiRequest')
         assertRequestUrl('@apiRequest', expectedRequestUrl)
       })
 
       it('should set filter from url', () => {
+        cy.intercept(
+          'GET',
+          `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+            fixtures.company.dnbGlobalUltimate.id
+          )}?include_manually_linked_companies=true`,
+          { reduced_tree: false }
+        ).as('relatedCompaniesApiRequest')
         cy.intercept('GET', companyActivitiesEndPoint).as('apiRequest')
         cy.visit(
           `${urls.companies.activity.index(
             fixtures.company.dnbGlobalUltimate.id
-          )}${expectedRequestUrl}`
+          )}${urlQuery}`
         )
+        cy.wait('@relatedCompaniesApiRequest')
         assertRequestUrl('@apiRequest', expectedRequestUrl)
-        cy.get(showDnBHierarchyFilter).find(`input`).should('be.checked')
+        cy.get(relatedCompaniesFilter).should('be.checked')
       })
     })
   })


### PR DESCRIPTION
## Description of change

Use the `RelatedCompaniesCheckboxGroup` as part of the activity stream filtering page, replacing the existing Include related companies

## Test instructions

Using any company, go to their activity feed. You will be able the new filter to choose between including parent and subsidiary companies

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/d53b64e1-3f12-4cf1-8944-b1372c464c00)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/f6d83004-0cd8-4af6-8c74-c849761dcd31)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
