### PR TITLE
feature/CLS2-352-navigation-and-tabs-for-am-page

### DIFF
--- a/src/apps/companies/apps/account-management/controllers.js
+++ b/src/apps/companies/apps/account-management/controllers.js
@@ -1,0 +1,21 @@
+/* eslint-disable camelcase */
+
+async function renderAccountManagement(req, res) {
+  const { company, dnbRelatedCompaniesCount } = res.locals
+  const permissions = res.locals.user.permissions
+
+  res.render('companies/apps/account-management/views/client-container', {
+    props: {
+      dnbRelatedCompaniesCount,
+      permissions,
+      localNavItems: res.locals.localNavItems,
+      flashMessages: res.locals.getMessages(),
+      companyId: company.id,
+      flashMessages: res.locals.getMessages(),
+    },
+  })
+}
+
+module.exports = {
+  renderAccountManagement,
+}

--- a/src/apps/companies/apps/account-management/router.js
+++ b/src/apps/companies/apps/account-management/router.js
@@ -1,0 +1,11 @@
+const router = require('express').Router()
+
+const urls = require('../../../../lib/urls')
+const { renderAccountManagement } = require('./controllers')
+
+router.get(
+  urls.companies.accountManagement.index.route,
+  renderAccountManagement
+)
+
+module.exports = router

--- a/src/apps/companies/apps/account-management/views/client-container.njk
+++ b/src/apps/companies/apps/account-management/views/client-container.njk
@@ -1,0 +1,9 @@
+{% extends "_layouts/template-no-local-header.njk" %}
+
+{% block body %}
+  {% component 'react-slot', {
+    id: 'account-management',
+    props: props
+  } %}
+
+{% endblock %}

--- a/src/apps/companies/router.js
+++ b/src/apps/companies/router.js
@@ -58,6 +58,7 @@ const companyListsRouter = require('../company-lists/router')
 const advisersRouter = require('./apps/advisers/router')
 const referralsRouter = require('./apps/referrals/router')
 const { companyPipelineRouter } = require('../my-pipeline/router')
+const accountManagementRouter = require('./apps/account-management/router')
 
 const {
   setCompanyHierarchyLocalNav,
@@ -138,5 +139,6 @@ router.use(exportsRouter)
 router.use(referralsRouter)
 router.use(companyPipelineRouter)
 router.use(companyOverviewRouter)
+router.use(accountManagementRouter)
 
 module.exports = router

--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -31,7 +31,6 @@ const reactRoutes = [
   '/export/:exportId/delete',
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',
-  '/companies/:companyId/account-management',
   '/companies/:companyId/account-management/strategy/create',
 ]
 

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -73,6 +73,7 @@ import LinkGlobalHQ from './modules/Companies/CompanyBusinessDetails/LinkGlobalH
 import LinkSubsidiary from './modules/Companies/CompanyBusinessDetails/LinkSubsidiary'
 import EditProjectSummary from './modules/Investments/Projects/EditProjectSummary'
 import EditProjectRequirements from './modules/Investments/Projects/EditProjectRequirements'
+import AccountManagement from './modules/Companies/AccountManagement'
 
 import * as companyListsTasks from './components/CompanyLists/tasks'
 import * as referralTasks from '../apps/companies/apps/referrals/details/client/tasks'
@@ -383,7 +384,6 @@ import {
   TASK_EDIT_INVESTMENT_PROJECT_REQUIREMENTS,
 } from './modules/Investments/Projects/state'
 import { updateInvestmentProject } from './modules/Investments/Projects/tasks'
-import AccountManagement from './modules/Companies/AccountManagement'
 
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -383,6 +383,7 @@ import {
   TASK_EDIT_INVESTMENT_PROJECT_REQUIREMENTS,
 } from './modules/Investments/Projects/state'
 import { updateInvestmentProject } from './modules/Investments/Projects/tasks'
+import AccountManagement from './modules/Companies/AccountManagement'
 
 function parseProps(domNode) {
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}
@@ -881,7 +882,11 @@ function App() {
         <Mount selector="#edit-project-requirements">
           {(props) => <EditProjectRequirements {...props} />}
         </Mount>
-
+        <Mount selector="#account-management">
+          {(props) => (
+            <AccountManagement csrfToken={globalProps.csrfToken} {...props} />
+          )}
+        </Mount>
         <Mount selector="#react-app">
           {() => (
             <Switch>

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { useParams } from 'react-router-dom'
 import { CompanyResource } from '../../../components/Resource'
 import { H3, Link } from 'govuk-react'
 import Button from '@govuk-react/button'
@@ -8,8 +7,8 @@ import { format } from '../../../../client/utils/date'
 import { GridCol, GridRow } from 'govuk-react'
 import styled from 'styled-components'
 import { DARK_GREY, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
-import { DefaultLayout } from '../../../components'
 import { FONT_SIZE } from '@govuk-react/constants'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -75,19 +74,26 @@ const Strategy = ({ company }) => (
   </>
 )
 
-const AccountManagement = ({}) => {
-  const { companyId } = useParams()
+const AccountManagement = ({
+  localNavItems,
+  companyId,
+  dnbRelatedCompaniesCount,
+  flashMessages,
+  csrfToken,
+}) => {
   return (
     <CompanyResource id={companyId}>
       {(company) => (
-        <DefaultLayout
-          heading={'Account Management'}
-          pageTitle={'Account Management'}
+        <CompanyLayout
+          company={company}
           breadcrumbs={[{ text: 'Account Management' }]}
-          useReactRouter={false}
+          localNavItems={localNavItems}
+          dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+          flashMessages={flashMessages}
+          csrfToken={csrfToken}
         >
           <Strategy company={company} />
-        </DefaultLayout>
+        </CompanyLayout>
       )}
     </CompanyResource>
   )

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -86,7 +86,7 @@ const AccountManagement = ({
       {(company) => (
         <CompanyLayout
           company={company}
-          breadcrumbs={[{ text: 'Account Management' }]}
+          breadcrumbs={[{ text: 'Account management' }]}
           localNavItems={localNavItems}
           dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
           flashMessages={flashMessages}

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -37,11 +37,6 @@ const routes = {
       module: 'datahub:companies',
       component: CompanyTree,
     },
-    // {
-    //   path: '/companies/:companyId/account-management',
-    //   module: 'datahub:companies',
-    //   component: AccountManagement,
-    // },
     {
       path: '/companies/:companyId/account-management/strategy/create',
       module: 'datahub:companies',

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -18,7 +18,6 @@ import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
 import ExportDetails from './modules/ExportPipeline/ExportDetails'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
 import CompanyTree from './modules/Companies/CompanyHierarchy/CompanyTree'
-import AccountManagement from './modules/Companies/AccountManagement'
 import Strategy from './modules/Companies/AccountManagement/strategy'
 
 const routes = {
@@ -38,11 +37,11 @@ const routes = {
       module: 'datahub:companies',
       component: CompanyTree,
     },
-    {
-      path: '/companies/:companyId/account-management',
-      module: 'datahub:companies',
-      component: AccountManagement,
-    },
+    // {
+    //   path: '/companies/:companyId/account-management',
+    //   module: 'datahub:companies',
+    //   component: AccountManagement,
+    // },
     {
       path: '/companies/:companyId/account-management/strategy/create',
       module: 'datahub:companies',

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -7,6 +7,18 @@ const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
 const companyId = fixtures.company.allActivitiesCompany.id
+
+const assertBreadcrumbs = (company) => {
+  it('should render breadcrumbs', () => {
+    assertBreadcrumbs({
+      Home: urls.dashboard.index(),
+      Companies: urls.companies.index(),
+      [company.name]: urls.companies.detail(company.id),
+      'Account management': null,
+    })
+  })
+}
+
 describe('Company account management', () => {
   const companyWithStrategy = companyFaker({
     strategy: 'ABC',
@@ -24,6 +36,8 @@ describe('Company account management', () => {
       ).as('companyApi')
       cy.visit(urls.companies.accountManagement.index(companyId))
     })
+
+    assertBreadcrumbs(fixtures.company.allActivitiesCompany)
 
     it('should display the strategy heading', () => {
       cy.get('h3').contains('Strategy')
@@ -68,6 +82,8 @@ describe('Company account management', () => {
         ).as('companyApi')
         cy.visit(urls.companies.accountManagement.index(companyId))
       })
+
+      assertBreadcrumbs(fixtures.company.allActivitiesCompany)
 
       it('should display the strategy heading', () => {
         cy.get('h3').contains('Strategy')


### PR DESCRIPTION
## Description of change

The new account management page will be a tab inside the company page. In order to reuse the same permissions logic for calculating allowed tabs, this page has to be changed to use a node js controller with a nunjucks view :( 
The alternative is to move the permissions and route authentication logic out of node completely and into a react component, however that is outside of the scope of this ticket

## Test instructions

The account management page will now display with the company header, and tabs. The account management page will not appear in the list of tabs yet, and needs to be accessed directly:
Company with a strategy - http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/account-management
Company without a strategy - http://localhost:3000/companies/fd8220b1-c59f-413e-8f0b-61d692c15c3a/account-management

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/6c57ab24-396b-4bcf-acf1-1cb832594a3e)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/1c726721-fe28-4e6e-93b6-6d980a122a6b)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
