### PR TITLE
feature/RR-1065-remove-user-test-on-typeahead-selection

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -340,7 +340,7 @@ const Typeahead = ({
                       aria-setsize={filteredOptions.length}
                       aria-posinset={index}
                       onClick={() => {
-                        inputRef.current && inputRef.current.focus()
+                        inputRef.current && inputRef.current.select()
                         onOptionToggle(option)
                         onChange(
                           getNewSelectedOptions({

--- a/test/component/cypress/specs/Typeahead.cy.jsx
+++ b/test/component/cypress/specs/Typeahead.cy.jsx
@@ -127,7 +127,7 @@ describe('Typeahead2', () => {
         .should('have.attr', 'value', '')
     })
 
-    it('should highlight entered text when option is clicked and replace when new text when entered', () => {
+    it('should highlight entered text when option is clicked and replace when new text is entered', () => {
       cy.get('@component')
         .find('[data-test="typeahead-input"]')
         .clear()
@@ -338,7 +338,7 @@ describe('Typeahead2', () => {
         .should('have.attr', 'value', '')
     })
 
-    it('should highlight entered text when option is clicked and replace when new text when entered', () => {
+    it('should highlight entered text when option is clicked and replace when new text is entered', () => {
       cy.get('@component')
         .find('[data-test="typeahead-input"]')
         .clear()

--- a/test/component/cypress/specs/Typeahead.cy.jsx
+++ b/test/component/cypress/specs/Typeahead.cy.jsx
@@ -126,6 +126,21 @@ describe('Typeahead2', () => {
         .click()
         .should('have.attr', 'value', '')
     })
+
+    it('should highlight entered text when option is clicked and replace when new text when entered', () => {
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .clear()
+        .type('Bl')
+      cy.get('@component').find('[data-test="typeahead-input"]').click()
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .clear()
+        .type('An')
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .should('have.value', 'An')
+    })
   })
 
   context('static multi-select', () => {
@@ -321,6 +336,21 @@ describe('Typeahead2', () => {
         .blur()
         .click()
         .should('have.attr', 'value', '')
+    })
+
+    it('should highlight entered text when option is clicked and replace when new text when entered', () => {
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .clear()
+        .type('Bl')
+      cy.get('@component').find('[data-test="typeahead-input"]').click()
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .clear()
+        .type('An')
+      cy.get('@component')
+        .find('[data-test="typeahead-input"]')
+        .should('have.value', 'An')
     })
   })
 


### PR DESCRIPTION
## Description of change

When a multiselect typeahead option is clicked, highlight the previously entered user text. Highlighting is preferred over simply removing the text for accessibility reasons

## Test instructions

Use any multi select typeahead, for example the Sector on the companies page http://localhost:3000/companies. Type in some text that matches at least 1 option. Select that option, the text you previously entered will now be highlighted. You can then continue typing and the text you entered will be replaced by the new text

## Screenshots

### Before

![chrome_txffm2bDNx](https://github.com/uktrade/data-hub-frontend/assets/102232401/7e1958db-81b6-4e5c-ae4f-18a3468ebff0)


### After

![chrome_UXilFDU2uM](https://github.com/uktrade/data-hub-frontend/assets/102232401/2a34a912-326b-4369-ae72-c9ec54626398)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
