### PR TITLE
Link and styling removed from hierarchy box

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -402,7 +402,7 @@ const HierarchyItem = ({
               <AddCompanyLink
                 href={urls.companies.createFromDNB(company.duns_number)}
                 aria-label={`Add ${company.name} to data Hub`}
-                data-test={`add-${companyName}`}
+                data-test={`add-company-${companyName}`}
               >
                 Add {company.name} to Data Hub
               </AddCompanyLink>

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -397,15 +397,17 @@ const HierarchyItem = ({
             </InlineDescriptionList>
           </ToggleSection>
         ) : (
-          <AddCompanyLinkDiv>
-            <AddCompanyLink
-              href={urls.companies.createFromDNB(company.duns_number)}
-              aria-label={`Add ${company.name} to data Hub`}
-              data-test={`add-${companyName}`}
-            >
-              Add {company.name} to Data Hub
-            </AddCompanyLink>
-          </AddCompanyLinkDiv>
+          company.duns_number && (
+            <AddCompanyLinkDiv>
+              <AddCompanyLink
+                href={urls.companies.createFromDNB(company.duns_number)}
+                aria-label={`Add ${company.name} to data Hub`}
+                data-test={`add-${companyName}`}
+              >
+                Add {company.name} to Data Hub
+              </AddCompanyLink>
+            </AddCompanyLinkDiv>
+          )
         )}
       </HierarchyItemContents>
       <Subsidiaries

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -75,8 +75,9 @@ export const HierarchyItemContents = styled.div`
   `}
   }
   ${({ hierarchy }) =>
-    hierarchy != 1 &&
-    `
+    !hierarchy ||
+    (hierarchy != 1 &&
+      `
       transform-style: preserve-3d;
 
       :before {
@@ -85,7 +86,7 @@ export const HierarchyItemContents = styled.div`
         top: 16px;
         left: -30px;
       }
-  `}
+  `)}
 `
 
 export const HierarchyItemHeading = styled.div`

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -75,9 +75,9 @@ export const HierarchyItemContents = styled.div`
   `}
   }
   ${({ hierarchy }) =>
-    !hierarchy ||
-    (hierarchy != 1 &&
-      `
+    hierarchy &&
+    hierarchy != 1 &&
+    `
       transform-style: preserve-3d;
 
       :before {
@@ -86,7 +86,7 @@ export const HierarchyItemContents = styled.div`
         top: 16px;
         left: -30px;
       }
-  `)}
+  `}
 `
 
 export const HierarchyItemHeading = styled.div`

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -225,7 +225,7 @@ describe('D&B Company hierarchy tree', () => {
     })
 
     it('should hide the add to Data Hub link', () => {
-      cy.get('[data-test="add-"]').should('not.exist')
+      cy.get('[data-test="add-company-"]').should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -409,7 +409,7 @@ describe('D&B Company hierarchy tree', () => {
 
     it('should have a link to add the company to Data Hub', () => {
       cy.get('[data-test="expand-tree-button"]').click()
-      cy.get(`[data-test=add-not-on-data-hub-ltd`).click()
+      cy.get(`[data-test=add-company-not-on-data-hub-ltd`).click()
       cy.location().should((loc) => {
         expect(loc.search).to.eq('?duns_number=123456789')
       })

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -223,6 +223,10 @@ describe('D&B Company hierarchy tree', () => {
     it('should hide the show subsidiaries button', () => {
       cy.get('[data-test="toggle-subsidiaries-button"]').should('not.exist')
     })
+
+    it('should hide the add to Data Hub link', () => {
+      cy.get('[data-test="add-"]').should('not.exist')
+    })
   })
 
   context('When a company has no subsidiaries', () => {


### PR DESCRIPTION
## Description of change

Clean up company tree when there are no results

## Test instructions

Navigate to a company with no hierarchy (D&B locally doesn't). Verify that there is no additional grey line to the left and there is no link to add to Data Hub

## Screenshots

### Before

![Screenshot 2023-08-10 at 16 28 40](https://github.com/uktrade/data-hub-frontend/assets/72826129/8a0e93fd-2664-44fb-987c-dc900b88685a)

### After

![Screenshot 2023-08-10 at 16 25 29](https://github.com/uktrade/data-hub-frontend/assets/72826129/27609742-20d0-4f03-9edd-82341e155044)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
