### PR TITLE
feature/CLS2-340-create-objective-urls

### DIFF
--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -245,6 +245,16 @@ module.exports = {
         ),
         edit: url('/companies', '/:companyId/account-management/strategy/edit'),
       },
+      objectives: {
+        create: url(
+          '/companies',
+          '/:companyId/account-management/objective/create'
+        ),
+        edit: url(
+          '/companies',
+          '/:companyId/account-management/objective/:objectiveId/edit'
+        ),
+      },
     },
   },
   companyLists: {


### PR DESCRIPTION
## Description of change

Add the urls for creating and editing company objectives. The pages don't yet exist, but we need these urls in place to use in `<Link>` components on the objectives list page


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
