### PR TITLE
bugfix/revert-typeahead-auto-clearing-text

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -40,7 +40,6 @@ import {
   maintainScrollVisibility,
   menuActions,
   getNewSelectedOptions,
-  TIMEOUT,
 } from './utils'
 import reducer from './reducer'
 import { TASK_GET_TYPEAHEAD_OPTIONS } from './state'
@@ -203,7 +202,7 @@ const Typeahead = ({
   const onInputKeyDown = (event) => {
     const max = filteredOptions.length - 1
     const action = getActionFromKey(event.code, menuOpen)
-    setTimeout(() => TIMEOUT.clearAllTimeouts()) // clear onInputKeyUp timeouts
+
     switch (action) {
       case menuActions.next:
       case menuActions.last:
@@ -240,17 +239,6 @@ const Typeahead = ({
         return
     }
   }
-
-  // Average typing speed between 150-200 character per minute(CPM)/60
-  // which converted into milliseconds(1sec/1000)
-  const onInputKeyUp = (setTimeoutFn, averageTypingTimeout = 3000) => {
-    TIMEOUT.setTimeout(() => {
-      selectTextInput(name)
-    }, averageTypingTimeout)
-  }
-
-  const selectTextInput = (elementId) =>
-    document.getElementById(elementId).select()
 
   const menuActive = loadOptions ? !!input : true
   return (
@@ -307,7 +295,6 @@ const Typeahead = ({
             }
           }}
           onKeyDown={onInputKeyDown}
-          onKeyUp={onInputKeyUp}
           error={error}
           ref={inputRef}
           data-test="typeahead-input"

--- a/src/client/components/Typeahead/__stories__/usage.md
+++ b/src/client/components/Typeahead/__stories__/usage.md
@@ -1,5 +1,3 @@
 This is a new accessible typeahead designed to replace the old typeahead. Typing into the input will filter options - this can be operated in both multi and single select modes. In multi-select mode, the selected options are shown outside of the input box as removable chips.
 
-It allows average users to keep typing a keyword search and select options without removing previous string.
-
 This is based on [accessibility research by Microsoft's Sarah Higley](https://www.24a11y.com/2019/select-your-poison-part-2/).

--- a/src/client/components/Typeahead/utils.js
+++ b/src/client/components/Typeahead/utils.js
@@ -96,16 +96,3 @@ export const maintainScrollVisibility = ({ parent, target }) => {
     parent.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight)
   }
 }
-
-export const TIMEOUT = {
-  timeoutIds: [],
-  setTimeout(setTimeoutFn, timeoutDelay) {
-    const id = setTimeout(setTimeoutFn, timeoutDelay)
-    this.timeoutIds.push(id)
-  },
-  clearAllTimeouts() {
-    while (this.timeoutIds.length) {
-      clearTimeout(this.timeoutIds.pop())
-    }
-  },
-}

--- a/test/component/cypress/specs/Typeahead.cy.jsx
+++ b/test/component/cypress/specs/Typeahead.cy.jsx
@@ -52,10 +52,6 @@ export const mockLoadOptions = (query = '') =>
   )
 
 describe('Typeahead2', () => {
-  // Average typing speed between 150-200 character per minute(CPM)/60
-  // which converted into milliseconds(1sec/1000)
-  const averageTypingTimeout = 3000
-
   context('static single-select', () => {
     beforeEach(() => {
       store.dispatch(RESET_ACTION)
@@ -249,50 +245,6 @@ describe('Typeahead2', () => {
         .should('have.text', options[3].label)
         .should('have.attr', 'aria-selected', 'true')
     })
-
-    it('should keeps typing new filter when input typed having multi keywords', () => {
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .click()
-        .type('black') // 1st filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should('have.text', 'Blackberry')
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .trigger('keyup')
-        .wait(averageTypingTimeout)
-        .type('bana') // 2nd filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should('have.text', 'Banana')
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .trigger('keyup')
-        .wait(averageTypingTimeout)
-        .type('papa') // 3rd filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should('have.text', 'Papaya')
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
-    })
   })
 
   context('async single-select', () => {
@@ -466,53 +418,6 @@ describe('Typeahead2', () => {
         .find('[data-test="typeahead-menu-option"]')
         .eq(1)
         .should('have.attr', 'aria-selected', 'false')
-    })
-
-    it('should keeps typing new filter when input typed having multi keywords', () => {
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .click()
-        .type('nis') // 1st filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should('have.text', 'Dennis Kennedy')
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .trigger('keyup')
-        .wait(averageTypingTimeout)
-        .type('zil') // 2nd filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should('have.text', 'Denzil Lincoln')
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
-      cy.get('@component')
-        .find('[data-test="typeahead-input"]')
-        .trigger('keyup')
-        .wait(averageTypingTimeout)
-        .type('nard') // 3rd filter string keyword
-      cy.get('@component')
-        .find('[data-test="typeahead-menu"]')
-        .should('be.visible')
-        .find('[data-test="typeahead-menu-option"]')
-        .should('have.length', 1)
-        .first()
-        .should(
-          'have.text',
-          'Bernard Harris-Patelc - Welsh Government (Investment)'
-        )
-        .click()
-        .should('have.attr', 'aria-selected', 'true')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Remove timeout clearing the users text without any notice

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
