### PR TITLE
Highlight inactive advisors by  adding inactive text after their name

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
@@ -64,8 +64,10 @@ const StepReferralDetails = ({
                 .then(({ data: { results } }) =>
                   results
                     .filter((adviser) => adviser?.name.trim().length)
-                    .map(({ id, name, dit_team }) => ({
-                      label: `${name}${dit_team ? ', ' + dit_team.name : ''}`,
+                    .map(({ id, name, dit_team, is_active }) => ({
+                      label: `${name}${!is_active ? ' - INACTIVE' : ''}${
+                        dit_team ? ', ' + dit_team.name : ''
+                      }`,
                       value: id,
                     }))
                 ),

--- a/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/send-referral-spec.js
@@ -194,6 +194,39 @@ describe('Send a referral form', () => {
     )
   })
 
+  describe('Advisor input fields', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.referrals.send(fixtures.company.withContacts.id))
+    })
+
+    context('When you search advisors', () => {
+      it('should return inactive advisers with text indicating they are inactive next to their name', () => {
+        cy.get(selectors.sendReferral.adviserField).within(() => {
+          cy.intercept('/api-proxy/adviser/?*').as('adviserResults')
+          cy.get('input').clear().type('John Doe')
+          cy.wait('@adviserResults')
+          cy.get('[data-test="typeahead-menu-option"]')
+            .first()
+            .should(
+              'contain',
+              'John Doe - INACTIVE, Heart of the South West LEP'
+            )
+        })
+      })
+
+      it('should return active advisers without an inactive text next to their name', () => {
+        cy.get(selectors.sendReferral.adviserField).within(() => {
+          cy.intercept('/api-proxy/adviser/?*').as('adviserResults')
+          cy.get('input').clear().type('Shawn Cohen')
+          cy.wait('@adviserResults')
+          cy.get('[data-test="typeahead-menu-option"]')
+            .first()
+            .should('contain', 'Shawn Cohen, Charles Gilbert')
+        })
+      })
+    })
+  })
+
   context(
     'when "Continue" button is clicked with just mandatory fields filled in',
     () => {

--- a/test/sandbox/fixtures/autocomplete-adviser-list.json
+++ b/test/sandbox/fixtures/autocomplete-adviser-list.json
@@ -1464,6 +1464,28 @@
          "uk_region":null,
          "country":"a55f66a0-5d95-e211-a939-e4115bead28a"
       }
+   },
+   {
+      "id":"19abd740-d4bd-40c6-a276-b51f7c7b8d33",
+      "is_active":false,
+      "last_login":null,
+      "first_name":"John",
+      "last_name":"Doe",
+      "name": "John Doe",
+      "email":"john.doe@example.com",
+      "contact_email":"",
+      "telephone_number":"",
+      "dit_team":{
+         "id":"08d987f8-6525-e511-b6bc-e4115bead28a",
+         "disabled_on":null,
+         "name":"Heart of the South West LEP",
+         "tags":[
+
+         ],
+         "role":"62329c18-6095-e211-a939-e4115bead28a",
+         "uk_region":null,
+         "country":"a55f66a0-5d95-e211-a939-e4115bead28a"
+      }
    }
   ]
 }


### PR DESCRIPTION
## Description of change

When adding a company referral, its not currently possible to differentiate between inactive and active advisors. Instead of hiding inactive advisors (as they may still be needed) the team have decided we should continue to show them but make it clear they are inactive.

## Test instructions

`- INACTIVE` shown next to the names of inactive advisors.

## Screenshots

### Before

<img width="732" alt="Screenshot 2023-09-25 at 12 12 08" src="https://github.com/uktrade/data-hub-frontend/assets/22541658/171c4351-3499-4fa3-afff-5a420c7e8b46">

### After

<img width="732" alt="Screenshot 2023-09-25 at 11 51 09" src="https://github.com/uktrade/data-hub-frontend/assets/22541658/15158012-5d87-49aa-8ffd-d1d76e9213e6">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
