### PR TITLE
bugfix/CLS2-375-handle-missing-company-in-step-1

### DIFF
--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -22,6 +22,7 @@ import {
 import { FORM_LAYOUT } from '../../../../../common/constants'
 
 function EditOneListForm({
+  company,
   companyId,
   companyName,
   oneListTiers,
@@ -42,7 +43,7 @@ function EditOneListForm({
       flashMessage={() => 'One List information has been updated.'}
       showStepInUrl={true}
     >
-      {({ values }) => (
+      {({ values, currentStep, goToStep }) => (
         <>
           <LocalHeader
             heading={`Add or edit ${companyName} One List information`}
@@ -57,8 +58,6 @@ function EditOneListForm({
             ]}
           />
           <Main>
-            {/* if there is a request to skip the first step, but company is missing a one list tier, need to show the first step */}
-
             <Step name="oneListTier">
               <FieldRadios
                 label="Company One List tier"
@@ -81,6 +80,14 @@ function EditOneListForm({
                     label="Advisers on the core team (optional)"
                     isMulti={true}
                   />
+                  <>
+                    {/* If there is a request to skip the first step, but company is missing a one list tier, 
+                we need to force them back to the first step */}
+                    {currentStep === 1 &&
+                      !values[TIER_FIELD_NAME] &&
+                      !company.oneListGroupTier &&
+                      goToStep('oneListTier')}
+                  </>
                 </Step>
               </FormLayout>
             )}

--- a/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
+++ b/src/apps/companies/apps/edit-one-list/client/EditOneListForm.jsx
@@ -40,6 +40,9 @@ function EditOneListForm({
       redirectTo={() =>
         returnUrl ? returnUrl : urls.companies.businessDetails(companyId)
       }
+      cancelRedirectTo={() =>
+        returnUrl ? returnUrl : urls.companies.businessDetails(companyId)
+      }
       flashMessage={() => 'One List information has been updated.'}
       showStepInUrl={true}
     >

--- a/src/apps/companies/apps/edit-one-list/controllers.js
+++ b/src/apps/companies/apps/edit-one-list/controllers.js
@@ -38,6 +38,7 @@ async function renderEditOneList(req, res) {
   res.locals.title = `Edit One List information - ${company.name} - Companies`
   res.render('companies/apps/edit-one-list/views/client-container', {
     props: {
+      company,
       companyId: company.id,
       companyName: company.name,
       oneListTiers: filterOneListTiers(oneListTiers),

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -133,6 +133,7 @@ const _Form = ({
     values,
     touched,
     steps,
+    goToStep,
     getStepIndex: (stepName) => {
       const index = steps?.indexOf(stepName)
       return index !== -1 ? index : null

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -160,20 +160,43 @@ describe('Edit One List', () => {
 
   context('when skipping step 1', () => {
     const testCompany = fixtures.company.oneListCorp
+    const noOneListCompany = fixtures.company.dnbCorp
 
-    before(() => {
-      cy.visit(
-        `${urls.companies.editOneList(testCompany.id)}?step=oneListAdvisers`
-      )
+    context('with a company that has a one list tier', () => {
+      before(() => {
+        cy.visit(
+          `${urls.companies.editOneList(testCompany.id)}?step=oneListAdvisers`
+        )
+      })
+
+      it('should show the one list advisers step', () => {
+        cy.get('[data-test="field-global_account_manager"]').then((element) => {
+          assertFieldTypeahead({
+            element,
+            label: 'Global Account Manager',
+            value: `${testCompany.one_list_group_global_account_manager.name}, ${testCompany.one_list_group_global_account_manager.dit_team.name}`,
+            isMulti: false,
+          })
+        })
+      })
     })
 
-    it('should show the one list advisers step', () => {
-      cy.get('[data-test="field-global_account_manager"]').then((element) => {
-        assertFieldTypeahead({
-          element,
-          label: 'Global Account Manager',
-          value: `${testCompany.one_list_group_global_account_manager.name}, ${testCompany.one_list_group_global_account_manager.dit_team.name}`,
-          isMulti: false,
+    context('with a company that is missing a one list tier', () => {
+      before(() => {
+        cy.visit(
+          `${urls.companies.editOneList(
+            noOneListCompany.id
+          )}?step=oneListAdvisers`
+        )
+      })
+
+      it('should still show step 1 as this field is needed', () => {
+        cy.get(selectors.companyEditOneList.tierField).then((element) => {
+          assertFieldRadios({
+            element,
+            label: 'Company One List tier',
+            optionsCount: 8,
+          })
         })
       })
     })


### PR DESCRIPTION
## Description of change

Redirect the user back to step 1 when a company doesn't have a one list tier set, as this causes an error when saving the form if you have to skipped straight to step 2.

This change is already part of https://github.com/uktrade/data-hub-frontend/pull/6008, but has been separated out to unblock https://github.com/uktrade/data-hub-frontend/pull/6004

## Test instructions

Using any company without a one list tier and try to skip to the 2nd step, for example http://localhost:3000/companies/e11f2a0d-b925-4a18-8b7b-1456f59af2a3/edit-one-list?step=oneListAdvisers. You will be sent back to step one where you need to first choose a tier


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
