### PR TITLE
feature/CLS2-375-allow-skipping-steps-in-edit-core-team-page

### DIFF
--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -26,6 +26,7 @@ function EditOneListForm({
   companyName,
   oneListTiers,
   formInitialValues,
+  returnUrl,
 }) {
   return (
     <Form
@@ -35,8 +36,11 @@ function EditOneListForm({
       submissionTaskName={TASK_SAVE_ONE_LIST_DETAILS}
       analyticsFormName="editOneList"
       transformPayload={(values) => ({ values, companyId })}
-      redirectTo={() => urls.companies.businessDetails(companyId)}
+      redirectTo={() =>
+        returnUrl ? returnUrl : urls.companies.businessDetails(companyId)
+      }
       flashMessage={() => 'One List information has been updated.'}
+      showStepInUrl={true}
     >
       {({ values }) => (
         <>
@@ -53,6 +57,8 @@ function EditOneListForm({
             ]}
           />
           <Main>
+            {/* if there is a request to skip the first step, but company is missing a one list tier, need to show the first step */}
+
             <Step name="oneListTier">
               <FieldRadios
                 label="Company One List tier"

--- a/src/apps/companies/apps/edit-one-list/controllers.js
+++ b/src/apps/companies/apps/edit-one-list/controllers.js
@@ -45,6 +45,7 @@ async function renderEditOneList(req, res) {
       oneListGroupGlobalAccountManager,
       oneListCoreTeam,
       formInitialValues,
+      returnUrl: req.query.returnUrl,
     },
   })
 }

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -156,4 +156,24 @@ describe('Edit One List', () => {
       )
     })
   })
+
+  context('when skipping step 1', () => {
+    const testCompany = fixtures.company.oneListCorp
+
+    before(() => {
+      cy.visit(urls.companies.editOneList(testCompany.id))
+    })
+
+    it('should show the one list advisers step', () => {})
+  })
+
+  context('when needing to override the return url', () => {
+    const testCompany = fixtures.company.oneListCorp
+
+    before(() => {
+      cy.visit(urls.companies.editOneList(testCompany.id))
+    })
+
+    it('should return the user to the requested url', () => {})
+  })
 })

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -2,6 +2,7 @@ const {
   assertLocalHeader,
   assertBreadcrumbs,
   assertFieldRadios,
+  assertFieldTypeahead,
 } = require('../../support/assertions')
 
 const fixtures = require('../../fixtures')
@@ -161,19 +162,43 @@ describe('Edit One List', () => {
     const testCompany = fixtures.company.oneListCorp
 
     before(() => {
-      cy.visit(urls.companies.editOneList(testCompany.id))
+      cy.visit(
+        `${urls.companies.editOneList(testCompany.id)}?step=oneListAdvisers`
+      )
     })
 
-    it('should show the one list advisers step', () => {})
+    it('should show the one list advisers step', () => {
+      cy.get('[data-test="field-global_account_manager"]').then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Global Account Manager',
+          value: `${testCompany.one_list_group_global_account_manager.name}, ${testCompany.one_list_group_global_account_manager.dit_team.name}`,
+          isMulti: false,
+        })
+      })
+    })
   })
 
   context('when needing to override the return url', () => {
     const testCompany = fixtures.company.oneListCorp
 
     before(() => {
-      cy.visit(urls.companies.editOneList(testCompany.id))
+      cy.visit(
+        `${urls.companies.editOneList(
+          testCompany.id
+        )}?step=oneListAdvisers&returnUrl=${urls.companies.accountManagement.index(
+          testCompany.id
+        )}`
+      )
     })
 
-    it('should return the user to the requested url', () => {})
+    it('should return the user to the requested url on form submit', () => {
+      cy.contains('Submit').click()
+
+      cy.location('pathname').should(
+        'eq',
+        urls.companies.accountManagement.index(testCompany.id)
+      )
+    })
   })
 })


### PR DESCRIPTION
## Description of change

Allow a user to skip the first step of the edit core team form, as this is an optional step and we want to link directly to step 2 as part of the new account management page

## Test instructions

Using any company, for example http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/edit-one-list?step=oneListAdvisers. If you include ?step=oneListAdvisers as a query param you will go straight to the second step



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
