### PR TITLE
Add tasks endpoints to sandbox

### DIFF
--- a/test/sandbox/routes/v4/task/index.js
+++ b/test/sandbox/routes/v4/task/index.js
@@ -1,12 +1,16 @@
 const { faker } = require('@faker-js/faker')
-const { generateTasks } = require('./tasks')
+const { generateTask, generateTasks } = require('./tasks')
 
 exports.getTasks = function (req, res) {
   res.json(generateTasks())
 }
 
 exports.getTask = function (req, res) {
-  res.json(generateTasks().results[0])
+  res.json(
+    generateTask({
+      id: req.params.taskId,
+    })
+  )
 }
 
 exports.createTask = function (req, res) {

--- a/test/sandbox/routes/v4/task/index.js
+++ b/test/sandbox/routes/v4/task/index.js
@@ -1,0 +1,18 @@
+const { faker } = require('@faker-js/faker')
+const { generateTasks } = require('./tasks')
+
+exports.getTasks = function (req, res) {
+  res.json(generateTasks())
+}
+
+exports.getTask = function (req, res) {
+  res.json(generateTasks().results[0])
+}
+
+exports.createTask = function (req, res) {
+  res.status(201).json({ ...req.body, id: faker.string.uuid() })
+}
+
+exports.updateTask = function (req, res) {
+  res.status(200).json({ ...req.body })
+}

--- a/test/sandbox/routes/v4/task/tasks.js
+++ b/test/sandbox/routes/v4/task/tasks.js
@@ -1,6 +1,8 @@
+// TODO - the logic in this should be moved to the fakers folder once there is a real api to call
+
 const { faker } = require('@faker-js/faker')
 
-const generateTask = () => {
+const generateTask = (overrides = {}) => {
   return {
     id: faker.string.uuid(),
     title: faker.word.sample(),
@@ -12,6 +14,7 @@ const generateTask = () => {
     archived_by: null,
     created_by: generatePerson(),
     modified_by: generatePerson(),
+    ...overrides,
   }
 }
 
@@ -35,4 +38,4 @@ const generateTasks = () => {
   }
 }
 
-module.exports = { generateTasks }
+module.exports = { generateTask, generateTasks }

--- a/test/sandbox/routes/v4/task/tasks.js
+++ b/test/sandbox/routes/v4/task/tasks.js
@@ -8,10 +8,10 @@ const generateTask = () => {
     due_date: faker.date.future(),
     reminder_days: faker.helpers.rangeToNumber({ min: 0, max: 100 }),
     email_reminders_enabled: true,
-    advisers: [generatePerson, generatePerson],
+    advisers: [generatePerson(), generatePerson()],
     archived_by: null,
-    created_by: generatePerson,
-    modified_by: generatePerson,
+    created_by: generatePerson(),
+    modified_by: generatePerson(),
   }
 }
 

--- a/test/sandbox/routes/v4/task/tasks.js
+++ b/test/sandbox/routes/v4/task/tasks.js
@@ -1,0 +1,38 @@
+const { faker } = require('@faker-js/faker')
+
+const generateTask = () => {
+  return {
+    id: faker.string.uuid(),
+    title: faker.word.sample(),
+    description: faker.word.words(),
+    due_date: faker.date.future(),
+    reminder_days: faker.helpers.rangeToNumber({ min: 0, max: 100 }),
+    email_reminders_enabled: true,
+    advisers: [generatePerson, generatePerson],
+    archived_by: null,
+    created_by: generatePerson,
+    modified_by: generatePerson,
+  }
+}
+
+const generatePerson = () => {
+  const firstName = faker.person.firstName()
+  const lastName = faker.person.lastName()
+  return {
+    id: faker.string.uuid(),
+    first_name: firstName,
+    last_name: lastName,
+    name: firstName + ' ' + lastName,
+  }
+}
+
+const generateTasks = () => {
+  return {
+    count: 3,
+    next: null,
+    previous: null,
+    results: [...Array(3)].map(() => generateTask()),
+  }
+}
+
+module.exports = { generateTasks }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -60,6 +60,7 @@ var v4Reminders = require('./routes/v4/reminders/index.js')
 var v4Reminder = require('./routes/v4/reminder/reminder.js')
 var v4SearchAdviser = require('./routes/v4/search/adviser.js')
 var v4Objective = require('./routes/v4/objective/index.js')
+var v4Task = require('./routes/v4/task/index.js')
 
 // Datahub API 3rd party dependencies
 var consentService = require('./routes/api/consentService.js')
@@ -614,6 +615,12 @@ app.post(
   v4SearchExports.fetchExportHistory
 )
 app.post('/v4/search/adviser', v4SearchAdviser.advisers)
+
+// V4 Tasks
+app.get('/v4/task', v4Task.getTasks)
+app.get('/v4/task/:taskId', v4Task.getTask)
+app.post('/v4/task', v4Task.createTask)
+app.patch('/v4/task/:taskId', v4Task.updateTask)
 
 // Whoami endpoint
 app.get('/whoami', user.whoami)


### PR DESCRIPTION
## Description of change

This work is to help speed up development of tasks in the frontend as we do not currently have all API endpoints working.

Created endpoints in the sandbox for tasks
Get tasks: GET `/v4/task`
Get task:  GET `/v4/task/{taskId}`
Create task: POST `/v4/task`
Update task: PATCH `/v4/task/{taskId}`

## Test instructions

When running the sandbox environment, hitting any of the endpoints should return their respective responses:
`/v4/task`: Returns 3 tasks
`/v4/task/{taskId}`: Returns a single task
`/v4/task`: Returns provided body and 201 response
`/v4/task/{taskId}`: Returns 200 response


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
