### PR TITLE
Temporarily change the export potential score to 'Coming soon'

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -24,10 +24,6 @@ const StyledLink = styled(Link)`
   margin-bottom: ${SPACING.SCALE_5};
 `
 
-const getExportPotential = (exportPotential) =>
-  exportPotentialLabels[exportPotential] &&
-  exportPotentialLabels[exportPotential].text
-
 const ExportsIndex = ({
   companyId,
   returnUrl,
@@ -73,9 +69,7 @@ const ExportsIndex = ({
               heading={exportDetailsLabels.exportPotential}
               key={exportDetailsLabels.exportPotential}
             >
-              {company.exportPotential
-                ? getExportPotential(company.exportPotential)
-                : 'No score given'}
+              Coming soon
             </SummaryTable.Row>
           </SummaryTable>
 

--- a/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
@@ -11,7 +11,6 @@ import {
   ExportExperienceCategoriesResource,
 } from '../../../components/Resource'
 import { transformArrayIdNameToValueLabel } from '../../../transformers'
-import { buildExportPotential } from './transformers'
 import { exportDetailsLabels } from '../../../../apps/companies/labels'
 import { buildCompanyBreadcrumbs } from '../utils'
 
@@ -74,7 +73,7 @@ export default ({ companyId }) => (
                   </StyledDd>
 
                   <StyledDt>{exportDetailsLabels.exportPotential}</StyledDt>
-                  <StyledDd>{buildExportPotential(company)}</StyledDd>
+                  <StyledDd>Coming soon</StyledDd>
                 </dl>
                 <FieldInput
                   type="hidden"

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -94,7 +94,7 @@ describe('Export', () => {
           assertTable([
             'Export growth',
             'No profile',
-            'No score given',
+            'Coming soon',
             'None',
             'None',
             'None',
@@ -112,7 +112,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'None',
             'None',
             'None',
@@ -152,7 +152,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'None',
             'None',
             'None',
@@ -175,7 +175,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'France, Germany',
             'None',
             'None',
@@ -191,7 +191,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'France, Germany',
             'None',
             'None',
@@ -218,7 +218,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'Brazil, France, Germany',
             'Honduras',
             'Chile',
@@ -245,7 +245,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'No score given',
+            'Coming soon',
             'None',
             'None',
             'None',

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -65,7 +65,7 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: 'No profile',
           },
-          { label: 'Export potential', value: 'No score given' },
+          { label: 'Export potential', value: 'Coming soon' },
         ])
       })
 
@@ -117,7 +117,7 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: '"Find a supplier" profile (opens in a new window or tab)',
           },
-          { label: 'Export potential', value: 'Medium' },
+          { label: 'Export potential', value: 'Coming soon' },
         ])
 
         cy.contains('"Find a supplier" profile').should(

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -79,7 +79,7 @@ describe('Company Export tab', () => {
         assertExportsTable(fixtures.company.dnbCorp.id, [
           { label: 'Export win category', value: 'None' },
           { label: 'great.gov.uk business profile', value: 'No profile' },
-          { label: 'Export potential', value: 'No score given' },
+          { label: 'Export potential', value: 'Coming soon' },
         ])
       })
 
@@ -261,7 +261,7 @@ describe('Company Export tab', () => {
             value: '"Find a supplier" profile (opens in a new window or tab)',
           },
 
-          { label: 'Export potential', value: 'Medium' },
+          { label: 'Export potential', value: 'Coming soon' },
         ])
 
         cy.contains('"Find a supplier" profile').should(


### PR DESCRIPTION
## Description of change
Nearly four years ago the field `export_potential` was added to the company model in the Data Hub API. Subsequently that field was populated by a DB maintenance command called `update_company_export_potential` which imported the values from a CSV file derived from the Data Science platform. We believe that command was only run once, again, four years ago, only recently has it come to light that the export potential value for all companies hasn't been updated since. Backend work will commence shortly to fix this problem, in the interim, we'll change the export potential value to "Coming soon" (this may change once the content designer is back next week) rather than hiding it completely.

## Before
<img width="1026" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/3f663d61-51ef-4549-8cda-59ead39f0b1c">

## After
<img width="1026" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/bbb1e0f2-d737-4dad-947d-6ea4e8ecf703">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
