### PR TITLE
Fix/dit team name failure

### DIFF
--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -33,7 +33,7 @@ const RenderHasAccountManager = ({
         <Table.CellHeader setWidth="33%">Email</Table.CellHeader>
       </Table.Row>
       <Table.Row>
-        <Table.Cell>{leadITA.ditTeam.name}</Table.Cell>
+        <Table.Cell>{leadITA.ditTeam?.name}</Table.Cell>
         <Table.Cell>{leadITA.name}</Table.Cell>
         <Table.Cell>
           {leadITA.contactEmail ? (

--- a/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
+++ b/src/apps/companies/apps/advisers/client/LeadAdvisers.jsx
@@ -33,7 +33,7 @@ const RenderHasAccountManager = ({
         <Table.CellHeader setWidth="33%">Email</Table.CellHeader>
       </Table.Row>
       <Table.Row>
-        <Table.Cell>{leadITA.ditTeam?.name}</Table.Cell>
+        <Table.Cell>{leadITA.ditTeam ? leadITA.ditTeam.name : '-'}</Table.Cell>
         <Table.Cell>{leadITA.name}</Table.Cell>
         <Table.Cell>
           {leadITA.contactEmail ? (
@@ -71,7 +71,9 @@ const RenderHasAccountManager = ({
 
 export const LeadITA = ({ company, permissions }) => (
   <>
-    <H2 size={LEVEL_SIZE[3]}>Lead ITA for {company.name}</H2>
+    <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
+      Lead ITA for {company.name}
+    </H2>
     {!!company.oneListGroupGlobalAccountManager ? (
       <RenderHasAccountManager
         leadITA={company.oneListGroupGlobalAccountManager}

--- a/src/apps/companies/apps/business-details/client/SectionOneList.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionOneList.jsx
@@ -38,7 +38,9 @@ const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
 
         <SummaryTable.Row heading="Global Account Manager">
           {company.oneListGroupGlobalAccountManager.name}
-          {company.oneListGroupGlobalAccountManager.ditTeam?.name}
+          {company.oneListGroupGlobalAccountManager.ditTeam
+            ? company.oneListGroupGlobalAccountManager.ditTeam.name
+            : '-'}
           {getLocation(company.oneListGroupGlobalAccountManager.ditTeam)}
         </SummaryTable.Row>
       </SummaryTable>

--- a/src/apps/companies/apps/business-details/client/SectionOneList.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionOneList.jsx
@@ -38,7 +38,7 @@ const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
 
         <SummaryTable.Row heading="Global Account Manager">
           {company.oneListGroupGlobalAccountManager.name}
-          {company.oneListGroupGlobalAccountManager.ditTeam.name}
+          {company.oneListGroupGlobalAccountManager.ditTeam?.name}
           {getLocation(company.oneListGroupGlobalAccountManager.ditTeam)}
         </SummaryTable.Row>
       </SummaryTable>

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -3,6 +3,7 @@ import { companyFaker } from '../../fakers/companies'
 import { userFaker } from '../../fakers/users'
 import { format } from 'date-fns'
 import objectiveListFaker, { objectiveFaker } from '../../fakers/objective'
+import { adviserFaker } from '../../fakers/advisers'
 import { assertRequestUrl } from '../../support/assertions'
 
 const fixtures = require('../../fixtures')
@@ -11,6 +12,7 @@ const urls = require('../../../../../src/lib/urls')
 const companyId = fixtures.company.allActivitiesCompany.id
 
 const company = fixtures.company.oneListCorp
+const companyTierD = fixtures.company.oneListTierDita
 const globalAccountManager = company.one_list_group_global_account_manager
 
 const coreTeamResponse = {
@@ -283,4 +285,80 @@ describe('One List core team', () => {
       cy.get('[data-test=advisers-table]').should('not.exist')
     })
   })
+})
+
+describe('One List core Tier D team', () => {
+  context('when viewing a One List Tier D company', () => {
+    before(() => {
+      cy.visit(urls.companies.accountManagement.index(companyTierD.id))
+    })
+
+    it('should render the heading', () => {
+      cy.get('[data-test=lead-ita-heading]')
+        .should('exist')
+        .should('have.text', "Lead ITA for Ian's Camper Vans Ltd")
+    })
+
+    it('should render the Lead ITA table', () => {
+      assertTable({
+        element: '[data-test="lead-adviser-table"]',
+        rows: [
+          ['Team', 'Lead ITA', 'Email'],
+          [
+            companyTierD.one_list_group_global_account_manager.dit_team.name,
+            companyTierD.one_list_group_global_account_manager.name,
+            companyTierD.one_list_group_global_account_manager.contact_email,
+          ],
+        ],
+      })
+    })
+  })
+
+  context(
+    'when viewing a One List Tier D company without DIT team name for account manager',
+    () => {
+      const companyTierDNoTeam = companyFaker({
+        one_list_group_global_account_manager: adviserFaker({
+          dit_team: undefined,
+        }),
+        one_list_group_tier: { id: '1929c808-99b4-4abf-a891-45f2e187b410' },
+        id: companyTierD.id,
+      })
+
+      before(() => {
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${companyTierD.id}`,
+          companyTierDNoTeam
+        ).as('companyApi')
+        cy.visit(urls.companies.accountManagement.index(companyTierD.id))
+        cy.wait('@companyApi')
+      })
+      before(() => {
+        companyTierD.one_list_group_global_account_manager.dit_team = null
+        cy.visit(urls.companies.accountManagement.index(companyTierD.id))
+      })
+
+      it('should render the heading', () => {
+        cy.get('[data-test=lead-ita-heading]')
+          .should('exist')
+          .should('have.text', `Lead ITA for ${companyTierDNoTeam.name}`)
+      })
+
+      it('should render the Lead ITA table', () => {
+        assertTable({
+          element: '[data-test="lead-adviser-table"]',
+          rows: [
+            ['Team', 'Lead ITA', 'Email'],
+            [
+              '-',
+              companyTierDNoTeam.one_list_group_global_account_manager.name,
+              companyTierDNoTeam.one_list_group_global_account_manager
+                .contact_email,
+            ],
+          ],
+        })
+      })
+    }
+  )
 })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -350,7 +350,10 @@ describe('One List core Tier D team', () => {
               '-',
               companyTierDNoTeam.one_list_group_global_account_manager.name,
               companyTierDNoTeam.one_list_group_global_account_manager
-                .contact_email,
+                .contact_email
+                ? companyTierDNoTeam.one_list_group_global_account_manager
+                    .contact_email
+                : '-',
             ],
           ],
         })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -334,10 +334,6 @@ describe('One List core Tier D team', () => {
         cy.visit(urls.companies.accountManagement.index(companyTierD.id))
         cy.wait('@companyApi')
       })
-      before(() => {
-        companyTierD.one_list_group_global_account_manager.dit_team = null
-        cy.visit(urls.companies.accountManagement.index(companyTierD.id))
-      })
 
       it('should render the heading', () => {
         cy.get('[data-test=lead-ita-heading]')


### PR DESCRIPTION
## Description of change

Fix for error that occurs when a companies account manager has no DIT team set. 

## Test instructions

Set an account manager for a company to a user that has no DIT team provided.

## Screenshots

### Before

<img width="860" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/b876ca00-9b1f-4996-8447-da318144991e">

### After

<img width="824" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/699259/634a9506-64ed-421b-a949-e17aad833f7f">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
