### PR TITLE
feature/CLS2-359-refer-button-font-size-change

### DIFF
--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyRefer.jsx
@@ -16,10 +16,7 @@ const StyledCompanyReferButton = styled('button')`
   span {
     pointer-events: none;
     display: inline-block;
-    font-size: ${FONT_SIZE.SIZE_16};
   }
-`
-const StyledButton = styled(StyledCompanyReferButton)`
   background-color: ${GREY_3};
   border-bottom: 3px solid ${GREY_3_LEGACY};
 `
@@ -30,9 +27,12 @@ const LocalHeaderCompanyRefer = ({ companyId }) => {
   }
   return (
     <>
-      <StyledButton data-test="refer-company-button" onClick={handleClickRefer}>
+      <StyledCompanyReferButton
+        data-test="refer-company-button"
+        onClick={handleClickRefer}
+      >
         <span>Refer this company</span>
-      </StyledButton>
+      </StyledCompanyReferButton>
     </>
   )
 }


### PR DESCRIPTION
## Description of change

Made refer button font size 14 to match add to list button font size.

## Test instructions

Go to any company page, for example http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/overview. The button text for Add to list and Refer this company are now the same

## Screenshots

### Before
![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/a88a77a0-a843-4817-8021-74c8d912900c)

### After
![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/d1c03416-d488-4d64-bdb3-200da1efcaf3)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
