### PR TITLE
Add aria role attribute for better accessibility

### DIFF
--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -125,7 +125,7 @@ function FilteredCollectionHeader({
   return (
     <CollectionHeaderRowContainer>
       <CollectionHeaderRow actions={actions}>
-        <StyledDiv>
+        <StyledDiv role="status">
           <StyledHeaderText>
             <StyledResultCount data-test="collectionCount">
               {formattedTotal}

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -162,7 +162,7 @@ const ExportList = ({
               </FiltersContainer>
             )}
           </Task.Status>
-          <HeaderContainer>
+          <HeaderContainer role="status">
             <StyledHeader>
               <StyledResultCount data-test="collectionCount">
                 {count}

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -3,6 +3,7 @@ import {
   assertCollectionBreadcrumbs,
   assertAddItemButton,
   assertBadge,
+  assertRole,
   assertMetadataItem,
   assertListLength,
 } from '../../support/collection-list-assertions'
@@ -72,6 +73,10 @@ describe('Company Collections - React', () => {
   })
 
   assertCollectionBreadcrumbs('Companies')
+
+  it('should contain a status role', () => {
+    assertRole('status')
+  })
 
   it('should have a link to add company', () => {
     assertAddItemButton('Add company', '/companies/create')

--- a/test/functional/cypress/specs/companies/contact-collection-spec.js
+++ b/test/functional/cypress/specs/companies/contact-collection-spec.js
@@ -15,6 +15,7 @@ const {
   assertArchiveSummary,
   assertUnarchiveLink,
   assertUpdatedOn,
+  assertRole,
   assertTitle,
 } = require('../../support/collection-list-assertions')
 const { collectionListRequest } = require('../../support/actions')
@@ -114,6 +115,10 @@ describe('Company Contacts Collections', () => {
     assertCompanyCollectionBreadcrumbs(dnbFixture, 'Contacts')
     assertTitle('2 contacts')
     assertRemoveAllFiltersNotPresent()
+
+    it('should contain a status role', () => {
+      assertRole('status')
+    })
 
     it('should render an "Add contact" button', () => {
       assertAddItemButton(

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -12,6 +12,7 @@ const {
   assertArchiveMessage,
   assertArchiveSummary,
   assertUnarchiveLink,
+  assertRole,
   assertTitle,
 } = require('../../../support/collection-list-assertions')
 const { collectionListRequest } = require('../../../support/actions')
@@ -129,6 +130,10 @@ describe('Company Investments Collection Page', () => {
     assertCompanyCollectionBreadcrumbs(dnbCorp, 'Investment')
     assertTitle('3 investment projects')
     assertRemoveAllFiltersNotPresent()
+
+    it('should contain a status role', () => {
+      assertRole('status')
+    })
 
     it('should render an "Add investment project" button', () => {
       assertAddItemButton(

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -11,6 +11,7 @@ import {
   assertAddItemButtonNotPresent,
   assertListLength,
   assertBadge,
+  assertRole,
   assertMetadataItem,
   assertMetadataItemNotPresent,
   assertItemLink,
@@ -81,6 +82,10 @@ describe('Company Orders (OMIS) Collection Page', () => {
   })
 
   assertCompanyCollectionBreadcrumbs(oneListCorp, 'Orders (OMIS)')
+
+  it('should contain a status role', () => {
+    assertRole('status')
+  })
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'One List Corp')

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -1,4 +1,5 @@
 import {
+  assertRole,
   getCollectionList,
   assertCollectionBreadcrumbs,
   assertBadge,
@@ -75,6 +76,10 @@ describe('Contacts Collections', () => {
   })
 
   assertCollectionBreadcrumbs('Contacts')
+
+  it('should contain a status role', () => {
+    assertRole('status')
+  })
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Contacts')

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -1,5 +1,6 @@
 import { assertErrorDialog } from '../../support/assertions'
 import {
+  assertRole,
   assertCollectionBreadcrumbs,
   assertAddItemButton,
   assertPaginationSummary,
@@ -21,6 +22,10 @@ describe('Event Collection List Page - React', () => {
       })
 
       assertCollectionBreadcrumbs('Events')
+
+      it('should contain a status role', () => {
+        assertRole('status')
+      })
 
       it('should display the events result count header', () => {
         cy.get('[data-test="activity-feed-collection-header"]').contains(

--- a/test/functional/cypress/specs/interaction/collection-spec.js
+++ b/test/functional/cypress/specs/interaction/collection-spec.js
@@ -1,8 +1,9 @@
 import { omit } from 'lodash'
 
 import {
-  assertCollectionBreadcrumbs,
+  assertRole,
   assertListLength,
+  assertCollectionBreadcrumbs,
 } from '../../support/collection-list-assertions'
 import { collectionListRequest } from '../../support/actions'
 import { interactions } from '../../../../../src/lib/urls'
@@ -175,6 +176,10 @@ describe('Interactions Collections', () => {
   })
 
   assertCollectionBreadcrumbs('Interactions')
+
+  it('should contain a status role', () => {
+    assertRole('status')
+  })
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Interactions')

--- a/test/functional/cypress/specs/omis/collection-spec.js
+++ b/test/functional/cypress/specs/omis/collection-spec.js
@@ -10,6 +10,7 @@ import {
   assertOMISSumary,
   assertItemLink,
   assertUpdatedOn,
+  assertRole,
 } from '../../support/collection-list-assertions'
 import { omisCollectionListRequest } from '../../support/actions'
 import { omis } from '../../../../../src/lib/urls'
@@ -55,6 +56,10 @@ describe('Orders (OMIS) Collection List Page', () => {
   })
 
   assertCollectionBreadcrumbs('Orders (OMIS)')
+
+  it('should contain a status role', () => {
+    assertRole('status')
+  })
 
   it('should render a title', () => {
     cy.get('h1').should('have.text', 'Orders (OMIS)')

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -113,6 +113,12 @@ const assertUpdatedOn = (item, text) => {
   cy.get(item).find('h4').should('have.text', text)
 }
 
+const assertRole = (roleType) => {
+  it('should contain a status role', () => {
+    cy.get(`[role="${roleType}"]`).should('exist')
+  })
+}
+
 const assertTitle = (headingText) => {
   it('should render a title', () => {
     cy.get('h2').should('contain', headingText)
@@ -148,6 +154,7 @@ module.exports = {
   assertArchiveMessage,
   assertUnarchiveLink,
   assertUpdatedOn,
+  assertRole,
   assertTitle,
   assertBadgeShouldNotExist,
   assertPaginationSummary,


### PR DESCRIPTION
## Description of change

**Accessibility problem**
When a filter is applied to any collection list page, screen reader users are not informed that the filter was applied successfully or that the results had updated. This means that they could be confused about whether or not the filter was successfully applied and attempt to apply it more than once.

**Accessibility solution**
Ensure that all filters which update the search results inform the user that they have been successfully applied. This can be done by having the number of results updates being announced to screen readers to inform them of when it updates to have less or more results.

```js
// Apply the aria attribute status role to the header container
<div role="status">
  <h2>
    <span data-test="collectionCount">176,475</span> companies
  </h2>
</div>
```

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
