### PR TITLE
bugfix/CLS2-338-investment-project-filters

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -52,9 +52,9 @@ const LOCAL_NAV = [
     label: 'Lead adviser',
   },
   {
-    path: 'investments/projects',
+    path: 'investments',
     label: 'Investment',
-    search: '?page=1&sortby=created_on%3Adesc',
+    search: '/projects?page=1&sortby=created_on%3Adesc',
     permissions: [
       'investment.view_all_investmentproject',
       'investment.view_associated_investmentproject',

--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -52,8 +52,9 @@ const LOCAL_NAV = [
     label: 'Lead adviser',
   },
   {
-    path: 'investments',
+    path: 'investments/projects',
     label: 'Investment',
+    search: '?page=1&sortby=created_on%3Adesc',
     permissions: [
       'investment.view_all_investmentproject',
       'investment.view_associated_investmentproject',

--- a/test/functional/cypress/specs/companies/tab-history-spec.js
+++ b/test/functional/cypress/specs/companies/tab-history-spec.js
@@ -11,7 +11,7 @@ const testTab = (tabText) => {
     'Business details': 'tab-business-details',
     'Company contacts': 'tab-contacts',
     'Lead adviser': 'tab-advisers',
-    Investment: 'tab-investments/projects',
+    Investment: 'tab-investments',
     Export: 'tab-exports',
     Orders: 'tab-orders',
   }

--- a/test/functional/cypress/specs/companies/tab-history-spec.js
+++ b/test/functional/cypress/specs/companies/tab-history-spec.js
@@ -11,7 +11,7 @@ const testTab = (tabText) => {
     'Business details': 'tab-business-details',
     'Company contacts': 'tab-contacts',
     'Lead adviser': 'tab-advisers',
-    Investment: 'tab-investments',
+    Investment: 'tab-investments/projects',
     Export: 'tab-exports',
     Orders: 'tab-orders',
   }


### PR DESCRIPTION
## Description of change

Fix the issue where the projects task is loading twice as the page gets redirected while the first task is loading

## Test instructions

Go to any company on dev, then click the Investment tab (click the tab, don't type the link manually). You will see the console error about a duplicate task.
Using this branch, try the same test. You will go directly to /investments/projects?page=1&sortby=created_on%3Adesc and will not get the duplicate task error



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
