### PR TITLE
Add tasks feature flag to tasks reminder field radios

### DIFF
--- a/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskAdd.jsx
+++ b/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskAdd.jsx
@@ -10,7 +10,7 @@ import Task from '../../../../components/Task'
 import { DefaultLayout } from '../../../../components'
 import TaskForm from '../../../Tasks/TaskForm'
 
-const TaskAdd = ({ currentAdviserId, investmentProject }) => {
+const TaskAdd = ({ currentAdviserId, investmentProject, activeFeatures }) => {
   const { projectId } = useParams()
   const investorCompanyName = investmentProject?.investorCompany?.name || ''
   return (
@@ -49,6 +49,7 @@ const TaskAdd = ({ currentAdviserId, investmentProject }) => {
               )}
               submissionTaskName={TASK_SAVE_INVESTMENT_PROJECT_TASK}
               additionalPayloadData={{ investmentProject: investmentProject }}
+              activeFeatures={activeFeatures}
             />
           )
         }

--- a/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskEdit.jsx
+++ b/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskEdit.jsx
@@ -15,7 +15,7 @@ import { DefaultLayout } from '../../../../components'
 import TaskForm from '../../../Tasks/TaskForm'
 import { TASK_SAVE_TASK_DETAILS } from '../../../Tasks/TaskForm/state'
 
-const TaskEdit = ({ currentAdviserId, task }) => {
+const TaskEdit = ({ currentAdviserId, task, activeFeatures }) => {
   const { taskId } = useParams()
   const investmentProject = task?.investmentProject
   const investorCompanyName = investmentProject?.investorCompany.name || ''
@@ -53,6 +53,7 @@ const TaskEdit = ({ currentAdviserId, task }) => {
                 investmentProject.id
               )}
               submissionTaskName={TASK_SAVE_TASK_DETAILS}
+              activeFeatures={activeFeatures}
             />
           )
         }

--- a/src/client/modules/Investments/Projects/Tasks/state.js
+++ b/src/client/modules/Investments/Projects/Tasks/state.js
@@ -9,10 +9,12 @@ export const state2props = (state) => {
   const { project } = state[INVESTMENT_PROJECT_ID]
   const { task } = state[TASK_ID]
   const currentAdviserId = state.currentAdviserId
+  const activeFeatures = state.activeFeatures
 
   return {
     investmentProject: project,
     currentAdviserId,
     task: task && transformAPIValuesForForm(task, currentAdviserId),
+    activeFeatures: activeFeatures,
   }
 }

--- a/src/client/modules/Tasks/TaskForm/index.jsx
+++ b/src/client/modules/Tasks/TaskForm/index.jsx
@@ -17,6 +17,7 @@ import { validateDaysRange, validateIfDateInFuture } from './validators'
 import { FORM_LAYOUT, OPTIONS_YES_NO } from '../../../../common/constants'
 import { OPTIONS } from './constants'
 import urls from '../../../../lib/urls'
+import { adviserTasksFeatureFlag } from '../../AdviserTasks/constants'
 
 const StyledFieldInput = styled(FieldInput)`
   text-align: center;
@@ -35,6 +36,9 @@ const taskDueDateOptions = [
   { label: 'No due date', value: 'none' },
 ]
 
+const userCanViewTaskReminders = (activeFeatures) =>
+  activeFeatures.includes(adviserTasksFeatureFlag)
+
 const TaskForm = ({
   currentAdviserId,
   task,
@@ -43,6 +47,7 @@ const TaskForm = ({
   redirectToUrl,
   submissionTaskName,
   additionalPayloadData,
+  activeFeatures,
 }) => {
   return (
     <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
@@ -119,17 +124,19 @@ const TaskForm = ({
                 }),
               }))}
             />
-            <FieldRadios
-              name="taskRemindersEnabled"
-              legend="Do you want to set a reminder for this task?"
-              required="Select reminder"
-              options={OPTIONS_YES_NO.map((option) => ({
-                ...option,
-                ...(option.label === 'Yes' && {
-                  children: <FieldReminder />,
-                }),
-              }))}
-            />
+            {userCanViewTaskReminders(activeFeatures) && (
+              <FieldRadios
+                name="taskRemindersEnabled"
+                legend="Do you want to set a reminder for this task?"
+                required="Select reminder"
+                options={OPTIONS_YES_NO.map((option) => ({
+                  ...option,
+                  ...(option.label === 'Yes' && {
+                    children: <FieldReminder />,
+                  }),
+                }))}
+              />
+            )}
             <Details summary="Find out more about task reminders">
               <p>
                 By default reminders are sent at 8am, on the specified date by:

--- a/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
@@ -400,3 +400,31 @@ describe('Task form', () => {
     })
   })
 })
+
+describe('Task form feature flag', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <TaskForm {...props} />
+    </DataHubProvider>
+  )
+
+  context('When advisers-task feature flag is disabled', () => {
+    beforeEach(() => {
+      cy.mount(<Component activeFeatures={[]} />)
+    })
+
+    it('should not display the task reminder field radios', () => {
+      cy.get('[data-test="field-taskRemindersEnabled"]').should('not.exist')
+    })
+  })
+
+  context('When advisers-task feature flag is enabled', () => {
+    beforeEach(() => {
+      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
+    })
+
+    it('should display the task reminder field radios', () => {
+      cy.get('[data-test="field-taskRemindersEnabled"]').should('exist')
+    })
+  })
+})

--- a/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
@@ -20,6 +20,7 @@ import advisersListFaker, {
 } from '../../../../../functional/cypress/fakers/advisers'
 import { OPTION_NO, OPTION_YES } from '../../../../../../src/common/constants'
 import { convertDateToFieldDateObject } from '../../../../../../src/client/utils/date'
+import { adviserTasksFeatureFlag } from '../../../../../../src/client/modules/AdviserTasks/constants'
 
 describe('Task form', () => {
   const Component = (props) => (
@@ -30,7 +31,12 @@ describe('Task form', () => {
 
   context('When a task form renders without initial values', () => {
     beforeEach(() => {
-      cy.mount(<Component cancelRedirectUrl={urls.companies.index()} />)
+      cy.mount(
+        <Component
+          cancelRedirectUrl={urls.companies.index()}
+          activeFeatures={[adviserTasksFeatureFlag]}
+        />
+      )
     })
 
     it('should display the task title field', () => {
@@ -95,6 +101,7 @@ describe('Task form', () => {
         <Component
           cancelRedirectUrl={urls.companies.index()}
           task={transformAPIValuesForForm(investmentProjectTask)}
+          activeFeatures={[adviserTasksFeatureFlag]}
         />
       )
     })
@@ -174,6 +181,7 @@ describe('Task form', () => {
               investmentProjectTask,
               currentAdviser.id
             )}
+            activeFeatures={[adviserTasksFeatureFlag]}
           />
         )
       })
@@ -208,6 +216,7 @@ describe('Task form', () => {
               investmentProjectTask,
               currentAdviser.id
             )}
+            activeFeatures={[adviserTasksFeatureFlag]}
           />
         )
       })
@@ -247,6 +256,7 @@ describe('Task form', () => {
             <Component
               cancelRedirectUrl={urls.companies.index()}
               task={transformAPIValuesForForm(investmentProjectTask)}
+              activeFeatures={[adviserTasksFeatureFlag]}
             />
           )
         })
@@ -266,7 +276,7 @@ describe('Task form', () => {
 
   context('When a task is missing all mandatory fields', () => {
     beforeEach(() => {
-      cy.mount(<Component />)
+      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
       clickButton('Save task')
     })
 
@@ -296,7 +306,7 @@ describe('Task form', () => {
 
   context('When creating a task assigned to someone else', () => {
     beforeEach(() => {
-      cy.mount(<Component />)
+      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
 
       cy.get('[data-test=task-assigned-to-someone-else]').click()
     })
@@ -313,7 +323,7 @@ describe('Task form', () => {
 
   context('When a task is created a task with a custom date', () => {
     beforeEach(() => {
-      cy.mount(<Component />)
+      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
       cy.get('[data-test=task-due-date-custom-date]').click()
     })
 
@@ -355,7 +365,7 @@ describe('Task form', () => {
 
   context('When creating a task with task reminders', () => {
     beforeEach(() => {
-      cy.mount(<Component />)
+      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
 
       cy.get('[data-test=field-taskRemindersEnabled]').click()
     })

--- a/test/functional/cypress/specs/investments/project-add-task-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-task-spec.js
@@ -54,6 +54,10 @@ describe('Add investment project task', () => {
       )
     })
 
+    after(() => {
+      cy.resetUser()
+    })
+
     it('add task button should send expected values to the api', () => {
       cy.get('[data-test=task-assigned-to-me]').click()
 
@@ -67,6 +71,10 @@ describe('Add investment project task', () => {
       cy.visit(
         investments.projects.tasks.create(investment.investmentWithDetails.id)
       )
+    })
+
+    after(() => {
+      cy.resetUser()
     })
 
     it('add task button should send expected values to the api', () => {

--- a/test/functional/cypress/specs/investments/project-add-task-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-task-spec.js
@@ -12,6 +12,7 @@ import {
 } from '../../support/assertions'
 import { fill, fillMultiOptionTypeahead } from '../../support/form-fillers'
 import { clickButton } from '../../../../functional/cypress/support/actions'
+import { adviserTasksFeatureFlag } from '../../../../../src/client/modules/AdviserTasks/constants'
 
 const autoCompleteAdvisers =
   require('../../../../sandbox/fixtures/autocomplete-adviser-list.json').results
@@ -47,6 +48,7 @@ describe('Add investment project task', () => {
 
   context('When creating a task for me', () => {
     before(() => {
+      cy.setUserFeatures([adviserTasksFeatureFlag])
       cy.visit(
         investments.projects.tasks.create(investment.investmentWithDetails.id)
       )
@@ -61,6 +63,7 @@ describe('Add investment project task', () => {
 
   context('When creating a task for someone else', () => {
     before(() => {
+      cy.setUserFeatures([adviserTasksFeatureFlag])
       cy.visit(
         investments.projects.tasks.create(investment.investmentWithDetails.id)
       )


### PR DESCRIPTION
## Description of change

Tasks reminders field now has a feature flag around it. This will be removed once the work for reminders/notifications is completed

## Test instructions

With the feature flag active you should see the 'Do you want to set a reminder' radio buttons on `/investments/projects/{investment_project_id}/tasks/create`. With it inactive you should not see these radio buttons but should be able to create a task still.

## Screenshots

### Before
![Screenshot 2023-10-25 at 14 35 55](https://github.com/uktrade/data-hub-frontend/assets/54268863/1d5848a2-3f55-4b7a-962a-9ee9524de64b)

### After
![Screenshot 2023-10-25 at 14 36 46](https://github.com/uktrade/data-hub-frontend/assets/54268863/c40a057b-5195-4c96-8f0c-fc49c17e6083)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
