### PR TITLE
Ensure vertical scroll is always visible when scrolling typeahead lists

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -37,7 +37,6 @@ import {
   getActionFromKey,
   getFilteredOptions,
   getUpdatedIndex,
-  maintainScrollVisibility,
   menuActions,
   getNewSelectedOptions,
 } from './utils'
@@ -183,7 +182,7 @@ const Typeahead = ({
     })
   }, [JSON.stringify(initialValue), isMulti])
   const inputRef = React.useRef(null)
-  const menuRef = React.useRef(null)
+  const listRef = React.useRef(null)
   const ignoreFilter =
     !isMulti && selectedOptions.map(({ label }) => label).includes(input)
   const filteredOptions = getFilteredOptions({
@@ -194,11 +193,12 @@ const Typeahead = ({
     menuOpen && filteredOptions[activeIndex]
       ? `${name}-${filteredOptions[activeIndex].value}`
       : ''
-  const scrollMenuToIndex = (index) =>
-    maintainScrollVisibility({
-      parent: menuRef.current,
-      target: menuRef.current.children[index],
-    })
+  const scrollItemAtIndexIntoView = (index) => {
+    const item = listRef.current?.children[index]
+    if (item) {
+      item.scrollIntoView({ block: 'nearest' })
+    }
+  }
   const onInputKeyDown = (event) => {
     const max = filteredOptions.length - 1
     const action = getActionFromKey(event.code, menuOpen)
@@ -211,7 +211,7 @@ const Typeahead = ({
         event.preventDefault()
         const newActiveIndex = getUpdatedIndex(activeIndex, max, action)
         onActiveChange(newActiveIndex)
-        scrollMenuToIndex(newActiveIndex)
+        scrollItemAtIndexIntoView(newActiveIndex)
         return
       case menuActions.closeSelect:
         event.preventDefault()
@@ -235,7 +235,7 @@ const Typeahead = ({
         return
       case menuActions.open:
         onMenuOpen()
-        scrollMenuToIndex(activeIndex)
+        scrollItemAtIndexIntoView(activeIndex)
         return
     }
   }
@@ -285,7 +285,7 @@ const Typeahead = ({
           onBlur={onBlur}
           onClick={() => {
             onMenuOpen()
-            scrollMenuToIndex(activeIndex)
+            scrollItemAtIndexIntoView(activeIndex)
           }}
           onInput={(e) => {
             onInput(e)
@@ -305,7 +305,6 @@ const Typeahead = ({
           role="listbox"
           aria-labelledby={`${name}-label`}
           aria-multiselectable="true"
-          ref={menuRef}
           data-test="typeahead-menu"
         >
           {menuOpen && menuActive && (
@@ -323,7 +322,7 @@ const Typeahead = ({
               }}
             >
               {() => (
-                <>
+                <div ref={listRef}>
                   {filteredOptions.map((option, index) => (
                     <ListboxOption
                       id={`${name}-${option.value}`}
@@ -374,7 +373,7 @@ const Typeahead = ({
                       {noOptionsMessage}
                     </NoOptionsMessage>
                   )}
-                </>
+                </div>
               )}
             </Task.Status>
           )}

--- a/src/client/components/Typeahead/utils.js
+++ b/src/client/components/Typeahead/utils.js
@@ -82,17 +82,3 @@ export const getNewSelectedOptions = ({ selectedOptions, option, isMulti }) =>
  **/
 export const valueAsArray = (value) =>
   value ? (Array.isArray(value) ? value : [value]) : []
-
-export const maintainScrollVisibility = ({ parent, target }) => {
-  if (!parent || !target) {
-    return
-  }
-  const { offsetHeight: parentOffsetHeight, scrollTop } = parent
-  const { offsetHeight, offsetTop } = target
-
-  if (offsetTop <= scrollTop) {
-    parent.scrollTo(0, offsetTop)
-  } else if (offsetTop + offsetHeight > scrollTop + parentOffsetHeight) {
-    parent.scrollTo(0, offsetTop - parentOffsetHeight + offsetHeight)
-  }
-}


### PR DESCRIPTION
## Description of change
At present, when scrolling typeahead lists with the **keyboard down arrow** the vertical scroll is not visible. This makes it difficult to know where you are in the list as the current selection disappears out of view. This fix ensures the vertical scrollbar remains visible at all times.

## Screenshots

### Before
https://github.com/uktrade/data-hub-frontend/assets/964268/77c905c8-f4bb-4a7a-9bf1-8be6deca0d2e

### After
https://github.com/uktrade/data-hub-frontend/assets/964268/169db978-9534-4821-b141-44f76f270b00
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
