### PR TITLE
Cls2 385 manage core team from account management

### DIFF
--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -40,16 +40,13 @@ function EditOneListForm({
       redirectTo={() =>
         returnUrl ? returnUrl : urls.companies.businessDetails(companyId)
       }
-      cancelRedirectTo={() =>
-        returnUrl ? returnUrl : urls.companies.businessDetails(companyId)
-      }
-      flashMessage={() => 'One List information has been updated.'}
+      flashMessage={() => 'Core team has been updated.'}
       showStepInUrl={true}
     >
       {({ values, currentStep, goToStep }) => (
         <>
           <LocalHeader
-            heading={`Add or edit ${companyName} One List information`}
+            heading={`Edit core team of ${companyName}`}
             breadcrumbs={[
               { link: urls.dashboard.index(), text: 'Home' },
               {
@@ -57,7 +54,7 @@ function EditOneListForm({
                 text: 'Companies',
               },
               { link: urls.companies.detail(companyId), text: companyName },
-              { text: 'Edit One List information' },
+              { text: 'Edit core team' },
             ]}
           />
           <Main>

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -1,25 +1,24 @@
 import React from 'react'
+import { H3, H4, Link, GridCol, GridRow } from 'govuk-react'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+import Button from '@govuk-react/button'
+import Details from '@govuk-react/details'
+
+import styled from 'styled-components'
+import { Metadata, NewWindowLink } from '../../../components'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import {
   CompanyObjectivesCountResource,
   CompanyObjectivesResource,
   CompanyResource,
 } from '../../../components/Resource'
-import { H3, H4, Link } from 'govuk-react'
-import Button from '@govuk-react/button'
 import urls from '../../../../lib/urls'
 import { format } from '../../../../client/utils/date'
-import { GridCol, GridRow } from 'govuk-react'
-import styled from 'styled-components'
 import { DARK_GREY, GREY_2, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
-import { FONT_SIZE, SPACING } from '@govuk-react/constants'
-import CompanyLayout from '../../../components/Layout/CompanyLayout'
-import { Metadata } from '../../../components'
 import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
 import { ONE_LIST_EMAIL } from './constants'
-import Details from '@govuk-react/details'
-import { NewWindowLink } from '../../../components'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -53,6 +53,14 @@ const ArchivedObjectivesLink = styled(GridCol)`
   padding-top: 7px;
 `
 
+const canEditOneList = (permissions) =>
+  permissions &&
+  permissions.includes('company.change_company') &&
+  permissions.includes('company.change_one_list_core_team_member') &&
+  permissions.includes(
+    'company.change_one_list_tier_and_global_account_manager'
+  )
+
 const Strategy = ({ company }) => (
   <SectionGridRow data-test="strategy-row">
     <GridCol>
@@ -238,6 +246,11 @@ const AccountManagement = ({
             <LeadITA company={company} permissions={permissions} />
           ) : (
             <CoreTeamAdvisers company={company} oneListEmail={ONE_LIST_EMAIL} />
+          )}
+          {canEditOneList(permissions) && (
+            <Button as={Link} href={urls.companies.editVirtualTeam(companyId)}>
+              Edit core team
+            </Button>
           )}
         </CompanyLayout>
       )}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -256,6 +256,7 @@ const AccountManagement = ({
               {canEditOneList(permissions) && (
                 <div>
                   <Button
+                    data-test="edit-core-team-button"
                     as={Link}
                     href={urls.companies.editVirtualTeam(companyId)}
                   >
@@ -285,5 +286,3 @@ const AccountManagement = ({
 }
 
 export default AccountManagement
-
-//

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -18,6 +18,8 @@ import { LeadITA } from '../../../../apps/companies/apps/advisers/client/LeadAdv
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
 import { ONE_LIST_EMAIL } from './constants'
+import Details from '@govuk-react/details'
+import { NewWindowLink } from '../../../components'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -52,6 +54,7 @@ const AddObjectiveButton = styled(GridCol)`
 const ArchivedObjectivesLink = styled(GridCol)`
   padding-top: 7px;
 `
+const oneListEmail = 'one.list@invest-trade.uk'
 
 const canEditOneList = (permissions) =>
   permissions &&
@@ -252,6 +255,19 @@ const AccountManagement = ({
               Edit core team
             </Button>
           )}
+          <Details
+            summary="Need to find out more, or edit the One List tier information?"
+            data-test="core-team-details"
+          >
+            For more information, or if you need to change the One List tier or
+            account management team for this company, go to the{' '}
+            <NewWindowLink
+              href={urls.external.digitalWorkspace.accountManagement}
+            >
+              Digital Workspace
+            </NewWindowLink>{' '}
+            or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
+          </Details>
         </CompanyLayout>
       )}
     </CompanyResource>
@@ -259,3 +275,5 @@ const AccountManagement = ({
 }
 
 export default AccountManagement
+
+//

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -248,12 +248,22 @@ const AccountManagement = ({
           isItaTierDAccount(company.oneListGroupTier) ? (
             <LeadITA company={company} permissions={permissions} />
           ) : (
-            <CoreTeamAdvisers company={company} oneListEmail={ONE_LIST_EMAIL} />
-          )}
-          {canEditOneList(permissions) && (
-            <Button as={Link} href={urls.companies.editVirtualTeam(companyId)}>
-              Edit core team
-            </Button>
+            <div>
+              <CoreTeamAdvisers
+                company={company}
+                oneListEmail={ONE_LIST_EMAIL}
+              />
+              {canEditOneList(permissions) && (
+                <div>
+                  <Button
+                    as={Link}
+                    href={urls.companies.editVirtualTeam(companyId)}
+                  >
+                    Edit core team
+                  </Button>
+                </div>
+              )}
+            </div>
           )}
           <Details
             summary="Need to find out more, or edit the One List tier information?"

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -47,6 +47,19 @@ export const CoreTeamAdvisers = ({ company, oneListEmail }) => (
   <CompanyOneListTeamResource id={company.id}>
     {(oneListTeam) => (
       <>
+        <Details
+          summary="Need to find out more, or edit the One List tier information?"
+          data-test="core-team-details"
+        >
+          For more information, or if you need to change the One List tier or
+          account management team for this company, go to the{' '}
+          <NewWindowLink
+            href={urls.external.digitalWorkspace.accountManagement}
+          >
+            Digital Workspace
+          </NewWindowLink>{' '}
+          or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
+        </Details>
         <H2 size={LEVEL_SIZE[3]} data-test="core-team-heading">
           Advisers on the core team
         </H2>
@@ -75,19 +88,6 @@ export const CoreTeamAdvisers = ({ company, oneListEmail }) => (
             {buildAdviserRows(oneListTeam)}
           </Table>
         )}
-        <Details
-          summary="Need to find out more, or edit the One List tier information?"
-          data-test="core-team-details"
-        >
-          For more information, or if you need to change the One List tier or
-          account management team for this company, go to the{' '}
-          <NewWindowLink
-            href={urls.external.digitalWorkspace.accountManagement}
-          >
-            Digital Workspace
-          </NewWindowLink>{' '}
-          or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
-        </Details>
       </>
     )}
   </CompanyOneListTeamResource>

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { H2, Table } from 'govuk-react'
+import { H2, Table, Link } from 'govuk-react'
 import { LEVEL_SIZE } from '@govuk-react/constants'
 
 import { CompanyOneListTeamResource } from '../../../components/Resource'

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -2,13 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { H2, Table } from 'govuk-react'
 import { LEVEL_SIZE } from '@govuk-react/constants'
-import Details from '@govuk-react/details'
-import Link from '@govuk-react/link'
 
 import { CompanyOneListTeamResource } from '../../../components/Resource'
 import { transformOneListCoreTeamToCollection } from './transformers'
-import { NewWindowLink } from '../../../components'
-import urls from '../../../../lib/urls'
 
 const getSubheadingText = (company) => {
   const endText = ` an account managed company on the One List (${company.oneListGroupTier.name})`
@@ -43,23 +39,10 @@ const buildAdviserRows = (oneListTeam) => {
   return advisers.length > 0 ? buildRow(advisers) : null
 }
 
-export const CoreTeamAdvisers = ({ company, oneListEmail }) => (
+export const CoreTeamAdvisers = ({ company }) => (
   <CompanyOneListTeamResource id={company.id}>
     {(oneListTeam) => (
       <>
-        <Details
-          summary="Need to find out more, or edit the One List tier information?"
-          data-test="core-team-details"
-        >
-          For more information, or if you need to change the One List tier or
-          account management team for this company, go to the{' '}
-          <NewWindowLink
-            href={urls.external.digitalWorkspace.accountManagement}
-          >
-            Digital Workspace
-          </NewWindowLink>{' '}
-          or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
-        </Details>
         <H2 size={LEVEL_SIZE[3]} data-test="core-team-heading">
           Advisers on the core team
         </H2>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -147,6 +147,10 @@ module.exports = {
     documents: url('/companies', '/:companyId/documents'),
     businessDetails: url('/companies', '/:companyId/business-details'),
     editOneList: url('/companies', '/:companyId/edit-one-list'),
+    editVirtualTeam: url(
+      '/companies',
+      '/:companyId/edit-one-list?step=oneListAdvisers'
+    ),
     interactions: createInteractionsSubApp(
       '/companies',
       '/:companyId/interactions'

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -298,6 +298,12 @@ describe('One List core team', () => {
       })
     })
 
+    it('should render the edit core team button', () => {
+      cy.get('[data-test="edit-core-team-button"]')
+        .should('exist')
+        .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
+    })
+
     it('should render the details section', () => {
       cy.get('[data-test=core-team-details]')
         .click()
@@ -363,6 +369,9 @@ describe('One List core Tier D team', () => {
           ],
         ],
       })
+    })
+    it('it should not render a button to edit core team', () => {
+      cy.get('[data-test="edit-core-team-button"]').should('not.exist')
     })
   })
 

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -18,7 +18,7 @@ describe('Edit One List', () => {
     })
 
     it('should render the header', () => {
-      assertLocalHeader(`Add or edit ${testCompany.name} One List information`)
+      assertLocalHeader(`Edit core team of ${testCompany.name}`)
     })
 
     it('should render breadcrumbs', () => {
@@ -26,7 +26,7 @@ describe('Edit One List', () => {
         Home: urls.dashboard.index(),
         Companies: urls.companies.index(),
         [testCompany.name]: urls.companies.detail(testCompany.id),
-        'Edit One List information': null,
+        'Edit core team': null,
       })
     })
   })


### PR DESCRIPTION
## Description of change

Global account manager's can manage their virtual team from the Account Management tab

## Test instructions

When viewing a core team company in the account management tab, a 'Edit core team' button should be present. 

companies/346f78a5-1d23-4213-b4c2-bf48246a13c3/account-management

## Screenshots

### Before

![Capture-2023-08-29-111924](https://github.com/uktrade/data-hub-frontend/assets/14827050/543b4e29-d2f2-4ccb-8d7d-6f04c4ce2f7b)


### After

<img width="1034" alt="Screenshot 2023-08-29 at 11 14 30" src="https://github.com/uktrade/data-hub-frontend/assets/14827050/7b13529e-23dc-4796-a23e-cc971c951bbd">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
