### PR TITLE
Cls2 339 edit strategy

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -32,6 +32,7 @@ const reactRoutes = [
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',
   '/companies/:companyId/account-management/strategy/create',
+  '/companies/:companyId/account-management/strategy/edit',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/Companies/AccountManagement/Strategy.jsx
+++ b/src/client/modules/Companies/AccountManagement/Strategy.jsx
@@ -47,6 +47,7 @@ const Strategy = () => {
                 urls.companies.accountManagement.index(companyId)
               }
               submissionTaskName={TASK_SAVE_STRATEGY}
+              initialValues={company}
               transformPayload={({ strategy }) => ({ companyId, strategy })}
               flashMessage={() => 'Strategy saved'}
               submitButtonLabel="Save strategy"

--- a/src/client/modules/Companies/AccountManagement/Strategy.jsx
+++ b/src/client/modules/Companies/AccountManagement/Strategy.jsx
@@ -19,7 +19,11 @@ const Strategy = () => {
     <CompanyResource id={companyId}>
       {(company) => (
         <DefaultLayout
-          heading={`Add strategy for ${company.name}`}
+          heading={
+            company.strategy
+              ? `Edit strategy for ${company.name}`
+              : `Add strategy for ${company.name}`
+          }
           pageTitle={'Strategy'}
           breadcrumbs={buildCompanyBreadcrumbs(
             [

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -31,7 +31,7 @@ const Strategy = ({ company }) => (
       {company.strategy && (
         <div>
           <StyledLink
-            href={urls.companies.accountManagement.create(company.id)}
+            href={urls.companies.accountManagement.edit(company.id)}
             data-test="edit-strategy-link"
           >
             Edit

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -27,7 +27,7 @@ const Strategy = ({ company }) => (
       {company.strategy && (
         <div>
           <Link
-            href={urls.companies.accountManagement.create(company.id)}
+            href={urls.companies.accountManagement.edit(company.id)}
             data-test="edit-strategy-link"
           >
             Edit

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -42,6 +42,11 @@ const routes = {
       module: 'datahub:companies',
       component: Strategy,
     },
+    {
+      path: '/companies/:companyId/account-management/strategy/edit',
+      module: 'datahub:companies',
+      component: Strategy,
+    },
   ],
   contacts: [
     {

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -242,6 +242,7 @@ module.exports = {
         '/companies',
         '/:companyId/account-management/strategy/create'
       ),
+      edit: url('/companies', '/:companyId/account-management/strategy/edit'),
     },
   },
   companyLists: {

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -70,7 +70,7 @@ describe('Company account management', () => {
       cy.get('[data-test="edit-strategy-link"]').should(
         'have.attr',
         'href',
-        urls.companies.accountManagement.create(companyId)
+        urls.companies.accountManagement.edit(companyId)
       )
     })
   })

--- a/test/functional/cypress/specs/companies/strategy-spec.js
+++ b/test/functional/cypress/specs/companies/strategy-spec.js
@@ -100,7 +100,6 @@ describe('Company account management strategy', () => {
           hint: "This should outline a plan than provides a concise overview of the business direction and DBT's approach to help them achieve that.",
           value: allActivitiesCompany.strategy,
         })
-        // clear the field
         cy.get('[id="strategy"]').clear()
         fill('[data-test=field-strategy]', 'test strategy')
         cy.get('[data-test="submit-button"]').contains('Save strategy').click()

--- a/test/functional/cypress/specs/companies/strategy-spec.js
+++ b/test/functional/cypress/specs/companies/strategy-spec.js
@@ -9,34 +9,41 @@ const {
 
 const { fill } = require('../../support/form-fillers')
 
-const company = fixtures.company.allActivitiesCompany
+const dnbCorpCompany = fixtures.company.dnbCorp
+const dnbCorpCompanyUrl = urls.companies.accountManagement.index(
+  dnbCorpCompany.id
+)
 
-const endpoint = `/api-proxy/v4/company/${company.id}`
-
-const companyAccountManagementUrl = urls.companies.accountManagement.index(
-  company.id
+const allActivitiesCompany = fixtures.company.allActivitiesCompany
+const allActivitiesCompanyUrl = urls.companies.accountManagement.index(
+  allActivitiesCompany.id
 )
 
 describe('Company account management strategy', () => {
   context('When visiting the strategy create page', () => {
     beforeEach(() => {
-      cy.intercept('PATCH', endpoint).as('apiRequest')
-      cy.visit(urls.companies.accountManagement.create(company.id))
+      cy.intercept('PATCH', `/api-proxy/v4/company/${dnbCorpCompany.id}`).as(
+        'apiRequest'
+      )
+      cy.visit(urls.companies.accountManagement.create(dnbCorpCompany.id))
     })
 
     it('should display the header', () => {
-      cy.get('h1').should('have.text', `Add strategy for ${company.name}`)
+      cy.get('h1').should(
+        'have.text',
+        `Add strategy for ${dnbCorpCompany.name}`
+      )
     })
 
     it('should render breadcrumbs', () => {
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
         Companies: urls.companies.index(),
-        [company.name]: urls.companies.detail(company.id),
+        [dnbCorpCompany.name]: urls.companies.detail(dnbCorpCompany.id),
         'Account management': urls.companies.accountManagement.index(
-          company.id
+          dnbCorpCompany.id
         ),
-        [`Strategy for ${company.name}`]: null,
+        [`Strategy for ${dnbCorpCompany.name}`]: null,
       })
     })
 
@@ -51,15 +58,61 @@ describe('Company account management strategy', () => {
     })
 
     it('save strategy button should link to company account management page', () => {
-      fill('[data-test=field-strategy]', 'Example strategy')
+      fill('[data-test=field-strategy]', 'test strategy')
       cy.get('[data-test="submit-button"]').contains('Save strategy').click()
-      assertPayload('@apiRequest', { strategy: 'Example strategy' })
-      cy.location('pathname').should('eq', companyAccountManagementUrl)
+      assertPayload('@apiRequest', {
+        strategy: 'test strategy',
+      })
+      cy.location('pathname').should('eq', dnbCorpCompanyUrl)
     })
 
     it('cancels form when back link is clicked', () => {
       cy.get('[data-test="cancel-button"]').contains('Back').click()
-      cy.location('pathname').should('eq', companyAccountManagementUrl)
+      cy.location('pathname').should('eq', dnbCorpCompanyUrl)
+    })
+
+    it('displays a success flash message when form is submitted', () => {
+      cy.get('[data-test="submit-button"]').contains('Save strategy').click()
+      assertFlashMessage('Strategy saved')
+    })
+  })
+  context('When visiting the strategy edit page', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'PATCH',
+        `/api-proxy/v4/company/${allActivitiesCompany.id}`
+      ).as('apiRequest')
+      cy.visit(urls.companies.accountManagement.edit(allActivitiesCompany.id))
+    })
+
+    it('should display the header', () => {
+      cy.get('h1').should(
+        'have.text',
+        `Edit strategy for ${allActivitiesCompany.name}`
+      )
+    })
+
+    it('should edit the strategy field', () => {
+      cy.get('[data-test="field-strategy"]').then((element) => {
+        assertFieldTextarea({
+          element,
+          label: 'Strategy',
+          hint: "This should outline a plan than provides a concise overview of the business direction and DBT's approach to help them achieve that.",
+          value: allActivitiesCompany.strategy,
+        })
+        // clear the field
+        cy.get('[id="strategy"]').clear()
+        fill('[data-test=field-strategy]', 'test strategy')
+        cy.get('[data-test="submit-button"]').contains('Save strategy').click()
+        assertPayload('@apiRequest', {
+          strategy: 'test strategy',
+        })
+      })
+    })
+
+    it('cancels form when back link is clicked', () => {
+      cy.get('[data-test="cancel-button"]').contains('Back').click()
+      cy.location('pathname').should('eq', allActivitiesCompanyUrl)
     })
 
     it('displays a success flash message when form is submitted', () => {


### PR DESCRIPTION
## Description of change

Users can edit a summary of strategy to a company page, so they can update strategic information relating to the company

## Test instructions

If a company has a strategy you should be able to click the edit button in account management and edit the strategy.

## Screenshots

### Before


### After
<img width="1407" alt="Screenshot 2023-08-02 at 15 51 44" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/93b33824-f349-4cb7-8f76-08bb8e4384ef">

<img width="1134" alt="Screenshot 2023-08-02 at 15 52 08" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/7c137a26-c3c0-49d5-93bb-5d8ccfdb37c6">



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
