### PR TITLE
bugfix/CLS2-465-hide-archived-tasks

### DIFF
--- a/src/client/modules/Investments/Projects/ProjectTasks.jsx
+++ b/src/client/modules/Investments/Projects/ProjectTasks.jsx
@@ -67,6 +67,7 @@ const ProjectTasks = ({ project }) => {
           limit: ITEMS_PER_PAGE,
           offset: activePage * ITEMS_PER_PAGE - ITEMS_PER_PAGE,
           sortby: 'task__due_date',
+          archived: false,
         }}
       >
         {(projectTasks, count) => {

--- a/test/functional/cypress/specs/investments/project-tasks-spec.js
+++ b/test/functional/cypress/specs/investments/project-tasks-spec.js
@@ -43,7 +43,7 @@ describe('Investment project tasks', () => {
     before(() => {
       cy.intercept(
         'GET',
-        `/api-proxy/v4/investmentprojecttask?investment_project=${fixtures.investment.investmentWithDetails.id}&limit=10&offset=0&sortby=task__due_date`,
+        `/api-proxy/v4/investmentprojecttask?investment_project=${fixtures.investment.investmentWithDetails.id}&limit=10&offset=0&sortby=task__due_date&archived=false`,
         {
           body: {
             count: 2,


### PR DESCRIPTION
## Description of change

Don't show archived tasks on the investment project page

## Test instructions

Archive a task, it should no longer show on the investment project page

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/51a5141b-6f15-4cc9-9a60-386613c21ad0)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/cd589cf3-1f6e-43e9-87d5-c66c17e62366)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
