### PR TITLE
Added hq type tag to company tree

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -38,6 +38,7 @@ import {
 import { addressToString } from '../../../utils/addresses'
 import { GREY_4, BLACK, WHITE, BLUE } from '../../../utils/colours'
 import { format } from '../../../utils/date'
+import { hqLabels } from '../../../../apps/companies/labels'
 
 const ToggleSubsidiariesButton = ({
   isOpen,
@@ -299,6 +300,14 @@ const HierarchyItem = ({
                 data-test={`${companyName}-one-list-tag`}
               >
                 One List {company.one_list_tier.name.slice(0, 6)}
+              </HierarchyTag>
+            )}
+            {company.headquarter_type?.name && (
+              <HierarchyTag
+                colour="grey"
+                data-test={`${companyName}-headquarter-type-tag`}
+              >
+                {hqLabels[company.headquarter_type.name]}
               </HierarchyTag>
             )}
             {company.address?.country.name && (

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -29,6 +29,7 @@ const companyTreeItemFaker = (overrides = {}) => ({
   one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
   archived: false,
   trading_names: [faker.company.name()],
+  headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
   hierarchy: 1,
   subsidiaries: [],
   ...overrides,

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -6,6 +6,7 @@ import {
 } from '../../fakers/dnb-hierarchy'
 import { DARK_BLUE_LEGACY } from '../../../../../src/client/utils/colours'
 import hexRgb from 'hex-rgb'
+import { hqLabels } from '../../../../../src/apps/companies/labels'
 
 const {
   assertErrorDialog,
@@ -59,6 +60,7 @@ const companyNoAdditionalTagData = companyTreeFaker({
       uk_region: null,
       address: null,
       trading_names: [],
+      headquarter_type: null,
     }),
     ultimate_global_companies_count: 1,
     family_tree_companies_count: 1,
@@ -349,6 +351,10 @@ describe('D&B Company hierarchy tree', () => {
         'contain.text',
         tagContent.one_list_tier.name.slice(0, 6)
       )
+      cy.get(`[data-test=${companyName}-headquarter-type-tag]`).should(
+        'contain.text',
+        hqLabels[tagContent.headquarter_type.name]
+      )
     })
   })
 
@@ -374,6 +380,9 @@ describe('D&B Company hierarchy tree', () => {
       cy.get(`[data-test=${companyName}-uk-region-tag]`).should('not.exist')
       cy.get(`[data-test=${companyName}-country-tag]`).should('not.exist')
       cy.get(`[data-test=${companyName}-one-list-tag]`).should('not.exist')
+      cy.get(`[data-test=${companyName}-headquarter-type-tag]`).should(
+        'not.exist'
+      )
     })
 
     it('should not show any trading names', () => {


### PR DESCRIPTION
## Description of change

Added headquarter type tag to company tree.


## Screenshots

### After

<img width="979" alt="Screenshot 2023-08-04 at 16 02 38" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/3aaeb8db-e708-4856-bce0-0a39be936f9e">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
