### PR TITLE
Feature/cls2 251 activity tab related company ids

### DIFF
--- a/src/apps/companies/__test__/repos.test.js
+++ b/src/apps/companies/__test__/repos.test.js
@@ -143,4 +143,17 @@ describe('Company repository', () => {
       expect(actual).to.deep.equal({ hello: true })
     })
   })
+
+  describe('getRelatedCompanies', () => {
+    it('should make the correct call to the API', async () => {
+      const authorisedRequestStub = sinon.stub().resolves({})
+      const repo = makeRepositoryWithAuthRequest(authorisedRequestStub)
+
+      await repo.getRelatedCompanies(stubRequest, '123', false, true)
+
+      expect(authorisedRequestStub).to.be.calledOnceWithExactly(stubRequest, {
+        url: `${config.apiRoot}/v4/dnb/123/related-companies?include_subsidiary_companies=true&include_parent_companies=false`,
+      })
+    })
+  })
 })

--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -92,9 +92,7 @@ describe('Activity feed controllers', () => {
       before(async () => {
         middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
-          requestQuery: {
-            showDnbHierarchy: false,
-          },
+          requestQuery: {},
         })
 
         await controllers.fetchActivityFeedHandler(
@@ -221,7 +219,6 @@ describe('Activity feed controllers', () => {
           middlewareParameters = buildMiddlewareParameters({
             company: companyMock,
             requestQuery: {
-              showDnbHierarchy: false,
               activityType: ['dataHubActivity'],
             },
           })
@@ -329,7 +326,6 @@ describe('Activity feed controllers', () => {
           middlewareParameters = buildMiddlewareParameters({
             company: companyMock,
             requestQuery: {
-              showDnbHierarchy: false,
               activityType: ['externalActivity'],
             },
           })
@@ -456,7 +452,6 @@ describe('Activity feed controllers', () => {
             middlewareParameters = buildMiddlewareParameters({
               company: companyMock,
               requestQuery: {
-                showDnbHierarchy: false,
                 activityType: ['dataHubActivity', 'externalActivity'],
               },
             })
@@ -629,7 +624,6 @@ describe('Activity feed controllers', () => {
         middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
-            showDnbHierarchy: false,
             ditParticipantsAdviser: [123],
           },
           user: {
@@ -784,7 +778,6 @@ describe('Activity feed controllers', () => {
         middlewareParameters = buildMiddlewareParameters({
           company: companyMock,
           requestQuery: {
-            showDnbHierarchy: false,
             createdByOthers: [123],
           },
           user: {
@@ -948,7 +941,6 @@ describe('Activity feed controllers', () => {
           company: companyMock,
           requestQuery: {
             feedType: FILTER_FEED_TYPE.ALL,
-            showDnbHierarchy: false,
           },
         })
 
@@ -1081,7 +1073,6 @@ describe('Activity feed controllers', () => {
           company: companyMock,
           requestQuery: {
             feedType: 'recent',
-            showDnbHierarchy: false,
           },
         })
 
@@ -1262,7 +1253,6 @@ describe('Activity feed controllers', () => {
           company: companyMock,
           requestQuery: {
             feedType: 'upcoming',
-            showDnbHierarchy: false,
           },
         })
 
@@ -1464,7 +1454,6 @@ describe('Activity feed controllers', () => {
             requestQuery: {
               dateAfter: '2002-06-13',
               dateBefore: '2022-06-13',
-              showDnbHierarchy: false,
             },
           })
 
@@ -1664,14 +1653,15 @@ describe('Activity feed controllers', () => {
     )
 
     context(
-      'when applying both Data Hub activity and DnB hierarchical filters',
+      'when applying both Data Hub activity and related company filters',
       () => {
         before(async () => {
           middlewareParameters = buildMiddlewareParameters({
             company: {
               ...companyMock,
               is_global_ultimate: true,
-              showDnbHierarchy: true,
+              include_parent_companies: true,
+              include_subsidiary_companies: true,
             },
             user: {
               id: 123,
@@ -1834,9 +1824,7 @@ describe('Activity feed controllers', () => {
         before(async () => {
           middlewareParameters = buildMiddlewareParameters({
             company: companyMock,
-            requestQuery: {
-              showDnbHierarchy: false,
-            },
+            requestQuery: {},
             user: {
               id: 123,
             },

--- a/src/apps/companies/apps/activity-feed/__test__/translators.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/translators.test.js
@@ -10,7 +10,6 @@ describe('Converting query String types', () => {
         requestQuery: {
           from: '0',
           size: '20',
-          showDnbHierarchy: 'false',
         },
       })
 
@@ -25,7 +24,6 @@ describe('Converting query String types', () => {
       expect(middlewareParameters.reqMock.query).to.deep.equal({
         from: 0,
         size: 20,
-        showDnbHierarchy: 'false',
       })
     })
 

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -260,13 +260,14 @@ async function fetchActivityFeedHandler(req, res, next) {
     } = req.query
     let relatedCompanyIds = []
     if (include_parent_companies || include_subsidiary_companies) {
-      const { related_companies } = await getRelatedCompanies(
+      const relatedCompaniesResponse = await getRelatedCompanies(
         req,
         company.id,
         include_parent_companies,
         include_subsidiary_companies
       )
-      relatedCompanyIds = related_companies
+
+      relatedCompanyIds = relatedCompaniesResponse.related_companies
     }
 
     const filteredContacts = filterContactListOnEmail(company.contacts)

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -258,6 +258,7 @@ async function fetchActivityFeedHandler(req, res, next) {
       createdByOthers = [],
       activityType = [],
     } = req.query
+
     let relatedCompanyIds = []
     if (include_parent_companies || include_subsidiary_companies) {
       const relatedCompaniesResponse = await getRelatedCompanies(

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -259,7 +259,7 @@ async function fetchActivityFeedHandler(req, res, next) {
       activityType = [],
     } = req.query
 
-    let relatedCompanyIds = []
+    const relatedCompanyIds = []
     if (include_parent_companies || include_subsidiary_companies) {
       const relatedCompaniesResponse = await getRelatedCompanies(
         req,
@@ -268,7 +268,7 @@ async function fetchActivityFeedHandler(req, res, next) {
         include_subsidiary_companies
       )
 
-      relatedCompanyIds = relatedCompaniesResponse.related_companies
+      relatedCompanyIds.push(...relatedCompaniesResponse.related_companies)
     }
 
     const filteredContacts = filterContactListOnEmail(company.contacts)

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -12,7 +12,7 @@ const {
 
 const { ACTIVITIES_PER_PAGE } = require('../../../contacts/constants')
 
-const { getGlobalUltimateHierarchy } = require('../../repos')
+const { getRelatedCompanies } = require('../../repos')
 const urls = require('../../../../lib/urls')
 const { fetchActivityFeed, fetchMatchingDataHubContact } = require('./repos')
 const config = require('../../../../config')
@@ -253,22 +253,20 @@ async function fetchActivityFeedHandler(req, res, next) {
       dateAfter = null,
       feedType = FILTER_FEED_TYPE.ALL,
       ditParticipantsAdviser = [],
-      showDnbHierarchy = false,
+      include_parent_companies = false,
+      include_subsidiary_companies = false,
       createdByOthers = [],
       activityType = [],
     } = req.query
-    let dnbHierarchyIds = []
-    if (
-      company.is_global_ultimate &&
-      (showDnbHierarchy === true || showDnbHierarchy[0] === 'true')
-    ) {
-      const { results } = await getGlobalUltimateHierarchy(
+    let relatedCompanyIds = []
+    if (include_parent_companies || include_subsidiary_companies) {
+      const { related_companies } = await getRelatedCompanies(
         req,
-        company.global_ultimate_duns_number
+        company.id,
+        include_parent_companies,
+        include_subsidiary_companies
       )
-      dnbHierarchyIds = results
-        .filter((company) => !company.is_global_ultimate)
-        .map((company) => company.id)
+      relatedCompanyIds = related_companies
     }
 
     const filteredContacts = filterContactListOnEmail(company.contacts)
@@ -286,7 +284,7 @@ async function fetchActivityFeedHandler(req, res, next) {
     const query = dataHubCompanyActivityQuery({
       from,
       size,
-      companyIds: [company.id, ...dnbHierarchyIds],
+      companyIds: [company.id, ...relatedCompanyIds],
       contacts: filteredContacts,
       dateAfter,
       dateBefore,

--- a/src/apps/companies/apps/activity-feed/translators.js
+++ b/src/apps/companies/apps/activity-feed/translators.js
@@ -11,12 +11,6 @@ const convertQueryTypes = (req, res, next) => {
     req.query.size = parseInt(size, 10)
   }
 
-  // Convert [String] to Boolean
-  const { showDnbHierarchy } = req.query
-  if (showDnbHierarchy !== undefined && showDnbHierarchy === ['true']) {
-    req.query.showDnbHierarchy = true
-  }
-
   next()
 }
 

--- a/src/apps/companies/repos.js
+++ b/src/apps/companies/repos.js
@@ -144,6 +144,17 @@ function createDnbChangeRequest(req, dunsNumber, changes) {
   })
 }
 
+function getRelatedCompanies(
+  req,
+  companyId,
+  include_parent_companies,
+  include_subsidiary_companies
+) {
+  return authorisedRequest(req, {
+    url: `${config.apiRoot}/v4/dnb/${companyId}/related-companies?include_subsidiary_companies=${include_subsidiary_companies}&include_parent_companies=${include_parent_companies}`,
+  })
+}
+
 module.exports = {
   saveCompany,
   getDitCompany,
@@ -161,4 +172,5 @@ module.exports = {
   createDnbCompanyInvestigation,
   linkDataHubCompanyToDnBCompany,
   createDnbChangeRequest,
+  getRelatedCompanies,
 }

--- a/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
@@ -243,6 +243,7 @@ describe('Company Activity Feed Filter', () => {
         '/data**'
       const urlQuery = `?size=10&from=0&sortby=date:desc&include_related_companies[0]=include_parent_companies&include_related_companies[1]=include_subsidiary_companies`
       const expectedRequestUrl = `?size=10&from=0&sortby=date:desc&include_parent_companies=true&include_subsidiary_companies=true`
+
       it('Should render the subsidiary companies option disabled when related companies large', () => {
         cy.intercept(
           'GET',

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -74,3 +74,9 @@ exports.relatedCompaniesCount = function (req, res) {
         }
   )
 }
+exports.relatedCompanies = function (req, res) {
+  res.json({
+    related_companies: [],
+    reduced_tree: false,
+  })
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -470,6 +470,7 @@ app.get(
   '/v4/dnb/:companyId/related-companies/count',
   v4Dnb.relatedCompaniesCount
 )
+app.get('/v4/dnb/:companyId/related-companies', v4Dnb.relatedCompanies)
 
 // V4 legacy company list
 app.get('/v4/user/company-list/:companyId', v4Company.getCompanyList)


### PR DESCRIPTION
## Description of change

Change the activity feed controller to use the new related companies endpoint, instead of the manually linked companies endpoint. This pulls data from the DNB family tree service, and will produce a larger number of related companies than relying on the manually linked endpoint

## Test instructions

One list corp (http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0)has been setup on dev to have a subsidiary with an interaction. The subsidiary is http://localhost:3000/companies/a958335f-e085-4180-816f-03836f50fcc4/activity. This subsidiary also has a subsidiary with an interaction - http://localhost:3000/companies/f3638266-c7e8-4818-8a32-89a56bdbe07e/activity

Using these 3 companies you can apply the filters for both parent and subsidiary to include additional activities

## Screenshots

No visible changes

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
