### PR TITLE
Add verified tag to company tree

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -294,6 +294,14 @@ const HierarchyItem = ({
       >
         <HierarchyItemHeading>
           <GridColTags>
+            {isOnDataHub && (
+              <HierarchyTag
+                colour="turquoise"
+                data-test={`${companyName}-verified-tag`}
+              >
+                Verified
+              </HierarchyTag>
+            )}
             {company.one_list_tier?.name && (
               <HierarchyTag
                 colour="grey"

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -355,6 +355,17 @@ describe('D&B Company hierarchy tree', () => {
         'contain.text',
         hqLabels[tagContent.headquarter_type.name]
       )
+      cy.get(`[data-test=${companyName}-verified-tag]`).should(
+        'contain.text',
+        'Verified'
+      )
+    })
+
+    it('should not have a verified tag', () => {
+      const company = companyOnlyImmediateSubsidiaries.ultimate_global_company
+      cy.get(`[data-test=${kebabCase(company.name)}-verified-tag]`).should(
+        'not.exist'
+      )
     })
   })
 
@@ -368,11 +379,11 @@ describe('D&B Company hierarchy tree', () => {
       cy.wait('@treeApi')
     })
 
-    it('should not show any tag information', () => {
+    it('should not show any tag information except for verified', () => {
       cy.get(`[data-test=requested-company`)
         .children()
         .find('strong')
-        .should('not.exist')
+        .should('exist')
 
       cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
         'not.exist'
@@ -382,6 +393,11 @@ describe('D&B Company hierarchy tree', () => {
       cy.get(`[data-test=${companyName}-one-list-tag]`).should('not.exist')
       cy.get(`[data-test=${companyName}-headquarter-type-tag]`).should(
         'not.exist'
+      )
+      const company = companyNoAdditionalTagData.ultimate_global_company
+      cy.get(`[data-test=${kebabCase(company.name)}-verified-tag]`).should(
+        'contain.text',
+        'Verified'
       )
     })
 


### PR DESCRIPTION
## Description of change

highlight which companies are verified by DnB to users

## Test instructions

When a company is verified on Datahub they get a 'Verified' badge

## Screenshots

### Before

<img width="965" alt="Screenshot 2023-08-07 at 16 28 14" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/91107fb4-4901-4d62-b5b8-7b434e29cb62">

### After

<img width="967" alt="Screenshot 2023-08-07 at 16 27 29" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/e0fbfbaf-f3e7-43f5-9b6a-47968a0247d9">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ x ] Has the branch been rebased to main?
- [ x ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ x ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
