### PR TITLE
feature/CLS2-408-add-user-permissions-to-redux

### DIFF
--- a/src/client/reducers.js
+++ b/src/client/reducers.js
@@ -181,6 +181,7 @@ const {
   currentAdviserName,
   activeFeatures,
   activeFeatureGroups,
+  userPermissions,
 } = parseProps(appWrapper)
 
 export const reducers = {
@@ -189,6 +190,7 @@ export const reducers = {
   activeFeatures: () => activeFeatures,
   activeFeatureGroups: () => activeFeatureGroups,
   modulePermissions: () => modulePermissions,
+  userPermissions: () => userPermissions,
   tasks,
   [FLASH_MESSAGE_ID]: flashMessageReducer,
   [COMPANY_LISTS_STATE_ID]: companyListsReducer,

--- a/src/client/reducers.js
+++ b/src/client/reducers.js
@@ -168,6 +168,7 @@ const parseProps = (domNode) => {
       currentAdviserName: '',
       activeFeatures: null,
       activeFeatureGroups: null,
+      userPermissions: [],
     }
   }
   return 'props' in domNode.dataset ? JSON.parse(domNode.dataset.props) : {}

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -20,6 +20,7 @@ module.exports = () => {
       currentAdviserName: req.session?.user?.name,
       activeFeatures: req.session?.user?.active_features || [],
       activeFeatureGroups: req.session?.user?.active_feature_groups || [],
+      userPermissions: req.session?.user?.permissions || [],
     }
     next()
   }

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -22,6 +22,7 @@ const reducer = (state, action) =>
     ...Form.reducerSpread,
     activeFeatureGroups: () => [],
     modulePermissions: () => [],
+    userPermissions: () => [],
   })(action.type === 'RESET' ? undefined : state, action)
 
 export const store = legacy_createStore(


### PR DESCRIPTION
## Description of change

On app start add the logged in users permissions into the redux store. This will be needed in an upcoming ticket

## Test instructions

Open any page and check the redux store, there is now a new property called `userPermissions` that contains all the user's permissions from the api

## Screenshots

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/a6f4baec-324e-48de-8411-af26f69a5539)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
