### PR TITLE
Allow job rows to be shown when there are 0 jobs

### DIFF
--- a/src/client/modules/Investments/Projects/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/ProjectDetails.jsx
@@ -333,7 +333,7 @@ const ProjectDetails = ({ projectId, currentAdviserId }) => (
               }
             />
           )}
-          {project.numberNewJobs && (
+          {(project.numberNewJobs || project.numberNewJobs === 0) && (
             <SummaryTable.TextRow
               heading="New jobs"
               value={project.numberNewJobs + ' new jobs'}
@@ -345,7 +345,8 @@ const ProjectDetails = ({ projectId, currentAdviserId }) => (
               value={project.averageSalary?.name}
             />
           )}
-          {project.numberSafeguardedJobs && (
+          {(project.numberSafeguardedJobs ||
+            project.numberSafeguardedJobs === 0) && (
             <SummaryTable.TextRow
               heading="Safeguarded jobs"
               value={project.numberSafeguardedJobs + ' safeguarded jobs'}

--- a/test/functional/cypress/fixtures/investment/investment-has-existing-value.json
+++ b/test/functional/cypress/fixtures/investment/investment-has-existing-value.json
@@ -106,7 +106,7 @@
   "foreign_equity_investment": "200000",
   "government_assistance": true,
   "some_new_jobs": null,
-  "number_new_jobs": 20,
+  "number_new_jobs": 0,
   "will_new_jobs_last_two_years": null,
   "average_salary": {
     "name": "Below £25,000",

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -172,7 +172,7 @@ describe('Investment project details', () => {
           'Capital expenditure value': '£200,000',
           'Gross Value Added (GVA)': '£34,568',
           'Government assistance': 'Has government assistance',
-          'New jobs': '20 new jobs',
+          'New jobs': '0 new jobs',
           'Average salary of new jobs': 'Below £25,000',
           'Safeguarded jobs': '11234 safeguarded jobs',
           'R&D budget': R_AND_D_FALSE,

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -5122,7 +5122,7 @@
       "foreign_equity_investment": "200000",
       "government_assistance": true,
       "some_new_jobs": null,
-      "number_new_jobs": 20,
+      "number_new_jobs": 0,
       "will_new_jobs_last_two_years": null,
       "average_salary": {
         "name": "Below £25,000",


### PR DESCRIPTION
## Description of change

For investment project values, previously when setting `number_new_jobs` or `number_safeguarded_jobs` to 0, the row failed to display correcly. Adding the additional check for `<no_job> === 0` allows them to be displayed while still allowing them to be hidden when undefined.

## Test instructions

Setting an investment project value to have 0 new jobs or 0 safeguarded jobs will highlight the bug.

## Screenshots

### Before
https://www.datahub.staging.uktrade.io/investments/projects/953f04f1-1cc1-4af8-adf7-82dc57d817f2/details
<img width="964" alt="Screenshot 2023-09-14 at 16 41 51" src="https://github.com/uktrade/data-hub-frontend/assets/22541658/ae00a02c-e8e2-4fca-a87c-63861e6f4be1">

### After

<img width="964" alt="Screenshot 2023-09-14 at 16 47 26" src="https://github.com/uktrade/data-hub-frontend/assets/22541658/d94c1df6-2591-4ecc-a5f7-a93af1657a1c">

## Checklist
- [] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
