### PR TITLE
Add a cancel link to the first form step

### DIFF
--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -136,7 +136,10 @@ const InteractionDetailsForm = ({
                         {/* Step registered if creating the interaction
                   and haven't come from an investment project */}
                         {!interactionId && !investmentId && (
-                          <Step name="interaction_type">
+                          <Step
+                            name="interaction_type"
+                            cancelUrl={urls.companies.detail(companyId)}
+                          >
                             {() => <StepInteractionType />}
                           </Step>
                         )}

--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -22,10 +22,10 @@ const StepInteractionType = () => {
 
       // If we do not clean up, then the form values object contains keys and values
       // relevant to the initial form interaction, as the user completes the form
-      // some keys and values are overwritten, others are not, the latter causes
-      // problems with API validation when saving the form as the wrong keys are
-      // sent as part of the payload, which ultimately means the user cannot save
-      // the form (HTTP 400), meaning they have to start over - very frustrating.
+      // a second time some keys and values are overwritten, others are not, the
+      // latter causes problems with API validation when saving the form as the
+      // wrong keys are sent as part of the payload, which ultimately means the
+      // user cannot save the form (HTTP 400), meaning they have to start over.
       // Therefore, the cleanest approach is to reset the fields within the form
       // the moment the users lands on the "Add interaction ..." page:
 

--- a/src/client/components/Form/elements/Step.jsx
+++ b/src/client/components/Form/elements/Step.jsx
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import Button from '@govuk-react/button'
+import Link from '@govuk-react/link'
 
 import { useFormContext } from '../hooks'
 import ButtonLink from '../../ButtonLink'
 import FormActions from './FormActions'
 
-function Step({ name, backButton, forwardButton, children }) {
+function Step({ name, backButton, forwardButton, cancelUrl, children }) {
   const {
     currentStep,
     goBack,
@@ -69,6 +70,12 @@ function Step({ name, backButton, forwardButton, children }) {
     return forwardButton
   }
 
+  const renderCancelLink = () => (
+    <Link data-test="cancel-link" href={cancelUrl}>
+      Cancel
+    </Link>
+  )
+
   return (
     <>
       {typeof children === 'function' ? children() : children}
@@ -77,6 +84,7 @@ function Step({ name, backButton, forwardButton, children }) {
         {renderForwardButton()}
 
         {!isFirstStep() && renderBackButton()}
+        {isFirstStep() && cancelUrl && renderCancelLink()}
       </FormActions>
     </>
   )

--- a/test/component/cypress/specs/Form/Step.cy.jsx
+++ b/test/component/cypress/specs/Form/Step.cy.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+
+import { Form } from '../../../../../src/client/components'
+import { Step } from '../../../../../src/client/components'
+import DataHubProvider from '../provider'
+
+describe('Step', () => {
+  context('When there are no steps', () => {
+    const Component = () => (
+      <DataHubProvider>
+        <Form id="my-form"></Form>
+      </DataHubProvider>
+    )
+    it('should render a save button', () => {
+      cy.mount(<Component />)
+      cy.get('button').contains('Save')
+    })
+  })
+
+  context('When there is 1 step', () => {
+    const Component = (props) => (
+      <DataHubProvider>
+        <Form id="my-form">
+          <Step name="step1" {...props}>
+            <div>Page content 1</div>
+          </Step>
+        </Form>
+      </DataHubProvider>
+    )
+    it('should render the content and submit button only', () => {
+      cy.mount(<Component />)
+      cy.contains('Page content 1')
+      cy.get('button').should('have.text', 'Submit')
+      cy.get('[data-test="cancel-link"]').should('not.exist')
+    })
+    it('should render the content, submit and cancel link', () => {
+      cy.mount(<Component cancelUrl="/" />)
+      cy.contains('Page content 1')
+      cy.get('button').should('have.text', 'Submit')
+      cy.get('[data-test="cancel-link"]').should('have.text', 'Cancel')
+    })
+  })
+
+  context('When there are 2 steps', () => {
+    const Component = () => (
+      <DataHubProvider>
+        <Form id="my-form">
+          <Step name="step1" cancelUrl="/">
+            <div>Page content 1</div>
+          </Step>
+          <Step name="step2" cancelUrl="/">
+            <div>Page content 2</div>
+          </Step>
+        </Form>
+      </DataHubProvider>
+    )
+    it('should only render the cancel link on the first step', () => {
+      cy.mount(<Component />)
+      cy.contains('Page content 1')
+      cy.get('[data-test="cancel-link"]').should('exist')
+      cy.get('button').contains('Continue').click()
+      cy.contains('Page content 2')
+      // The cancel link can only live on the first step, after that
+      // it's either continue or submit (if it's the last step).
+      cy.get('[data-test="cancel-link"]').should('not.exist')
+      cy.get('button').contains('Submit')
+      cy.get('button').contains('Back')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Added a cancel link to the very first step of a form. The step now takes an additional argument called `cancelUrl` which is passed to the href of the cancel link.

## Test instructions

Go to: `/companies/<company-uuid>/interactions/create?step=interaction_type`

## Screenshots

### After
<img width="400" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/484ad495-55fa-42c2-ae17-0b5a965dd548">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
