### PR TITLE
Add trading names to company tree hierarchy

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -342,8 +342,11 @@ const HierarchyItem = ({
             ) : (
               `${company.name} (not on Data Hub)`
             )}
-            {company?.trading_names.length > 0 && (
-              <TradingNames>
+            {company?.trading_names?.length > 0 && (
+              <TradingNames
+                data-test={`${companyName}-trading-names`}
+                isRequestedCompanyId={isRequestedCompanyId}
+              >
                 Trading as: {company?.trading_names.join(', ')}
               </TradingNames>
             )}

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Button, H2, Link } from 'govuk-react'
+import { Button, GridCol, H2, Link } from 'govuk-react'
 import { isEmpty, isFunction, kebabCase } from 'lodash'
 import pluralize from 'pluralize'
 import { BsFillPersonFill } from 'react-icons/bs'
@@ -31,6 +31,8 @@ import {
   StyledLinkedSubsidiaryButton,
   AddCompanyLink,
   AddCompanyLinkDiv,
+  GridColTags,
+  TradingNames,
 } from './styled'
 import { addressToString } from '../../../utils/addresses'
 import { GREY_4, BLACK, WHITE, BLUE } from '../../../utils/colours'
@@ -289,54 +291,63 @@ const HierarchyItem = ({
         }
       >
         <HierarchyItemHeading>
-          {Object.keys(company).length === 0 ? (
-            `No related companies found`
-          ) : company?.id ? (
-            <Link
-              href={urls.companies.overview.index(company.id)}
-              aria-label={`Go to ${company.name} details`}
-            >
-              {company.name}
-            </Link>
-          ) : (
-            `${company.name} (not on Data Hub)`
-          )}
-          {company.one_list_tier?.name && (
-            <HierarchyTag
-              colour="grey"
-              data-test={`${companyName}-one-list-tag`}
-            >
-              One List {company.one_list_tier.name.slice(0, 6)}
-            </HierarchyTag>
-          )}
-          {company.address?.country.name && (
-            <HierarchyTag
-              colour="blue"
-              data-test={`${companyName}-country-tag`}
-            >
-              {company.address.country.name}
-            </HierarchyTag>
-          )}
-          {company.uk_region?.name && (
-            <HierarchyTag
-              colour="blue"
-              data-test={`${companyName}-uk-region-tag`}
-            >
-              {company.uk_region.name}
-            </HierarchyTag>
-          )}
-          {(company.number_of_employees || company.employee_range?.name) && (
-            <HierarchyTag
-              colour="blue"
-              data-test={`${companyName}-number-of-employees-tag`}
-            >
-              <BsFillPersonFill
-                size={'12'}
-                style={{ verticalAlign: 'top', paddingTop: '1px' }}
-              />
-              <CompanyNumberOfEmployees company={company} />
-            </HierarchyTag>
-          )}
+          <GridColTags>
+            {company.one_list_tier?.name && (
+              <HierarchyTag
+                colour="grey"
+                data-test={`${companyName}-one-list-tag`}
+              >
+                One List {company.one_list_tier.name.slice(0, 6)}
+              </HierarchyTag>
+            )}
+            {company.address?.country.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-country-tag`}
+              >
+                {company.address.country.name}
+              </HierarchyTag>
+            )}
+            {company.uk_region?.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-uk-region-tag`}
+              >
+                {company.uk_region.name}
+              </HierarchyTag>
+            )}
+            {(company.number_of_employees || company.employee_range?.name) && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-number-of-employees-tag`}
+              >
+                <BsFillPersonFill
+                  size={'12'}
+                  style={{ verticalAlign: 'top', paddingTop: '1px' }}
+                />
+                <CompanyNumberOfEmployees company={company} />
+              </HierarchyTag>
+            )}
+          </GridColTags>
+          <GridCol setWidth="two-thirds">
+            {Object.keys(company).length === 0 ? (
+              `No related companies found`
+            ) : company?.id ? (
+              <Link
+                href={urls.companies.overview.index(company.id)}
+                aria-label={`Go to ${company.name} details`}
+              >
+                {company.name}
+              </Link>
+            ) : (
+              `${company.name} (not on Data Hub)`
+            )}
+            {company?.trading_names.length > 0 && (
+              <TradingNames>
+                Trading as: {company?.trading_names.join(', ')}
+              </TradingNames>
+            )}
+          </GridCol>
         </HierarchyItemHeading>
         {isOnDataHub ? (
           <ToggleSection

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react'
-import { Button, GridCol, H2, Link } from 'govuk-react'
+import { Button, H2, Link } from 'govuk-react'
 import { isEmpty, isFunction, kebabCase } from 'lodash'
 import pluralize from 'pluralize'
 import { BsFillPersonFill } from 'react-icons/bs'
@@ -32,6 +32,7 @@ import {
   AddCompanyLink,
   AddCompanyLinkDiv,
   GridColTags,
+  GridColHeader,
   TradingNames,
 } from './styled'
 import { addressToString } from '../../../utils/addresses'
@@ -329,7 +330,7 @@ const HierarchyItem = ({
               </HierarchyTag>
             )}
           </GridColTags>
-          <GridCol setWidth="two-thirds">
+          <GridColHeader>
             {Object.keys(company).length === 0 ? (
               `No related companies found`
             ) : company?.id ? (
@@ -350,7 +351,7 @@ const HierarchyItem = ({
                 Trading as: {company?.trading_names.join(', ')}
               </TradingNames>
             )}
-          </GridCol>
+          </GridColHeader>
         </HierarchyItemHeading>
         {isOnDataHub ? (
           <ToggleSection

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -225,6 +225,11 @@ export const GridColTags = styled(GridCol)`
   width: auto;
 `
 
+export const GridColHeader = styled(GridCol)`
+  setwidth: two-thirds;
+  padding-left: 0px;
+`
+
 export const TradingNames = styled.div`
   font-size: ${FONT_SIZE.SIZE_16};
   ${({ isRequestedCompanyId }) =>

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -1,4 +1,4 @@
-import { Button, Link } from 'govuk-react'
+import { Button, Link, GridCol } from 'govuk-react'
 import styled, { css } from 'styled-components'
 import {
   GREY_2,
@@ -217,4 +217,15 @@ export const AddCompanyLinkDiv = styled('div')`
 
 export const AddCompanyLink = styled(Link)`
   font-size: ${FONT_SIZE.SIZE_16};
+`
+
+export const GridColTags = styled(GridCol)`
+  setwidth: one-third;
+  float: right;
+  width: auto;
+`
+
+export const TradingNames = styled.div`
+  font-size: ${FONT_SIZE.SIZE_16};
+  color: ${DARK_GREY};
 `

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -227,5 +227,6 @@ export const GridColTags = styled(GridCol)`
 
 export const TradingNames = styled.div`
   font-size: ${FONT_SIZE.SIZE_16};
-  color: ${DARK_GREY};
+  ${({ isRequestedCompanyId }) =>
+    isRequestedCompanyId ? `color: ${WHITE};` : `color: ${DARK_GREY};`}
 `

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -28,6 +28,7 @@ const companyTreeItemFaker = (overrides = {}) => ({
   latest_interaction_date: faker.date.past(),
   one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
   archived: false,
+  trading_names: [faker.company.name()],
   hierarchy: 1,
   subsidiaries: [],
   ...overrides,
@@ -108,6 +109,7 @@ const manuallyLinkedCompanyFaker = () => {
     one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
     archived: false,
     hierarchy: 0,
+    trading_names: [faker.company.name()],
   }
 }
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -58,6 +58,7 @@ const companyNoAdditionalTagData = companyTreeFaker({
       one_list_tier: [],
       uk_region: null,
       address: null,
+      trading_names: [],
     }),
     ultimate_global_companies_count: 1,
     family_tree_companies_count: 1,
@@ -253,6 +254,14 @@ describe('D&B Company hierarchy tree', () => {
     it('should hide the show subsidiaries button', () => {
       cy.get('[data-test="toggle-subsidiaries-button"]').should('not.exist')
     })
+
+    it('should show trading names under heading', () => {
+      const company = companyNoSubsidiaries.ultimate_global_company
+      cy.get(`[data-test="${kebabCase(company.name)}-trading-names"]`).should(
+        'have.text',
+        `Trading as: ${company.trading_names}`
+      )
+    })
   })
 
   context('When a company has only immediate subsidiaries', () => {
@@ -294,6 +303,14 @@ describe('D&B Company hierarchy tree', () => {
       cy.get(`[data-test=${companyName}-uk-region-tag]`).should(
         'contain.text',
         tagContent.uk_region.name
+      )
+    })
+
+    it('should show trading names under heading', () => {
+      const company = companyOnlyImmediateSubsidiaries.ultimate_global_company
+      cy.get(`[data-test="${kebabCase(company.name)}-trading-names"]`).should(
+        'have.text',
+        `Trading as: ${company.trading_names}`
       )
     })
 
@@ -357,6 +374,13 @@ describe('D&B Company hierarchy tree', () => {
       cy.get(`[data-test=${companyName}-uk-region-tag]`).should('not.exist')
       cy.get(`[data-test=${companyName}-country-tag]`).should('not.exist')
       cy.get(`[data-test=${companyName}-one-list-tag]`).should('not.exist')
+    })
+
+    it('should not show any trading names', () => {
+      const company = companyNoAdditionalTagData.ultimate_global_company
+      cy.get(`[data-test="${kebabCase(company.name)}-trading-names"]`).should(
+        'not.exist'
+      )
     })
   })
 

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -390,9 +390,12 @@ describe('Company Export tab - Export countries history', () => {
             .find('div span')
             .should('contain', 'Interaction')
 
-          assertionTasks.reduce(($details, { assertion, value }) => {
-            return $details.should(assertion, value)
-          }, cy.get('@' + interaction).find('details'))
+          assertionTasks.reduce(
+            ($details, { assertion, value }) => {
+              return $details.should(assertion, value)
+            },
+            cy.get('@' + interaction).find('details')
+          )
         }
 
         cy.contains('5 results')

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -390,12 +390,9 @@ describe('Company Export tab - Export countries history', () => {
             .find('div span')
             .should('contain', 'Interaction')
 
-          assertionTasks.reduce(
-            ($details, { assertion, value }) => {
-              return $details.should(assertion, value)
-            },
-            cy.get('@' + interaction).find('details')
-          )
+          assertionTasks.reduce(($details, { assertion, value }) => {
+            return $details.should(assertion, value)
+          }, cy.get('@' + interaction).find('details'))
         }
 
         cy.contains('5 results')


### PR DESCRIPTION
## Description of change

Display trading names on company tree items

## Test instructions

When using the dev env file on local you should be able to see trading names on some items in the One List Corp company tree: http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/company-tree

This link has an example of trading names on the highlighted tree item where the text should be white instead: http://localhost:3000/companies/fd8220b1-c59f-413e-8f0b-61d692c15c3a/company-tree

## Screenshots

### Before
![Screenshot 2023-07-26 at 14 28 17](https://github.com/uktrade/data-hub-frontend/assets/54268863/570e1394-f3f0-4211-b65c-c9a85348a438)

### After
![Screenshot 2023-07-26 at 14 28 27](https://github.com/uktrade/data-hub-frontend/assets/54268863/c4fea400-ffc1-4d27-a36a-519a98738b60)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
