### PR TITLE
Add padding to move edit link in main content body

### DIFF
--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -18,6 +18,10 @@ const LastUpdatedHeading = styled.div`
   font-size: ${FONT_SIZE.SIZE_14};
 `
 
+const StyledLink = styled(Link)`
+  padding-right: 15px;
+`
+
 const Strategy = ({ company }) => (
   <>
     <GridRow>
@@ -26,12 +30,12 @@ const Strategy = ({ company }) => (
       </GridCol>
       {company.strategy && (
         <div>
-          <Link
+          <StyledLink
             href={urls.companies.accountManagement.create(company.id)}
             data-test="edit-strategy-link"
           >
             Edit
-          </Link>
+          </StyledLink>
         </div>
       )}
     </GridRow>


### PR DESCRIPTION
## Description of change

Edit strategy link was coming out of the main content body on the right. This change moves it in line with other elements

## Screenshots

### Before
![Screenshot 2023-08-02 at 16 07 25](https://github.com/uktrade/data-hub-frontend/assets/54268863/3538ed93-5300-4128-b2b4-b3a25b186f06)

### After

![Screenshot 2023-08-02 at 16 07 40](https://github.com/uktrade/data-hub-frontend/assets/54268863/718bbebe-e7f4-4679-b661-94c8abb43150)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
