### PR TITLE
Change background colour to White for company detail

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -192,7 +192,7 @@ export const HierarchyTag = styled(Tag)`
 
 export const InlineDescriptionList = styled.dl`
   padding: 15px;
-  background-color: ${GREY_4};
+  background-color: WHITE;
   border-top: 1px solid ${GREY_2};
   dt,
   dd {


### PR DESCRIPTION
## Description of change

For better accessibility we have changed the background colour for company details from grey to white.

## Test instructions

When viewing a company in the company hierarchy and clicking the view more details toggle, the company details box should have a white background.

## Screenshots

### Before
<img width="960" alt="Screenshot 2023-08-23 at 12 27 32" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/37ec235c-97af-4173-b7a2-622ead90ad86">



### After

<img width="962" alt="Screenshot 2023-08-23 at 12 24 31" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/ad88863f-46db-4f83-be70-12068f143f18">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ x ] Has the branch been rebased to main?
- [ x ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ x ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
