### PR TITLE
Add loading message to company tree

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -522,6 +522,7 @@ const CompanyTree = ({ company, familyTree }) => {
       <Task.Status
         name={TASK_GET_DNB_FAMILY_TREE}
         id={ID}
+        progressMessage="Loading all the related companies in this company tree"
         startOnRender={{
           payload: { companyId: companyId },
           onSuccessDispatch: DNB_FAMILY_TREE_LOADED,


### PR DESCRIPTION
## Description of change

A loading message displays on the company tree so that it is clear what is happening when bigger trees take a while to load

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/54268863/d9136236-109b-43c0-b329-2b87eccb1467)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
