### PR TITLE
Tidy up duplicate table assertions

### DIFF
--- a/test/end-to-end/cypress/specs/DA/collection-spec.js
+++ b/test/end-to-end/cypress/specs/DA/collection-spec.js
@@ -7,21 +7,9 @@ const {
 } = require('../../../../../src/lib/urls')
 
 const { assertCollection } = require('../../support/assertions')
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
+const {
+  assertGovReactTable,
+} = require('../../../../functional/cypress/support/assertions')
 
 describe('Collection', () => {
   describe('company', () => {
@@ -96,7 +84,7 @@ describe('Collection', () => {
       })
 
       it('should return the investment project team summary', () => {
-        assertTable({
+        assertGovReactTable({
           element: '[data-test="crm-table"]',
           rows: [
             ['Role', 'Adviser', 'Team'],

--- a/test/end-to-end/cypress/specs/DIT/investment-team-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/investment-team-spec.js
@@ -7,28 +7,10 @@ const {
 } = require('../../../../functional/cypress/support/actions')
 const {
   assertFlashMessage,
+  assertGovReactTable,
 } = require('../../../../functional/cypress/support/assertions')
 
 const teamSelectors = selectors.investment.team
-
-const assertTable = ({ element, headings, rows }) => {
-  cy.get(element).as('table')
-
-  if (headings) {
-    cy.get('@table').find('th')
-  }
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
 
 const testSubForm = ({ selector, header, checkForm, expectedResults }) => {
   cy.get(teamSelectors[selector].button).click()
@@ -39,7 +21,7 @@ const testSubForm = ({ selector, header, checkForm, expectedResults }) => {
   clickButton('Save')
   assertFlashMessage('Investment details updated')
 
-  assertTable({
+  assertGovReactTable({
     element: teamSelectors[selector].table,
     rows: expectedResults,
   })

--- a/test/end-to-end/cypress/specs/LEP/collection-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/collection-spec.js
@@ -7,21 +7,9 @@ const {
 } = require('../../../../../src/lib/urls')
 
 const { assertCollection } = require('../../support/assertions')
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
+const {
+  assertGovReactTable,
+} = require('../../../../functional/cypress/support/assertions')
 
 describe('Collection', () => {
   describe('company', () => {
@@ -96,7 +84,7 @@ describe('Collection', () => {
       })
 
       it('should return the investment project team summary', () => {
-        assertTable({
+        assertGovReactTable({
           element: '[data-test="crm-table"]',
           rows: [
             ['Role', 'Adviser', 'Team'],

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -7,6 +7,7 @@ import objectiveListFaker, { objectiveFaker } from '../../fakers/objective'
 import { adviserFaker } from '../../fakers/advisers'
 import {
   assertCompanyBreadcrumbs,
+  assertGovReactTable,
   assertRequestUrl,
 } from '../../support/assertions'
 
@@ -34,21 +35,6 @@ const coreTeamResponse = {
     },
   },
   isGlobalAccountManager: true,
-}
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table').find('th')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
 }
 
 const assertBreadcrumbs = (company) => {
@@ -269,7 +255,7 @@ describe('One List core team', () => {
     })
 
     it('should render the global account manager table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
           ['Team', 'Location', 'Global Account Manager', 'Email'],
@@ -284,7 +270,7 @@ describe('One List core team', () => {
     })
 
     it('should render the advisers table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="advisers-table"]',
         rows: [
           ['Team', 'Location', 'Adviser on core team', 'Email'],
@@ -334,7 +320,7 @@ describe('One List core team', () => {
     })
 
     it('should only render the global account manager table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
           ['Team', 'Location', 'Global Account Manager', 'Email'],
@@ -364,7 +350,7 @@ describe('One List core Tier D team', () => {
     })
 
     it('should render the Lead ITA table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="lead-adviser-table"]',
         rows: [
           ['Team', 'Lead ITA', 'Email'],
@@ -409,7 +395,7 @@ describe('One List core Tier D team', () => {
       })
 
       it('should render the Lead ITA table', () => {
-        assertTable({
+        assertGovReactTable({
           element: '[data-test="lead-adviser-table"]',
           rows: [
             ['Team', 'Lead ITA', 'Email'],

--- a/test/functional/cypress/specs/companies/core-team-spec.js
+++ b/test/functional/cypress/specs/companies/core-team-spec.js
@@ -1,5 +1,6 @@
 import fixtures from '../../fixtures'
 import urls from '../../../../../src/lib/urls'
+import { assertGovReactTable } from '../../support/assertions'
 
 const company = fixtures.company.oneListCorp
 const globalAccountManager = company.one_list_group_global_account_manager
@@ -18,21 +19,6 @@ const coreTeamResponse = {
     },
   },
   isGlobalAccountManager: true,
-}
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table').find('th')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
 }
 
 describe('One List core team', () => {
@@ -57,7 +43,7 @@ describe('One List core team', () => {
     })
 
     it('should render the global account manager table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
           ['Team', 'Location', 'Global Account Manager', 'Email'],
@@ -72,7 +58,7 @@ describe('One List core team', () => {
     })
 
     it('should render the advisers table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="advisers-table"]',
         rows: [
           ['Team', 'Location', 'Adviser on core team', 'Email'],
@@ -116,7 +102,7 @@ describe('One List core team', () => {
     })
 
     it('should only render the global account manager table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
           ['Team', 'Location', 'Global Account Manager', 'Email'],

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -1,20 +1,6 @@
 const fixtures = require('../../../fixtures')
 const urls = require('../../../../../../src/lib/urls')
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table').find('th')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
+const { assertGovReactTable } = require('../../../support/assertions')
 
 describe('Lead advisers', () => {
   context('when viewing a non One List tier company', () => {
@@ -70,7 +56,7 @@ describe('Lead advisers', () => {
         cy.contains("Lead ITA for Ian's Camper Vans Ltd")
       })
       it('should render the global account manager table', () => {
-        assertTable({
+        assertGovReactTable({
           element: '[data-test="lead-adviser-table"]',
           rows: [
             ['Team', 'Lead ITA', 'Email'],

--- a/test/functional/cypress/specs/investments/project-evidence-spec.js
+++ b/test/functional/cypress/specs/investments/project-evidence-spec.js
@@ -1,20 +1,6 @@
 import urls from '../../../../../src/lib/urls'
 import fixtures from '../../fixtures'
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
+import { assertGovReactTable } from '../../support/assertions'
 
 describe('Investment project evidence', () => {
   context('When viewing a project with no evidence', () => {
@@ -59,7 +45,7 @@ describe('Investment project evidence', () => {
     })
 
     it('should render the evidence table', () => {
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="evidence-table"]',
         rows: [
           ['Verification criteria', 'Comment', '', ''],

--- a/test/functional/cypress/specs/investments/project-team-spec.js
+++ b/test/functional/cypress/specs/investments/project-team-spec.js
@@ -1,6 +1,7 @@
 const {
   assertLocalHeader,
   assertBreadcrumbs,
+  assertGovReactTable,
 } = require('../../support/assertions')
 const { investments } = require('../../../../../src/lib/urls')
 
@@ -10,21 +11,6 @@ const prospectProject = require('../../fixtures/investment/investment-has-existi
 
 const investmentTeams = require('../../fixtures/investment/investment-teams.json')
 const globalAccountManager = require('../../fixtures/investment/investment-global-manager.json')
-
-const assertTable = ({ element, rows }) => {
-  cy.get(element).as('table')
-
-  cy.get('@table')
-    .find('tbody')
-    .find('tr')
-    .each((el, i) => {
-      cy.wrap(el)
-        .children()
-        .each((el, j) => {
-          cy.wrap(el).should('have.text', rows[i][j])
-        })
-    })
-}
 
 const assertViewHeader = ({ project }) => {
   it('should render the header', () => {
@@ -56,7 +42,7 @@ describe('Viewing the team of a project', () => {
         'Client relationship management'
       )
 
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="crm-table"]',
         rows: [
           ['Role', 'Adviser', 'Team'],
@@ -76,7 +62,7 @@ describe('Viewing the team of a project', () => {
         'Project management'
       )
 
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="pm-table"]',
         rows: [
           ['Role', 'Adviser', 'Team'],
@@ -100,7 +86,7 @@ describe('Viewing the team of a project', () => {
         'Project specialist and team members'
       )
 
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="team-table"]',
         rows: [
           ['Role', 'Adviser', 'Team'],
@@ -135,7 +121,7 @@ describe('Viewing the team of a project', () => {
         'Client relationship management'
       )
 
-      assertTable({
+      assertGovReactTable({
         element: '[data-test="crm-table"]',
         rows: [
           ['Role', 'Adviser', 'Team'],


### PR DESCRIPTION
## Description of change

I have noticed that there are a few duplicates of the same `Table` assertion. In a previous PR I added this into the `assertions` file and in this PR I have removed the duplicates.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
