### PR TITLE
Fix company urls for investment projects

### DIFF
--- a/src/client/modules/Investments/Projects/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/ProjectDetails.jsx
@@ -80,7 +80,9 @@ const ProjectDetails = ({ projectId, currentAdviserId }) => (
             heading="Client"
             value={
               <Link
-                href={urls.companies.index(project.investorCompany?.id)}
+                href={urls.companies.overview.index(
+                  project.investorCompany?.id
+                )}
                 data-test="company-link"
               >
                 {project.investorCompany?.name}
@@ -121,7 +123,7 @@ const ProjectDetails = ({ projectId, currentAdviserId }) => (
               heading="Client contacts"
               value={project.clientContacts.map((contact, i) => (
                 <Link
-                  href={urls.contacts.index(contact.id)}
+                  href={urls.contacts.contact(contact.id)}
                   data-test={`contact-` + i}
                 >
                   {contact.name}

--- a/src/client/modules/Investments/Projects/ProjectEvaluation.jsx
+++ b/src/client/modules/Investments/Projects/ProjectEvaluation.jsx
@@ -49,7 +49,7 @@ const landingTable = (ukCompany = null, actualLandDate) => (
       heading="UK company"
       value={
         ukCompany ? (
-          <Link href={urls.companies.index(ukCompany.id)}>
+          <Link href={urls.companies.overview.index(ukCompany.id)}>
             {ukCompany.name}
           </Link>
         ) : (
@@ -179,7 +179,7 @@ const ProjectEvaluation = ({ projectId }) => (
               <SummaryTable.TextRow
                 heading="Foreign investor"
                 value={
-                  <Link href={urls.companies.index(company.id)}>
+                  <Link href={urls.companies.overview.index(company.id)}>
                     {company.name}
                   </Link>
                 }
@@ -192,7 +192,9 @@ const ProjectEvaluation = ({ projectId }) => (
                 heading="UK company"
                 value={
                   project.ukCompany ? (
-                    <Link href={urls.companies.index(project.ukCompany.id)}>
+                    <Link
+                      href={urls.companies.overview.index(project.ukCompany.id)}
+                    >
                       {project.ukCompany.name}
                     </Link>
                   ) : (

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -55,7 +55,7 @@ describe('Investment project details', () => {
         .should(
           'have.attr',
           'href',
-          urls.companies.index(fixtures.investment.investmentWithDetails.id)
+          urls.companies.overview.index('0f5216e0-849f-11e6-ae22-56b6b6499611')
         )
       cy.get('[data-test="contact-0"]')
         .should('exist')
@@ -63,7 +63,7 @@ describe('Investment project details', () => {
         .should(
           'have.attr',
           'href',
-          urls.contacts.index(fixtures.contact.deanCox.id)
+          urls.contacts.contact(fixtures.contact.deanCox.id)
         )
       cy.get('[data-test="contact-1"]')
         .should('exist')
@@ -71,7 +71,7 @@ describe('Investment project details', () => {
         .should(
           'have.attr',
           'href',
-          urls.contacts.index(fixtures.contact.johnnyCakeman.id)
+          urls.contacts.contact(fixtures.contact.johnnyCakeman.id)
         )
     })
 


### PR DESCRIPTION
## Description of change

Some of the investment project company URLs are incorrect. This PR fixes this.

## Test instructions

Go to one of the changes pages and click on the company link. It should take you to the company overview page.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
