### PR TITLE
Update text for button on company tree

### DIFF
--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -57,11 +57,15 @@ const ToggleSubsidiariesButton = ({
       data-test={dataTest}
     >
       <span>{isOpen ? `-` : `+`}</span>
-      <span>
-        {isOpen
-          ? `Hide ${count} ${pluralize(label, count)}`
-          : `Show ${count} ${pluralize(label, count)}`}
-      </span>
+      {dataTest === 'expand-tree-button' ? (
+        <span>{isOpen ? 'Hide all' : 'Show all'}</span>
+      ) : (
+        <span>
+          {isOpen
+            ? `Hide ${count} ${pluralize(label, count)}`
+            : `Show ${count} ${pluralize(label, count)}`}
+        </span>
+      )}
     </StyledButton>
   </ToggleSubsidiariesButtonContent>
 )

--- a/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
+++ b/test/functional/cypress/specs/companies/dnb-hierarchy-tree-spec.js
@@ -649,8 +649,10 @@ describe('D&B Company hierarchy tree', () => {
 
       assertRelatedCompaniesPage({ company: dnbGlobalUltimate })
 
-      it('should have correct count of ultimate global companies in button', () => {
-        cy.get('[data-test="expand-tree-button"]').should('exist').contains('2')
+      it('should have correct text in button', () => {
+        cy.get('[data-test="expand-tree-button"]')
+          .should('exist')
+          .contains('Show all')
       })
 
       it('should show header with count of ultimate global and manually linked companies', () => {
@@ -659,7 +661,7 @@ describe('D&B Company hierarchy tree', () => {
     }
   )
 
-  context('When a company has a reduced companytree', () => {
+  context('When a company has a reduced company tree', () => {
     before(() => {
       cy.intercept(
         `api-proxy/v4/dnb/${dnbGlobalUltimate.id}/family-tree`,


### PR DESCRIPTION
## Description of change

Update text on button to be simplified

## Test instructions

When viewing a company tree, the top level 'show all' button should now be simplified whilst the expanding buttons in the tree should still specify the number of companies to be shown.

## Screenshots

### Before
<img width="1007" alt="Screenshot 2023-09-11 at 17 10 41" src="https://github.com/uktrade/data-hub-frontend/assets/54268863/41ddd564-4a15-487f-920a-d2f9d768ae81">

### After
<img width="925" alt="Screenshot 2023-09-11 at 17 09 46" src="https://github.com/uktrade/data-hub-frontend/assets/54268863/c220fbb7-2a61-4a00-8630-d8772c70e252">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
