### PR TITLE
feature/CLS2-294-show-out-of-business-tag

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -293,7 +293,7 @@ const HierarchyItem = ({
         }
       >
         <HierarchyItemHeading>
-          <GridColHeader>
+          <GridColHeader data-test="company-name-header">
             {Object.keys(company).length === 0 ? (
               `No related companies found`
             ) : company?.id ? (
@@ -304,7 +304,7 @@ const HierarchyItem = ({
                 {company.name}
               </Link>
             ) : (
-              `${company.name} (not on Data Hub)`
+              <span>{`${company.name} (not on Data Hub)`}</span>
             )}
             {company?.trading_names?.length > 0 && (
               <TradingNames
@@ -316,6 +316,14 @@ const HierarchyItem = ({
             )}
           </GridColHeader>
           <GridColTags>
+            {company.is_out_of_business && (
+              <HierarchyTag
+                colour="orange"
+                data-test={`${companyName}-out-of-business`}
+              >
+                Out of business
+              </HierarchyTag>
+            )}
             {company.one_list_tier?.name && (
               <HierarchyTag
                 colour="grey"

--- a/src/client/modules/Companies/CompanyHierarchy/styled.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/styled.jsx
@@ -10,7 +10,7 @@ import {
 } from '../../../utils/colours'
 import { Tag, ToggleSection } from '../../../components'
 import { ToggleButton } from '../../../components/ToggleSection/BaseToggleSection'
-import { FONT_SIZE } from '@govuk-react/constants'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 
 const horizontalLine = css`
   //This is the horizontal line to the left of the div
@@ -187,7 +187,8 @@ export const HierarchyHeaderContents = styled.div`
 
 export const HierarchyTag = styled(Tag)`
   float: right;
-  margin-left: 15px;
+  margin-left: ${SPACING.SCALE_3};
+  margin-top: ${SPACING.SCALE_1};
 `
 
 export const InlineDescriptionList = styled.dl`

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -32,6 +32,7 @@ const companyTreeItemFaker = (overrides = {}) => ({
   headquarter_type: faker.helpers.arrayElement(HEADQUARTER_TYPE),
   hierarchy: 1,
   subsidiaries: [],
+  is_out_of_business: false,
   ...overrides,
 })
 

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -45,11 +45,6 @@ const companyWith10LevelsOfSubsidiaries = companyTreeFaker({
   minCompaniesPerLevel: 3,
   maxCompaniesPerLevel: 4,
 })
-const companyName = kebabCase(
-  companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0].name
-)
-const tagContent =
-  companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
 
 const companyNoAdditionalTagData = companyTreeFaker({
   globalCompany: {
@@ -100,6 +95,10 @@ const companyManuallyLinkedSubsidiaries = companyTreeFaker({
 const reducedTreeCompanyTree = companyTreeFaker({})
 reducedTreeCompanyTree.reduced_tree = true
 reducedTreeCompanyTree.ultimate_global_companies_count = 15000
+
+const companyOnlyImmediateSubsidiariesCompanyName = kebabCase(
+  companyOnlyImmediateSubsidiaries.ultimate_global_company.name
+)
 
 const assertRelatedCompaniesPage = ({ company }) => {
   it('should render the header', () => {
@@ -271,7 +270,15 @@ describe('D&B Company hierarchy tree', () => {
   })
 
   context('When a company has only immediate subsidiaries', () => {
+    const subsidiaryCompanyName = kebabCase(
+      companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
+        .name
+    )
+    const subsidiaryTagContent =
+      companyOnlyImmediateSubsidiaries.ultimate_global_company.subsidiaries[0]
+
     before(() => {
+      companyOnlyImmediateSubsidiaries.ultimate_global_company.is_out_of_business = true
       cy.intercept(
         `api-proxy/v4/dnb/${dnbGlobalUltimate.id}/family-tree`,
         companyOnlyImmediateSubsidiaries
@@ -296,20 +303,29 @@ describe('D&B Company hierarchy tree', () => {
     it('should display the global company with the correct company details', () => {
       cy.get('[data-test="hierarchy-item"]')
         .first()
-        .find('div')
+        .get('[data-test="company-name-header"]')
         .first()
         .should(
           'contain.text',
           `${companyOnlyImmediateSubsidiaries.ultimate_global_company.name} (not on Data Hub)`
         )
-      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
+
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-number-of-employees-tag]`
+      ).should(
         'contain.text',
-        tagContent.number_of_employees
+        companyOnlyImmediateSubsidiaries.ultimate_global_company
+          .number_of_employees
       )
-      cy.get(`[data-test=${companyName}-uk-region-tag]`).should(
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-uk-region-tag]`
+      ).should(
         'contain.text',
-        tagContent.uk_region.name
+        companyOnlyImmediateSubsidiaries.ultimate_global_company.uk_region.name
       )
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-out-of-business]`
+      ).should('contain.text', 'Out of business')
     })
 
     it('should show trading names under heading', () => {
@@ -338,26 +354,32 @@ describe('D&B Company hierarchy tree', () => {
               .subsidiaries[0].id
           )
         )
+    })
 
-      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
+    it('should show the expected tags', () => {
+      cy.get(
+        `[data-test=${subsidiaryCompanyName}-number-of-employees-tag]`
+      ).should('contain.text', subsidiaryTagContent.number_of_employees)
+      cy.get(`[data-test=${subsidiaryCompanyName}-uk-region-tag]`).should(
         'contain.text',
-        tagContent.number_of_employees
+        subsidiaryTagContent.uk_region.name
       )
-      cy.get(`[data-test=${companyName}-uk-region-tag]`).should(
+      cy.get(`[data-test=${subsidiaryCompanyName}-country-tag]`).should(
         'contain.text',
-        tagContent.uk_region.name
+        subsidiaryTagContent.address.country.name
       )
-      cy.get(`[data-test=${companyName}-country-tag]`).should(
+      cy.get(`[data-test=${subsidiaryCompanyName}-one-list-tag]`).should(
         'contain.text',
-        tagContent.address.country.name
+        subsidiaryTagContent.one_list_tier.name.slice(0, 6)
       )
-      cy.get(`[data-test=${companyName}-one-list-tag]`).should(
+      cy.get(
+        `[data-test=${subsidiaryCompanyName}-headquarter-type-tag]`
+      ).should(
         'contain.text',
-        tagContent.one_list_tier.name.slice(0, 6)
+        hqLabels[subsidiaryTagContent.headquarter_type.name]
       )
-      cy.get(`[data-test=${companyName}-headquarter-type-tag]`).should(
-        'contain.text',
-        hqLabels[tagContent.headquarter_type.name]
+      cy.get(`[data-test=${subsidiaryCompanyName}-out-of-business]`).should(
+        'not.exist'
       )
     })
   })
@@ -378,15 +400,21 @@ describe('D&B Company hierarchy tree', () => {
         .find('strong')
         .should('not.exist')
 
-      cy.get(`[data-test=${companyName}-number-of-employees-tag]`).should(
-        'not.exist'
-      )
-      cy.get(`[data-test=${companyName}-uk-region-tag]`).should('not.exist')
-      cy.get(`[data-test=${companyName}-country-tag]`).should('not.exist')
-      cy.get(`[data-test=${companyName}-one-list-tag]`).should('not.exist')
-      cy.get(`[data-test=${companyName}-headquarter-type-tag]`).should(
-        'not.exist'
-      )
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-number-of-employees-tag]`
+      ).should('not.exist')
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-uk-region-tag]`
+      ).should('not.exist')
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-country-tag]`
+      ).should('not.exist')
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-one-list-tag]`
+      ).should('not.exist')
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-headquarter-type-tag]`
+      ).should('not.exist')
     })
 
     it('should not show any trading names', () => {


### PR DESCRIPTION
## Description of change

Add the out of business tag to the company tree

## Test instructions

The API change is not yet in place, however the functional tests have added the new property to the fakers so this can be tested using cypress

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/4b409510-486b-4a43-bbbe-94aa13bdc876)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/37513114-09c8-400c-ad07-91335f782bf3)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
