### PR TITLE
Ensure OMIS delivery date error is displayed

### DIFF
--- a/src/apps/omis/apps/edit/steps.js
+++ b/src/apps/omis/apps/edit/steps.js
@@ -26,6 +26,20 @@ const steps = merge({}, createSteps, {
     templatePath: 'omis/apps/edit/views',
     template: 'assignee-time.njk',
   },
+  '/quote-details': {
+    heading: 'Edit quote information',
+    fields: ['description', 'delivery_date'],
+  },
+  '/internal-details': {
+    heading: 'Edit internal information',
+    fields: [
+      'service_types',
+      'sector',
+      'further_info',
+      'existing_agents',
+      'contacts_not_to_approach',
+    ],
+  },
   '/invoice-details': {
     heading: 'Edit invoice details',
     fields: ['vat_status', 'vat_number', 'vat_verified', 'po_number'],

--- a/src/client/modules/Omis/validators.js
+++ b/src/client/modules/Omis/validators.js
@@ -1,11 +1,14 @@
-import { isDateInFuture } from '../../utils/date'
+import { addDays, isDateAfter, parseDateISO } from '../../utils/date'
 import { transformDateObjectToDateString } from '../../transformers'
 
 export const validateIfDateInFuture = (values) => {
   if (values?.year) {
-    return isDateInFuture(transformDateObjectToDateString(values))
+    const deliveryDate = parseDateISO(transformDateObjectToDateString(values))
+    const twentyDaysLater = addDays(new Date(), 20)
+
+    return isDateAfter(deliveryDate, twentyDaysLater)
       ? null
-      : 'Delivery date of work must be in the future'
+      : 'Delivery date must be at least 21 days in the future'
   }
   return null
 }

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -90,6 +90,10 @@ function isDateInFuture(date) {
   return isFuture(parseISO(date))
 }
 
+function parseDateISO(date) {
+  return parseISO(date)
+}
+
 /**
  * Date validation functions
  */
@@ -311,4 +315,5 @@ module.exports = {
   formatStartAndEndDate,
   convertDateToFieldShortDateObject,
   isDateInFuture,
+  parseDateISO,
 }

--- a/test/functional/cypress/specs/omis/edit-quote-spec.js
+++ b/test/functional/cypress/specs/omis/edit-quote-spec.js
@@ -27,6 +27,6 @@ describe('View edit quote information', () => {
     cy.get('[data-test="delivery_date-month"]').type('02')
     cy.get('[data-test="delivery_date-year"]').type('2000')
     cy.get('[data-test=submit-button]').click()
-    assertErrorSummary(['Delivery date of work must be in the future'])
+    assertErrorSummary(['Delivery date must be at least 21 days in the future'])
   })
 })


### PR DESCRIPTION
## Description of change

An error message notifying the user that the delivery date for an OMIS order is incorrect (as they are less than 21 days in the future) was not displaying to the users. This has now been fixed, and the validation on the delivery date field has been updated to prevent dates less than 21 days in the future from being added (this issue was present in the Nunjucks implementation also).

## Test instructions

Go to a draft OMIS order with a delivery date before the 1st November and click the 'Preview quote' button. An error should appear saying that the delivery date must be 21 days in the future.

Go to a draft OMIS order, scroll down to 'Information for the quote' and click the Edit button. You should not be able to add a delivery date before the 1st November.

## Screenshots

### Before

![MicrosoftTeams-image (2)](https://github.com/uktrade/data-hub-frontend/assets/36161814/3a21cd96-a895-400e-a057-c88c75ec22d9)

### After

<img width="998" alt="Screenshot 2023-10-11 at 11 35 42" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/89e11369-c414-4f97-83ef-7b2e86f68283">

<img width="507" alt="Screenshot 2023-10-11 at 11 32 05" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/727ca637-e8ea-48f8-8c41-e3159ddda0a6">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
