### PR TITLE
Add `/details` to investment search URL

### DIFF
--- a/src/apps/investments/transformers/__test__/collection.test.js
+++ b/src/apps/investments/transformers/__test__/collection.test.js
@@ -13,7 +13,7 @@ describe('Investment project transformers', () => {
       })
 
       it('should provide the id', () => {
-        expect(this.transformedItem.id).to.equal(this.rawItem.id)
+        expect(this.transformedItem.id).to.equal(this.rawItem.id + '/details')
       })
 
       it('should provide the name', () => {

--- a/src/apps/investments/transformers/collection.js
+++ b/src/apps/investments/transformers/collection.js
@@ -39,7 +39,7 @@ function transformInvestmentProjectToListItem({
   })
 
   return {
-    id,
+    id: id + '/details',
     name,
     type: 'investments/project',
     subTitle: {


### PR DESCRIPTION
## Description of change

When going to the URL for an investment project without anything at the end (such as the URLs that the homepage search uses), it leads to an error page. Until we have all the investment URLs within React Router (or until the homepage search is reactified) I have come up with a temporary solution to this problem.

## Test instructions

Look up an investment project in the homepage search and open it. You will be redirected to the project's details page.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
