### PR TITLE
Update so that maxemail is shown on internalActivity

### DIFF
--- a/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
+++ b/src/apps/companies/apps/activity-feed/__test__/controllers.test.js
@@ -166,6 +166,25 @@ describe('Activity feed controllers', () => {
                     {
                       bool: {
                         must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
                           { term: { 'object.type': 'dit:aventri:Event' } },
                           {
                             terms: {
@@ -370,25 +389,6 @@ describe('Activity feed controllers', () => {
                           must: [
                             {
                               term: {
-                                'object.type': 'dit:maxemail:Campaign',
-                              },
-                            },
-                            {
-                              terms: {
-                                id: [
-                                  'dit:maxemail:Campaign:123:Create',
-                                  'dit:maxemail:Campaign:124:Create',
-                                ],
-                              },
-                            },
-                          ],
-                        },
-                      },
-                      {
-                        bool: {
-                          must: [
-                            {
-                              term: {
                                 'object.type':
                                   'dit:directoryFormsApi:Submission',
                               },
@@ -492,25 +492,6 @@ describe('Activity feed controllers', () => {
                             must: [
                               {
                                 term: {
-                                  'object.type': 'dit:maxemail:Campaign',
-                                },
-                              },
-                              {
-                                terms: {
-                                  id: [
-                                    'dit:maxemail:Campaign:123:Create',
-                                    'dit:maxemail:Campaign:124:Create',
-                                  ],
-                                },
-                              },
-                            ],
-                          },
-                        },
-                        {
-                          bool: {
-                            must: [
-                              {
-                                term: {
                                   'object.type':
                                     'dit:directoryFormsApi:Submission',
                                 },
@@ -534,6 +515,25 @@ describe('Activity feed controllers', () => {
                                     'fred@acme.org',
                                     'fred@acme.org',
                                     'byvanuwenu@yahoo.com',
+                                  ],
+                                },
+                              },
+                            ],
+                          },
+                        },
+                        {
+                          bool: {
+                            must: [
+                              {
+                                term: {
+                                  'object.type': 'dit:maxemail:Campaign',
+                                },
+                              },
+                              {
+                                terms: {
+                                  id: [
+                                    'dit:maxemail:Campaign:123:Create',
+                                    'dit:maxemail:Campaign:124:Create',
                                   ],
                                 },
                               },
@@ -672,6 +672,31 @@ describe('Activity feed controllers', () => {
                                 'fred@acme.org',
                                 'fred@acme.org',
                                 'byvanuwenu@yahoo.com',
+                              ],
+                            },
+                          },
+                          {
+                            term: {
+                              'object.attributedTo.id':
+                                'dit:DataHubAdviser:123',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
                               ],
                             },
                           },
@@ -845,6 +870,33 @@ describe('Activity feed controllers', () => {
                     {
                       bool: {
                         must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
+                              ],
+                            },
+                          },
+                        ],
+                        must_not: [
+                          {
+                            term: {
+                              'object.attributedTo.id':
+                                'dit:DataHubAdviser:123',
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
                           { term: { 'object.type': 'dit:aventri:Event' } },
                           {
                             terms: {
@@ -992,6 +1044,25 @@ describe('Activity feed controllers', () => {
                     {
                       bool: {
                         must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
+                              ],
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
                           { term: { 'object.type': 'dit:aventri:Event' } },
                           {
                             terms: {
@@ -1127,6 +1198,37 @@ describe('Activity feed controllers', () => {
                                 'fred@acme.org',
                                 'fred@acme.org',
                                 'byvanuwenu@yahoo.com',
+                              ],
+                            },
+                          },
+                          {
+                            script: {
+                              script: {
+                                lang: 'painless',
+                                source:
+                                  "ZonedDateTime filterDateTime = ((doc['object.startTime'].size() > 0) ? doc['object.startTime'].value : doc['object.published'].value); ZonedDateTime dateBefore = ZonedDateTime.parse(params['dateBefore']); return (filterDateTime.isBefore(dateBefore))",
+                                params: {
+                                  dateBefore: '2015-10-02T03:41:20.000Z',
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
                               ],
                             },
                           },
@@ -1316,6 +1418,37 @@ describe('Activity feed controllers', () => {
                                 'fred@acme.org',
                                 'fred@acme.org',
                                 'byvanuwenu@yahoo.com',
+                              ],
+                            },
+                          },
+                          {
+                            script: {
+                              script: {
+                                lang: 'painless',
+                                source:
+                                  "ZonedDateTime filterDateTime = ((doc['object.startTime'].size() > 0) ? doc['object.startTime'].value : doc['object.published'].value); ZonedDateTime dateAfter = ZonedDateTime.parse(params['dateAfter']); return (filterDateTime.isAfter(dateAfter))",
+                                params: {
+                                  dateAfter: '2015-10-02T03:41:20.000Z',
+                                },
+                              },
+                            },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      bool: {
+                        must: [
+                          {
+                            term: {
+                              'object.type': 'dit:maxemail:Campaign',
+                            },
+                          },
+                          {
+                            terms: {
+                              id: [
+                                'dit:maxemail:Campaign:123:Create',
+                                'dit:maxemail:Campaign:124:Create',
                               ],
                             },
                           },
@@ -1531,6 +1664,38 @@ describe('Activity feed controllers', () => {
                       {
                         bool: {
                           must: [
+                            {
+                              term: {
+                                'object.type': 'dit:maxemail:Campaign',
+                              },
+                            },
+                            {
+                              terms: {
+                                id: [
+                                  'dit:maxemail:Campaign:123:Create',
+                                  'dit:maxemail:Campaign:124:Create',
+                                ],
+                              },
+                            },
+                            {
+                              script: {
+                                script: {
+                                  lang: 'painless',
+                                  source:
+                                    "ZonedDateTime filterDateTime = ((doc['object.startTime'].size() > 0) ? doc['object.startTime'].value : doc['object.published'].value); ZonedDateTime dateAfter = ZonedDateTime.parse(params['dateAfter']); ZonedDateTime dateBefore = ZonedDateTime.parse(params['dateBefore']); return (filterDateTime.isAfter(dateAfter) && filterDateTime.isBefore(dateBefore))",
+                                  params: {
+                                    dateAfter: '2002-06-13T00:00:00.000Z',
+                                    dateBefore: '2022-06-13T23:59:59.999Z',
+                                  },
+                                },
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
                             { term: { 'object.type': 'dit:aventri:Event' } },
                             {
                               terms: {
@@ -1685,6 +1850,25 @@ describe('Activity feed controllers', () => {
                                   'fred@acme.org',
                                   'fred@acme.org',
                                   'byvanuwenu@yahoo.com',
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        bool: {
+                          must: [
+                            {
+                              term: {
+                                'object.type': 'dit:maxemail:Campaign',
+                              },
+                            },
+                            {
+                              terms: {
+                                id: [
+                                  'dit:maxemail:Campaign:123:Create',
+                                  'dit:maxemail:Campaign:124:Create',
                                 ],
                               },
                             },

--- a/src/apps/companies/apps/activity-feed/controllers.js
+++ b/src/apps/companies/apps/activity-feed/controllers.js
@@ -7,7 +7,6 @@ const {
   EVENT_AVENTRI_ATTENDEES_STATUSES,
   EVENT_ATTENDEES_MAPPING,
   FILTER_FEED_TYPE,
-  FILTER_KEYS,
 } = require('./constants')
 
 const { ACTIVITIES_PER_PAGE } = require('../../../contacts/constants')
@@ -103,13 +102,6 @@ async function getMaxemailEmailsByCampaign(req, next, contacts) {
   } catch (error) {
     next(error)
   }
-}
-
-const isExternalActivityFilter = (activityType) => {
-  return (
-    activityType.includes(FILTER_KEYS.externalActivity) ||
-    activityType.includes(FILTER_KEYS.dataHubAndExternalActivity)
-  )
 }
 
 // Filter Contacts with empty email addresses or Null Emails
@@ -280,9 +272,11 @@ async function fetchActivityFeedHandler(req, res, next) {
     )
     const aventriEventIds = Object.keys(aventriEvents)
 
-    const maxemailCampaigns = isExternalActivityFilter(activityType)
-      ? await getMaxemailEmailsByCampaign(req, next, filteredContacts)
-      : {}
+    const maxemailCampaigns = await getMaxemailEmailsByCampaign(
+      req,
+      next,
+      filteredContacts
+    )
 
     const query = dataHubCompanyActivityQuery({
       from,

--- a/src/apps/companies/apps/activity-feed/es-queries/data-hub-company-activity-query.js
+++ b/src/apps/companies/apps/activity-feed/es-queries/data-hub-company-activity-query.js
@@ -120,6 +120,10 @@ const dataHubCompanyActivityQuery = ({
         ],
       },
     }
+    shouldCriteria.push(externalActivityCriteria)
+  }
+
+  if (isInternalActivityFilter(activityType)) {
     if (maxemailCampaignIds?.length) {
       const criteria = {
         bool: {
@@ -139,10 +143,7 @@ const dataHubCompanyActivityQuery = ({
       }
       shouldCriteria.push(criteria)
     }
-    shouldCriteria.push(externalActivityCriteria)
-  }
 
-  if (isInternalActivityFilter(activityType)) {
     if (aventriEventIds?.length) {
       const criteria = {
         bool: {

--- a/test/unit/data/activity-feed/activity-feed-default-query.json
+++ b/test/unit/data/activity-feed/activity-feed-default-query.json
@@ -33,6 +33,25 @@
               "must":[
                 {
                   "term":{
+                    "object.type": "dit:maxemail:Campaign"
+                  }
+                },
+                {
+                  "terms":{
+                    "id":[
+                      "dit:maxemail:Campaign:123:Create",
+                      "dit:maxemail:Campaign:124:Create"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "bool":{
+              "must":[
+                {
+                  "term":{
                     "object.type":"dit:aventri:Event"
                   }
                 },


### PR DESCRIPTION
## Description of change

Business requested that maxemail activity stream to be displayed in the default "internal activity" for a companies activity.

## Test instructions

BAU

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
