### PR TITLE
Cls 459 sort tasks

### DIFF
--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -59,7 +59,9 @@ export const LocalNavLink = ({
 }) => (
   <Route>
     {({ location: { pathname } }) => {
-      const NavLink = pathname === href ? StyledActiveLink : StyledInactiveLink
+      const NavLink = href?.includes(pathname)
+        ? StyledActiveLink
+        : StyledInactiveLink
       return (
         <NavLink href={href} data-test={dataTest} {...rest}>
           {children}

--- a/src/client/modules/Investments/Projects/ProjectTasks.jsx
+++ b/src/client/modules/Investments/Projects/ProjectTasks.jsx
@@ -4,6 +4,7 @@ import { LEVEL_SIZE } from '@govuk-react/constants'
 import { useParams } from 'react-router-dom'
 import { useSearchParam } from 'react-use'
 import { connect } from 'react-redux'
+import qs from 'qs'
 
 import { CollectionList } from '../../../components'
 import { InvestmentProjectTasksResource } from '../../../components/Resource'
@@ -22,6 +23,7 @@ import { INVESTMENT__PROJECT_LOADED } from '../../../actions'
 const ProjectTasks = ({ project }) => {
   const { projectId } = useParams()
 
+  const parsedQueryString = qs.parse(location.search.slice(1))
   const activePage = parseInt(useSearchParam('page'), 10) || 1
   const getPageUrl = (page) => `${window.location.pathname}?page=${page}`
   const setActivePage = (page) =>
@@ -49,7 +51,7 @@ const ProjectTasks = ({ project }) => {
     >
       <H2 size={LEVEL_SIZE[3]}>Investment tasks</H2>
       <p>
-        An investment tasks is an upcoming action that is associated with this
+        An investment task is an upcoming action that is associated with this
         investment project. Once a task is marked as complete it will not be
         visible here.
       </p>
@@ -66,12 +68,26 @@ const ProjectTasks = ({ project }) => {
           investment_project: projectId,
           limit: ITEMS_PER_PAGE,
           offset: activePage * ITEMS_PER_PAGE - ITEMS_PER_PAGE,
-          sortby: 'task__due_date',
+          sortby: parsedQueryString.sortby,
           archived: false,
         }}
       >
         {(projectTasks, count) => {
           const tasks = projectTasks.map(transformTaskToListItem)
+          const sortOptions = [
+            {
+              name: 'Recently created',
+              value: '-task__created_on',
+            },
+            {
+              name: 'Oldest',
+              value: 'task__created_on',
+            },
+            {
+              name: 'Due date',
+              value: 'task__due_date',
+            },
+          ]
 
           return (
             <CollectionList
@@ -82,6 +98,7 @@ const ProjectTasks = ({ project }) => {
               isComplete={true}
               onPageClick={onPageClick}
               activePage={activePage}
+              sortOptions={count ? sortOptions : null}
             />
           )
         }}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -454,7 +454,11 @@ module.exports = {
       evaluation: url('/investments', '/projects/:projectId/evaluation'),
       tasks: {
         create: url('/investments', '/projects/:projectId/tasks/create'),
-        index: url('/investments', '/projects/:projectId/tasks'),
+        index: url(
+          '/investments',
+          '/projects/:projectId/tasks',
+          '?sortby=-task__created_on'
+        ),
       },
     },
     profiles: {

--- a/test/functional/cypress/specs/investments/project-tasks-spec.js
+++ b/test/functional/cypress/specs/investments/project-tasks-spec.js
@@ -3,6 +3,7 @@ import urls from '../../../../../src/lib/urls'
 import { investmentProjectTaskFaker, taskFaker } from '../../fakers/task'
 import { format } from '../../../../../src/client/utils/date'
 import { NOT_SET_TEXT } from '../../../../../src/apps/companies/constants'
+import { assertQueryParams } from '../../support/assertions'
 
 const investmentProjectTaskWithAllOptionalFields = investmentProjectTaskFaker()
 const investmentProjectTaskMissingAllOptionalFields =
@@ -40,10 +41,10 @@ const assertTaskItem = (index, investmentTask) => {
 
 describe('Investment project tasks', () => {
   context('When the project has tasks', () => {
-    before(() => {
+    beforeEach(() => {
       cy.intercept(
         'GET',
-        `/api-proxy/v4/investmentprojecttask?investment_project=${fixtures.investment.investmentWithDetails.id}&limit=10&offset=0&sortby=task__due_date&archived=false`,
+        `/api-proxy/v4/investmentprojecttask?investment_project=${fixtures.investment.investmentWithDetails.id}**`,
         {
           body: {
             count: 2,
@@ -81,6 +82,21 @@ describe('Investment project tasks', () => {
             fixtures.investment.investmentWithDetails.id
           )
         )
+    })
+
+    it('should sort by oldest tasks', () => {
+      cy.get('[data-test="sortby"] select').select('task__created_on')
+      assertQueryParams('sortby', 'task__created_on')
+    })
+
+    it('should sort by due date', () => {
+      cy.get('[data-test="sortby"] select').select('task__due_date')
+      assertQueryParams('sortby', 'task__due_date')
+    })
+
+    it('should sort by recently created tasks', () => {
+      cy.get('[data-test="sortby"] select').select('-task__created_on')
+      assertQueryParams('sortby', '-task__created_on')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Tasks can be sorted by recently created, oldest and due date. It defaults to recently created.

Also added a fix for the styling of the local nav items where urls with any query params were not styled to be the active link. This fixes the styling for the tasks and propositions pages.

## Test instructions

Go to a Investment project and select tasks in the menu. If a project has any tasks then an option to sort them will be available. The order should change depending on the selected item. The default is sorted by recently created.

## Screenshots

### Before
![Screenshot 2023-10-16 at 14 15 13](https://github.com/uktrade/data-hub-frontend/assets/54268863/e9705fa8-24ae-436c-94cd-ef5834ef3b1a)

### After

![Screenshot 2023-10-16 at 14 15 43](https://github.com/uktrade/data-hub-frontend/assets/54268863/fd2a231a-248e-494d-b239-cee93568f075)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
