### PR TITLE
Allow interactions related to were export countries discussed to be edited

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -164,7 +164,10 @@ const InteractionDetailsForm = ({
                                   },
                                 })
                               }}
-                              {...props}
+                              {
+                                ...props
+                                /** The props contains values object from this form */
+                              }
                             />
                           )}
                         </Step>

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -142,7 +142,6 @@ const validatedDuplicatedCountries = (countries, field, { values }) =>
     (status) =>
       countries &&
       values[status] &&
-      values[status].length &&
       countries.some((country) => values[status].includes(country))
   )
     ? 'A country that was discussed cannot be entered in multiple fields'

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -435,7 +435,7 @@ const StepInteractionDetails = ({
         </>
       )}
 
-      {!values.id && values.theme !== THEMES.INVESTMENT && (
+      {values.theme !== THEMES.INVESTMENT && (
         <>
           <FieldRadios
             inline={true}
@@ -443,6 +443,7 @@ const StepInteractionDetails = ({
             legend="Were any countries discussed? (optional)"
             options={OPTIONS_YES_NO}
           />
+
           {values.were_countries_discussed === OPTION_YES && (
             <>
               <FieldTypeahead
@@ -450,6 +451,7 @@ const StepInteractionDetails = ({
                 label="Countries currently exporting to"
                 hint="Select all countries discussed"
                 placeholder="-- Search countries --"
+                value={values.currently_exporting}
                 options={countries}
                 validate={[
                   validateRequiredCountries,
@@ -462,6 +464,7 @@ const StepInteractionDetails = ({
                 label="Future countries of interest"
                 hint="Select all countries discussed"
                 placeholder="-- Search countries --"
+                value={values.future_interest}
                 options={countries}
                 validate={[
                   validateRequiredCountries,
@@ -474,6 +477,7 @@ const StepInteractionDetails = ({
                 label="Countries not interested in"
                 hint="Select all countries discussed"
                 placeholder="-- Search countries --"
+                value={values.not_interested}
                 options={countries}
                 validate={[
                   validateRequiredCountries,

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -131,7 +131,9 @@ const buildServicesHierarchy = (services) =>
   )
 
 const validateRequiredCountries = (countries, field, { values }) =>
-  !EXPORT_INTEREST_STATUS_VALUES.some((status) => values[status])
+  !EXPORT_INTEREST_STATUS_VALUES.some(
+    (status) => values[status] && values[status].length
+  )
     ? 'Select at least one country in one of the three fields'
     : null
 
@@ -140,11 +142,11 @@ const validatedDuplicatedCountries = (countries, field, { values }) =>
     (status) =>
       countries &&
       values[status] &&
+      values[status].length &&
       countries.some((country) => values[status].includes(country))
   )
     ? 'A country that was discussed cannot be entered in multiple fields'
     : null
-
 const exportBarrierTypes = {
   FINANCE: '758c4132-a07b-4e4d-a43d-f2f630113023',
   KNOWLEDGE: 'ef9b19d8-510b-4819-8304-5387e4c6df29',

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -43,8 +43,8 @@ const FIELDS_TO_OMIT = [
 
 const HTTP_201_CREATED = 201
 
-const isNoneExportCountriesWereDiscussed = (wereCountriesDiscussed) =>
-  wereCountriesDiscussed === OPTION_NO || !wereCountriesDiscussed ? true : false
+const isWereCountriesDiscussed = (wereCountriesDiscussed) =>
+  wereCountriesDiscussed === OPTION_YES || wereCountriesDiscussed === true
 
 function transformExportCountries(values) {
   return EXPORT_INTEREST_STATUS_VALUES.filter(
@@ -316,17 +316,13 @@ export function saveInteraction({ values, companyIds, referralId }) {
       kind: KINDS.INTERACTION,
     }),
 
-    // Added to ensure were_countries_discussed has a valid values
-    were_countries_discussed: !isNoneExportCountriesWereDiscussed(
-      values.were_countries_discussed
-    )
-      ? OPTION_YES
-      : OPTION_NO,
+    // Added to ensure were_countries_discussed has a valid value
+    were_countries_discussed: transformToYesNo(
+      isWereCountriesDiscussed(values.were_countries_discussed)
+    ),
 
-    // Added to ensure export_countries has a valid values
-    export_countries: !isNoneExportCountriesWereDiscussed(
-      values.were_countries_discussed
-    )
+    // Added to ensure export_countries has a valid value
+    export_countries: isWereCountriesDiscussed(values.were_countries_discussed)
       ? transformExportCountries(values)
       : [],
   }

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -43,10 +43,10 @@ const FIELDS_TO_OMIT = [
 
 const HTTP_201_CREATED = 201
 
+const isNoneExportCountriesWereDiscussed = (wereCountriesDiscussed) =>
+  wereCountriesDiscussed === OPTION_NO || !wereCountriesDiscussed ? true : false
+
 function transformExportCountries(values) {
-  if (values.were_countries_discussed === OPTION_NO) {
-    return
-  }
   return EXPORT_INTEREST_STATUS_VALUES.filter(
     (status) => values[status]
   ).reduce(
@@ -315,8 +315,20 @@ export function saveInteraction({ values, companyIds, referralId }) {
     ...(values.theme == THEMES.TRADE_AGREEMENT && {
       kind: KINDS.INTERACTION,
     }),
-    // Added export countries object as common payload
-    export_countries: transformExportCountries(values),
+
+    // Added to ensure were_countries_discussed has a valid values
+    were_countries_discussed: !isNoneExportCountriesWereDiscussed(
+      values.were_countries_discussed
+    )
+      ? OPTION_YES
+      : OPTION_NO,
+
+    // Added to ensure export_countries has a valid values
+    export_countries: !isNoneExportCountriesWereDiscussed(
+      values.were_countries_discussed
+    )
+      ? transformExportCountries(values)
+      : [],
   }
 
   const payload = values.id

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -4,6 +4,7 @@ const { format, isDateValid } = require('../client/utils/date')
 const { OPTION_NO, OPTION_YES } = require('./constants')
 
 const { hqLabels } = require('./companies/labels')
+const groupExportCountries = require('../lib/group-export-countries')
 
 function transformObjectToOption({ id, name }) {
   return {
@@ -119,10 +120,14 @@ const transformObjectToTypeahead = (value) => {
 
 const transformToYesNo = (value) => (value ? OPTION_YES : OPTION_NO)
 
+const transformExportCountriesToGroupStatus = (countries) =>
+  groupExportCountries(countries)
+
 module.exports = {
   transformHQCodeToLabelledOption,
   transformObjectToOption,
   transformStringToOption,
+  transformExportCountriesToGroupStatus,
   transformContactToOption,
   transformCountryToOptionWithIsoCode,
   transformIdToObject,

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -45,6 +45,7 @@ module.exports = {
     withReferral: require('../../../sandbox/fixtures/v3/interaction/interaction-with-referral.json'),
     withInvestmentTheme: require('./interaction/investment-theme.json'),
     withExportCountries: require('../../../sandbox/fixtures/v4/interaction/interaction-with-export-countries.json'),
+    withoutExportCountries: require('../../../sandbox/fixtures/v4/interaction/interaction-with-no-countries-discussed.json'),
     withBusIntel: require('../../../sandbox/fixtures/v4/interaction/interaction-with-business-intelligence.json'),
   },
   investment: {

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -1249,6 +1249,47 @@ describe('Editing an interaction without a theme', () => {
   })
 })
 
+describe('Editing an interaction related to were countries disscussed', () => {
+  context('when editing interaction with countries discussed', () => {
+    before(() => {
+      cy.visit(
+        urls.interactions.edit(fixtures.interaction.withExportCountries.id)
+      )
+      cy.intercept(
+        'PATCH',
+        `/api-proxy/v4/interaction/${fixtures.interaction.withExportCountries.id}`
+      ).as('apiRequest')
+    })
+    it('should changed values from were any countries discussed if user select from yes to no', () => {
+      cy.contains(ELEMENT_COUNTRIES.legend).next().find('input').check('no')
+      cy.contains('button', 'Save interaction').click()
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.were_countries_discussed).to.equal('no')
+        expect(request.body.export_countries).to.empty
+      })
+    })
+  })
+
+  context('when editing interaction with no countries discussed', () => {
+    before(() => {
+      cy.visit(
+        urls.interactions.edit(fixtures.interaction.withoutExportCountries.id)
+      )
+      cy.intercept(
+        'PATCH',
+        `/api-proxy/v4/interaction/${fixtures.interaction.withoutExportCountries.id}`
+      ).as('apiRequest')
+    })
+    it('should changed values from were any countries discussed if user select from no to yes', () => {
+      cy.contains(ELEMENT_COUNTRIES.legend).next().find('input').check('yes')
+      cy.contains('button', 'Save interaction').click()
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.were_countries_discussed).to.equal('yes')
+      })
+    })
+  })
+})
+
 describe('Interaction landing page error checking', () => {
   beforeEach(() => {
     cy.visit(urls.companies.interactions.create(company.id))

--- a/test/sandbox/fixtures/v4/interaction/interaction-with-export-countries.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-with-export-countries.json
@@ -23,7 +23,7 @@
     "created_by": null,
     "event": null,
     "is_event": null,
-    "status": "complete",
+    "status": "draft",
     "kind": "interaction",
     "modified_by": null,
     "modifiedOn": "2022-10-07T13:24:41.613400Z",
@@ -42,7 +42,7 @@
           }
         }
       ],
-    "communicationChannel": {
+    "communication_channel": {
       "name": "Letter/Fax",
       "id": "74c226d7-5d95-e211-a939-e4115bead28a"
     },
@@ -63,9 +63,9 @@
     "policyAreas": [],
     "policyFeedbackNotes": "",
     "policyIssueTypes": [],
-    "wasPolicyFeedbackProvided": false,
-    "wereCountriesDiscussed": true,
-    "exportCountries": [
+    "was_policy_feedback_provided": false,
+    "were_countries_discussed": true,
+    "export_countries": [
       {
         "country": {
           "name": "Afghanistan",

--- a/test/sandbox/fixtures/v4/interaction/interaction-with-no-countries-discussed.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-with-no-countries-discussed.json
@@ -1,5 +1,5 @@
 {
-    "id": "c58d8d92-5340-436f-a7f0-5ca08d91b078",
+    "id": "c58d8d92-5340-436f-a7f0-5ca08d91b079",
     "company": {
       "name": "Venus Ltd",
       "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"

--- a/test/sandbox/fixtures/v4/interaction/interaction-with-no-countries-discussed.json
+++ b/test/sandbox/fixtures/v4/interaction/interaction-with-no-countries-discussed.json
@@ -1,0 +1,82 @@
+{
+    "id": "c58d8d92-5340-436f-a7f0-5ca08d91b078",
+    "company": {
+      "name": "Venus Ltd",
+      "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    },
+    "companies": [
+        {
+          "name": "Venus Ltd",
+          "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+        }
+      ],
+    "contacts": [
+        {
+          "name": "Theodore Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",
+          "first_name": "Theodore",
+          "last_name": "Schaden|6e4b048d-5bb5-4868-9455-aa712f4ceffd",
+          "job_title": "Internal Assurance Officer",
+          "id": "71906039-858e-47ba-8016-f3c80da69ace"
+        }
+    ],
+    "created_on": "2022-10-07T11:32:19.336297Z",
+    "created_by": null,
+    "event": null,
+    "is_event": null,
+    "status": "draft",
+    "kind": "interaction",
+    "modified_by": null,
+    "modifiedOn": "2022-10-07T13:24:41.613400Z",
+    "date": "2022-10-07",
+    "dit_participants": [
+        {
+          "adviser": {
+            "name": "Brendan Smith",
+            "first_name": "Brendan",
+            "last_name": "Smith",
+            "id": "8891ec72-b4ec-4977-9656-839346bc6011"
+          },
+          "team": {
+            "name": "Aberdeen City Council",
+            "id": "cff02898-9698-e211-a939-e4115bead28a"
+          }
+        }
+      ],
+    "communication_channel": {
+      "name": "Letter/Fax",
+      "id": "74c226d7-5d95-e211-a939-e4115bead28a"
+    },
+    "grantAmountOffered": null,
+    "investmentProject": null,
+    "largeCapitalOpportunity": null,
+    "netCompanyReceipt": null,
+    "service": {
+      "name": "Export win",
+      "id": "350bba2b-3499-e211-a939-e4115bead28a"
+    },
+    "serviceAnswers": {},
+    "serviceDeliveryStatus": null,
+    "subject": "Meeting where no countries were discussed",
+    "theme": "export",
+    "notes": "",
+    "archivedDocumentsUrlPath": "",
+    "policyAreas": [],
+    "policyFeedbackNotes": "",
+    "policyIssueTypes": [],
+    "was_policy_feedback_provided": false,
+    "were_countries_discussed": false,
+    "export_countries": [],
+    "archived": false,
+    "archivedBy": null,
+    "archivedOn": null,
+    "archivedReason": "",
+    "companyReferral": null,
+    "hasRelatedTradeAgreements": false,
+    "relatedTradeAgreements": [],
+    "helped_remove_export_barrier": true,
+    "export_barrier_types": [{
+      "name": "Other",
+      "id": "8ef83315-2b0f-4d5e-98da-a16f8b2217a6"
+    }],
+    "export_barrier_notes": "My export barrier notes..."
+  }

--- a/test/sandbox/routes/v4/interaction/interaction.js
+++ b/test/sandbox/routes/v4/interaction/interaction.js
@@ -14,6 +14,7 @@ var interactionWithReferral = require('../../../fixtures/v4/interaction/interact
 var interactionWithoutTheme = require('../../../fixtures/v4/interaction/interaction-without-theme')
 var interactionInvestmentTheme = require('../../../fixtures/v4/interaction/interaction-investment-theme.json')
 var interactionWithExportCountries = require('../../../fixtures/v4/interaction/interaction-with-export-countries.json')
+var interactionWithoutExportCountries = require('../../../fixtures/v4/interaction/interaction-with-no-countries-discussed.json')
 var interactionWithBusIntel = require('../../../fixtures/v4/interaction/interaction-with-business-intelligence.json')
 
 var getInteractions = function (req, res) {
@@ -45,6 +46,7 @@ var getInteractionById = function (req, res) {
     '65e984ad-1ad5-4d89-9b12-71cdff5f412c': interactionWithoutTheme,
     '4dcb3748-c097-4f20-b84f-0114bbb1a8e3': interactionInvestmentTheme,
     'c58d8d92-5340-436f-a7f0-5ca08d91b078': interactionWithExportCountries,
+    'c58d8d92-5340-436f-a7f0-5ca08d91b079': interactionWithoutExportCountries,
     '54281b53-ee73-48bc-a09e-281e9b7c5f00': interactionWithBusIntel,
   }
 


### PR DESCRIPTION
## Description of change

At the moment, the interaction related to were any countries being discussed not editable. Now, this PR has ability to modify an optional export countries being discussed upon creation.

## Test instructions

Navigate to DH - Interactions, then select one on the list with `interaction` label. From interaction details page, click `Edit interaction`.
- Previously, in won't allows you to edit `Were any countries discussed? (optional)` despite export countries being defined.
- Now this PR has ability to changed the optional answer from `Edit interaction form` including export countries related to interaction that being set.

## Screenshots

### Before

- Interaction details with export countries discussed

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/e5401534-3f69-4950-becf-b9463c9d4529)


- Edit interaction page `Were any export countries discussed (optional)` not being shown or editable

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/c8251f26-f6a1-4a0d-92a7-1bba3eb1e483)

- Other screen recording details

https://github.com/uktrade/data-hub-frontend/assets/28296624/edd77d74-09bf-498b-b761-3756a9d5d7b2



### After

![image](https://github.com/uktrade/data-hub-frontend/assets/28296624/34ec90bd-f8bb-4b96-bff2-c12a3613b195)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
