### PR TITLE
Hide Company List and Referrals dashboard tabs for DA/LEP users

### DIFF
--- a/src/client/components/DashboardTabs/index.jsx
+++ b/src/client/components/DashboardTabs/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { connect } from 'react-redux'
 
 import NoInvestmentProjects from '../MyInvestmentProjects/NoInvestmentProjects'
 import MyInvestmentProjects from '../MyInvestmentProjects'
@@ -9,12 +10,25 @@ import ExportList from '../../modules/ExportPipeline/ExportList'
 import urls from '../../../lib/urls'
 import TabNav from '../TabNav'
 import ReferralList from '../ReferralList'
+import { state2props } from './state'
 
 const StyledDiv = styled('div')`
   padding-top: 16px;
 `
 
-const DashboardTabs = ({ id, adviser, hasInvestmentProjects, onTabChange }) => (
+const canViewCompanyLists = (permissions) =>
+  permissions.includes('company_list.view_companylist')
+
+const canViewReferrals = (permissions) =>
+  permissions.includes('company_referral.view_companyreferral')
+
+const DashboardTabs = ({
+  id,
+  adviser,
+  hasInvestmentProjects,
+  onTabChange,
+  userPermissions,
+}) => (
   <StyledDiv data-test="dashboard-tabs">
     <TabNav
       id={`${id}.TabNav`}
@@ -23,10 +37,12 @@ const DashboardTabs = ({ id, adviser, hasInvestmentProjects, onTabChange }) => (
       keepQueryParams={false}
       onTabChange={onTabChange}
       tabs={{
-        [urls.dashboard.index()]: {
-          label: 'Company lists',
-          content: <CompanyLists />,
-        },
+        ...(canViewCompanyLists(userPermissions) && {
+          [urls.dashboard.index()]: {
+            label: 'Company lists',
+            content: <CompanyLists />,
+          },
+        }),
         [urls.dashboard.investmentProjects()]: {
           label: 'Investment projects',
           content: hasInvestmentProjects ? (
@@ -39,10 +55,12 @@ const DashboardTabs = ({ id, adviser, hasInvestmentProjects, onTabChange }) => (
           label: 'Export projects',
           content: <ExportList />,
         },
-        [urls.companies.referrals.list()]: {
-          label: 'Referrals',
-          content: <ReferralList id="ReferralList" />,
-        },
+        ...(canViewReferrals(userPermissions) && {
+          [urls.companies.referrals.list()]: {
+            label: 'Referrals',
+            content: <ReferralList id="ReferralList" />,
+          },
+        }),
       }}
     />
   </StyledDiv>
@@ -54,4 +72,4 @@ DashboardTabs.propTypes = {
   onTabChange: PropTypes.func,
 }
 
-export default DashboardTabs
+export default connect(state2props)(DashboardTabs)

--- a/src/client/components/DashboardTabs/state.js
+++ b/src/client/components/DashboardTabs/state.js
@@ -1,0 +1,3 @@
+export const state2props = (state) => {
+  return { userPermissions: state.userPermissions }
+}

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -30,10 +30,10 @@ describe('DA Permission', () => {
 
   describe('dashboard', () => {
     before(() => {
-      cy.visit(urls.dashboard.index())
+      cy.visit(urls.dashboard.investmentProjects())
     })
 
-    it('should display DA only tabs', () => {
+    it('should display DA only header tabs', () => {
       assertLocalNav(selectors.nav.headerNav, [
         'Companies',
         'Contacts',
@@ -42,6 +42,11 @@ describe('DA Permission', () => {
         'Market access',
         'Support',
       ])
+    })
+
+    it('should display DA only dashboard tabs', () => {
+      cy.get('[data-test="tab-item"]').as('tabItems')
+      assertLocalNav('@tabItems', ['Investment projects', 'Export projects'])
     })
   })
 

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -25,6 +25,16 @@ describe('DBT Permission', () => {
         'Support',
       ])
     })
+
+    it('should display all four dashboard tabs', () => {
+      cy.get('[data-test="tab-item"]').as('tabItems')
+      assertLocalNav('@tabItems', [
+        'Company lists',
+        'Investment projects',
+        'Export projects',
+        'Referrals',
+      ])
+    })
   })
 
   describe('activity', () => {

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -29,16 +29,21 @@ describe('LEP Permission', () => {
 
   describe('dashboard', () => {
     before(() => {
-      cy.visit(urls.dashboard.index())
+      cy.visit(urls.dashboard.investmentProjects())
     })
 
-    it('should display LEP only tabs', () => {
+    it('should display LEP only header tabs', () => {
       assertLocalNav(selectors.nav.headerNav, [
         'Companies',
         'Contacts',
         'Investments',
         'Support',
       ])
+    })
+
+    it('should display LEP only dashboard tabs', () => {
+      cy.get('[data-test="tab-item"]').as('tabItems')
+      assertLocalNav('@tabItems', ['Investment projects', 'Export projects'])
     })
   })
 

--- a/test/sandbox/fixtures/whoami.json
+++ b/test/sandbox/fixtures/whoami.json
@@ -93,7 +93,8 @@
     "company.view_companyexportcountry",
     "company.change_companyexportcountry",
     "company.change_one_list_tier_and_global_account_manager",
-    "company.change_one_list_core_team_member"
+    "company.change_one_list_core_team_member",
+    "company_referral.view_companyreferral"
   ],
   "features": [],
   "active_features": [],


### PR DESCRIPTION
## Description of change

When viewing the dashboard as a DA or LEP user, two out of the four dashboard tabs contain `Task` error messages as they do not have access to these parts of the site. These two tabs are now hidden for these restricted user groups.

## Test instructions

Run the frontend as either a DA or a LEP (the simplest way of doing this is with the e2e environment). There should only be two tabs visible.

Run the frontend normally and all four tabs should still be visible.

## Screenshots

### Before

<img width="1206" alt="Screenshot 2023-09-08 at 17 40 12" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/64132998-ea39-496c-924c-4a6807885dd1">

### After

<img width="848" alt="Screenshot 2023-09-08 at 18 00 34" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/b7a23883-b65c-49ce-b95b-bd24fbf02e8f">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
