### PR TITLE
Add invalid email warnings for contacts

### DIFF
--- a/src/apps/contacts/transformers.js
+++ b/src/apps/contacts/transformers.js
@@ -23,6 +23,7 @@ function transformContactToListItem({
   primary,
   full_telephone_number,
   email,
+  valid_email,
 } = {}) {
   if (!id || (!first_name && !last_name)) {
     return
@@ -36,6 +37,11 @@ function transformContactToListItem({
     { key: 'company_uk_region', value: company_uk_region },
     { key: 'telephone', value: full_telephone_number },
     { key: 'email', value: email },
+    {
+      key: 'valid_email',
+      value: valid_email === false ? 'UNKNOWN EMAIL' : null,
+      type: 'badge',
+    },
     {
       key: 'contact_type',
       value: primary ? 'Primary' : null,

--- a/src/client/components/SummaryTable/index.jsx
+++ b/src/client/components/SummaryTable/index.jsx
@@ -3,9 +3,14 @@ import styled from 'styled-components'
 import React from 'react'
 import PropTypes from 'prop-types'
 import { isEmpty } from 'lodash'
-import { GREY_2 } from '../../../client/utils/colours'
+import { GREY_2, ERROR_COLOUR } from '../../../client/utils/colours'
 import { typography } from '@govuk-react/lib'
-import { SPACING, FONT_SIZE, LINE_HEIGHT } from '@govuk-react/constants'
+import {
+  SPACING,
+  FONT_SIZE,
+  LINE_HEIGHT,
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+} from '@govuk-react/constants'
 
 import { currencyGBP } from '../../utils/number-utils'
 import Tag from '../Tag'
@@ -48,9 +53,18 @@ const StyledTableRow = styled(Table.Row)`
   font-size: ${FONT_SIZE.SIZE_16};
   line-height: ${LINE_HEIGHT.SIZE_24};
   white-space: pre-wrap;
+
+  /* Conditionally apply the red border when flag is false */
+  ${(props) =>
+    props.invalid &&
+    `
+      border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+      margin-right: ${SPACING.SCALE_3};
+      padding-left: ${SPACING.SCALE_2};
+    `}
 `
 
-SummaryTable.Row = ({ heading, children, hideWhenEmpty }) => {
+SummaryTable.Row = ({ heading, children, hideWhenEmpty, flag }) => {
   if (hideWhenEmpty && isEmpty(children)) {
     return null
   }
@@ -72,7 +86,7 @@ SummaryTable.Row = ({ heading, children, hideWhenEmpty }) => {
   }
 
   return (
-    <StyledTableRow>
+    <StyledTableRow invalid={flag}>
       {heading && <Table.CellHeader>{heading}</Table.CellHeader>}
       <Table.Cell>{renderChildren()}</Table.Cell>
     </StyledTableRow>

--- a/src/client/modules/Contacts/CollectionList/transformers.js
+++ b/src/client/modules/Contacts/CollectionList/transformers.js
@@ -2,6 +2,7 @@
 const { get } = require('lodash')
 
 import { formatMediumDateTime } from '../../../utils/date'
+import { BABY_PINK_50 } from '../../../../client/utils/colours'
 
 import urls from '../../../../lib/urls'
 
@@ -20,7 +21,10 @@ export const transformContactToListItem = (companyId) => (contact) => {
   ].filter((item) => !(item.label === 'Company' && companyId))
 
   const badges = [
-    { text: contact.valid_email === false ? 'UNKNOWN EMAIL' : null },
+    {
+      text: contact.valid_email === false ? 'UNKNOWN EMAIL' : null,
+      borderColour: BABY_PINK_50,
+    },
     { text: contact.primary ? 'Primary' : null },
     { text: contact.archived ? 'Archived' : null },
   ]

--- a/src/client/modules/Contacts/CollectionList/transformers.js
+++ b/src/client/modules/Contacts/CollectionList/transformers.js
@@ -20,6 +20,7 @@ export const transformContactToListItem = (companyId) => (contact) => {
   ].filter((item) => !(item.label === 'Company' && companyId))
 
   const badges = [
+    { text: contact.valid_email === false ? 'UNKNOWN EMAIL' : null },
     { text: contact.primary ? 'Primary' : null },
     { text: contact.archived ? 'Archived' : null },
   ]

--- a/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
+++ b/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
@@ -2,8 +2,9 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
-import { BLACK, GREY_3 } from '../../../../client/utils/colours'
 
+import { BLACK, GREY_3 } from '../../../../client/utils/colours'
+import { ErrorSummary } from '../../../components'
 import { ContactResource } from '../../../components/Resource'
 import { SummaryTable } from '../../../components'
 import urls from '../../../../lib/urls'
@@ -44,11 +45,20 @@ const getAddress = (contact, companyAddress) => {
   return Object.values(addressCleaned).join(', ')
 }
 
+const errorMsg = 'Emails sent to the current address bounced back as invalid.'
+
 const ContactDetails = ({ contactId, companyAddress, permissions }) => (
   <ContactResource id={contactId}>
     {(contact) => (
       <>
         <ContactLayout contact={contact} permissions={permissions}>
+          {contact.validEmail === false && (
+            <ErrorSummary
+              heading="Please update the email address"
+              description={errorMsg}
+              errors={[]}
+            />
+          )}
           <SummaryTable
             caption="Contact details"
             data-test="contact-details-table"
@@ -63,7 +73,11 @@ const ContactDetails = ({ contactId, companyAddress, permissions }) => (
               heading="Address"
               children={getAddress(contact, companyAddress)}
             />
-            <SummaryTable.Row heading="Email" children={contact.email} />
+            <SummaryTable.Row
+              heading="Email"
+              children={contact.email}
+              flag={contact.validEmail === false}
+            />
             {contact.notes && (
               <SummaryTable.Row
                 heading="More details"

--- a/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
+++ b/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
@@ -4,9 +4,8 @@ import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
 
 import { BLACK, GREY_3 } from '../../../../client/utils/colours'
-import { ErrorSummary } from '../../../components'
 import { ContactResource } from '../../../components/Resource'
-import { SummaryTable } from '../../../components'
+import { SummaryTable, ErrorSummary } from '../../../components'
 import urls from '../../../../lib/urls'
 import {
   EMAIL_CONSENT_NO,
@@ -45,7 +44,7 @@ const getAddress = (contact, companyAddress) => {
   return Object.values(addressCleaned).join(', ')
 }
 
-const errorMsg = 'Emails sent to the current address bounced back as invalid.'
+const errorMsg = 'The email address has been flagged as invalid'
 
 const ContactDetails = ({ contactId, companyAddress, permissions }) => (
   <ContactResource id={contactId}>

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -36,6 +36,7 @@ describe('Contacts Collections', () => {
     primary: true,
     full_telephone_number: '+44 02071234567',
     modified_on: '2020-08-10T19:09:35.276Z',
+    valid_email: true,
   })
 
   const foreignContact = contactFaker({
@@ -58,10 +59,16 @@ describe('Contacts Collections', () => {
     archived: true,
   })
 
+  const invalidEmail = contactFaker({
+    id: '4',
+    valid_email: false,
+  })
+
   const contactsList = [
     ukContact,
     foreignContact,
     archivedContact,
+    invalidEmail,
     ...contactsListFaker(7),
   ]
 
@@ -73,6 +80,7 @@ describe('Contacts Collections', () => {
     getCollectionList()
     cy.get('@collectionItems').eq(1).as('secondListItem')
     cy.get('@collectionItems').eq(2).as('thirdListItem')
+    cy.get('@collectionItems').eq(3).as('forthListItem')
   })
 
   assertCollectionBreadcrumbs('Contacts')
@@ -100,6 +108,10 @@ describe('Contacts Collections', () => {
 
     it('should not contain an archived badge', () => {
       assertBadgeNotPresent('@firstListItem', 'Archived')
+    })
+
+    it('should not contain an unknown email badge', () => {
+      assertBadgeNotPresent('@firstListItem', 'UNKNOWN EMAIL')
     })
 
     it('should render the updated date and time', () => {
@@ -164,6 +176,12 @@ describe('Contacts Collections', () => {
   context('Archived contact', () => {
     it('should contain an archived badge', () => {
       assertBadge('@thirdListItem', 'Archived')
+    })
+  })
+
+  context('Contact with invalid email', () => {
+    it('should contain an unknown email badge', () => {
+      assertBadge('@forthListItem', 'UNKNOWN EMAIL')
     })
   })
 })

--- a/test/functional/cypress/specs/contacts/details-spec.js
+++ b/test/functional/cypress/specs/contacts/details-spec.js
@@ -9,6 +9,7 @@ const incompleteUKContact = require('../../../../sandbox/fixtures/v3/contact/con
 const companyAddresscontact = require('../../../../sandbox/fixtures/v3/contact/contact-with-company-address.json')
 const usContact = require('../../../../sandbox/fixtures/v3/contact/contact-with-us-address.json')
 const archiveContact = require('../../../../sandbox/fixtures/v3/contact/contact-archived.json')
+const invalidEmailContact = require('../../../../sandbox/fixtures/v3/contact/contact-invalid-email.json')
 
 const ARCHIVE_INTERCEPT = 'archiveHttpRequest'
 
@@ -209,6 +210,47 @@ describe('View contact details', () => {
 
     it('should not render the archive container', () => {
       cy.get('[data-test=archive-contact-container]').should('not.exist')
+    })
+
+    it('should not render the invalid email message when email is valid', () => {
+      cy.contains('Please update the email address').should('not.exist')
+    })
+  })
+
+  context('when viewing a contact with an invalid email flagged', () => {
+    before(() => {
+      cy.visit('/contacts/2341fb21-ee64-4898-8f2e-ebf924e1e63f')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: '/',
+        Contacts: contacts.index(),
+        'Joseph Woof': null,
+      })
+    })
+
+    it('should render the invalid email message', () => {
+      cy.contains('Please update the email address').should('exist')
+      cy.contains('The email address has been flagged as invalid').should(
+        'exist'
+      )
+    })
+
+    it('should render the subheading', () => {
+      cy.contains('Contact details').should('exist')
+    })
+
+    it('should render the details table', () => {
+      assertKeyValueTable('contact-details-table', {
+        'Job title': invalidEmailContact.job_title,
+        'Phone number': invalidEmailContact.full_telephone_number,
+        Address:
+          '123 Test Street, Address Line 2, Sandbox Town, Test County, AB1 2CD, United Kingdom',
+        Email: invalidEmailContact.email,
+        'More details': invalidEmailContact.notes,
+        'Email marketing': EMAIL_CONSENT_YES,
+      })
     })
   })
 

--- a/test/sandbox/fixtures/v3/contact/contact-invalid-email.json
+++ b/test/sandbox/fixtures/v3/contact/contact-invalid-email.json
@@ -1,0 +1,50 @@
+{
+    "id":"1ba51fde-88be-43b3-8701-5c9adcc5cbfb",
+    "title":null,
+    "first_name":"Joseph",
+    "last_name":"Woof",
+    "name":"Joseph Woof",
+    "job_title":"Dog master",
+    "company":{
+       "name":"Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+       "id":"4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+    },
+    "adviser":{
+       "name":"DBT Staff",
+       "first_name":"DBT",
+       "last_name":"Staff",
+       "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+    },
+    "primary":true,
+    "telephone_countrycode":"",
+    "telephone_number":"",
+    "full_telephone_number":"222 3453454",
+    "email":"contact@bob.com",
+    "address_same_as_company":false,
+    "address_1":"123 Test Street",
+    "address_2":"Address Line 2",
+    "address_town":"Sandbox Town",
+    "address_county":"Test County",
+    "address_country": {
+        "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+        "name": "United Kingdom"
+      },
+    "address_postcode":"AB1 2CD",
+    "telephone_alternative":null,
+    "email_alternative":null,
+    "notes":"An example of a contact for testing purposes",
+    "accepts_dit_email_marketing":true,
+    "archived":false,
+    "archived_documents_url_path":"/document/123",
+    "archived_on":"2019-07-04T15:59:14.267412Z",
+    "archived_reason":"Left the company",
+    "archived_by":{
+        "name":"Bernard Harris-Patel",
+        "first_name":"Bernard",
+        "last_name":"Harris-Patel",
+        "id":"7d19d407-9aec-4d06-b190-d3f404627f21"
+     },
+    "created_on":"2019-02-04T15:59:14.267412Z",
+    "modified_on":"2019-02-05T13:17:23.112153Z",
+    "valid_email": false
+  }

--- a/test/sandbox/routes/v3/contact/contact.js
+++ b/test/sandbox/routes/v3/contact/contact.js
@@ -8,6 +8,7 @@ const incompleteUKContact = require('../../../fixtures/v3/contact/contact-incomp
 const contactWithCompanyAddress = require('../../../fixtures/v3/contact/contact-with-company-address.json')
 const contactWithUSAddress = require('../../../fixtures/v3/contact/contact-with-us-address.json')
 const archivedContact = require('../../../fixtures/v3/contact/contact-archived.json')
+const invalidEmailContact = require('../../../fixtures/v3/contact/contact-invalid-email.json')
 const aventriContact = require('../../../fixtures/v4/activity-feed/aventri-attendees.json')
 const ditContactforAventri = require('../../../fixtures/v3/contact/contact-aventri.json')
 const noContact = require('../../../fixtures/v3/contact/no-contact.json')
@@ -88,6 +89,7 @@ exports.contactById = function (req, res) {
     'a55af9e5-c53c-4696-9647-065b28ea02de': contactWithCompanyAddress,
     'b0cb178b-49d3-467a-9cd7-90cb0fe0f30a': contactWithUSAddress,
     '1ba51fde-88be-43b3-8701-5c9adcc5cbfb': archivedContact,
+    '2341fb21-ee64-4898-8f2e-ebf924e1e63f': invalidEmailContact,
   }
 
   res.json(contacts[req.params.contactId] || contactByIdUS)


### PR DESCRIPTION
## Description of change

Adding warning messages and badges so managers take action on updating contact emails flagged as invalid

## Test instructions

BAU

## Screenshots

### Before

<img width="1137" alt="Screenshot 2023-09-22 at 09 23 48" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/995c67ac-59f0-4e9a-804f-d9ffff4c2800">

<img width="1080" alt="Screenshot 2023-09-22 at 09 23 37" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/6d47dd89-bcf1-4a51-97c6-b4c90e21ac1b">



### After

<img width="1004" alt="Screenshot 2023-09-22 at 09 23 17" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/798d4cee-b4cf-4c0c-955f-b385545cc1ea">

<img width="888" alt="Screenshot 2023-09-22 at 09 22 59" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/b4c3512b-7da2-4c0f-8e1f-ff4a73e11eac">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
