### PR TITLE
bugfix/missing-one-list-team-causing-error

### DIFF
--- a/src/apps/companies/apps/business-details/client/SectionOneList.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionOneList.jsx
@@ -12,12 +12,19 @@ const StyledSummaryFooterLink = styled(Link)`
   display: block;
 `
 
-const getLocation = (managerTeam) =>
-  managerTeam.ukRegion
-    ? managerTeam.ukRegion.name
-    : managerTeam.country
-    ? managerTeam.country.name
+const getLocation = (manager) => {
+  if (!manager) {
+    return '-'
+  }
+  if (!manager.ditTeam) {
+    return '-'
+  }
+  return manager.ditTeam.ukRegion
+    ? manager.ditTeam.ukRegion.name
+    : manager.ditTeam.country
+    ? manager.ditTeam.country.name
     : '-'
+}
 
 const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
   company.oneListGroupGlobalAccountManager ? (
@@ -41,7 +48,7 @@ const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
           {company.oneListGroupGlobalAccountManager.ditTeam
             ? company.oneListGroupGlobalAccountManager.ditTeam.name
             : '-'}
-          {getLocation(company.oneListGroupGlobalAccountManager.ditTeam)}
+          {getLocation(company.oneListGroupGlobalAccountManager)}
         </SummaryTable.Row>
       </SummaryTable>
 

--- a/src/apps/companies/apps/business-details/client/SectionOneList.jsx
+++ b/src/apps/companies/apps/business-details/client/SectionOneList.jsx
@@ -13,12 +13,10 @@ const StyledSummaryFooterLink = styled(Link)`
 `
 
 const getLocation = (manager) => {
-  if (!manager) {
+  if (!manager || !manager.ditTeam) {
     return '-'
   }
-  if (!manager.ditTeam) {
-    return '-'
-  }
+
   return manager.ditTeam.ukRegion
     ? manager.ditTeam.ukRegion.name
     : manager.ditTeam.country


### PR DESCRIPTION
## Description of change

When a one list account manager does not belong to a team, the business details page displays an error

## Test instructions

This company on dev causes an error https://www.datahub.dev.uktrade.io/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/business-details
Using this branch, check the same company on local and it will show a "-" in place of location http://localhost:3000/companies/375094ac-f79a-43e5-9c88-059a7caa17f0/business-details


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
