### PR TITLE
feature/CLS2-474-add-due-date-approaching-reminder-settings

### DIFF
--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -8,7 +8,10 @@ import qs from 'qs'
 import { connect } from 'react-redux'
 
 import { DefaultLayout, RemindersToggleSection } from '../../../components'
-import { RemindersSettingsTable } from './RemindersSettingsTable'
+import {
+  RemindersSettingsTable,
+  EmailRemindersSettingsTable,
+} from './RemindersSettingsTable'
 import Resource from '../../../components/Resource/Resource'
 import urls from '../../../../lib/urls'
 import { state2props, TASK_GET_SUBSCRIPTION_SUMMARY } from '../state'
@@ -18,9 +21,11 @@ import {
   INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
   COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
   COMPANIES_NEW_INTERACTIONS_LABEL,
+  MY_TASKS_DUE_DATE_APPROACHING_LABEL,
   REMINDERS_SETTINGS,
   INVESTMENTS_ESTIMATED_LAND_DATES,
   INVESTMENTS_NO_RECENT_INTERACTIONS,
+  MY_TASKS_DUE_DATE_APPROACHING,
   COMPANIES_NO_RECENT_INTERACTIONS,
   COMPANIES_NEW_INTERACTIONS,
 } from '../constants'
@@ -167,6 +172,32 @@ export const ExportReminderSettings = ({
     </>
   )
 
+export const TasksAssignedToMeSettings = ({
+  upcomingTaskReminder,
+  openSettingsSections,
+}) => (
+  <>
+    <H2 size={LEVEL_SIZE[3]}>Tasks assigned to me</H2>
+    <ToggleSectionContainer>
+      <RemindersToggleSection
+        label={MY_TASKS_DUE_DATE_APPROACHING_LABEL}
+        id={`${MY_TASKS_DUE_DATE_APPROACHING}-toggle`}
+        data-test={`${MY_TASKS_DUE_DATE_APPROACHING}-toggle`}
+        isOpen={isSettingOpen(
+          openSettingsSections,
+          MY_TASKS_DUE_DATE_APPROACHING
+        )}
+        borderBottom={false}
+      >
+        <EmailRemindersSettingsTable
+          dataName={MY_TASKS_DUE_DATE_APPROACHING}
+          data={upcomingTaskReminder}
+        />
+      </RemindersToggleSection>
+    </ToggleSectionContainer>
+  </>
+)
+
 export const RemindersSettings = ({
   hasInvestmentFeatureGroup,
   hasExportFeatureGroup,
@@ -192,6 +223,7 @@ export const RemindersSettings = ({
           noRecentInteraction,
           exportNoRecentInteractions,
           exportNewInteractions,
+          upcomingTaskReminder,
         }) => (
           <>
             <InvestmentReminderSettings
@@ -205,6 +237,11 @@ export const RemindersSettings = ({
               hasExportFeatureGroup={hasExportFeatureGroup}
               exportNoRecentInteractions={exportNoRecentInteractions}
               exportNewInteractions={exportNewInteractions}
+              openSettingsSections={openSettingsSections}
+            />
+
+            <TasksAssignedToMeSettings
+              upcomingTaskReminder={upcomingTaskReminder}
               openSettingsSections={openSettingsSections}
             />
 

--- a/src/client/modules/Reminders/constants.js
+++ b/src/client/modules/Reminders/constants.js
@@ -80,6 +80,12 @@ export const REMINDERS_SETTINGS = [
     settingsQSParam: snakeCase(COMPANIES_NEW_INTERACTIONS),
     url: urls.reminders.exports.newInteractions(),
   },
+  {
+    id: MY_TASKS_DUE_DATE_APPROACHING,
+    label: MY_TASKS_DUE_DATE_APPROACHING_LABEL,
+    settingsQSParam: snakeCase(MY_TASKS_DUE_DATE_APPROACHING),
+    url: urls.reminders.myTasks.dueDateApproaching(),
+  },
 ]
 
 export const reminderTypeToLabel = {

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -200,6 +200,10 @@ const transformSubscriptionSummary = ({ data }) => ({
     data.new_export_interaction,
     'days after a new interaction was posted'
   ),
+  upcomingTaskReminder: transformDaysAndEmailReminders(
+    data.upcoming_task_reminder,
+    'days before the task due date'
+  ),
 })
 
 const transformDaysAndEmailReminders = (

--- a/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
+++ b/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {
   InvestmentReminderSettings,
   ExportReminderSettings,
+  TasksAssignedToMeSettings,
 } from '../../../../../src/client/modules/Reminders/Settings/RemindersSettings.jsx'
 import DataHubProvider from '../provider'
 import {
@@ -14,6 +15,8 @@ import {
   INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
   INVESTMENTS_NO_RECENT_INTERACTIONS,
   INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+  MY_TASKS_DUE_DATE_APPROACHING,
+  MY_TASKS_DUE_DATE_APPROACHING_LABEL,
 } from '../../../../../src/client/modules/Reminders/constants.js'
 import { assertKeyValueTable } from '../../../../functional/cypress/support/assertions.js'
 
@@ -224,6 +227,46 @@ describe('ExportReminderSettings', () => {
     assertToggleSection(
       COMPANIES_NEW_INTERACTIONS,
       COMPANIES_NEW_INTERACTIONS_LABEL
+    )
+  })
+})
+
+describe('TasksAssignedToMeSettings', () => {
+  const Component = (props) => <TasksAssignedToMeSettings {...props} />
+
+  context('When component loads', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component upcomingTaskReminder={{}} />
+        </DataHubProvider>
+      )
+    })
+
+    it('should return all my tasks reminder setting sections', () => {
+      cy.get(getToggle(MY_TASKS_DUE_DATE_APPROACHING)).should('be.visible')
+    })
+  })
+
+  context('When due date approaching setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            openSettingsSections={[{ id: MY_TASKS_DUE_DATE_APPROACHING }]}
+            upcomingTaskReminder={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(MY_TASKS_DUE_DATE_APPROACHING)
+
+    assertEmailTableData(MY_TASKS_DUE_DATE_APPROACHING, setting)
+
+    assertToggleSection(
+      MY_TASKS_DUE_DATE_APPROACHING,
+      MY_TASKS_DUE_DATE_APPROACHING_LABEL
     )
   })
 })

--- a/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
+++ b/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
@@ -43,6 +43,13 @@ const assertReminderAndEmailTableData = (dataTest, setting) => {
     })
   })
 }
+const assertEmailTableData = (dataTest, setting) => {
+  it('should show the table with expected data', () => {
+    assertKeyValueTable(`${dataTest}-table`, {
+      'Email notifications': setting.emailRemindersOnOff,
+    })
+  })
+}
 
 const assertEditLink = (dataTest) => {
   it('should show the edit link', () => {

--- a/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
@@ -5,6 +5,7 @@ import {
   INVESTMENTS_NO_RECENT_INTERACTIONS,
   COMPANIES_NO_RECENT_INTERACTIONS,
   COMPANIES_NEW_INTERACTIONS,
+  MY_TASKS_DUE_DATE_APPROACHING,
 } from '../../../../../../src/client/modules/Reminders/constants'
 
 const summaryEndpoint = '/api-proxy/v4/reminder/subscription/summary'
@@ -13,6 +14,7 @@ const eslDataTest = INVESTMENTS_ESTIMATED_LAND_DATES
 const nriDataTest = INVESTMENTS_NO_RECENT_INTERACTIONS
 const enriDataTest = COMPANIES_NO_RECENT_INTERACTIONS
 const eniDataTest = COMPANIES_NEW_INTERACTIONS
+const ddaDataTest = MY_TASKS_DUE_DATE_APPROACHING
 
 const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
 const getLink = (dataTest) => `[data-test="${dataTest}-link"]`
@@ -26,6 +28,8 @@ const interceptAPICalls = ({
   enri_email_reminders_enabled = true,
   eni_reminder_days = [2, 4, 7],
   eni_email_reminders_enabled = true,
+  dda_reminder_days = [10],
+  dda_email_reminders_enabled = true,
 } = {}) => {
   cy.intercept('GET', summaryEndpoint, {
     body: {
@@ -44,6 +48,10 @@ const interceptAPICalls = ({
       new_export_interaction: {
         email_reminders_enabled: eni_email_reminders_enabled,
         reminder_days: eni_reminder_days,
+      },
+      upcoming_task_reminder: {
+        email_reminders_enabled: dda_email_reminders_enabled,
+        reminder_days: dda_reminder_days,
       },
     },
   }).as('summaryRequest')
@@ -108,5 +116,6 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableVisible('NRI', nriDataTest)
     assertSettingsTableVisible('ENRI', enriDataTest)
     assertSettingsTableVisible('ENI', eniDataTest)
+    assertSettingsTableVisible('DDA', ddaDataTest, false)
   })
 })


### PR DESCRIPTION
## Description of change

- Added a new section for the upcoming task reminder settings


## Test instructions

Go to http://localhost:3000/reminders/my-tasks-due-date-approaching, and click the Settings link above the list of reminders. You will be taken to the settings page.

The ability to change these settings is coming in a future ticket, however you can use the api to changes these values and view the changes on the frontend

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/e37d2960-7960-4d85-b370-410efa4f77d9)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/17a44b76-bfd8-4d12-8902-76f3b06fb9cb)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
