### PR TITLE
CLS2-342/display-strategy-on-ac-tab

### DIFF
--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -1,16 +1,92 @@
 import React from 'react'
+import { useParams } from 'react-router-dom'
+import { CompanyResource } from '../../../components/Resource'
+import { H2, H4, Link } from 'govuk-react'
+import Button from '@govuk-react/button'
+import urls from '../../../../lib/urls'
+import { format } from '../../../../client/utils/date'
+import { GridCol, GridRow } from 'govuk-react'
+import styled from 'styled-components'
+import { DARK_GREY, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 import { DefaultLayout } from '../../../components'
 
-const AccountManagement = () => {
+const LastUpdatedHeading = styled(H4)`
+  color: ${DARK_GREY};
+  font-weight: normal;
+  margin-top: -25px;
+`
+
+const Strategy = ({ company }) => (
+  <>
+    <GridRow>
+      <GridCol>
+        <H2>Strategy</H2>
+      </GridCol>
+      {company.strategy && (
+        <div>
+          <Link
+            href={urls.companies.accountManagement.create(company.id)}
+            data-test="edit-strategy-link"
+          >
+            Edit
+          </Link>
+        </div>
+      )}
+    </GridRow>
+
+    {company.strategy && (
+      <>
+        <GridCol>
+          <GridRow>
+            <LastUpdatedHeading data-test="last-updated-details">
+              <span>{`Last updated by ${company?.modifiedBy?.name}: ${format(
+                company.modifiedOn
+              )}. `}</span>
+              <span>
+                View changes in{' '}
+                <Link
+                  href={urls.companies.editHistory.index(company.id)}
+                  data-test="edit-history-link"
+                >
+                  Edit history page
+                </Link>
+              </span>
+            </LastUpdatedHeading>
+          </GridRow>
+        </GridCol>
+        <p>{company.strategy}</p>
+      </>
+    )}
+
+    {!company.strategy && (
+      <Button
+        data-test="add-strategy-button"
+        as={Link}
+        href={urls.companies.accountManagement.create(company.id)}
+        buttonColour={GREY_3}
+        buttonTextColour={TEXT_COLOUR}
+      >
+        Add strategy
+      </Button>
+    )}
+  </>
+)
+
+const AccountManagement = ({}) => {
+  const { companyId } = useParams()
   return (
-    <DefaultLayout
-      heading={'Account Management'}
-      pageTitle={'Account Management'}
-      breadcrumbs={[]}
-      useReactRouter={false}
-    >
-      <h1>Account Management</h1>
-    </DefaultLayout>
+    <CompanyResource id={companyId}>
+      {(company) => (
+        <DefaultLayout
+          heading={'Account Management'}
+          pageTitle={'Account Management'}
+          breadcrumbs={[{ text: 'Account Management' }]}
+          useReactRouter={false}
+        >
+          <Strategy company={company} />
+        </DefaultLayout>
+      )}
+    </CompanyResource>
   )
 }
 

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useParams } from 'react-router-dom'
 import { CompanyResource } from '../../../components/Resource'
-import { H2, H4, Link } from 'govuk-react'
+import { H3, Link } from 'govuk-react'
 import Button from '@govuk-react/button'
 import urls from '../../../../lib/urls'
 import { format } from '../../../../client/utils/date'
@@ -9,18 +9,21 @@ import { GridCol, GridRow } from 'govuk-react'
 import styled from 'styled-components'
 import { DARK_GREY, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 import { DefaultLayout } from '../../../components'
+import { FONT_SIZE } from '@govuk-react/constants'
 
-const LastUpdatedHeading = styled(H4)`
+const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
   font-weight: normal;
-  margin-top: -25px;
+  margin-top: -20px;
+  margin-bottom: -10px;
+  font-size: ${FONT_SIZE.SIZE_14};
 `
 
 const Strategy = ({ company }) => (
   <>
     <GridRow>
       <GridCol>
-        <H2>Strategy</H2>
+        <H3>Strategy</H3>
       </GridCol>
       {company.strategy && (
         <div>

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -26,7 +26,7 @@ describe('Company account management', () => {
     })
 
     it('should display the strategy heading', () => {
-      cy.get('h2').contains('Strategy')
+      cy.get('h3').contains('Strategy')
     })
 
     it('should display the edit history details link', () => {
@@ -70,7 +70,7 @@ describe('Company account management', () => {
       })
 
       it('should display the strategy heading', () => {
-        cy.get('h2').contains('Strategy')
+        cy.get('h3').contains('Strategy')
       })
 
       it('should display the add strategy button', () => {

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -1,15 +1,85 @@
+import { faker } from '@faker-js/faker'
+import { companyFaker } from '../../fakers/companies'
+import { userFaker } from '../../fakers/users'
+import { format } from 'date-fns'
+
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
+const companyId = fixtures.company.allActivitiesCompany.id
 describe('Company account management', () => {
-  context('When visiting the account management page', () => {
-    it('should display the h1 heading of Account Management', () => {
-      cy.visit(
-        urls.companies.accountManagement.index(
-          fixtures.company.allActivitiesCompany.id
-        )
+  const companyWithStrategy = companyFaker({
+    strategy: 'ABC',
+    id: companyId,
+    modifiedBy: userFaker(),
+    modifiedOn: faker.date.past(),
+  })
+
+  context('When visiting the account management page with a strategy', () => {
+    before(() => {
+      cy.intercept(
+        'GET',
+        `/api-proxy/v4/company/${companyId}`,
+        companyWithStrategy
+      ).as('companyApi')
+      cy.visit(urls.companies.accountManagement.index(companyId))
+    })
+
+    it('should display the strategy heading', () => {
+      cy.get('h2').contains('Strategy')
+    })
+
+    it('should display the edit history details link', () => {
+      cy.get('[data-test="edit-history-link"]').should(
+        'have.attr',
+        'href',
+        urls.companies.editHistory.index(companyId)
       )
-      cy.get('h1').contains('Account Management')
+    })
+
+    it('should display the updated by information', () => {
+      cy.get('[data-test="last-updated-details"] > span')
+        .eq(0)
+        .contains(
+          `Last updated by ${companyWithStrategy.modifiedBy.name}: ${format(
+            companyWithStrategy.modifiedOn,
+            'dd MMM yyyy'
+          )}. `
+        )
+    })
+
+    it('should display the edit strategy link', () => {
+      cy.get('[data-test="edit-strategy-link"]').should(
+        'have.attr',
+        'href',
+        urls.companies.accountManagement.create(companyId)
+      )
     })
   })
+
+  context(
+    'When visiting the account management page without a strategy',
+    () => {
+      before(() => {
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${companyId}`,
+          companyFaker({ strategy: undefined, id: companyId })
+        ).as('companyApi')
+        cy.visit(urls.companies.accountManagement.index(companyId))
+      })
+
+      it('should display the strategy heading', () => {
+        cy.get('h2').contains('Strategy')
+      })
+
+      it('should display the add strategy button', () => {
+        cy.get('[data-test="add-strategy-button"]').should(
+          'have.attr',
+          'href',
+          urls.companies.accountManagement.create(companyId)
+        )
+      })
+    }
+  )
 })


### PR DESCRIPTION
## Description of change

Add the strategy field to the account management page. When this field is populated it is shown, along with links to edit the field and to view the history.
When the field is missing, a button is shown that redirects to the create strategy page

## Test instructions

Company with a strategy - http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/account-management
Company without a strategy - http://localhost:3000/companies/fd8220b1-c59f-413e-8f0b-61d692c15c3a/account-management

## Screenshots

### Without a strategy

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/2285db72-2ec3-4b3c-8452-0e1e9401a2dd)

### With a strategy

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/396fa454-e733-43bd-b40d-f35836ae1bdc)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
