### PR TITLE
Add null check for referral source adviser

### DIFF
--- a/src/client/modules/Investments/Projects/EditProjectSummary.jsx
+++ b/src/client/modules/Investments/Projects/EditProjectSummary.jsx
@@ -34,12 +34,15 @@ import {
 } from './InvestmentFormFields'
 import urls from '../../../../lib/urls'
 import { transformObjectForTypeahead } from '../../../../apps/investments/client/projects/team/transformers'
-import { transformArrayForTypeahead } from './transformers'
+import {
+  transformArrayForTypeahead,
+  transformRadioOptionToBool,
+  transformProjectSummaryForApi,
+} from './transformers'
 import { transformDateStringToDateObject } from '../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../apps/constants'
 import { GREY_2 } from '../../../utils/colours'
 import { TASK_EDIT_INVESTMENT_PROJECT_SUMMARY } from './state'
-import { transformProjectSummaryForApi } from './transformers'
 
 const StyledFieldWrapper = styled(FieldWrapper)`
   border: 1px solid ${GREY_2};
@@ -47,8 +50,18 @@ const StyledFieldWrapper = styled(FieldWrapper)`
   padding: 16px 16px;
 `
 
+const checkReferralSourceAdviserIsCurrentAdviser = (
+  currentAdviser,
+  referralSourceAdviser
+) => (currentAdviser === referralSourceAdviser ? OPTION_YES : OPTION_NO)
+
 const checkReferralSourceAdviser = (currentAdviser, referralSourceAdviser) =>
-  currentAdviser === referralSourceAdviser
+  referralSourceAdviser == null
+    ? null
+    : checkReferralSourceAdviserIsCurrentAdviser(
+        currentAdviser,
+        referralSourceAdviser
+      )
 
 const EditProjectSummary = ({ projectId, currentAdviser }) => (
   <InvestmentResource id={projectId}>
@@ -124,19 +137,17 @@ const EditProjectSummary = ({ projectId, currentAdviser }) => (
             />
             <FieldReferralSourceAdviser
               name="is_referral_source"
-              initialValue={
-                checkReferralSourceAdviser(
-                  currentAdviser,
-                  project.referralSourceAdviser.id
-                )
-                  ? OPTION_YES
-                  : OPTION_NO
-              }
+              initialValue={checkReferralSourceAdviser(
+                currentAdviser,
+                project.referralSourceAdviser?.id
+              )}
               label="Referral source adviser"
               typeaheadInitialValue={
-                checkReferralSourceAdviser(
-                  currentAdviser,
-                  project.referralSourceAdviser.id
+                transformRadioOptionToBool(
+                  checkReferralSourceAdviser(
+                    currentAdviser,
+                    project.referralSourceAdviser?.id
+                  )
                 )
                   ? null
                   : transformObjectForTypeahead(project.referralSourceAdviser)

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -12,7 +12,8 @@ export const transformArrayForTypeahead = (advisers) =>
 export const transformBoolToRadioOption = (boolean) =>
   boolean ? OPTION_YES : OPTION_NO
 
-const transformRadioOptionToBool = (radioOption) => radioOption === OPTION_YES
+export const transformRadioOptionToBool = (radioOption) =>
+  radioOption === OPTION_YES
 
 const setReferralSourceEvent = (values) => {
   const {


### PR DESCRIPTION
## Description of change

The new implementation of the investment details form didn't check whether the Referral Source Adviser field was null or not. This rectifies that issue.

The failing test is the one fixed in #5900.

## Test instructions

With your local FE pointing to dev, go to [this project](http://localhost:3000/investments/projects/1e6799b4-ff98-444e-b56b-231e44006841/edit-details). The form should open.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
