### PR TITLE
Hide company investment download button

### DIFF
--- a/src/apps/investments/client/projects/ProjectsCollection.jsx
+++ b/src/apps/investments/client/projects/ProjectsCollection.jsx
@@ -120,7 +120,7 @@ const ProjectsCollection = ({
         sortOptions={optionMetadata.sortOptions}
         taskProps={collectionListTask}
         selectedFilters={selectedFilters}
-        baseDownloadLink="/investments/projects/export"
+        baseDownloadLink={!company ? '/investments/projects/export' : null}
         entityName="project"
         addItemUrl={
           !company


### PR DESCRIPTION
## Description of change

Company investment download button should not be displayed given there is no functionality to support it.

## Test instructions

BAU

## Before

<img width="677" alt="Screenshot 2023-08-02 at 08 31 37" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/d7439212-70e6-43ed-9408-8563ca1295ac">

## After

<img width="850" alt="Screenshot 2023-08-02 at 08 31 24" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/308c17d6-f60a-429c-b19f-2cbf7ef170e4">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
