### PR TITLE
bugfix/empty-objective-sandbox-route

### DIFF
--- a/test/sandbox/routes/v4/objective/index.js
+++ b/test/sandbox/routes/v4/objective/index.js
@@ -1,3 +1,7 @@
 exports.objectives = function (req, res) {
   res.json({ results: [] })
 }
+
+exports.objectivesCount = function (req, res) {
+  res.json({ archived_count: 0, not_archived_count: 0 })
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -449,6 +449,7 @@ app.patch(
   v4Company.patchOneListCoreTeam
 )
 app.get('/v4/company/:companyId/objective', v4Objective.objectives)
+app.get('/v4/company/:companyId/objective/count', v4Objective.objectivesCount)
 
 // V4 interactions
 app.get('/v4/interaction', v4Interaction.getInteractions)


### PR DESCRIPTION
## Description of change

Added empty route for objectives count endpoint into the sandbox to get rid of task failures in the network tab


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
