### PR TITLE
Initial new account management page and test

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -31,6 +31,7 @@ const reactRoutes = [
   '/export/:exportId/delete',
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',
+  '/companies/:companyId/account-management',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DefaultLayout } from '../../../components'
+
+const AccountManagement = () => {
+  return (
+    <DefaultLayout
+      heading={'Account Management'}
+      pageTitle={'Account Management'}
+      breadcrumbs={[]}
+      useReactRouter={false}
+    >
+      <h1>Account Management</h1>
+    </DefaultLayout>
+  )
+}
+
+export default AccountManagement

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -18,6 +18,7 @@ import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
 import ExportDetails from './modules/ExportPipeline/ExportDetails'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
 import CompanyTree from './modules/Companies/CompanyHierarchy/CompanyTree'
+import AccountManagement from './modules/Companies/AccountManagement'
 
 const routes = {
   companies: [
@@ -35,6 +36,11 @@ const routes = {
       path: '/companies/:companyId/company-tree',
       module: 'datahub:companies',
       component: CompanyTree,
+    },
+    {
+      path: '/companies/:companyId/account-management',
+      module: 'datahub:companies',
+      component: AccountManagement,
     },
   ],
   contacts: [

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -229,6 +229,9 @@ module.exports = {
       index: url('/companies', '/:companyId/subsidiaries'),
       link: url('/companies', '/:companyId/subsidiaries/link'),
     },
+    accountManagement: {
+      index: url('/companies', '/:companyId/account-management'),
+    },
   },
   companyLists: {
     index: url('/company-lists'),

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -1,0 +1,15 @@
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Company account management', () => {
+  context('When visiting the account management page', () => {
+    it('should display the h1 heading of Account Management', () => {
+      cy.visit(
+        urls.companies.accountManagement.index(
+          fixtures.company.allActivitiesCompany.id
+        )
+      )
+      cy.get('h1').contains('Account Management')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Create new account management page so we can work on changes before it is added into the company page tabs. 

Path: account-management e.g. https://www.datahub.trade.gov.uk/companies/02092cd3-a098-e211-a939-e4115bead28a/account-management

## Test instructions

Navigate to the url and view a page containing a title and heading of Account Management

## Screenshots

### Before

![Screenshot 2023-07-26 at 16 11 40](https://github.com/uktrade/data-hub-frontend/assets/72826129/769ba180-0b11-4f2c-a940-d10053032764)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
