### PR TITLE
bugfix/CLS2-350-hide-related-companies-filter-for-companies-without-duns-number

### DIFF
--- a/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
+++ b/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
@@ -28,33 +28,41 @@ const RoutedRelatedCompaniesCheckboxGroup = ({ company, selectedOptions }) => (
   <>
     {company.dunsNumber && (
       <RelatedCompaniesCountResource id={company.id}>
-        {(count) => (
-          <FilterToggleSection
-            id="ProjectCollection.include-related-companies-filters"
-            label="Related companies"
-            isOpen={true}
-          >
-            <RoutedCheckboxGroupField
-              legend="Include related companies"
-              name="include_related_companies"
-              qsParam="include_related_companies"
-              options={
-                count.reducedTree
-                  ? INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY
-                  : INCLUDE_RELATED_COMPANIES
-              }
-              selectedOptions={selectedOptions}
-              data-test="include-related-companies-filter"
-              aria-description={
-                count.reducedTree ? SUBSIDIARIES_LIMITED_LABEL : undefined
-              }
-            />
-            {count.reducedTree && (
-              <StyledDetails summary="Why can't I filter by subsidiary companies?">
-                <StyledParagraph>{SUBSIDIARIES_LIMITED_LABEL}</StyledParagraph>
-              </StyledDetails>
+        {(relatedCompaniesCountResponse) => (
+          <>
+            {relatedCompaniesCountResponse.relatedCompaniesCount > 0 && (
+              <FilterToggleSection
+                id="ProjectCollection.include-related-companies-filters"
+                label="Related companies"
+                isOpen={true}
+              >
+                <RoutedCheckboxGroupField
+                  legend="Include related companies"
+                  name="include_related_companies"
+                  qsParam="include_related_companies"
+                  options={
+                    relatedCompaniesCountResponse.reducedTree
+                      ? INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY
+                      : INCLUDE_RELATED_COMPANIES
+                  }
+                  selectedOptions={selectedOptions}
+                  data-test="include-related-companies-filter"
+                  aria-description={
+                    relatedCompaniesCountResponse.reducedTree
+                      ? SUBSIDIARIES_LIMITED_LABEL
+                      : undefined
+                  }
+                />
+                {relatedCompaniesCountResponse.reducedTree && (
+                  <StyledDetails summary="Why can't I filter by subsidiary companies?">
+                    <StyledParagraph>
+                      {SUBSIDIARIES_LIMITED_LABEL}
+                    </StyledParagraph>
+                  </StyledDetails>
+                )}
+              </FilterToggleSection>
             )}
-          </FilterToggleSection>
+          </>
         )}
       </RelatedCompaniesCountResource>
     )}

--- a/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
+++ b/src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter.jsx
@@ -25,36 +25,40 @@ const StyledDetails = styled(Details)`
 `
 
 const RoutedRelatedCompaniesCheckboxGroup = ({ company, selectedOptions }) => (
-  <RelatedCompaniesCountResource id={company.id}>
-    {(count) => (
-      <FilterToggleSection
-        id="ProjectCollection.include-related-companies-filters"
-        label="Related companies"
-        isOpen={true}
-      >
-        <RoutedCheckboxGroupField
-          legend="Include related companies"
-          name="include_related_companies"
-          qsParam="include_related_companies"
-          options={
-            count.reducedTree
-              ? INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY
-              : INCLUDE_RELATED_COMPANIES
-          }
-          selectedOptions={selectedOptions}
-          data-test="include-related-companies-filter"
-          aria-description={
-            count.reducedTree ? SUBSIDIARIES_LIMITED_LABEL : undefined
-          }
-        />
-        {count.reducedTree && (
-          <StyledDetails summary="Why can't I filter by subsidiary companies?">
-            <StyledParagraph>{SUBSIDIARIES_LIMITED_LABEL}</StyledParagraph>
-          </StyledDetails>
+  <>
+    {company.dunsNumber && (
+      <RelatedCompaniesCountResource id={company.id}>
+        {(count) => (
+          <FilterToggleSection
+            id="ProjectCollection.include-related-companies-filters"
+            label="Related companies"
+            isOpen={true}
+          >
+            <RoutedCheckboxGroupField
+              legend="Include related companies"
+              name="include_related_companies"
+              qsParam="include_related_companies"
+              options={
+                count.reducedTree
+                  ? INCLUDE_RELATED_COMPANIES_DISABLED_SUBSIDIARY
+                  : INCLUDE_RELATED_COMPANIES
+              }
+              selectedOptions={selectedOptions}
+              data-test="include-related-companies-filter"
+              aria-description={
+                count.reducedTree ? SUBSIDIARIES_LIMITED_LABEL : undefined
+              }
+            />
+            {count.reducedTree && (
+              <StyledDetails summary="Why can't I filter by subsidiary companies?">
+                <StyledParagraph>{SUBSIDIARIES_LIMITED_LABEL}</StyledParagraph>
+              </StyledDetails>
+            )}
+          </FilterToggleSection>
         )}
-      </FilterToggleSection>
+      </RelatedCompaniesCountResource>
     )}
-  </RelatedCompaniesCountResource>
+  </>
 )
 
 export default RoutedRelatedCompaniesCheckboxGroup

--- a/test/component/cypress/specs/RoutedRelatedCompaniesCheckboxGroup.cy.jsx
+++ b/test/component/cypress/specs/RoutedRelatedCompaniesCheckboxGroup.cy.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import RoutedRelatedCompaniesCheckboxGroup from '../../../../src/client/components/RoutedRelatedCompaniesCheckboxGroup/Filter'
+import DataHubProvider from './provider'
+
+describe('RoutedRelatedCompaniesCheckboxGroup', () => {
+  const Component = (props) => (
+    <DataHubProvider
+      tasks={{
+        ['RelatedCompaniesCount']: () => {
+          return {}
+        },
+      }}
+    >
+      <RoutedRelatedCompaniesCheckboxGroup {...props} />
+    </DataHubProvider>
+  )
+
+  context('When company does not have a duns number', () => {
+    it('should not render the filter', () => {
+      cy.mount(<Component company={{ dunsNumber: null }} />)
+      cy.get('[data-test="include-related-companies-filter"]').should(
+        'not.exist'
+      )
+    })
+  })
+
+  context('When company has a duns number', () => {
+    it('should render the filter', () => {
+      cy.mount(<Component company={{ dunsNumber: 1234 }} />)
+      cy.get('[data-test="include-related-companies-filter"]').should('exist')
+    })
+  })
+})

--- a/test/component/cypress/specs/RoutedRelatedCompaniesCheckboxGroup.cy.jsx
+++ b/test/component/cypress/specs/RoutedRelatedCompaniesCheckboxGroup.cy.jsx
@@ -3,15 +3,16 @@ import RoutedRelatedCompaniesCheckboxGroup from '../../../../src/client/componen
 import DataHubProvider from './provider'
 
 describe('RoutedRelatedCompaniesCheckboxGroup', () => {
-  const Component = (props) => (
+  const Component = ({ company, taskResponse = {} }) => (
     <DataHubProvider
+      resetTasks={true}
       tasks={{
         ['RelatedCompaniesCount']: () => {
-          return {}
+          return taskResponse
         },
       }}
     >
-      <RoutedRelatedCompaniesCheckboxGroup {...props} />
+      <RoutedRelatedCompaniesCheckboxGroup company={company} />
     </DataHubProvider>
   )
 
@@ -24,10 +25,32 @@ describe('RoutedRelatedCompaniesCheckboxGroup', () => {
     })
   })
 
-  context('When company has a duns number', () => {
-    it('should render the filter', () => {
-      cy.mount(<Component company={{ dunsNumber: 1234 }} />)
-      cy.get('[data-test="include-related-companies-filter"]').should('exist')
+  context('When company has a duns number and no related companies', () => {
+    it('should not render the filter', () => {
+      cy.mount(
+        <Component
+          company={{ dunsNumber: 1234 }}
+          taskResponse={{ relatedCompaniesCount: 0 }}
+        />
+      )
+      cy.get('[data-test="include-related-companies-filter"]').should(
+        'not.exist'
+      )
     })
   })
+
+  context(
+    'When company has a duns number and at least 1 related company',
+    () => {
+      it('should render the filter', () => {
+        cy.mount(
+          <Component
+            company={{ dunsNumber: 1234 }}
+            taskResponse={{ relatedCompaniesCount: 1 }}
+          />
+        )
+        cy.get('[data-test="include-related-companies-filter"]').should('exist')
+      })
+    }
+  )
 })

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -31,9 +31,10 @@ export const store = legacy_createStore(
 
 const runMiddlewareOnce = _.once((tasks) => sagaMiddleware.run(rootSaga(tasks)))
 
-export default ({ children, tasks }) => {
+export default ({ children, tasks = {}, resetTasks = false }) => {
   // We only ever want to start the sagas once
-  runMiddlewareOnce(tasks || {})
+  resetTasks ? sagaMiddleware.run(rootSaga(tasks)) : runMiddlewareOnce(tasks)
+
   return (
     <Provider store={store}>
       <BrowserRouter>{children}</BrowserRouter>

--- a/test/functional/cypress/specs/companies/investments/filter-spec.js
+++ b/test/functional/cypress/specs/companies/investments/filter-spec.js
@@ -9,6 +9,13 @@ const searchEndpoint = '/api-proxy/v3/search/investment_project'
 
 describe('Company Investments Filter', () => {
   before(() => {
+    cy.intercept(
+      'GET',
+      `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+        dnbCorp.id
+      )}?include_manually_linked_companies=true`,
+      { reduced_tree: false, related_companies_count: 1, total: 1 }
+    ).as('relatedCompaniesApiRequest')
     cy.visit(urls.companies.investments.companyInvestmentProjects(dnbCorp.id))
   })
 

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -104,8 +104,6 @@ describe('Company Investments Collection Page', () => {
   )}?${buildQueryString()}`
 
   before(() => {
-    // const queryString = buildQueryString()
-
     collectionListRequest(
       'v3/search/investment_project',
       investmentProjects,
@@ -235,7 +233,7 @@ describe('Company Investments Collection Page', () => {
           `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
             dnbCorp.id
           )}?include_manually_linked_companies=true`,
-          { reduced_tree: true }
+          { reduced_tree: true, related_companies_count: 2000 }
         ).as('relatedCompaniesApiRequest')
         cy.visit(visitLink)
       })

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -104,6 +104,13 @@ describe('Company Investments Collection Page', () => {
   )}?${buildQueryString()}`
 
   before(() => {
+    cy.intercept(
+      'GET',
+      `/api-proxy${urls.companies.dnbHierarchy.relatedCompaniesCount(
+        dnbCorp.id
+      )}?include_manually_linked_companies=true`,
+      { reduced_tree: false, related_companies_count: 1, total: 1 }
+    ).as('relatedCompaniesApiRequest')
     collectionListRequest(
       'v3/search/investment_project',
       investmentProjects,

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -67,8 +67,8 @@ exports.relatedCompaniesCount = function (req, res) {
           reduced_tree: false,
         }
       : {
-          total: 1,
-          related_companies_count: 1,
+          total: 0,
+          related_companies_count: 0,
           manually_linked_subsidiaries_count: 0,
           reduced_tree: false,
         }

--- a/test/sandbox/routes/v4/dnb/index.js
+++ b/test/sandbox/routes/v4/dnb/index.js
@@ -67,8 +67,8 @@ exports.relatedCompaniesCount = function (req, res) {
           reduced_tree: false,
         }
       : {
-          total: 0,
-          related_companies_count: 0,
+          total: 1,
+          related_companies_count: 1,
           manually_linked_subsidiaries_count: 0,
           reduced_tree: false,
         }


### PR DESCRIPTION
## Description of change

When the company has no duns number or related companies, hide the related companies filter

## Test instructions

Use a company that has no related companies, for example https://www.datahub.dev.uktrade.io/companies/05532b0e-49e8-4940-b96d-99ef2be18699/investments/projects?page=1&sortby=created_on%3Adesc. You can see the parent and subsidiary checkboxes are visible, when there are no related companies to include in the filter

Checkout this branch, and view the same company on local. That filter will no longer show http://localhost:3000/companies/05532b0e-49e8-4940-b96d-99ef2be18699/investments/projects?page=1&sortby=created_on%3Adesc

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/61d6bde4-601d-4e06-8a49-06efbc07687c)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/84f57766-1bc3-4a4e-aa24-942e705d3144)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
