### PR TITLE
Add in-house parallel script for functional tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,9 +74,47 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - run:
+          name: Determine specs to run
+          command: |
+            # List all spec files
+            SPEC_FILES=$(find test/functional/cypress/specs -name '*.js')
+            TOTAL_SPECS=$(echo "$SPEC_FILES" | wc -l)
+
+            echo Total number of specs $TOTAL_SPECS
+
+            # Determine the number of files to run on this container
+            FILES_PER_CONTAINER=$(( TOTAL_SPECS / CIRCLE_NODE_TOTAL ))
+            
+            echo Files per container $FILES_PER_CONTAINER
+
+            REMAINDER=$(( TOTAL_SPECS % CIRCLE_NODE_TOTAL ))
+            
+            echo Remainder specs $REMAINDER
+
+            # Adjust the number of files for this container if necessary
+            if (( CIRCLE_NODE_INDEX < REMAINDER )); then
+              (( FILES_PER_CONTAINER++ ))
+            fi
+
+            # Determine the range of files to run on this container
+            START_INDEX=$(( CIRCLE_NODE_INDEX * FILES_PER_CONTAINER + 1 ))
+            if (( CIRCLE_NODE_INDEX < REMAINDER )); then
+              START_INDEX=$(( START_INDEX + CIRCLE_NODE_INDEX ))
+            else
+              START_INDEX=$(( START_INDEX + REMAINDER ))
+            fi
+            END_INDEX=$(( START_INDEX + FILES_PER_CONTAINER - 1 ))
+
+            # Get the list of files to run on this container
+            SPECS_TO_RUN=$(echo "$SPEC_FILES" | sed -n "$START_INDEX,$END_INDEX p" | tr '\n' ',')
+            SPECS_TO_RUN=$(echo "$SPECS_TO_RUN" | sed 's/,$//')
+            echo "export SPECS_TO_RUN=\"$SPECS_TO_RUN\"" >> $BASH_ENV
+            echo $SPECS_TO_RUN
       - run_make:
           label: Run functional tests
           target: start-mock functional-tests
+          spec_files: $SPECS_TO_RUN
       - store_cypress_artifacts
       - run:
           name: Prepare coverage report
@@ -223,13 +261,16 @@ commands:
         default: Execute make << parameters.target >>
       target:
         type: string
+      spec_files:
+        type: string
+        default: ""
     steps:
       - run:
           name: Copy config
           command: cp sample.env .env
       - run:
           name: << parameters.label >>
-          command: make << parameters.target >>
+          command: make << parameters.target >> SPEC_FILES="<< parameters.spec_files >>"
   store_cypress_artifacts:
     description: Store Cypress artifacts like screenshots and videos
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,41 +76,7 @@ jobs:
       - checkout
       - run:
           name: Determine specs to run
-          command: |
-            # List all spec files
-            SPEC_FILES=$(find test/functional/cypress/specs -name '*.js')
-            TOTAL_SPECS=$(echo "$SPEC_FILES" | wc -l)
-
-            echo Total number of specs $TOTAL_SPECS
-
-            # Determine the number of files to run on this container
-            FILES_PER_CONTAINER=$(( TOTAL_SPECS / CIRCLE_NODE_TOTAL ))
-            
-            echo Files per container $FILES_PER_CONTAINER
-
-            REMAINDER=$(( TOTAL_SPECS % CIRCLE_NODE_TOTAL ))
-            
-            echo Remainder specs $REMAINDER
-
-            # Adjust the number of files for this container if necessary
-            if (( CIRCLE_NODE_INDEX < REMAINDER )); then
-              (( FILES_PER_CONTAINER++ ))
-            fi
-
-            # Determine the range of files to run on this container
-            START_INDEX=$(( CIRCLE_NODE_INDEX * FILES_PER_CONTAINER + 1 ))
-            if (( CIRCLE_NODE_INDEX < REMAINDER )); then
-              START_INDEX=$(( START_INDEX + CIRCLE_NODE_INDEX ))
-            else
-              START_INDEX=$(( START_INDEX + REMAINDER ))
-            fi
-            END_INDEX=$(( START_INDEX + FILES_PER_CONTAINER - 1 ))
-
-            # Get the list of files to run on this container
-            SPECS_TO_RUN=$(echo "$SPEC_FILES" | sed -n "$START_INDEX,$END_INDEX p" | tr '\n' ',')
-            SPECS_TO_RUN=$(echo "$SPECS_TO_RUN" | sed 's/,$//')
-            echo "export SPECS_TO_RUN=\"$SPECS_TO_RUN\"" >> $BASH_ENV
-            echo $SPECS_TO_RUN
+          command: ./test-parallel.sh test/functional/cypress/specs
       - run_make:
           label: Run functional tests
           target: start-mock functional-tests
@@ -177,7 +143,7 @@ jobs:
     machine:
       image: ubuntu-2004:2022.07.1
       docker_layer_caching: true
-    parallelism: 3
+    parallelism: 1
     resource_class: xlarge
     parameters:
       staff:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,16 @@ else
 	log-command = version
 endif
 
+ifdef CI
+	start-command = up --build --force-recreate -d
+	cypress-spec-args = -- --spec $(SPEC_FILES)
+	log-command = logs --follow
+else
+	start-command = up --build --force-recreate
+	cypress-spec-args =
+	log-command = version
+endif
+
 # Helper commands to execute docker-compose for a specific setup
 # e.g. "`make base` logs"
 base:
@@ -102,7 +112,7 @@ endif
 
 functional-tests:
 	@echo "*** Requires the mock stack, it can be started with 'make start-mock' ***"
-	$(docker-mock) exec frontend bash -c '$(wait-for-frontend) && npm run test:functional $(cypress-args)'
+	$(docker-mock) exec frontend bash -c '$(wait-for-frontend) && npm run test:functional $(cypress-spec-args)'
 
 a11y-tests:
 	@echo "*** Requires the mock stack, it can be started with 'make start-mock' ***"

--- a/test-parallel.sh
+++ b/test-parallel.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# List all spec files
+SPEC_FILES=$(find test/functional/cypress/specs -name '*.js')
+TOTAL_SPECS=$(echo "$SPEC_FILES" | wc -l)
+
+echo Total number of specs $TOTAL_SPECS
+
+# Determine the number of files to run on this container
+FILES_PER_CONTAINER=$(( TOTAL_SPECS / CIRCLE_NODE_TOTAL ))
+
+echo Files per container $FILES_PER_CONTAINER
+
+REMAINDER=$(( TOTAL_SPECS % CIRCLE_NODE_TOTAL ))
+
+echo Remainder specs $REMAINDER
+
+# Adjust the number of files for this container if necessary
+if (( CIRCLE_NODE_INDEX < REMAINDER )); then
+  (( FILES_PER_CONTAINER++ ))
+fi
+
+# Determine the range of files to run on this container
+START_INDEX=$(( CIRCLE_NODE_INDEX * FILES_PER_CONTAINER + 1 ))
+if (( CIRCLE_NODE_INDEX < REMAINDER )); then
+  START_INDEX=$(( START_INDEX + CIRCLE_NODE_INDEX ))
+else
+  START_INDEX=$(( START_INDEX + REMAINDER ))
+fi
+END_INDEX=$(( START_INDEX + FILES_PER_CONTAINER - 1 ))
+
+# Get the list of files to run on this container
+SPECS_TO_RUN=$(echo "$SPEC_FILES" | sed -n "$START_INDEX,$END_INDEX p" | tr '\n' ',')
+SPECS_TO_RUN=$(echo "$SPECS_TO_RUN" | sed 's/,$//')
+echo "export SPECS_TO_RUN=\"$SPECS_TO_RUN\"" >> $BASH_ENV
+echo $SPECS_TO_RUN

--- a/test-parallel.sh
+++ b/test-parallel.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 
+# Spec directory argument
+SPEC_DIR=$1
+
+if [ -z "$SPEC_DIR" ]; then
+    echo "Error: Spec directory is required."
+    exit 1
+fi
+
 # List all spec files
-SPEC_FILES=$(find test/functional/cypress/specs -name '*.js')
+SPEC_FILES=$(find $SPEC_DIR -name '*.js')
 TOTAL_SPECS=$(echo "$SPEC_FILES" | wc -l)
 
 echo Total number of specs $TOTAL_SPECS


### PR DESCRIPTION
## Description of change

Due to a policy change in cypress dashboard, we now have a limit of 100k test runs per month for free instead of "unlimited" in the past.

This meant functional tests were taking over an hour to complete. This PR creates an in-house solution to parallelise functional tests without the need to use cypress dashboard.

## Test instructions

BAU

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
