### PR TITLE
On company tree move tags to below title when flexing

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -293,6 +293,28 @@ const HierarchyItem = ({
         }
       >
         <HierarchyItemHeading>
+          <GridColHeader>
+            {Object.keys(company).length === 0 ? (
+              `No related companies found`
+            ) : company?.id ? (
+              <Link
+                href={urls.companies.overview.index(company.id)}
+                aria-label={`Go to ${company.name} details`}
+              >
+                {company.name}
+              </Link>
+            ) : (
+              `${company.name} (not on Data Hub)`
+            )}
+            {company?.trading_names?.length > 0 && (
+              <TradingNames
+                data-test={`${companyName}-trading-names`}
+                isRequestedCompanyId={isRequestedCompanyId}
+              >
+                Trading as: {company?.trading_names.join(', ')}
+              </TradingNames>
+            )}
+          </GridColHeader>
           <GridColTags>
             {company.one_list_tier?.name && (
               <HierarchyTag
@@ -339,28 +361,6 @@ const HierarchyItem = ({
               </HierarchyTag>
             )}
           </GridColTags>
-          <GridColHeader>
-            {Object.keys(company).length === 0 ? (
-              `No related companies found`
-            ) : company?.id ? (
-              <Link
-                href={urls.companies.overview.index(company.id)}
-                aria-label={`Go to ${company.name} details`}
-              >
-                {company.name}
-              </Link>
-            ) : (
-              `${company.name} (not on Data Hub)`
-            )}
-            {company?.trading_names?.length > 0 && (
-              <TradingNames
-                data-test={`${companyName}-trading-names`}
-                isRequestedCompanyId={isRequestedCompanyId}
-              >
-                Trading as: {company?.trading_names.join(', ')}
-              </TradingNames>
-            )}
-          </GridColHeader>
         </HierarchyItemHeading>
         {isOnDataHub ? (
           <ToggleSection

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -227,6 +227,7 @@ export const GridColTags = styled(GridCol)`
 
 export const GridColHeader = styled(GridCol)`
   setwidth: two-thirds;
+  float: left;
   padding-left: 0px;
 `
 


### PR DESCRIPTION
## Description of change

On company tree if the company name and tags are too wide to fit on a single line, the tags should be below the name. 

## Test instructions

View the company tree. The tags should either be on right right hand side next to the name (if there is space) or tags should be below the name.

## Screenshots

### Before

<img width="599" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/3a897d95-c5c9-4f07-9fd5-32655411394e">

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/699259/b1d24902-a638-4d52-9e5e-4e1eb8d2c7b3)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
