### PR TITLE
Improve the NewWindowLink component by aligning it with GDS

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -28,7 +28,7 @@ const BusinessDetailsCard = ({ company }) => (
           company.companyNumber,
           <NewWindowLink
             href={urls.external.companiesHouse(company.companyNumber)}
-            aria-label="Opens on Companies House website"
+            aria-label={`Companies House number: ${company.companyNumber} (opens in new tab on Companies House website)`}
             data-test="companies-house-link"
           >
             {company.companyNumber}

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -50,7 +50,7 @@ const getFlashMessage = (interactionId, wasPolicyFeedbackProvided) => {
       const body = [
         'Thanks for submitting business intelligence (BI), which feeds into the Business Intelligence Unit’s reports. If they need more information, they will contact you.',
         '',
-        'For more on the value of BI, <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/business-intelligence-reports/" target="_blank" aria-label="Opens in a new window or tab">See the Digital Workspace article</a> (opens in new tab)',
+        'For more on the value of BI, <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/business-intelligence-reports/" rel="noopener noreferrer" target="_blank">See the Digital Workspace article (opens in new tab)</a>',
       ].join('<br />')
       return ['Interaction created', body]
     } else {

--- a/src/apps/investments/client/projects/team/GlobalAccountManagerDetails.jsx
+++ b/src/apps/investments/client/projects/team/GlobalAccountManagerDetails.jsx
@@ -27,11 +27,7 @@ const GlobalAccountManagerDetails = ({
     >
       If you need to change the Global Account Manager for this company, go to
       the{' '}
-      <NewWindowLink
-        href={urls.external.digitalWorkspace.accountManagement}
-        aria-label="Digital Workspace"
-        showHelpText={false}
-      >
+      <NewWindowLink href={urls.external.digitalWorkspace.accountManagement}>
         Digital Workspace
       </NewWindowLink>
       {' or '}

--- a/src/client/components/DataHubFeed/index.jsx
+++ b/src/client/components/DataHubFeed/index.jsx
@@ -1,24 +1,19 @@
 import React from 'react'
 import styled from 'styled-components'
 import { SPACING, FONT_SIZE } from '@govuk-react/constants'
-import { GREY_1, GREY_2 } from '../../utils/colours'
-import { Link } from 'govuk-react'
 import ListItem from '@govuk-react/list-item'
 import Paragraph from '@govuk-react/paragraph'
 import { H3 } from '@govuk-react/heading'
 import UnorderedList from '@govuk-react/unordered-list'
+
+import { GREY_2 } from '../../utils/colours'
 import urls from '../../../lib/urls'
+import NewWindowLink from '../NewWindowLink'
 
 const FeedContainer = styled.div({
   fontSize: FONT_SIZE.SIZE_14,
   borderTop: `2px solid ${GREY_2}`,
   padding: `${SPACING.SCALE_4} 0`,
-})
-
-const Note = styled('div')({
-  display: `inline`,
-  color: GREY_1,
-  fontSize: FONT_SIZE.SIZE_14,
 })
 
 const Date = styled('div')({
@@ -34,32 +29,23 @@ const DataHubFeed = ({ items, feedLimit = 5 }) => (
         <UnorderedList listStyleType="none">
           {items.slice(0, feedLimit).map((item, index) => (
             <ListItem key={index}>
-              <Link
+              <NewWindowLink
                 href={item.link}
-                target="_blank"
-                rel="noopener noreferrer"
                 data-test={`data-hub-feed-link-${index}`}
                 aria-labelledby="link-label"
               >
                 {item.heading}
-              </Link>
-              &nbsp;
-              <Note id="link-label" data-test={`data-hub-feed-note-${index}`}>
-                (Link opens in a new window)
-              </Note>
+              </NewWindowLink>
               <Date data-test={`data-hub-feed-date-${index}`}>{item.date}</Date>
             </ListItem>
           ))}
         </UnorderedList>
-        <Link
+        <NewWindowLink
           href={urls.external.helpCentre.allUpdates()}
-          target="_blank"
-          rel="noopener noreferrer"
           data-test={`data-hub-feed-view-all`}
-          aria-label="Opens in a new window or tab"
         >
           View all Data Hub updates
-        </Link>
+        </NewWindowLink>
       </>
     )}
     {!items.length && <Paragraph>No updates available</Paragraph>}

--- a/src/client/components/Footer/index.jsx
+++ b/src/client/components/Footer/index.jsx
@@ -120,7 +120,7 @@ export default function Footer() {
               href={urls.support()}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Opens in a new window or tab"
+              aria-label="Request Support (opens in new tab)"
             >
               Request Support
             </FooterLink>
@@ -130,7 +130,7 @@ export default function Footer() {
               href={urls.external.helpCentre.dhHomepage()}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Opens in a new window or tab"
+              aria-label="Help Centre (opens in new tab)"
             >
               Help Centre
             </FooterLink>
@@ -140,7 +140,7 @@ export default function Footer() {
               href={urls.external.helpCentre.privacyNotice()}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Opens in a new window or tab"
+              aria-label="Privacy Notice (opens in new tab)"
             >
               Privacy Notice
             </FooterLink>
@@ -150,7 +150,7 @@ export default function Footer() {
               href={urls.external.helpCentre.cookies()}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Opens in a new window or tab"
+              aria-label="Cookies (opens in new tab)"
             >
               Cookies
             </FooterLink>
@@ -160,7 +160,7 @@ export default function Footer() {
               href={urls.external.helpCentre.accessibilityStatement()}
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Opens in a new window or tab"
+              aria-label="Accessibility Statement (opens in new tab)"
             >
               Accessibility Statement
             </FooterLink>
@@ -170,7 +170,7 @@ export default function Footer() {
           href={urls.external.copyright}
           target="_blank"
           rel="noopener noreferrer"
-          aria-label="Opens in a new window or tab"
+          aria-label="Crown copyright (opens in new tab)"
         >
           &#169; Crown copyright
         </CopyrightLink>

--- a/src/client/components/NewWindowLink/__stories__/NewWindowLink.stories.jsx
+++ b/src/client/components/NewWindowLink/__stories__/NewWindowLink.stories.jsx
@@ -14,7 +14,10 @@ export const Default = () => (
 )
 
 export const CustomAriaLabel = () => (
-  <NewWindowLink href="https://example.com" aria-label="custom help text">
+  <NewWindowLink
+    href="https://example.com"
+    aria-label="custom help text for screen readers which overrides the link text"
+  >
     This is a link
   </NewWindowLink>
 )

--- a/src/client/components/NewWindowLink/index.jsx
+++ b/src/client/components/NewWindowLink/index.jsx
@@ -2,29 +2,43 @@ import React from 'react'
 import Link from '@govuk-react/link'
 import PropTypes from 'prop-types'
 
-const NewWindowLink = ({ href, showHelpText, children, ...rest }) => (
-  <>
-    <Link
-      data-test="newWindowLink"
-      href={href}
-      target="_blank"
-      aria-label="Opens in a new window or tab"
-      {...rest}
-    >
-      {children}
-    </Link>{' '}
-    {showHelpText && '(opens in a new window or tab)'}
-  </>
+/**
+ * When using a screen reader the aria-label attribute overrides
+ * the link text entirely.
+ *
+ * When setting the aria-label ensure the text contains both
+ * meaningful link text AND a warning.
+ *
+ *  For example:
+ * <NewWindowLink
+ *  href="tax-hike.html"
+ *  aria-label="Read more about a HMRC tax hike (opens in new tab)"
+ *  ...
+ * >
+ *  Read more...
+ * </NewWindowLink>
+ *
+ * GDS recommends to use (opens in new tab) as part of the link and not to mention 'window'.
+ * https://design-system.service.gov.uk/styles/typography/#links
+ */
+
+const NewWindowLink = ({ href, children, showWarning = true, ...rest }) => (
+  <Link
+    data-test="newWindowLink"
+    href={href}
+    rel="noreferrer noopener"
+    target="_blank"
+    {...rest}
+  >
+    {children}
+    {showWarning && ' (opens in new tab)'}
+  </Link>
 )
 
 NewWindowLink.propTypes = {
   href: PropTypes.string.isRequired,
-  showHelpText: PropTypes.bool,
   children: PropTypes.node.isRequired,
-}
-
-NewWindowLink.defaultProps = {
-  showHelpText: true,
+  showWarning: PropTypes.bool,
 }
 
 export default NewWindowLink

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditLocationForm.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditLocationForm.jsx
@@ -53,7 +53,7 @@ const EditLocationForm = ({ profile }) => {
                     ukRegionLocations
                   )}
                   placeholder="-- Select region --"
-                  arial-label="Uk locations of interest"
+                  aria-label="Uk locations of interest"
                   isMulti={true}
                 />
                 <FieldTypeahead
@@ -64,7 +64,7 @@ const EditLocationForm = ({ profile }) => {
                   )}
                   options={transformArrayIdNameToValueLabel(countries)}
                   placeholder="-- Select country --"
-                  arial-label="Other countries the investor is considering"
+                  aria-label="Other countries the investor is considering"
                   isMulti={true}
                 />
                 <FieldTextarea

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditProfileDetails.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditProfileDetails.jsx
@@ -115,7 +115,7 @@ const EditProfileDetails = ({ profile }) => {
                         investorTypeOptions
                       )}
                       placeholder="Please select an investor type"
-                      arial-label="Select an investor type"
+                      aria-label="Select an investor type"
                     />
                     <FormLayout setWidth={FORM_LAYOUT.TWO_THIRDS}>
                       <FieldCurrency

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/InvestorCheckDetails.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/InvestorCheckDetails.jsx
@@ -19,7 +19,7 @@ export const InvestorCheckDetails = ({ date, adviser }) => (
       name="adviser"
       label="Person responsible for most recent checks"
       placeholder="Select adviser"
-      arial-label="Select adviser"
+      aria-label="Select adviser"
       initialValue={
         adviser ? [{ value: adviser.id, label: adviser.name }] : undefined
       }

--- a/test/component/cypress/specs/NewWindowLink.cy.jsx
+++ b/test/component/cypress/specs/NewWindowLink.cy.jsx
@@ -2,23 +2,54 @@ import React from 'react'
 import NewWindowLink from '../../../../src/client/components/NewWindowLink'
 
 describe('NewWindowLink', () => {
-  const link = 'https://example.com'
-  const linkText = 'example'
-  const newTabText = 'opens in a new window or tab'
+  const href = 'https://example.com'
+  const text = 'Read more...'
+  const ariaLabel = 'Read more about something (opens in new tab)'
 
   const Component = (props) => <NewWindowLink {...props} />
 
-  context('when the "href" prop is passed', () => {
-    before(() => {
-      cy.mount(<Component href={link}>{linkText}</Component>)
+  context('When passing href', () => {
+    it('should correctly set the href attribute', () => {
+      cy.mount(<Component href={href}>{text}</Component>)
+      cy.get('[data-test="newWindowLink"]').should('have.attr', 'href', href)
     })
+  })
 
-    it('should render the link', () => {
-      cy.get('[data-test="newWindowLink"]')
-        .should('have.attr', 'aria-label', 'Opens in a new window or tab')
-        .should('have.attr', 'href', link)
-        .should('have.text', linkText)
-      cy.contains(newTabText).should('be.visible')
+  context('When passing text without warning', () => {
+    it('should correctly set the text without a warning', () => {
+      cy.mount(<Component showWarning={false}>{text}</Component>)
+      cy.get('[data-test="newWindowLink"]').should('have.text', text)
+    })
+  })
+
+  context('When passing text with a warning', () => {
+    it('should set the text and warning', () => {
+      cy.mount(<Component showWarning={true}>{text}</Component>)
+      cy.get('[data-test="newWindowLink"]').should(
+        'have.text',
+        `${text} (opens in new tab)`
+      )
+    })
+  })
+
+  context('When passing text with a warning (the default)', () => {
+    it('should set the text and warning', () => {
+      cy.mount(<Component>{text}</Component>)
+      cy.get('[data-test="newWindowLink"]').should(
+        'have.text',
+        `${text} (opens in new tab)`
+      )
+    })
+  })
+
+  context('When passing text and an arial label', () => {
+    it('should correctly set the text and aria-label attribute', () => {
+      cy.mount(<Component aria-label={ariaLabel}>{text}</Component>)
+      cy.get('[data-test="newWindowLink"]').should(
+        'have.attr',
+        'aria-label',
+        ariaLabel
+      )
     })
   })
 })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -309,7 +309,7 @@ describe('One List core team', () => {
         .click()
         .should('exist')
         .contains(
-          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in a new window or tab) or email'
+          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in new tab) or email'
         )
     })
   })

--- a/test/functional/cypress/specs/companies/core-team-spec.js
+++ b/test/functional/cypress/specs/companies/core-team-spec.js
@@ -97,7 +97,7 @@ describe('One List core team', () => {
         .click()
         .should('exist')
         .contains(
-          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in a new window or tab) or email'
+          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in new tab) or email'
         )
     })
   })

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -115,7 +115,7 @@ describe('Company Export tab - Edit exports', () => {
         assertReadOnlyItems([
           {
             label: 'great.gov.uk business profile',
-            value: '"Find a supplier" profile (opens in a new window or tab)',
+            value: '"Find a supplier" profile (opens in new tab)',
           },
           { label: 'Export potential', value: 'Unavailable' },
         ])

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -258,7 +258,7 @@ describe('Company Export tab', () => {
           { label: 'Export win category', value: 'Increasing export turnover' },
           {
             label: 'great.gov.uk business profile',
-            value: '"Find a supplier" profile (opens in a new window or tab)',
+            value: '"Find a supplier" profile (opens in new tab)',
           },
 
           { label: 'Export potential', value: 'Unavailable' },

--- a/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
@@ -41,7 +41,7 @@ describe('Referral help', () => {
         .next()
         .should(
           'have.text',
-          'Or find their contact details on Digital Workspace (opens in a new window or tab)'
+          'Or find their contact details on Digital Workspace (opens in new tab)'
         )
         .next()
         .should('have.prop', 'tagName', 'H2')

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -58,7 +58,7 @@ describe('Send a referral form', () => {
           .next()
           .should(
             'have.text',
-            'Referrals are for when you want to ask another DBT advisor to help out an account you are working on.Read more guidance here (opens in a new window or tab)'
+            'Referrals are for when you want to ask another DBT advisor to help out an account you are working on.Read more guidance here (opens in new tab)'
           )
           .find('a')
           .should(
@@ -78,7 +78,7 @@ describe('Send a referral form', () => {
             element,
             label: 'Adviser',
             placeholder: 'Search for an adviser',
-            hint: "This can be an adviser at post, a sector specialist or an international trade advisor. If you're not sure, you can find the right team and person on Digital Workspace (opens in a new window or tab).",
+            hint: "This can be an adviser at post, a sector specialist or an international trade advisor. If you're not sure, you can find the right team and person on Digital Workspace (opens in new tab).",
           })
         })
 

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -32,7 +32,10 @@ describe('Dashboard', () => {
     it('should display the info feed list', () => {
       cy.get('@dataHubFeed')
         .find('[data-test="data-hub-feed-link-0"]')
-        .should('have.text', 'Using Sectors in the Find Exporters Tool')
+        .should(
+          'have.text',
+          'Using Sectors in the Find Exporters Tool (opens in new tab)'
+        )
         .should('have.attr', 'href', 'https://test-url')
 
       cy.get('@dataHubFeed')
@@ -47,7 +50,7 @@ describe('Dashboard', () => {
     it('should display the view all link', () => {
       cy.get('@infoFeedTopLink')
         .should('exist')
-        .should('have.text', 'View all Data Hub updates')
+        .should('have.text', 'View all Data Hub updates (opens in new tab)')
         .should('have.attr', 'href', urls.external.helpCentre.allUpdates())
     })
   })

--- a/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
+++ b/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
@@ -49,12 +49,11 @@ describe('Dashboard - Data Hub feed', () => {
 
       cy.get('@dataHubFeed')
         .find('[data-test="data-hub-feed-link-0"]')
-        .should('have.text', 'Using Sectors in the Find Exporters Tool')
+        .should(
+          'have.text',
+          'Using Sectors in the Find Exporters Tool (opens in new tab)'
+        )
         .should('have.attr', 'href', 'https://test-url')
-
-      cy.get('@dataHubFeed')
-        .find('[data-test="data-hub-feed-note-0"]')
-        .should('have.text', '(Link opens in a new window)')
 
       cy.get('@dataHubFeed')
         .find('[data-test="data-hub-feed-date-0"]')

--- a/test/functional/cypress/specs/events/aventri-details-spec.js
+++ b/test/functional/cypress/specs/events/aventri-details-spec.js
@@ -12,8 +12,7 @@ describe('Event Aventri Details', () => {
 
   const aventriLink =
     'https://eu-admin.eventscloud.com/loggedin/eVent/index.php?eventid='
-  const aventriLinkText = 'View in Aventri'
-  const newTabText = 'opens in a new window or tab'
+  const aventriLinkText = 'View in Aventri (opens in new tab)'
 
   context('when it is a valid event ', () => {
     before(() => {
@@ -103,7 +102,6 @@ describe('Event Aventri Details', () => {
       })
       cy.get('[data-test="eventAventriDetails"]').within(() => {
         cy.get('[data-test="newWindowLink"]')
-          .should('have.attr', 'aria-label', 'Opens in a new window or tab')
           .should('have.attr', 'href', aventriLink + eventInPastId)
           .should('have.text', aventriLinkText)
       })
@@ -125,10 +123,8 @@ describe('Event Aventri Details', () => {
           aventriStatusContent
         )
         cy.get('[data-test="newWindowLink"]')
-          .should('have.attr', 'aria-label', 'Opens in a new window or tab')
           .should('have.attr', 'href', aventriLink + eventInPastId)
           .should('have.text', aventriLinkText)
-        cy.contains(newTabText).should('be.visible')
       })
     })
 
@@ -143,7 +139,6 @@ describe('Event Aventri Details', () => {
         })
         cy.get('[data-test="eventAventriDetails"]').within(() => {
           cy.get('[data-test="newWindowLink"]')
-            .should('have.attr', 'aria-label', 'Opens in a new window or tab')
             .should('have.attr', 'href', aventriLink + eventId)
             .should('have.text', aventriLinkText)
         })

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -35,7 +35,7 @@ describe('Event Details', () => {
       'Related programmes': 'Grown in Britain',
       'Related Trade Agreements': 'UK - Japan',
       Service: 'Events : UK based',
-      Documents: 'View files and documents (opens in a new window or tab)',
+      Documents: 'View files and documents (opens in new tab)',
     })
 
     cy.contains('a', 'View files and documents').should((el) => {
@@ -63,7 +63,7 @@ describe('Event Details', () => {
       'Related programmes': 'Grown in Britain',
       'Related Trade Agreements': 'UK - Japan',
       Service: 'Events : UK based',
-      Documents: 'View files and documents (opens in a new window or tab)',
+      Documents: 'View files and documents (opens in new tab)',
     })
   })
 

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -433,7 +433,7 @@ describe('Export theme - standard interaction', () => {
     it('should permanently show a description about when to select trade agreement', () => {
       cy.get('div [data-test="trade-agreement-guide"]').should(
         'contain',
-        `Select 'trade agreement' if your interaction deals with a named trade agreement.For more information see recording trade agreement activity (opens in a new window or tab).`
+        `Select 'trade agreement' if your interaction deals with a named trade agreement.For more information see recording trade agreement activity (opens in new tab).`
       )
     })
 

--- a/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
@@ -83,7 +83,7 @@ describe('Edit client relationship management page', () => {
     it('should render the hidden help text with visually hidden text for screen reader', () => {
       cy.get('[data-test="global-account-manager-links"]').click()
       cy.contains(
-        `If you need to change the Global Account Manager for this company, go to the Digital Workspace or opens email client for ${Cypress.env(
+        `If you need to change the Global Account Manager for this company, go to the Digital Workspace (opens in new tab) or opens email client for ${Cypress.env(
           'one_list_email'
         )}.`
       )
@@ -91,7 +91,7 @@ describe('Edit client relationship management page', () => {
 
     it('should always have a Digital Workspace link', () => {
       cy.get('[data-test="newWindowLink"]')
-        .should('contain', 'Digital Workspace')
+        .should('contain', 'Digital Workspace (opens in new tab)')
         .should(
           'have.attr',
           'href',


### PR DESCRIPTION
## Description of change

For some, the following points maybe helpful:
* GDS recommends to use (opens in new tab) as part of the link and not to mention 'window'.
* When using a screen reader the `aria-label` attribute overrides the link text entirely.
* Because of this override the `aria-label` value needs to ensure the text contains both meaningful link text AND a warning.

For example:

:white_check_mark: This is good as the screen reader will ignore the text and read out the `aria-label` which has plenty of detail in comparison to the text.
```js
 <NewWindowLink
   href="tax-hike.html"
   aria-label="Read more about a HMRC tax hike (opens in new tab)"
   ...
  >
   Read more... (opens in new tab)
  </NewWindowLink>
```
:white_check_mark: This is also good, however, no need for an `aria-label` as the text has enough information when being read by a screen reader.
```js
 <NewWindowLink
   href="tax-hike.html"
  >
   Read more about a HMRC tax hike (opens in new tab)
  </NewWindowLink>
```

:x: Adding an arial-label exactly the same as the text adds no value to screen readers. You may as well leave out the `aria-label` so the screen reader can read the text - there's no difference.
```js
 <NewWindowLink
   href="tax-hike.html"
    aria-label="Digital Workspace"
  >
    Digital Workspace
  </NewWindowLink>
```
:x: The issue below was picked up by the accessibility audit, we had quite a few of these in the codebase. Again, due to the presence of the `aria-label` the screen reader will read out "Opens in a new window or tab" which is unhelpful.
```js
<NewWindowLink
  href={urls.external.helpCentre.allUpdates()}
  aria-label="Opens in a new window or tab"
>
  View all Data Hub updates
</Link>
```

Reading the code there appears to be a misunderstanding in how the `aria-label` attribute works on a link amongst devs, including myself, by improving the docs and some minor refactoring it should be a lot clearer going forward.

Links:
* https://design-system.service.gov.uk/styles/typography/#links

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
