### PR TITLE
feature/CLS2-408-add-access-denied-to-react-routes

### DIFF
--- a/src/client/components/ProtectedRoute/index.jsx
+++ b/src/client/components/ProtectedRoute/index.jsx
@@ -4,12 +4,25 @@ import { connect } from 'react-redux'
 import { Route } from 'react-router-dom'
 import AccessDenied from '../AccessDenied'
 
-const ProtectedRoute = ({ module, modulePermissions, ...rest }) =>
-  modulePermissions.includes(module) ? <Route {...rest} /> : <AccessDenied />
+export const ProtectedRoute = ({
+  module,
+  modulePermissions,
+  userPermissions = [],
+  routePermissions = [],
+  ...rest
+}) =>
+  routePermissions.every((p) => userPermissions.includes(p)) &
+  modulePermissions.includes(module) ? (
+    <Route {...rest} />
+  ) : (
+    <AccessDenied />
+  )
 
 ProtectedRoute.propTypes = {
   module: PropTypes.string.isRequired,
   modulePermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  userPermissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  routePermissions: PropTypes.arrayOf(PropTypes.string),
   redirect: PropTypes.string,
 }
 

--- a/test/component/cypress/specs/ProtectedRoute.cy.jsx
+++ b/test/component/cypress/specs/ProtectedRoute.cy.jsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import DataHubProvider from './provider'
+import { ProtectedRoute } from '../../../../src/client/components/ProtectedRoute'
+
+describe('AccessDenied', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <ProtectedRoute {...props}>
+        <h1>I have permission</h1>
+      </ProtectedRoute>
+    </DataHubProvider>
+  )
+
+  context(
+    'When a user has the module and user permissions needed by the route',
+    () => {
+      it('should render the route', () => {
+        cy.mount(
+          <Component
+            module="m1"
+            modulePermissions={['m1']}
+            userPermissions={['u1']}
+            routePermissions={['u1']}
+          />
+        )
+        cy.get('h1').should('exist')
+      })
+    }
+  )
+
+  context(
+    'When a user is missing the module permissions needed by the route',
+    () => {
+      it('should render the access denied component', () => {
+        cy.mount(
+          <Component
+            module="m1"
+            modulePermissions={['m2']}
+            userPermissions={['u1']}
+            routePermissions={['u1']}
+          />
+        )
+        cy.get('[data-test="access-denied"]').should('exist')
+      })
+    }
+  )
+
+  context(
+    'When a user is missing all the user permissions needed by the route',
+    () => {
+      it('should render the access denied component', () => {
+        cy.mount(
+          <Component
+            module="m1"
+            modulePermissions={['m1']}
+            userPermissions={['u2']}
+            routePermissions={['u1']}
+          />
+        )
+        cy.get('[data-test="access-denied"]').should('exist')
+      })
+    }
+  )
+
+  context(
+    'When a user is missing some of the user permissions needed by the route',
+    () => {
+      it('should render the access denied component', () => {
+        cy.mount(
+          <Component
+            module="m1"
+            modulePermissions={['m1']}
+            userPermissions={['u2', 'u3']}
+            routePermissions={['u1', 'u2', 'u3']}
+          />
+        )
+        cy.get('[data-test="access-denied"]').should('exist')
+      })
+    }
+  )
+})


### PR DESCRIPTION
## Description of change

Extend the permissions implementation for react routes, by allowing a more granular permission process to be applied. Currently if a user has access to a particular module, they gain access to everything related to that module. 

We have an upcoming ticket where we want to be able to restrict permissions on some company pages to limit access to editing objectives, instead of anyone with a company module permission being able to view everything. These permissions already exist in django, and the checks added here are implemented inside the node controllers

## Test instructions

There are no pages that are implementing this yet, however some tests have been added for verifying the permissions checks


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
