### PR TITLE
Fix broken proposition test

### DIFF
--- a/test/functional/cypress/specs/investments/project-propositions-spec.js
+++ b/test/functional/cypress/specs/investments/project-propositions-spec.js
@@ -1,5 +1,6 @@
 import fixtures from '../../fixtures'
 import urls from '../../../../../src/lib/urls'
+import { formatWithoutParsing } from '../../../../../src/client/utils/date'
 
 describe('Investment project propositions', () => {
   context('When the project has one proposition linked', () => {
@@ -41,7 +42,10 @@ describe('Investment project propositions', () => {
 
       cy.get('[data-test="collection-item"]')
         .find('[data-test="metadata"]')
-        .should('contain', 'Deadline 25 August 2023')
+        .should(
+          'contain',
+          'Deadline ' + formatWithoutParsing(new Date(), 'dd MMMM yyyy')
+        )
         .and('contain', 'Created on 15 June 2017')
         .and('contain', 'Adviser Paula Churing')
       cy.get('[data-test="badge"]').should('exist').should('contain', 'Ongoing')


### PR DESCRIPTION
## Description of change

One of the tests in `project-propositions-spec` is broken because of a dynamic date used within the fixtures. The test has been updated to always check against today's date.

## Test instructions

The functional tests should pass.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
