### PR TITLE
Cls2 409 uk regional tags

### DIFF
--- a/src/client/modules/Companies/CollectionList/transformers.js
+++ b/src/client/modules/Companies/CollectionList/transformers.js
@@ -65,11 +65,14 @@ const transformCompanyToListItem = ({
     })
   }
 
-  const badges = [
-    { text: get(address, 'country.name') },
-    { text: get(uk_region, 'name') },
-    { text: labels.hqLabels[get(headquarter_type, 'name')] },
-  ].filter((item) => item.text)
+  const badges = [{ text: labels.hqLabels[get(headquarter_type, 'name')] }]
+
+  if (uk_region) {
+    badges.push({ text: `${get(uk_region, 'name')}, UK` })
+  } else {
+    badges.push({ text: get(address, 'country.name') })
+  }
+  const filteredBadges = badges.filter((item) => item.text)
 
   return {
     id,
@@ -78,7 +81,7 @@ const transformCompanyToListItem = ({
       : undefined,
     headingText: name,
     headingUrl: urls.companies.detail(id),
-    badges,
+    badges: filteredBadges,
     metadata: metadata.filter((item) => item.value),
   }
 }

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -344,20 +344,21 @@ const HierarchyItem = ({
                 {hqLabels[company.headquarter_type.name]}
               </HierarchyTag>
             )}
-            {company.address?.country.name && (
-              <HierarchyTag
-                colour="blue"
-                data-test={`${companyName}-country-tag`}
-              >
-                {company.address.country.name}
-              </HierarchyTag>
-            )}
+            {company.address?.country.name !== 'United Kingdom' &&
+              company.address?.country.name && (
+                <HierarchyTag
+                  colour="blue"
+                  data-test={`${companyName}-country-tag`}
+                >
+                  {company.address.country.name}
+                </HierarchyTag>
+              )}
             {company.uk_region?.name && (
               <HierarchyTag
                 colour="blue"
                 data-test={`${companyName}-uk-region-tag`}
               >
-                {company.uk_region.name}
+                {company.uk_region.name}, UK
               </HierarchyTag>
             )}
             {(company.number_of_employees || company.employee_range?.name) && (

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -344,15 +344,14 @@ const HierarchyItem = ({
                 {hqLabels[company.headquarter_type.name]}
               </HierarchyTag>
             )}
-            {company.address?.country.name !== 'United Kingdom' &&
-              company.address?.country.name && (
-                <HierarchyTag
-                  colour="blue"
-                  data-test={`${companyName}-country-tag`}
-                >
-                  {company.address.country.name}
-                </HierarchyTag>
-              )}
+            {!company.uk_region?.name && company.address?.country.name && (
+              <HierarchyTag
+                colour="blue"
+                data-test={`${companyName}-country-tag`}
+              >
+                {company.address.country.name}
+              </HierarchyTag>
+            )}
             {company.uk_region?.name && (
               <HierarchyTag
                 colour="blue"

--- a/test/component/cypress/specs/Companies/CompanyHierarchy/Hierarchy.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyHierarchy/Hierarchy.cy.jsx
@@ -18,7 +18,7 @@ import {
 import { format } from '../../../../../../src/client/utils/date'
 
 const {
-  company: { dnbGlobalUltimate },
+  company: { dnbGlobalUltimate, allOverviewDetails },
 } = require('../../../../../functional/cypress/fixtures')
 
 const companyNoRelatedRecords = companyTreeFaker({
@@ -33,6 +33,17 @@ const companyNoSubsidiaries = companyTreeFaker({
   globalCompany: {
     ultimate_global_company: companyTreeItemFaker({
       id: dnbGlobalUltimate.id,
+    }),
+    ultimate_global_companies_count: 1,
+    family_tree_companies_count: 1,
+  },
+})
+
+const companyNoUkRegion = companyTreeFaker({
+  globalCompany: {
+    ultimate_global_company: companyTreeItemFaker({
+      id: dnbGlobalUltimate.id,
+      uk_region: null,
     }),
     ultimate_global_companies_count: 1,
     family_tree_companies_count: 1,
@@ -98,6 +109,12 @@ reducedTreeCompanyTree.ultimate_global_companies_count = 15000
 
 const companyOnlyImmediateSubsidiariesCompanyName = kebabCase(
   companyOnlyImmediateSubsidiaries.ultimate_global_company.name
+)
+
+const companyWithAllDetailsCompanyName = kebabCase(allOverviewDetails.name)
+
+const companyNoUkRegionCompanyName = kebabCase(
+  companyNoUkRegion.ultimate_global_company.name
 )
 
 describe('D&B Company Tree Hierarchy component', () => {
@@ -275,10 +292,6 @@ describe('D&B Company Tree Hierarchy component', () => {
       cy.get(`[data-test=${subsidiaryCompanyName}-uk-region-tag]`).should(
         'contain.text',
         subsidiaryTagContent.uk_region.name
-      )
-      cy.get(`[data-test=${subsidiaryCompanyName}-country-tag]`).should(
-        'contain.text',
-        subsidiaryTagContent.address.country.name
       )
       cy.get(`[data-test=${subsidiaryCompanyName}-one-list-tag]`).should(
         'contain.text',
@@ -589,6 +602,50 @@ describe('D&B Company Tree Hierarchy component', () => {
         'have.text',
         `${reducedTreeCompanyTree.family_tree_companies_count} companies out of ${reducedTreeCompanyTree.ultimate_global_companies_count}`
       )
+    })
+  })
+
+  context('When a company only has UK region and a country set', () => {
+    beforeEach(() => {
+      cy.mount(
+        <Component
+          familyTree={companyOnlyImmediateSubsidiaries}
+          requestedCompanyId={allOverviewDetails.id}
+        />
+      )
+    })
+
+    it('should only display the UK region tag', () => {
+      cy.get(
+        `[data-test=${companyOnlyImmediateSubsidiariesCompanyName}-uk-region-tag]`
+      ).should(
+        'have.text',
+        `${companyOnlyImmediateSubsidiaries.ultimate_global_company.uk_region.name}, UK`
+      )
+      cy.get(
+        `[data-test=${companyWithAllDetailsCompanyName}-country-tag]`
+      ).should('not.exist')
+    })
+  })
+
+  context('When a company only has country and no Uk region set', () => {
+    beforeEach(() => {
+      cy.mount(
+        <Component
+          familyTree={companyNoUkRegion}
+          requestedCompanyId={dnbGlobalUltimate.id}
+        />
+      )
+    })
+
+    it('should only display the country tag', () => {
+      cy.get(`[data-test=${companyNoUkRegionCompanyName}-country-tag]`).should(
+        'have.text',
+        `${companyNoUkRegion.ultimate_global_company.address.country.name}`
+      )
+      cy.get(
+        `[data-test=${companyNoUkRegionCompanyName}-uk-region-tag]`
+      ).should('not.exist')
     })
   })
 })

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -107,7 +107,7 @@ describe('Company Collections - React', () => {
   })
 
   it('should contain UK Region Badge', () => {
-    assertBadge('@secondListItem', 'London')
+    assertBadge('@secondListItem', 'London, UK')
   })
 
   it('should contain Global HQ Badge', () => {


### PR DESCRIPTION
## Description of change

We want to hide the United Kingdom country tag for companies in the UK. In addition, the UK regional tags should have ‘,UK’ appended so it’s clear to all users where they are located.

## Test instructions

Go to the main companies page or the company tree page and you should see the badges/tags in the new format. 

## Screenshots

### Before

<img width="644" alt="Screenshot 2023-10-25 at 13 48 53" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/16fc74f5-f2fa-4996-9248-648bb4853124">


### After

<img width="649" alt="Screenshot 2023-10-25 at 13 49 33" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/908713c1-2189-4aec-a58f-dccb05577026">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
