### PR TITLE
fixed display for turnover

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -57,7 +57,7 @@ const BusinessDetailsCard = ({ company }) => (
     </SummaryTable.Row>
     <SummaryTable.Row heading="Turnover">
       {buildCellContents(
-        company.turnoverGbp && company.turnoverRange,
+        company.turnoverGbp || company.turnoverRange,
         company.turnoverGbp
           ? currencyGBP(company.turnoverGbp, {
               maximumSignificantDigits: 2,


### PR DESCRIPTION
Change condition to if either turnover or range condition is true.

Change condition to display turnover if range does not exist

## Test instructions

turnover displayed if not range is entered

## Screenshots

### Before

<img width="352" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/15215184/9c1c50dc-22be-421d-bfd0-8785aef52137">


### After
<img width="352" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/15215184/36ab8976-54ce-4527-a94e-d5133cf05ae7">

<img width="352" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/15215184/a52c12e1-ff75-4db8-8a39-2c45ea3e0766">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
