### PR TITLE
bugfix/CPS-486-investment-project-urls

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/ActiveInvestmentProjectsCard.jsx
@@ -204,7 +204,9 @@ const ActiveInvestmentProjectsCard = ({
       <StyledTableCell colSpan={2}>
         {stageList?.active ? (
           <Link
-            href={companies.investments.companyInvestmentProjects(companyId)}
+            href={companies.investments.companyInvestmentProjectsWithSearch(
+              companyId
+            )}
             data-test="active-investments-page-link"
           >
             {stageList?.active <= 3 && 'View all investments'}
@@ -219,7 +221,9 @@ const ActiveInvestmentProjectsCard = ({
           </Link>
         ) : (
           <Link
-            href={companies.investments.companyInvestmentProjects(companyId)}
+            href={companies.investments.companyInvestmentProjectsWithSearch(
+              companyId
+            )}
             data-test="investments-page-link"
           >
             View all investments

--- a/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/InvestmentStatusCard.jsx
@@ -120,7 +120,7 @@ const InvestmentStatusCard = ({
           <StyledTableRow>
             <StyledLastTableCell colSpan={2}>
               <Link
-                href={urls.companies.investments.companyInvestmentProjects(
+                href={urls.companies.investments.companyInvestmentProjectsWithSearch(
                   companyId
                 )}
                 data-test="investment-page-link"

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -216,6 +216,10 @@ module.exports = {
         '/companies',
         '/:companyId/investments/projects'
       ),
+      companyInvestmentProjectsWithSearch: url(
+        '/companies',
+        '/:companyId/investments/projects?page=1&sortby=created_on%3Adesc'
+      ),
       largeCapitalProfile: url(
         '/companies',
         '/:companyId/investments/large-capital-profile'


### PR DESCRIPTION
## Description of change

When the search param is not provided to the investment project page, the `TASK_GET_PROJECTS_LIST.projectsList` task fires twice causing an error that blocks the filters working

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/2a9e7c0a-c76e-4e4e-a865-a70f0f3ccf44)


## Test instructions

Using any company, for example http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/overview, scroll down to the Investment status and Active investment projects cards. Both have a link to the investment projects page, click the link in both cards and then check the filters are still working



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
