### PR TITLE
Add warning text informing the user why export potential is unavailable

### DIFF
--- a/src/apps/companies/apps/exports/client/ExportsIndex.jsx
+++ b/src/apps/companies/apps/exports/client/ExportsIndex.jsx
@@ -14,6 +14,7 @@ import { CompanyResource } from '../../../../../client/components/Resource'
 import CompanyLayout from '../../../../../client/components/Layout/CompanyLayout'
 import { exportDetailsLabels, exportPotentialLabels } from '../../../labels'
 import { transformExportCountries } from '../transformer'
+import WarningText from '@govuk-react/warning-text'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin-top: 0;
@@ -69,9 +70,14 @@ const ExportsIndex = ({
               heading={exportDetailsLabels.exportPotential}
               key={exportDetailsLabels.exportPotential}
             >
-              Coming soon
+              Unavailable
             </SummaryTable.Row>
           </SummaryTable>
+
+          <WarningText>
+            The export potential value is unavailable. This is because the
+            previous value was wrong. We are working to fix this.
+          </WarningText>
 
           <Details summary="What is export potential">
             The export potential score is a prediction of a company's likelihood

--- a/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
@@ -73,7 +73,7 @@ export default ({ companyId }) => (
                   </StyledDd>
 
                   <StyledDt>{exportDetailsLabels.exportPotential}</StyledDt>
-                  <StyledDd>Coming soon</StyledDd>
+                  <StyledDd>Unavailable</StyledDd>
                 </dl>
                 <FieldInput
                   type="hidden"

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -94,7 +94,7 @@ describe('Export', () => {
           assertTable([
             'Export growth',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'None',
             'None',
             'None',
@@ -112,7 +112,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'None',
             'None',
             'None',
@@ -152,7 +152,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'None',
             'None',
             'None',
@@ -175,7 +175,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'France, Germany',
             'None',
             'None',
@@ -191,7 +191,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'France, Germany',
             'None',
             'None',
@@ -218,7 +218,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'Brazil, France, Germany',
             'Honduras',
             'Chile',
@@ -245,7 +245,7 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Coming soon',
+            'Unavailable',
             'None',
             'None',
             'None',

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -65,7 +65,7 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: 'No profile',
           },
-          { label: 'Export potential', value: 'Coming soon' },
+          { label: 'Export potential', value: 'Unavailable' },
         ])
       })
 
@@ -117,7 +117,7 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: '"Find a supplier" profile (opens in a new window or tab)',
           },
-          { label: 'Export potential', value: 'Coming soon' },
+          { label: 'Export potential', value: 'Unavailable' },
         ])
 
         cy.contains('"Find a supplier" profile').should(

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -79,7 +79,7 @@ describe('Company Export tab', () => {
         assertExportsTable(fixtures.company.dnbCorp.id, [
           { label: 'Export win category', value: 'None' },
           { label: 'great.gov.uk business profile', value: 'No profile' },
-          { label: 'Export potential', value: 'Coming soon' },
+          { label: 'Export potential', value: 'Unavailable' },
         ])
       })
 
@@ -261,7 +261,7 @@ describe('Company Export tab', () => {
             value: '"Find a supplier" profile (opens in a new window or tab)',
           },
 
-          { label: 'Export potential', value: 'Coming soon' },
+          { label: 'Export potential', value: 'Unavailable' },
         ])
 
         cy.contains('"Find a supplier" profile').should(


### PR DESCRIPTION
## Test instructions

Go to `/companies/<company-uuid>/exports`

## Screenshots

### Before
<img width="1047" alt="b" src="https://github.com/uktrade/data-hub-frontend/assets/964268/733141aa-02c9-4b7e-b1ec-463f4b0344af">

### After
<img width="1079" alt="unavailable" src="https://github.com/uktrade/data-hub-frontend/assets/964268/cfc74bee-6cb4-47b0-b4f7-978604a79eda">
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
