### PR TITLE
Flakey test fix - Companies UK Region tags showing undefined

### DIFF
--- a/test/functional/cypress/fakers/companies.js
+++ b/test/functional/cypress/fakers/companies.js
@@ -6,6 +6,7 @@ import apiSchema from '../../../api-schema.json'
 import { addressFaker } from './addresses'
 import { listFaker } from './utils'
 import { adviserFaker } from './advisers'
+import { ukRegionFaker } from './regions'
 import { UNITED_KINGDOM_ID, CANADA_ID } from '../../../../src/common/constants'
 
 /**
@@ -24,6 +25,7 @@ const companyFaker = (overrides = {}) => ({
     id: faker.string.uuid(),
     name: faker.word.adjective(),
   },
+  uk_region: ukRegionFaker(),
   ...overrides,
 })
 

--- a/test/functional/cypress/specs/companies/collection-react-spec.js
+++ b/test/functional/cypress/specs/companies/collection-react-spec.js
@@ -28,6 +28,7 @@ describe('Company Collections - React', () => {
       id: 'b1959812-6095-e211-a939-e4115bead28a',
       name: 'Energy',
     },
+    uk_region: null,
   })
   const company2 = companyFaker({
     trading_names: ['Company Corp', 'Company Ltd'],


### PR DESCRIPTION
## Description of change

Fixed a flaky test for the uk region badges. The company faker was not generating the uk region properly.

## Test instructions

You should see the updated uk region badges on the main companies page.


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
