### PR TITLE
firebreak/use-app-tasks-and-reducers

### DIFF
--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -5,21 +5,14 @@ import { combineReducers, applyMiddleware, legacy_createStore } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 
 import rootSaga from '../../../../src/client/root-saga'
-import tasks from '../../../../src/client/components/Task/reducer'
-import Form from '../../../../src/client/components/Form'
-import Typeahead from '../../../../src/client/components/Typeahead/Typeahead'
-import FieldAddAnother from '../../../../src/client/components/Form/elements/FieldAddAnother/FieldAddAnother'
-import Resource from '../../../../src/client/components/Resource/Resource'
+import { reducers } from '../../../../src/client/reducers'
+import { tasks as appTasks } from '../../../../src/client/tasks'
 
 const sagaMiddleware = createSagaMiddleware()
 
 const reducer = (state, action) =>
   combineReducers({
-    tasks,
-    ...Resource.reducerSpread,
-    ...Typeahead.reducerSpread,
-    ...FieldAddAnother.reducerSpread,
-    ...Form.reducerSpread,
+    ...reducers,
     activeFeatureGroups: () => [],
     modulePermissions: () => [],
     userPermissions: () => [],
@@ -32,7 +25,7 @@ export const store = legacy_createStore(
 
 const runMiddlewareOnce = _.once((tasks) => sagaMiddleware.run(rootSaga(tasks)))
 
-export default ({ children, tasks = {}, resetTasks = false }) => {
+export default ({ children, tasks = appTasks, resetTasks = false }) => {
   // We only ever want to start the sagas once
   resetTasks ? sagaMiddleware.run(rootSaga(tasks)) : runMiddlewareOnce(tasks)
 


### PR DESCRIPTION
## Description of change

Use the app reducers and tasks in the component tests, instead of the current implementation where only a few are imported


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
