### PR TITLE
Hide disabled metadata for investment form fields

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -31,6 +31,7 @@ import {
   UNITED_KINGDOM_ID,
 } from '../../../../../common/constants'
 import ProjectLayout from '../../../../components/Layout/ProjectLayout'
+import { idNamesToValueLabels } from '../../../../utils'
 
 const ukObject = {
   name: 'United Kingdom',
@@ -171,6 +172,11 @@ const EditProjectRequirements = () => {
               )}
               placeholder="Select a delivery partner"
               isMulti={true}
+              resultToOptions={(result) =>
+                idNamesToValueLabels(
+                  result.filter((option) => !option.disabledOn)
+                )
+              }
             />
           </Form>
         </ProjectLayout>

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -29,9 +29,13 @@ import {
   SpecificInvestmentProgrammesResource,
 } from '../../../components/Resource'
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
-import { transformArrayForTypeahead } from './transformers'
+import {
+  transformArrayForTypeahead,
+  transformAndFilterArrayForTypeahead,
+} from './transformers'
 import { GREY_2 } from '../../../utils/colours'
 import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
+import { idNamesToValueLabels } from '../../../utils'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -189,57 +193,57 @@ export const FieldReferralSourceHierarchy = ({
           required="Choose a referral source activity"
           initialValue={initialValue}
           fullWidth={true}
-          options={transformArrayForTypeahead(referralSourceActivities).map(
-            (option) => ({
-              ...option,
-              ...(option.label === 'Marketing' && {
-                children: (
-                  <StyledContainer>
-                    <ResourceOptionsField
-                      name="referral_source_activity_marketing"
-                      label="Marketing"
-                      resource={ReferralSourceMarketingResource}
-                      field={FieldSelect}
-                      initialValue={marketingInitialValue}
-                      placeholder="Choose a marketing type"
-                      required="Choose the marketing type"
-                      fullWidth={true}
-                    />
-                  </StyledContainer>
-                ),
-              }),
-              ...(option.label === 'Website' && {
-                children: (
-                  <StyledContainer>
-                    <ResourceOptionsField
-                      name="referral_source_activity_website"
-                      label="Website"
-                      resource={ReferralSourceWebsiteResource}
-                      field={FieldSelect}
-                      initialValue={websiteInitialValue}
-                      placeholder="Choose a website"
-                      required="Choose the website"
-                      fullWidth={true}
-                    />
-                  </StyledContainer>
-                ),
-              }),
-              ...(option.label === 'Event' && {
-                children: (
-                  <StyledContainer>
-                    <StyledFieldInput
-                      label="Event"
-                      name="referral_source_activity_event"
-                      type="text"
-                      initialValue={eventInitialValue}
-                      placeholder={eventPlaceholder}
-                      required="Enter the event details"
-                    />
-                  </StyledContainer>
-                ),
-              }),
-            })
-          )}
+          options={transformAndFilterArrayForTypeahead(
+            referralSourceActivities
+          ).map((option) => ({
+            ...option,
+            ...(option.label === 'Marketing' && {
+              children: (
+                <StyledContainer>
+                  <ResourceOptionsField
+                    name="referral_source_activity_marketing"
+                    label="Marketing"
+                    resource={ReferralSourceMarketingResource}
+                    field={FieldSelect}
+                    initialValue={marketingInitialValue}
+                    placeholder="Choose a marketing type"
+                    required="Choose the marketing type"
+                    fullWidth={true}
+                  />
+                </StyledContainer>
+              ),
+            }),
+            ...(option.label === 'Website' && {
+              children: (
+                <StyledContainer>
+                  <ResourceOptionsField
+                    name="referral_source_activity_website"
+                    label="Website"
+                    resource={ReferralSourceWebsiteResource}
+                    field={FieldSelect}
+                    initialValue={websiteInitialValue}
+                    placeholder="Choose a website"
+                    required="Choose the website"
+                    fullWidth={true}
+                  />
+                </StyledContainer>
+              ),
+            }),
+            ...(option.label === 'Event' && {
+              children: (
+                <StyledContainer>
+                  <StyledFieldInput
+                    label="Event"
+                    name="referral_source_activity_event"
+                    type="text"
+                    initialValue={eventInitialValue}
+                    placeholder={eventPlaceholder}
+                    required="Enter the event details"
+                  />
+                </StyledContainer>
+              ),
+            }),
+          }))}
         />
       </StyledReferralSourceWrapper>
     )}
@@ -313,5 +317,8 @@ export const FieldSpecificProgramme = ({ initialValue = null }) => (
     field={FieldTypeahead}
     initialValue={initialValue}
     placeholder="Choose a specific programme"
+    resultToOptions={(result) =>
+      idNamesToValueLabels(result.filter((option) => !option.disabledOn))
+    }
   />
 )

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -19,6 +19,7 @@ import {
 import { format } from '../../../utils/date'
 import { BLACK, GREY_3 } from '../../../utils/colours'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
+import { idNamesToValueLabels } from '../../../utils'
 
 export const checkIfItemHasValue = (item) => (item ? item : null)
 
@@ -27,6 +28,16 @@ export const transformArrayForTypeahead = (advisers) =>
     label: value.name,
     value: value.id,
   }))
+
+export const transformAndFilterArrayForTypeahead = (array) => {
+  const filteredArray = idNamesToValueLabels(
+    array.filter((option) => !option.disabledOn)
+  )
+  return filteredArray.map((element) => ({
+    label: element.label,
+    value: element.value,
+  }))
+}
 
 export const transformObjectForTypeahead = (object) =>
   object

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -325,7 +325,7 @@ describe('Investment Detail Step Form Content', () => {
         element,
         label: 'Referral source activity',
         placeholder: 'Choose a referral source activity',
-        optionsCount: 49,
+        optionsCount: 46,
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -144,7 +144,7 @@ describe('Editing the project summary', () => {
         label: 'Referral source activity',
         placeholder: 'Choose a referral source activity',
         value: 'None',
-        optionsCount: 49,
+        optionsCount: 46,
       })
     })
     cy.get('[data-test="field-referral_source_activity_event"]').should(


### PR DESCRIPTION
## Description of change

Some of the investment form fields were displaying disabled metadata.

## Test instructions

Go to an investment project, edit the requirements and scroll to the delivery partners field. The item `Aylesbury Vale District Council` should no longer appear in the list.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
