### PR TITLE
Add three sort options allowing users to sort their export wins

### DIFF
--- a/src/client/modules/ExportPipeline/constants.js
+++ b/src/client/modules/ExportPipeline/constants.js
@@ -11,6 +11,31 @@ export const SORT_OPTIONS = [
     label: 'Export title Z-A',
     value: '-title',
   },
+  {
+    label: 'Company name A-Z',
+    value: 'company__name',
+  },
+  {
+    label: 'Company name Z-A',
+    value: '-company__name',
+  },
+  {
+    label: 'Earliest expected date for win',
+    value: 'estimated_win_date',
+  },
+  {
+    label: 'Latest expected date for win',
+    value: '-estimated_win_date',
+  },
+
+  {
+    label: 'Value increasing',
+    value: 'estimated_export_value_amount',
+  },
+  {
+    label: 'Value decreasing',
+    value: '-estimated_export_value_amount',
+  },
 ]
 
 export const EXPORT_POTENTIAL_OPTIONS = [

--- a/test/functional/cypress/specs/export-pipeline/sort-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/sort-spec.js
@@ -39,6 +39,21 @@ describe('Export pipeline sort', () => {
           { value: 'created_on:desc', label: 'Recently created' },
           { value: 'title', label: 'Export title A-Z' },
           { value: '-title', label: 'Export title Z-A' },
+          { value: 'company__name', label: 'Company name A-Z' },
+          { value: '-company__name', label: 'Company name Z-A' },
+          {
+            value: 'estimated_win_date',
+            label: 'Earliest expected date for win',
+          },
+          {
+            value: '-estimated_win_date',
+            label: 'Latest expected date for win',
+          },
+          { value: 'estimated_export_value_amount', label: 'Value increasing' },
+          {
+            value: '-estimated_export_value_amount',
+            label: 'Value decreasing',
+          },
         ])
       })
     })
@@ -49,28 +64,78 @@ describe('Export pipeline sort', () => {
     const exports = exportListFaker(3)
 
     beforeEach(() => {
-      // sortby=created_on:desc
+      // ----------------------------------------------------------------------------
+      // CreatedOn
+      // ----------------------------------------------------------------------------
+
       cy.intercept('GET', `${requestUrl}&sortby=created_on%3Adesc`, {
         body: {
           count: exports.length,
           results: exports,
         },
-      }).as('apiReqSortbyCreatedOn')
-      // sortby=title (A-Z)
+      }).as('apiReqCreatedOn')
+
+      // ----------------------------------------------------------------------------
+      // Title
+      // ----------------------------------------------------------------------------
+
       cy.intercept('GET', `${requestUrl}&sortby=title`, {
         body: {
           count: exports.length,
           results: exports,
         },
-      }).as('apiReqSortbyTitleA-Z')
-      // sortby=-title (Z-A)
+      }).as('apiReqTitleAsc')
+
       cy.intercept('GET', `${requestUrl}&sortby=-title`, {
         body: {
           count: exports.length,
           results: exports,
         },
-      }).as('apiReqSortbyTitleZ-A')
+      }).as('apiReqTitleDesc')
+
+      // ----------------------------------------------------------------------------
+      // Company name
+      // ----------------------------------------------------------------------------
+
+      cy.intercept('GET', `${requestUrl}&sortby=company__name`).as(
+        'apiReqCompanyAsc'
+      )
+
+      cy.intercept('GET', `${requestUrl}&sortby=-company__name`).as(
+        'apiReqCompanyDesc'
+      )
+
+      // ----------------------------------------------------------------------------
+      // Estimated win date
+      // ----------------------------------------------------------------------------
+
+      cy.intercept('GET', `${requestUrl}&sortby=estimated_win_date`).as(
+        'apiReqWinDateAsc'
+      )
+
+      cy.intercept('GET', `${requestUrl}&sortby=-estimated_win_date`).as(
+        'apiReqWinDateDesc'
+      )
+
+      // ----------------------------------------------------------------------------
+      // Estimated export value amount
+      // ----------------------------------------------------------------------------
+
+      cy.intercept(
+        'GET',
+        `${requestUrl}&sortby=estimated_export_value_amount`
+      ).as('apiReqValueAsc')
+
+      cy.intercept(
+        'GET',
+        `${requestUrl}&sortby=-estimated_export_value_amount`
+      ).as('apiReqValueDesc')
+
+      // ----------------------------------------------------------------------------
+      // Owner
+      // ----------------------------------------------------------------------------
       cy.intercept('GET', '/api-proxy/v4/export/owner', [])
+
       cy.visit(exportTab)
     })
 
@@ -78,22 +143,70 @@ describe('Export pipeline sort', () => {
       // As "Recently created" is the default sort
       // we need to select another option first
       cy.get(element).select('Export title A-Z')
-      cy.wait('@apiReqSortbyTitleA-Z')
+      cy.wait('@apiReqTitleAsc')
       cy.get(element).select('Recently created')
       assertRequestUrl(
-        '@apiReqSortbyCreatedOn',
+        '@apiReqCreatedOn',
         `${requestUrl}&sortby=created_on%3Adesc`
       )
     })
 
     it('should sort by "Export title A-Z"', () => {
       cy.get(element).select('Export title A-Z')
-      assertRequestUrl('@apiReqSortbyTitleA-Z', `${requestUrl}&sortby=title`)
+      assertRequestUrl('@apiReqTitleAsc', `${requestUrl}&sortby=title`)
     })
 
     it('should sort by "Export title Z-A"', () => {
       cy.get(element).select('Export title Z-A')
-      assertRequestUrl('@apiReqSortbyTitleZ-A', `${requestUrl}&sortby=-title`)
+      assertRequestUrl('@apiReqTitleDesc', `${requestUrl}&sortby=-title`)
+    })
+
+    it('should sort by "Company name A-Z"', () => {
+      cy.get(element).select('Company name A-Z')
+      assertRequestUrl(
+        '@apiReqCompanyAsc',
+        `${requestUrl}&sortby=company__name`
+      )
+    })
+
+    it('should sort by "Company name Z-A"', () => {
+      cy.get(element).select('Company name Z-A')
+      assertRequestUrl(
+        '@apiReqCompanyDesc',
+        `${requestUrl}&sortby=-company__name`
+      )
+    })
+
+    it('should sort by "Earliest expected date for win"', () => {
+      cy.get(element).select('Earliest expected date for win')
+      assertRequestUrl(
+        '@apiReqWinDateAsc',
+        `${requestUrl}&sortby=estimated_win_date`
+      )
+    })
+
+    it('should sort by "Latest expected date for win"', () => {
+      cy.get(element).select('Latest expected date for win')
+      assertRequestUrl(
+        '@apiReqWinDateDesc',
+        `${requestUrl}&sortby=-estimated_win_date`
+      )
+    })
+
+    it('should sort by "Value increasing"', () => {
+      cy.get(element).select('Value increasing')
+      assertRequestUrl(
+        '@apiReqValueAsc',
+        `${requestUrl}&sortby=estimated_export_value_amount`
+      )
+    })
+
+    it('should sort by "Value decreasing"', () => {
+      cy.get(element).select('Value decreasing')
+      assertRequestUrl(
+        '@apiReqValueDesc',
+        `${requestUrl}&sortby=-estimated_export_value_amount`
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change
Added the final three sort options allowing users to sort their export wins.

1. Company name A-Z and Z-A
2. Earliest expected date for win and Latest expected date for win
3. Value increasing and value decreasing

**Below is a list detailing all sort options including those above**

Company name A-Z *
Company name Z-A *
Title A-Z
Title Z-A
Earliest expected date for win *
Latest expected date for win *
Value increasing *
Value decreasing *
Recently created

\* What's been implemented.

## Test instructions

Go to `/export` and select any sort option from the list, the list will update accordngly. 

## Screenshots

### Before
<img width="923" alt="Screenshot 2023-08-18 at 07 41 16" src="https://github.com/uktrade/data-hub-frontend/assets/964268/1eb50606-2b95-49c5-967d-de53e3359567">

### After
<img width="923" alt="Screenshot 2023-08-18 at 07 40 59" src="https://github.com/uktrade/data-hub-frontend/assets/964268/0cbc0bcc-3905-4a43-add0-0759686ac5a5">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
