### PR TITLE
Hide complete button

### DIFF
--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -20,6 +20,9 @@ import { format } from '../../../utils/date'
 import { BLACK, GREY_3 } from '../../../utils/colours'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
+import { PropositionEvidenceResource } from '../../../components/Resource'
+import { buildEvidenceUrl } from '../Projects/Propositions/transformers'
+
 export const checkIfItemHasValue = (item) => (item ? item : null)
 
 export const transformArrayForTypeahead = (advisers) =>
@@ -211,28 +214,40 @@ export const transformPropositionToListItem = ({
   buttons:
     status === 'abandoned' || status === 'completed' ? null : (
       <>
-        <Button
-          as={Link}
-          href={urls.investments.projects.proposition.abandon(
-            investment_project.id,
-            id
-          )}
-          data-test="abandon-button"
-          buttonColour={GREY_3}
-          buttonTextColour={BLACK}
+        <PropositionEvidenceResource
+          id={buildEvidenceUrl(id, investment_project.id)}
         >
-          Abandon
-        </Button>{' '}
-        <Button
-          as={Link}
-          href={urls.investments.projects.proposition.complete(
-            investment_project.id,
-            id
+          {(evidence) => (
+            <>
+              <Button
+                as={Link}
+                href={urls.investments.projects.proposition.abandon(
+                  investment_project.id,
+                  id
+                )}
+                data-test="abandon-button"
+                buttonColour={GREY_3}
+                buttonTextColour={BLACK}
+              >
+                Abandon
+              </Button>{' '}
+              {evidence.count > 0 ? (
+                <Button
+                  as={Link}
+                  href={urls.investments.projects.proposition.complete(
+                    investment_project.id,
+                    id
+                  )}
+                  data-test="complete-button"
+                >
+                  Complete
+                </Button>
+              ) : (
+                ''
+              )}
+            </>
           )}
-          data-test="complete-button"
-        >
-          Complete
-        </Button>
+        </PropositionEvidenceResource>
       </>
     ),
 })


### PR DESCRIPTION
Hide complete button if no evidence has been uploaded

## Description of change

The 'complete' button was displaying when there was no evidence uploaded. This has been changed so the button only appears when there is at least 1 evidence uploaded to the proposition 
## Test instructions

The complete button no longer appears if an evidence has been uploaded
## Screenshots

### Before

<img width="762" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/15215184/cba56fb6-3ab5-4379-8352-1b16ddfc66f6">


### After

<img width="762" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/15215184/483fe3c8-f05c-48b1-8f0c-8cac1551c2ed">
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
