### PR TITLE
Update optional chaining to allow empty address countries, update conditional rendering to value being shown

### DIFF
--- a/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
+++ b/src/apps/companies/apps/company-overview/overview-table-cards/BusinessDetailsCard.jsx
@@ -21,8 +21,8 @@ const BusinessDetailsCard = ({ company }) => (
     caption="Business details"
     data-test="businessDetailsContainer"
   >
-    {(company.registeredAddress?.country.id == UNITED_KINGDOM_ID ||
-      company.address?.country.id == UNITED_KINGDOM_ID) && (
+    {(company.registeredAddress?.country?.id == UNITED_KINGDOM_ID ||
+      company.address?.country?.id == UNITED_KINGDOM_ID) && (
       <SummaryTable.Row heading="Companies House">
         {buildCellContents(
           company.companyNumber,
@@ -41,11 +41,9 @@ const BusinessDetailsCard = ({ company }) => (
         company.address,
         <StyledAddressList>
           {company.address?.line1 && <li>{company.address.line1}</li>}
-          {company.registeredAddress?.line2 && <li>{company.address.line2}</li>}
-          {company.registeredAddress?.town && <li>{company.address.town}</li>}
-          {company.registeredAddress?.postcode && (
-            <li>{company.address.postcode}</li>
-          )}
+          {company.address?.line2 && <li>{company.address.line2}</li>}
+          {company.address?.town && <li>{company.address.town}</li>}
+          {company.address?.postcode && <li>{company.address.postcode}</li>}
         </StyledAddressList>
       )}
     </SummaryTable.Row>
@@ -94,6 +92,7 @@ const BusinessDetailsCard = ({ company }) => (
     </StyledTableRow>
   </StyledSummaryTable>
 )
+
 BusinessDetailsCard.propTypes = {
   company: PropTypes.object.isRequired,
 }

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -191,7 +191,7 @@ describe('Company overview page', () => {
   })
   context('when viewing a UK business with only registered address', () => {
     const blankAddress = fixtures.company.allOverviewDetails
-    blankAddress.address = {}
+    blankAddress.address = null
     before(() => {
       cy.intercept(
         'GET',
@@ -209,6 +209,18 @@ describe('Company overview page', () => {
         .children()
         .first()
         .contains('Companies House')
+    })
+
+    it('should have address set as "Not set"', () => {
+      cy.get('[data-test="businessDetailsContainer"]')
+        .children()
+        .first()
+        .contains('Business details')
+        .next()
+        .children()
+        .contains('Trading Address')
+        .siblings()
+        .contains('td', 'Not set')
     })
   })
   context(


### PR DESCRIPTION
## Description of change

Added another optional chaining to allow for blank company address countries set in the django admin.
Updated the conditional rendering as well to match what was being displayed as previously this would cause the page to crash as it would try to display an undefined value.

## Test instructions

Conditional rendering change testing
- Load a company in the frontend and backend admin site
- Change the address to be empty (registered address can remain empty or filled)
- Reload frontend company page.
- See the page no longer crashes.

Optional chaining change testing
- Load a company in the frontend and backend admin site
- Set both the address and registered address countries to blank
- Reload company frontend page
- See page no longer crahses.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
