### PR TITLE
feature/CLS2-357-Add-advisers-to-account-management-page

### DIFF
--- a/src/apps/companies/apps/account-management/controllers.js
+++ b/src/apps/companies/apps/account-management/controllers.js
@@ -10,7 +10,7 @@ async function renderAccountManagement(req, res) {
       dnbRelatedCompaniesCount,
       permissions,
       localNavItems: localNavItems,
-      flashMessages: [],
+      flashMessages: res.locals.getMessages(),
       companyId: company.id,
       returnUrl: returnUrl,
     },

--- a/src/apps/companies/apps/account-management/controllers.js
+++ b/src/apps/companies/apps/account-management/controllers.js
@@ -1,17 +1,19 @@
 /* eslint-disable camelcase */
 
 async function renderAccountManagement(req, res) {
-  const { company, dnbRelatedCompaniesCount } = res.locals
+  const { company, dnbRelatedCompaniesCount, localNavItems, returnUrl } =
+    res.locals
   const permissions = res.locals.user.permissions
 
   res.render('companies/apps/account-management/views/client-container', {
     props: {
       dnbRelatedCompaniesCount,
       permissions,
-      localNavItems: res.locals.localNavItems,
-      flashMessages: res.locals.getMessages(),
+      localNavItems: localNavItems,
+      // flashMessages: res.locals.getMessages(),
+      flashMessages: [],
       companyId: company.id,
-      flashMessages: res.locals.getMessages(),
+      returnUrl: returnUrl,
     },
   })
 }

--- a/src/apps/companies/apps/account-management/controllers.js
+++ b/src/apps/companies/apps/account-management/controllers.js
@@ -10,7 +10,6 @@ async function renderAccountManagement(req, res) {
       dnbRelatedCompaniesCount,
       permissions,
       localNavItems: localNavItems,
-      // flashMessages: res.locals.getMessages(),
       flashMessages: [],
       companyId: company.id,
       returnUrl: returnUrl,

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -69,13 +69,13 @@ const RenderHasAccountManager = ({
   </div>
 )
 
-export const LeadITA = ({ company, companyId, permissions }) => (
+export const LeadITA = ({ company, permissions }) => (
   <>
     <H2 size={LEVEL_SIZE[3]}>Lead ITA for {company.name}</H2>
     {!!company.oneListGroupGlobalAccountManager ? (
       <RenderHasAccountManager
         leadITA={company.oneListGroupGlobalAccountManager}
-        companyId={companyId}
+        companyId={company.id}
         permissions={permissions}
         addUrl={urls.companies.advisers.assign(company.id)}
       />
@@ -99,6 +99,11 @@ export const LeadITA = ({ company, companyId, permissions }) => (
     )}
   </>
 )
+
+LeadITA.propTypes = {
+  company: PropTypes.object.isRequired,
+  permissions: PropTypes.array.isRequired,
+}
 
 const LeadAdvisers = ({
   companyId,

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -69,6 +69,37 @@ const RenderHasAccountManager = ({
   </div>
 )
 
+export const LeadITA = ({ company, companyId, permissions }) => (
+  <>
+    <H2 size={LEVEL_SIZE[3]}>Lead ITA for {company.name}</H2>
+    {!!company.oneListGroupGlobalAccountManager ? (
+      <RenderHasAccountManager
+        leadITA={company.oneListGroupGlobalAccountManager}
+        companyId={companyId}
+        permissions={permissions}
+        addUrl={urls.companies.advisers.assign(company.id)}
+      />
+    ) : (
+      <>
+        <p>
+          This company record has no Lead International Trade Adviser (ITA).
+        </p>
+        {hasPermissionToAddIta(permissions) && (
+          <>
+            <p>
+              You can add a Lead ITA. This will be visible to all Data Hub
+              users.
+            </p>
+            <Button as={Link} href={urls.companies.advisers.assign(company.id)}>
+              Add a Lead ITA
+            </Button>
+          </>
+        )}
+      </>
+    )}
+  </>
+)
+
 const LeadAdvisers = ({
   companyId,
   dnbRelatedCompaniesCount,
@@ -87,35 +118,11 @@ const LeadAdvisers = ({
         flashMessages={flashMessages}
         returnUrl={returnUrl}
       >
-        <H2 size={LEVEL_SIZE[3]}>Lead ITA for {company.name}</H2>
-        {!!company.oneListGroupGlobalAccountManager ? (
-          <RenderHasAccountManager
-            leadITA={company.oneListGroupGlobalAccountManager}
-            companyId={companyId}
-            permissions={permissions}
-            addUrl={urls.companies.advisers.assign(company.id)}
-          />
-        ) : (
-          <>
-            <p>
-              This company record has no Lead International Trade Adviser (ITA).
-            </p>
-            {hasPermissionToAddIta(permissions) && (
-              <>
-                <p>
-                  You can add a Lead ITA. This will be visible to all Data Hub
-                  users.
-                </p>
-                <Button
-                  as={Link}
-                  href={urls.companies.advisers.assign(company.id)}
-                >
-                  Add a Lead ITA
-                </Button>
-              </>
-            )}
-          </>
-        )}
+        <LeadITA
+          company={company}
+          companyId={companyId}
+          permissions={permissions}
+        ></LeadITA>
       </CompanyLayout>
     )}
   </CompanyResource>

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -123,11 +123,7 @@ const LeadAdvisers = ({
         flashMessages={flashMessages}
         returnUrl={returnUrl}
       >
-        <LeadITA
-          company={company}
-          companyId={companyId}
-          permissions={permissions}
-        ></LeadITA>
+        <LeadITA company={company} permissions={permissions}></LeadITA>
       </CompanyLayout>
     )}
   </CompanyResource>

--- a/src/client/components/Layout/CompanyLayout.jsx
+++ b/src/client/components/Layout/CompanyLayout.jsx
@@ -42,7 +42,6 @@ const CompanyLayout = ({
 
 CompanyLayout.propTypes = {
   company: PropTypes.object.isRequired,
-  permissions: PropTypes.array.isRequired,
   children: PropTypes.element.isRequired,
   isInvestment: PropTypes.bool,
   isLCP: PropTypes.bool,

--- a/src/client/modules/Companies/AccountManagement/constants.js
+++ b/src/client/modules/Companies/AccountManagement/constants.js
@@ -1,0 +1,3 @@
+//TODO - this is stored in vault, but React cannot access vault variables.
+// A separate ticket is investigating moving these into React
+export const ONE_LIST_EMAIL = 'one.list@invest-trade.uk'

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -207,6 +207,7 @@ const AccountManagement = ({
               companyId={companyId}
               company={company}
               permissions={permissions}
+              flashMessages={[flashMessages]}
             />
           ) : (
             <>Hello renderCoreTeamAdvisers</>

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -16,6 +16,7 @@ import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
+import { ONE_LIST_EMAIL } from './constants'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -206,10 +207,7 @@ const AccountManagement = ({
           isItaTierDAccount(company.oneListGroupTier) ? (
             <LeadITA company={company} permissions={permissions} />
           ) : (
-            <CoreTeamAdvisers
-              company={company}
-              oneListEmail={'one.list@example.com'}
-            />
+            <CoreTeamAdvisers company={company} oneListEmail={ONE_LIST_EMAIL} />
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -13,6 +13,7 @@ import { DARK_GREY, GREY_2, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import { Metadata } from '../../../components'
+import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -184,6 +185,7 @@ const AccountManagement = ({
   dnbRelatedCompaniesCount,
   flashMessages,
   csrfToken,
+  permissions,
 }) => {
   return (
     <CompanyResource id={companyId}>
@@ -193,11 +195,22 @@ const AccountManagement = ({
           breadcrumbs={[{ text: 'Account management' }]}
           localNavItems={localNavItems}
           dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
-          flashMessages={flashMessages}
+          flashMessages={[flashMessages]}
           csrfToken={csrfToken}
         >
           <Strategy company={company} />
           <Objectives company={company} />
+          {company.oneListGroupTier === null ||
+          company.oneListGroupTier.id ===
+            '1929c808-99b4-4abf-a891-45f2e187b410' ? (
+            <LeadITA
+              companyId={companyId}
+              company={company}
+              permissions={permissions}
+            />
+          ) : (
+            <>Hello renderCoreTeamAdvisers</>
+          )}
         </CompanyLayout>
       )}
     </CompanyResource>

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -16,7 +16,6 @@ import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
-import { oneList } from '../../../../config'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -207,7 +206,10 @@ const AccountManagement = ({
           isItaTierDAccount(company.oneListGroupTier) ? (
             <LeadITA company={company} permissions={permissions} />
           ) : (
-            <CoreTeamAdvisers company={company} oneListEmail={oneList.email} />
+            <CoreTeamAdvisers
+              company={company}
+              oneListEmail={'one.list@example.com'}
+            />
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -15,6 +15,7 @@ import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
+import { isItaTierDAccount } from '../utils'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -201,40 +202,19 @@ const AccountManagement = ({
         >
           <Strategy company={company} />
           <Objectives company={company} />
-          {/* <span>{console.log(company)}</span>
-          <span>
-            {console.log(
-              '!company.oneListGroupTier: ',
-              !company.oneListGroupTier
-            )}
-          </span>
-          <span>
-            {console.log(
-              'company.oneListGroupTier?.id: ',
-              company.oneListGroupTier?.id
-            )}
-          </span> */}
           {!company.oneListGroupTier ||
-          company.oneListGroupTier?.id ===
-            '1929c808-99b4-4abf-a891-45f2e187b410' ? (
-            <>
-              {' '}
-              {/* <span>{console.log('LEADITA')}</span> */}
-              <LeadITA
-                companyId={companyId}
-                company={company}
-                permissions={permissions}
-                flashMessages={[flashMessages]}
-              />
-            </>
+          isItaTierDAccount(company.oneListGroupTier) ? (
+            <LeadITA
+              companyId={companyId}
+              company={company}
+              permissions={permissions}
+              flashMessages={[flashMessages]}
+            />
           ) : (
-            <>
-              {/* <span>{console.log('CORETEAMADVISERS')}</span> */}
-              <CoreTeamAdvisers
-                company={company}
-                oneListEmail={'one.list@example.com'}
-              />
-            </>
+            <CoreTeamAdvisers
+              company={company}
+              oneListEmail={'one.list@example.com'}
+            />
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -14,6 +14,7 @@ import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
+import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -210,7 +211,10 @@ const AccountManagement = ({
               flashMessages={[flashMessages]}
             />
           ) : (
-            <>Hello renderCoreTeamAdvisers</>
+            <CoreTeamAdvisers
+              company={company}
+              oneListEmail={'one.list@example.com'}
+            />
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -16,6 +16,7 @@ import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
+import { oneList } from '../../../../config'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -197,24 +198,16 @@ const AccountManagement = ({
           breadcrumbs={[{ text: 'Account management' }]}
           localNavItems={localNavItems}
           dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
-          flashMessages={[flashMessages]}
+          flashMessages={flashMessages}
           csrfToken={csrfToken}
         >
           <Strategy company={company} />
           <Objectives company={company} />
           {!company.oneListGroupTier ||
           isItaTierDAccount(company.oneListGroupTier) ? (
-            <LeadITA
-              companyId={companyId}
-              company={company}
-              permissions={permissions}
-              flashMessages={[flashMessages]}
-            />
+            <LeadITA company={company} permissions={permissions} />
           ) : (
-            <CoreTeamAdvisers
-              company={company}
-              oneListEmail={'one.list@example.com'}
-            />
+            <CoreTeamAdvisers company={company} oneListEmail={oneList.email} />
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -201,20 +201,40 @@ const AccountManagement = ({
         >
           <Strategy company={company} />
           <Objectives company={company} />
-          {company.oneListGroupTier === null ||
-          company.oneListGroupTier.id ===
+          {/* <span>{console.log(company)}</span>
+          <span>
+            {console.log(
+              '!company.oneListGroupTier: ',
+              !company.oneListGroupTier
+            )}
+          </span>
+          <span>
+            {console.log(
+              'company.oneListGroupTier?.id: ',
+              company.oneListGroupTier?.id
+            )}
+          </span> */}
+          {!company.oneListGroupTier ||
+          company.oneListGroupTier?.id ===
             '1929c808-99b4-4abf-a891-45f2e187b410' ? (
-            <LeadITA
-              companyId={companyId}
-              company={company}
-              permissions={permissions}
-              flashMessages={[flashMessages]}
-            />
+            <>
+              {' '}
+              {/* <span>{console.log('LEADITA')}</span> */}
+              <LeadITA
+                companyId={companyId}
+                company={company}
+                permissions={permissions}
+                flashMessages={[flashMessages]}
+              />
+            </>
           ) : (
-            <CoreTeamAdvisers
-              company={company}
-              oneListEmail={'one.list@example.com'}
-            />
+            <>
+              {/* <span>{console.log('CORETEAMADVISERS')}</span> */}
+              <CoreTeamAdvisers
+                company={company}
+                oneListEmail={'one.list@example.com'}
+              />
+            </>
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -44,67 +44,83 @@ const buildAdviserRows = (oneListTeam) => {
   return advisers.length > 0 ? buildRow(advisers) : null
 }
 
+export const CoreTeamAdvisers = ({ company, oneListEmail }) => (
+  <CompanyOneListTeamResource id={company.id}>
+    {(oneListTeam) => (
+      <>
+        <H2 size={LEVEL_SIZE[3]} data-test="core-team-heading">
+          Advisers on the core team
+        </H2>
+        <p data-test="core-team-subheading">{getSubheadingText(company)}</p>
+        <Table data-test="global-acc-manager-table">
+          <Table.Row>
+            <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
+            <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
+            <Table.CellHeader setWidth="33%">
+              Global Account Manager
+            </Table.CellHeader>
+          </Table.Row>
+          {buildGAMRow(oneListTeam)}
+        </Table>
+        {buildAdviserRows(oneListTeam) && (
+          <Table data-test="advisers-table">
+            <Table.Row>
+              <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
+              <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
+              <Table.CellHeader setWidth="33%">
+                Adviser on core team
+              </Table.CellHeader>
+            </Table.Row>
+            {buildAdviserRows(oneListTeam)}
+          </Table>
+        )}
+        <Details
+          summary="Need to find out more, or edit the One List tier information?"
+          data-test="core-team-details"
+        >
+          For more information, or if you need to change the One List tier or
+          account management team for this company, go to the{' '}
+          <NewWindowLink
+            href={urls.external.digitalWorkspace.accountManagement}
+          >
+            Digital Workspace
+          </NewWindowLink>{' '}
+          or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
+        </Details>
+      </>
+    )}
+  </CompanyOneListTeamResource>
+)
+
+CoreTeamAdvisers.propTypes = {
+  company: PropTypes.object.isRequired,
+  oneListEmail: PropTypes.string.isRequired,
+}
+
 const CoreTeam = ({
   companyId,
   oneListEmail,
   dnbRelatedCompaniesCount,
   returnUrl,
   localNavItems,
+  permissions,
 }) => (
   <CompanyResource id={companyId}>
     {(company) => (
-      <CompanyOneListTeamResource id={companyId}>
-        {(oneListTeam) => (
-          <CompanyLayout
-            company={company}
-            breadcrumbs={[{ text: 'Core Team' }]}
-            dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
-            returnUrl={returnUrl}
-            localNavItems={localNavItems}
-          >
-            <H2 size={LEVEL_SIZE[3]} data-test="core-team-heading">
-              Advisers on the core team
-            </H2>
-            <p data-test="core-team-subheading">{getSubheadingText(company)}</p>
-            <Table data-test="global-acc-manager-table">
-              <Table.Row>
-                <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
-                <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
-                <Table.CellHeader setWidth="33%">
-                  Global Account Manager
-                </Table.CellHeader>
-              </Table.Row>
-              {buildGAMRow(oneListTeam)}
-            </Table>
-            {buildAdviserRows(oneListTeam) && (
-              <Table data-test="advisers-table">
-                <Table.Row>
-                  <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
-                  <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
-                  <Table.CellHeader setWidth="33%">
-                    Adviser on core team
-                  </Table.CellHeader>
-                </Table.Row>
-                {buildAdviserRows(oneListTeam)}
-              </Table>
-            )}
-            <Details
-              summary="Need to find out more, or edit the One List tier information?"
-              data-test="core-team-details"
-            >
-              For more information, or if you need to change the One List tier
-              or account management team for this company, go to the{' '}
-              <NewWindowLink
-                href={urls.external.digitalWorkspace.accountManagement}
-              >
-                Digital Workspace
-              </NewWindowLink>{' '}
-              or email{' '}
-              <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
-            </Details>
-          </CompanyLayout>
-        )}
-      </CompanyOneListTeamResource>
+      <CompanyLayout
+        company={company}
+        breadcrumbs={[{ text: 'Core Team' }]}
+        dnbRelatedCompaniesCount={dnbRelatedCompaniesCount}
+        returnUrl={returnUrl}
+        localNavItems={localNavItems}
+      >
+        <CoreTeamAdvisers
+          company={company}
+          companyId={company.id}
+          oneListEmail={oneListEmail}
+          permissions={permissions}
+        />
+      </CompanyLayout>
     )}
   </CompanyResource>
 )

--- a/test/functional/cypress/fakers/advisers.js
+++ b/test/functional/cypress/fakers/advisers.js
@@ -1,0 +1,18 @@
+import jsf from 'json-schema-faker'
+
+import apiSchema from '../../../api-schema.json'
+import { listFaker } from './utils'
+import { ditTeamFaker } from './dit-team'
+
+const adviserFaker = (overrides = {}) => ({
+  ...jsf.generate(apiSchema.components.schemas.Adviser),
+  dit_team: ditTeamFaker(),
+  ...overrides,
+})
+
+const advisersListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: adviserFaker, length, overrides })
+
+export { adviserFaker, advisersListFaker }
+
+export default advisersListFaker

--- a/test/functional/cypress/fakers/companies.js
+++ b/test/functional/cypress/fakers/companies.js
@@ -5,6 +5,7 @@ import apiSchema from '../../../api-schema.json'
 
 import { addressFaker } from './addresses'
 import { listFaker } from './utils'
+import { adviserFaker } from './advisers'
 
 /**
  * Generate fake data for a single company.
@@ -17,6 +18,11 @@ const companyFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
   address: addressFaker(),
   registered_address: addressFaker(),
+  one_list_group_global_account_manager: adviserFaker(),
+  one_list_group_tier: {
+    id: faker.string.uuid(),
+    name: faker.word.adjective(),
+  },
   ...overrides,
 })
 

--- a/test/functional/cypress/fakers/contacts.js
+++ b/test/functional/cypress/fakers/contacts.js
@@ -4,6 +4,7 @@ import jsf from 'json-schema-faker'
 import apiSchema from '../../../api-schema.json'
 import { listFaker } from './utils'
 import { userFaker } from './users'
+import { ditTeamFaker } from './dit-team'
 
 const UK = {
   NAME: 'United Kingdom',
@@ -17,12 +18,6 @@ const SECTOR_NAMES = [
   'Advanced Engineering',
   'Biotechnology and Pharmaceuticals',
   'Creative and Media',
-]
-
-const DIT_TEAM_NAMES = [
-  'Digital Data Hub - Live Service',
-  'Aberdeen City Council',
-  'Healthcare UK',
 ]
 
 const contactFaker = (overrides = {}) => ({
@@ -75,10 +70,7 @@ const contactFaker = (overrides = {}) => ({
   created_on: faker.date.past(),
   created_by: {
     ...userFaker(),
-    dit_team: {
-      name: faker.helpers.arrayElement(DIT_TEAM_NAMES),
-      id: faker.string.uuid(),
-    },
+    dit_team: ditTeamFaker(),
   },
   modified_on: faker.date.past(),
   ...overrides,

--- a/test/functional/cypress/fakers/dit-team.js
+++ b/test/functional/cypress/fakers/dit-team.js
@@ -1,0 +1,22 @@
+import { faker } from '@faker-js/faker'
+
+import { listFaker } from './utils'
+
+const DIT_TEAM_NAMES = [
+  'Digital Data Hub - Live Service',
+  'Aberdeen City Council',
+  'Healthcare UK',
+]
+
+const ditTeamFaker = (overrides = {}) => ({
+  id: faker.string.uuid(),
+  name: faker.helpers.arrayElement(DIT_TEAM_NAMES),
+  ...overrides,
+})
+
+const ditTeamsListFaker = (length = 1, overrides) =>
+  listFaker({ fakerFunction: ditTeamFaker, length, overrides })
+
+export { ditTeamFaker, ditTeamsListFaker }
+
+export default ditTeamsListFaker

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -39,6 +39,7 @@ describe('Company account management', () => {
         companyWithStrategy
       ).as('companyApi')
       cy.visit(urls.companies.accountManagement.index(companyId))
+      cy.wait('@companyApi')
     })
 
     assertBreadcrumbs(fixtures.company.allActivitiesCompany)
@@ -112,6 +113,7 @@ describe('Company account management', () => {
           results: [],
         }).as('objectiveApi')
         cy.visit(urls.companies.accountManagement.index(companyId))
+        cy.wait('@objectiveApi')
       })
 
       it('should not display any objectives', () => {

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -85,6 +85,7 @@ describe('Company account management', () => {
           companyFaker({ strategy: undefined, id: companyId })
         ).as('companyApi')
         cy.visit(urls.companies.accountManagement.index(companyId))
+        cy.wait('@companyApi')
       })
 
       assertBreadcrumbs(fixtures.company.allActivitiesCompany)


### PR DESCRIPTION
## Description of change

The adviser information should be displayed on the account management page of a company.

## Test instructions

When visiting a company's account management page the Lead ITA / Core team advisers blocks should be displayed underneath the current objectives.

Lead ITA example: [One corp list](http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/account-management)
Core team example: [Venus solutions limited](http://localhost:3000/companies/0f5216e0-849f-11e6-ae22-56b6b6499611/advisers)

## Screenshots

### Before

Lead ITA One List Tier D on existing tab not present on account management page
![image](https://github.com/uktrade/data-hub-frontend/assets/699259/4fd0d68a-aad8-4bbe-9eb1-2f0072f65239)

Core team advisers on existing tab not present on account management page
![image](https://github.com/uktrade/data-hub-frontend/assets/699259/751bc29c-8b24-4eaf-9487-359865b87bf9)


### After
On the account management page you should see:

Lead ITA One List Tier D 
<img width="820" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/a823e99f-b403-4883-a7df-97ebd9b38c4a">

Core team advisers
<img width="908" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/11c34b9e-3256-441f-a85b-a709acb3951b">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
