### PR TITLE
Add aria-expanded to the Data Hub nav button

### DIFF
--- a/src/client/components/DataHubHeader/DataHubBar.jsx
+++ b/src/client/components/DataHubHeader/DataHubBar.jsx
@@ -177,6 +177,7 @@ const DataHubBar = ({
           showVerticalNav={showVerticalNav}
           onClick={() => onShowVerticalNav(!showVerticalNav)}
           role="button"
+          aria-expanded={showVerticalNav}
           aria-label="Show or hide navigation"
           aria-controls="navigation sub-navigation logo-navigation"
         >


### PR DESCRIPTION
## Accessibility issue

**Screen reader user comments:** 
“When swiping through the companies page using VoiceOver, I located a ‘show or hide navigation’ button. At the first instance of use this element does not announce its state however once activated its state is then announced as expected. Allowing the state of the element to be announced at the first instance of use will make it simpler for Screen Reader Users to understand if the element is expanded or collapsed at the first instance it is encountered. This also applies to Talk back.”

**Solution:**
Ensure that all expandable and collapsible content announces its current state to the user. This can be done by adding aria-expanded to the element with “true” or “false” as the value depending on whether the content is expanded or collapsed, respectively.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
