### PR TITLE
Added auto scroll to likelihood of landing

### DIFF
--- a/src/client/modules/Investments/Projects/EditProjectSummary.jsx
+++ b/src/client/modules/Investments/Projects/EditProjectSummary.jsx
@@ -167,11 +167,13 @@ const EditProjectSummary = ({ projectId, currentAdviser }) => (
                 project.estimatedLandDate
               )}
             />
-            <FieldLikelihoodOfLanding
-              initialValue={transformObjectForTypeahead(
-                project.likelihoodToLand
-              )}
-            />
+            <FieldWrapper autoScroll={true}>
+              <FieldLikelihoodOfLanding
+                initialValue={transformObjectForTypeahead(
+                  project.likelihoodToLand
+                )}
+              />
+            </FieldWrapper>
             <FieldActualLandDate
               initialValue={transformDateStringToDateObject(
                 project.actualLandDate


### PR DESCRIPTION
## Description of change

Added an auto scroll so that page renders on likelihood of landing 

## Test instructions

When you edit an active investment from the company overview page, the page will auto focus on likelihood of landing. 


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x ] Has the branch been rebased to main?
- [x ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
