### PR TITLE
Email added to core team account management

### DIFF
--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -32,7 +32,7 @@ const buildRow = (transformedAdvisers) =>
       <Table.Cell>{location}</Table.Cell>
       <Table.Cell>{name}</Table.Cell>
       <Table.Cell>
-        {email ? <a href={`mailto:${email}`}>{email}</a> : '-'}
+        {email ? <Link href={`mailto:${email}`}>{email}</Link> : '-'}
       </Table.Cell>
     </Table.Row>
   ))

--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -26,11 +26,14 @@ const getSubheadingText = (company) => {
 }
 
 const buildRow = (transformedAdvisers) =>
-  transformedAdvisers.map(({ team, location, name }) => (
+  transformedAdvisers.map(({ team, location, name, email }) => (
     <Table.Row>
       <Table.Cell>{team}</Table.Cell>
       <Table.Cell>{location}</Table.Cell>
       <Table.Cell>{name}</Table.Cell>
+      <Table.Cell>
+        {email ? <a href={`mailto:${email}`}>{email}</a> : '-'}
+      </Table.Cell>
     </Table.Row>
   ))
 
@@ -54,22 +57,24 @@ export const CoreTeamAdvisers = ({ company, oneListEmail }) => (
         <p data-test="core-team-subheading">{getSubheadingText(company)}</p>
         <Table data-test="global-acc-manager-table">
           <Table.Row>
-            <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
-            <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
-            <Table.CellHeader setWidth="33%">
+            <Table.CellHeader setWidth="25%">Team</Table.CellHeader>
+            <Table.CellHeader setWidth="15%">Location</Table.CellHeader>
+            <Table.CellHeader setWidth="25%">
               Global Account Manager
             </Table.CellHeader>
+            <Table.CellHeader setWidth="35%">Email</Table.CellHeader>
           </Table.Row>
           {buildGAMRow(oneListTeam)}
         </Table>
         {buildAdviserRows(oneListTeam) && (
           <Table data-test="advisers-table">
             <Table.Row>
-              <Table.CellHeader setWidth="33%">Team</Table.CellHeader>
-              <Table.CellHeader setWidth="33%">Location</Table.CellHeader>
-              <Table.CellHeader setWidth="33%">
+              <Table.CellHeader setWidth="25%">Team</Table.CellHeader>
+              <Table.CellHeader setWidth="15%">Location</Table.CellHeader>
+              <Table.CellHeader setWidth="25%">
                 Adviser on core team
               </Table.CellHeader>
+              <Table.CellHeader setWidth="35%">Email</Table.CellHeader>
             </Table.Row>
             {buildAdviserRows(oneListTeam)}
           </Table>

--- a/src/client/modules/Companies/CoreTeam/transformers.js
+++ b/src/client/modules/Companies/CoreTeam/transformers.js
@@ -6,6 +6,7 @@ export const transformOneListCoreTeamToCollection = (advisers) => {
     const adviserTeam = adviser.ditTeam
     return {
       name: adviser.name,
+      email: adviser.contactEmail,
       team: adviserTeam ? adviserTeam.name : '-',
       location: adviserTeam?.ukRegion
         ? adviserTeam?.ukRegion.name

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -18,6 +18,7 @@ const globalAccountManager = company.one_list_group_global_account_manager
 const coreTeamResponse = {
   adviser: {
     name: 'Travis Greene',
+    contactEmail: 'travis@example.net',
     ditTeam: {
       name: 'IST - Sector Advisory Services',
       ukRegion: {
@@ -222,11 +223,12 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager'],
+          ['Team', 'Location', 'Global Account Manager', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
             globalAccountManager.name,
+            globalAccountManager.contact_email,
           ],
         ],
       })
@@ -236,12 +238,18 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="advisers-table"]',
         rows: [
-          ['Team', 'Location', 'Adviser on core team'],
-          ['Heart of the South West LEP', 'United Kingdom', 'Holly Collins'],
+          ['Team', 'Location', 'Adviser on core team', 'Email'],
+          [
+            'Heart of the South West LEP',
+            'United Kingdom',
+            'Holly Collins',
+            'holly@example.net',
+          ],
           [
             'IG - Specialists - Knowledge Intensive Industry',
             'London',
             'Jenny Carey',
+            '-',
           ],
         ],
       })
@@ -274,11 +282,12 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager'],
+          ['Team', 'Location', 'Global Account Manager', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
             globalAccountManager.name,
+            globalAccountManager.contact_email,
           ],
         ],
       })

--- a/test/functional/cypress/specs/companies/core-team-spec.js
+++ b/test/functional/cypress/specs/companies/core-team-spec.js
@@ -60,11 +60,12 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager'],
+          ['Team', 'Location', 'Global Account Manager', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
             globalAccountManager.name,
+            globalAccountManager.contact_email,
           ],
         ],
       })
@@ -74,12 +75,18 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="advisers-table"]',
         rows: [
-          ['Team', 'Location', 'Adviser on core team'],
-          ['Heart of the South West LEP', 'United Kingdom', 'Holly Collins'],
+          ['Team', 'Location', 'Adviser on core team', 'Email'],
+          [
+            'Heart of the South West LEP',
+            'United Kingdom',
+            'Holly Collins',
+            'holly@example.net',
+          ],
           [
             'IG - Specialists - Knowledge Intensive Industry',
             'London',
             'Jenny Carey',
+            '-',
           ],
         ],
       })
@@ -112,11 +119,12 @@ describe('One List core team', () => {
       assertTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager'],
+          ['Team', 'Location', 'Global Account Manager', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
             globalAccountManager.name,
+            '-',
           ],
         ],
       })

--- a/test/sandbox/fixtures/v4/company/one-list-group-core-team.json
+++ b/test/sandbox/fixtures/v4/company/one-list-group-core-team.json
@@ -4,6 +4,7 @@
       "name": "Travis Greene",
       "first_name": "Travis",
       "last_name": "Greene",
+      "contact_email": "travis@example.net",
       "dit_team": {
         "name": "IST - Sector Advisory Services",
         "uk_region": {
@@ -25,6 +26,7 @@
       "name": "Holly Collins",
       "first_name": "Holly",
       "last_name": "Collins",
+      "contact_email": "holly@example.net",
       "dit_team": {
         "name": "Heart of the South West LEP",
         "country": {


### PR DESCRIPTION
## Description of change

Users have fed back that they would like to see contact details of the core team on the Account Management tab. This ticket is to add that additional information

## Test instructions

Pull this branch then navigate to the Account Management tab for One List Corp to view email details for two of the accounts listed

## Screenshots

### Before
![Screenshot 2023-08-23 at 17 06 18](https://github.com/uktrade/data-hub-frontend/assets/72826129/a80a91fb-03e1-4bb5-946e-52b452cdf8ba)

### After
![Screenshot 2023-08-23 at 17 06 57](https://github.com/uktrade/data-hub-frontend/assets/72826129/7251a556-5ab0-4c08-9bad-bcdeeee5e299)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
