### PR TITLE
Add export company name link

### DIFF
--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -17,6 +17,7 @@ const GlobalStyles = createGlobalStyle`
 
 const DefaultLayout = ({
   heading,
+  headingLink,
   subheading,
   pageTitle,
   flashMessages,
@@ -37,6 +38,7 @@ const DefaultLayout = ({
       />
       <LocalHeader
         heading={heading}
+        headingLink={headingLink}
         subheading={subheading}
         flashMessages={flashMessages}
         breadcrumbs={
@@ -56,6 +58,10 @@ const DefaultLayout = ({
 
 DefaultLayout.propTypes = {
   heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]).isRequired,
+  headingLink: PropTypes.shape({
+    url: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+  }),
   subheading: PropTypes.string,
   pageTitle: PropTypes.string.isRequired,
   children: PropTypes.element.isRequired,

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -76,7 +76,12 @@ const ExportDetailsForm = ({ exportItem }) => {
   return (
     <DefaultLayout
       heading={exportItem ? exportItem.title : ''}
-      subheading={exportItem?.company?.name}
+      headingLink={
+        exportItem && {
+          url: `/companies/${exportItem.company.id}/overview`,
+          text: exportItem.company.name,
+        }
+      }
       pageTitle="Export details"
       breadcrumbs={getBreadcrumbs(exportItem)}
       useReactRouter={false}

--- a/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ItemRenderer.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import Link from '@govuk-react/link'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import Tag from '../../../components/Tag'
@@ -32,8 +31,13 @@ const TagContainer = styled('div')({
   justifyContent: 'space-between',
 })
 
-const Header = styled('h2')({
-  marginBottom: 0,
+const LinkContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+})
+
+const StyledHeader = styled('h3')({
+  marginBottom: 5,
   marginTop: SPACING.SCALE_4,
   fontSize: FONT_SIZE.SIZE_19,
   fontWeight: FONT_WEIGHTS.bold,
@@ -103,8 +107,14 @@ const ItemRenderer = (item) => {
         <Tag colour="grey">{`${exportPotential} POTENTIAL`}</Tag>
         <Tag colour={statusToColourMap[status]}>{status}</Tag>
       </TagContainer>
-      <Header>{item.company.name}</Header>
-      <Link href={`/export/${item.id}/details`}>{item.title}</Link>
+      <LinkContainer>
+        <StyledHeader>
+          <a href={`/companies/${item.company.id}/overview`}>
+            {item.company.name}
+          </a>
+        </StyledHeader>
+        <a href={`/export/${item.id}/details`}>{item.title}</a>
+      </LinkContainer>
       <DashboardToggleSection
         onOpen={(open) =>
           open ? setToggleLabel('Hide') : setToggleLabel('Show')

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -10,7 +10,7 @@ const assertStatusTag = (element, text) =>
   cy.get(element).find('strong').eq(1).should('have.text', text)
 
 const assertCompanyName = (element, text) => {
-  cy.get(element).find('h2').should('have.text', text)
+  cy.get(element).find('h3').should('have.text', text)
 }
 
 const assertDestination = (element, text) => {
@@ -36,9 +36,10 @@ const assertCreatedOnDate = (element, text) => {
   cy.get(element).find('dd').eq(5).should('have.text', text)
 }
 
-const assertTitleLink = (element, href, text) => {
+const assertLink = (element, index, href, text) => {
   cy.get(element)
     .find('a')
+    .eq(index)
     .should('have.attr', 'href', href)
     .should('have.text', text)
 }
@@ -77,6 +78,7 @@ describe('Export pipeline list', () => {
       export_potential: 'high',
       status: 'active',
       company: {
+        id: 1,
         name: 'Coca-Cola',
       },
       title: 'Export Coca-Cola',
@@ -99,6 +101,7 @@ describe('Export pipeline list', () => {
       export_potential: 'medium',
       status: 'won',
       company: {
+        id: 2,
         name: 'Alphabet',
       },
       title: 'Export Alphabet',
@@ -123,6 +126,7 @@ describe('Export pipeline list', () => {
       export_potential: 'low',
       status: 'inactive',
       company: {
+        id: 3,
         name: 'Meta',
       },
       title: 'Export Meta',
@@ -152,6 +156,7 @@ describe('Export pipeline list', () => {
       export_potential: 'low',
       status: 'inactive',
       company: {
+        id: 4,
         name: 'Sony',
       },
       title: 'Missing Migrated Data',
@@ -233,12 +238,47 @@ describe('Export pipeline list', () => {
       assertCompanyName('@fourthListItem', 'Sony')
     })
 
+    it('should display a link to the company', () => {
+      const linkIndex = 0
+      assertLink(
+        '@firstListItem',
+        linkIndex,
+        '/companies/1/overview',
+        'Coca-Cola'
+      )
+      assertLink(
+        '@secondListItem',
+        linkIndex,
+        '/companies/2/overview',
+        'Alphabet'
+      )
+      assertLink('@thirdListItem', linkIndex, '/companies/3/overview', 'Meta')
+      assertLink('@fourthListItem', linkIndex, '/companies/4/overview', 'Sony')
+    })
+
     it('should display a link to the export', () => {
-      assertTitleLink('@firstListItem', '/export/1/details', 'Export Coca-Cola')
-      assertTitleLink('@secondListItem', '/export/2/details', 'Export Alphabet')
-      assertTitleLink('@thirdListItem', '/export/3/details', 'Export Meta')
-      assertTitleLink(
+      const linkIndex = 1
+      assertLink(
+        '@firstListItem',
+        linkIndex,
+        '/export/1/details',
+        'Export Coca-Cola'
+      )
+      assertLink(
+        '@secondListItem',
+        linkIndex,
+        '/export/2/details',
+        'Export Alphabet'
+      )
+      assertLink(
+        '@thirdListItem',
+        linkIndex,
+        '/export/3/details',
+        'Export Meta'
+      )
+      assertLink(
         '@fourthListItem',
+        linkIndex,
         '/export/5/details',
         'Missing Migrated Data'
       )


### PR DESCRIPTION
## Description of change
Converted the export company name into a link for all items on the list page and the details page.

## Screenshot 1

### List changes 
Go to: `/export`

<img width="778" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/a492c6a5-7ea1-4b2a-bf6a-7af0df9cf4bc">

## Screenshot 2

### Details changes
Go to: `/export/<export-uuid>/details`

### After
<img width="891" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/4a62b5e0-89ad-4fc1-83e7-a7d85e85eb31">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
