### PR TITLE
Add basic page for create strategy

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -32,6 +32,7 @@ const reactRoutes = [
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',
   '/companies/:companyId/account-management',
+  '/companies/:companyId/account-management/strategy/create',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/Companies/AccountManagement/strategy.jsx
+++ b/src/client/modules/Companies/AccountManagement/strategy.jsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DefaultLayout } from '../../../components'
+
+const Strategy = () => {
+  return (
+    <DefaultLayout
+      heading={'Strategy'}
+      pageTitle={'Strategy'}
+      breadcrumbs={[]}
+      useReactRouter={false}
+    >
+      <h1>Strategy</h1>
+    </DefaultLayout>
+  )
+}
+
+export default Strategy

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -19,6 +19,7 @@ import ExportDetails from './modules/ExportPipeline/ExportDetails'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
 import CompanyTree from './modules/Companies/CompanyHierarchy/CompanyTree'
 import AccountManagement from './modules/Companies/AccountManagement'
+import Strategy from './modules/Companies/AccountManagement/strategy'
 
 const routes = {
   companies: [
@@ -41,6 +42,11 @@ const routes = {
       path: '/companies/:companyId/account-management',
       module: 'datahub:companies',
       component: AccountManagement,
+    },
+    {
+      path: '/companies/:companyId/account-management/strategy/create',
+      module: 'datahub:companies',
+      component: Strategy,
     },
   ],
   contacts: [

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -234,6 +234,10 @@ module.exports = {
     },
     accountManagement: {
       index: url('/companies', '/:companyId/account-management'),
+      create: url(
+        '/companies',
+        '/:companyId/account-management/strategy/create'
+      ),
     },
   },
   companyLists: {

--- a/test/functional/cypress/specs/companies/strategy-spec.js
+++ b/test/functional/cypress/specs/companies/strategy-spec.js
@@ -1,0 +1,15 @@
+const fixtures = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Company account management strategy', () => {
+  context('When visiting the strategy create page', () => {
+    it('should display the h1 heading of Strategy', () => {
+      cy.visit(
+        urls.companies.accountManagement.create(
+          fixtures.company.allActivitiesCompany.id
+        )
+      )
+      cy.get('h1').contains('Strategy')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Basic page for the create strategy on a company.

## Test instructions

Found at: /companies/{company-id}/account-management/strategy/create

## Screenshots

![Screenshot 2023-07-31 at 11 04 12](https://github.com/uktrade/data-hub-frontend/assets/54268863/7a12cd3b-9d38-4813-b6ac-70ec05f0b442)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
