### PR TITLE
feature/CLS2-474-refactor-reminder-settings

### DIFF
--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -3,12 +3,12 @@ import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 import { H2 } from '@govuk-react/heading'
 import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
-import { get } from 'lodash'
+import { first, get } from 'lodash'
 import qs from 'qs'
 import { connect } from 'react-redux'
 
 import { DefaultLayout, RemindersToggleSection } from '../../../components'
-import RemindersSettingsTable from './RemindersSettingsTable'
+import { RemindersSettingsTable } from './RemindersSettingsTable'
 import Resource from '../../../components/Resource/Resource'
 import urls from '../../../../lib/urls'
 import { state2props, TASK_GET_SUBSCRIPTION_SUMMARY } from '../state'
@@ -18,6 +18,11 @@ import {
   INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
   COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
   COMPANIES_NEW_INTERACTIONS_LABEL,
+  REMINDERS_SETTINGS,
+  INVESTMENTS_ESTIMATED_LAND_DATES,
+  INVESTMENTS_NO_RECENT_INTERACTIONS,
+  COMPANIES_NO_RECENT_INTERACTIONS,
+  COMPANIES_NEW_INTERACTIONS,
 } from '../constants'
 
 import FooterLink from '../FooterLink'
@@ -27,26 +32,16 @@ const ToggleSectionContainer = styled('div')({
   marginBottom: '40px',
 })
 
-const openSettings = (queryParamType, qsParams, label, reminderReturnUrl) => {
-  const settingsExpand = get(qsParams, queryParamType, false)
-
-  return {
-    isOpen: !!settingsExpand,
-    breadcrumbUrl: `${urls.reminders.settings.index()}/?${queryParamType}=true`,
-    breadcrumbLabel: label,
-    reminderReturnUrl,
-  }
-}
-
-const generateBreadcrumbs = (openSettingsBreadCrumb) => {
-  if (openSettingsBreadCrumb?.isOpen) {
+const generateBreadcrumbs = (openSettings) => {
+  const openSetting = first(openSettings)
+  if (openSetting) {
     return [
       {
         link: urls.dashboard.index(),
         text: 'Home',
       },
       {
-        link: openSettingsBreadCrumb.reminderReturnUrl,
+        link: openSetting.url,
         text: 'Reminders',
       },
       {
@@ -54,7 +49,7 @@ const generateBreadcrumbs = (openSettingsBreadCrumb) => {
         text: 'Settings',
       },
       {
-        text: openSettingsBreadCrumb.breadcrumbLabel,
+        text: openSetting.label,
       },
     ]
   } else {
@@ -74,43 +69,113 @@ const generateBreadcrumbs = (openSettingsBreadCrumb) => {
   }
 }
 
-const RemindersSettings = ({
+const isSettingOpen = (openSettingsSections, setting) =>
+  openSettingsSections &&
+  !!openSettingsSections.find((openSetting) => openSetting.id === setting)
+
+const getOpenSettings = (qsParams) =>
+  REMINDERS_SETTINGS.filter((x) => get(qsParams, x.settingsQSParam, false))
+
+export const InvestmentReminderSettings = ({
+  hasInvestmentFeatureGroup,
+  estimatedLandDate,
+  noRecentInteraction,
+  openSettingsSections,
+}) =>
+  hasInvestmentFeatureGroup && (
+    <>
+      <H2 size={LEVEL_SIZE[3]}>Investment</H2>
+      <ToggleSectionContainer>
+        <RemindersToggleSection
+          label={INVESTMENTS_ESTIMATED_LAND_DATES_LABEL}
+          id={`${INVESTMENTS_ESTIMATED_LAND_DATES}-toggle`}
+          data-test={`${INVESTMENTS_ESTIMATED_LAND_DATES}-toggle`}
+          isOpen={isSettingOpen(
+            openSettingsSections,
+            INVESTMENTS_ESTIMATED_LAND_DATES
+          )}
+        >
+          <RemindersSettingsTable
+            dataName={INVESTMENTS_ESTIMATED_LAND_DATES}
+            data={estimatedLandDate}
+            to={urls.reminders.settings.investments.estimatedLandDate()}
+          />
+        </RemindersToggleSection>
+        <RemindersToggleSection
+          label={INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL}
+          id={`${INVESTMENTS_NO_RECENT_INTERACTIONS}-toggle`}
+          data-test={`${INVESTMENTS_NO_RECENT_INTERACTIONS}-toggle`}
+          isOpen={isSettingOpen(
+            openSettingsSections,
+            INVESTMENTS_NO_RECENT_INTERACTIONS
+          )}
+          borderBottom={true}
+        >
+          <RemindersSettingsTable
+            dataName={INVESTMENTS_NO_RECENT_INTERACTIONS}
+            data={noRecentInteraction}
+            to={urls.reminders.settings.investments.noRecentInteraction()}
+          />
+        </RemindersToggleSection>
+      </ToggleSectionContainer>
+    </>
+  )
+
+export const ExportReminderSettings = ({
+  hasExportFeatureGroup,
+  exportNoRecentInteractions,
+  exportNewInteractions,
+  openSettingsSections,
+}) =>
+  hasExportFeatureGroup && (
+    <>
+      <H2 size={LEVEL_SIZE[3]}>Export</H2>
+      <ToggleSectionContainer>
+        <RemindersToggleSection
+          label={COMPANIES_NO_RECENT_INTERACTIONS_LABEL}
+          id={`${COMPANIES_NO_RECENT_INTERACTIONS}-toggle`}
+          data-test={`${COMPANIES_NO_RECENT_INTERACTIONS}-toggle`}
+          isOpen={isSettingOpen(
+            openSettingsSections,
+            COMPANIES_NO_RECENT_INTERACTIONS
+          )}
+          borderBottom={true}
+        >
+          <RemindersSettingsTable
+            dataName={COMPANIES_NO_RECENT_INTERACTIONS}
+            data={exportNoRecentInteractions}
+            to={urls.reminders.settings.exports.noRecentInteraction()}
+          />
+        </RemindersToggleSection>
+        <RemindersToggleSection
+          label={COMPANIES_NEW_INTERACTIONS_LABEL}
+          id={`${COMPANIES_NEW_INTERACTIONS}-toggle`}
+          data-test={`${COMPANIES_NEW_INTERACTIONS}-toggle`}
+          isOpen={isSettingOpen(
+            openSettingsSections,
+            COMPANIES_NEW_INTERACTIONS
+          )}
+          borderBottom={true}
+        >
+          <RemindersSettingsTable
+            dataName={COMPANIES_NEW_INTERACTIONS}
+            data={exportNewInteractions}
+            to={urls.reminders.settings.exports.newInteraction()}
+          />
+        </RemindersToggleSection>
+      </ToggleSectionContainer>
+    </>
+  )
+
+export const RemindersSettings = ({
   hasInvestmentFeatureGroup,
   hasExportFeatureGroup,
 }) => {
   const location = useLocation()
   const qsParams = qs.parse(location.search.slice(1))
 
-  const openESL = openSettings(
-    'investments_estimated_land_dates',
-    qsParams,
-    INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
-    urls.reminders.investments.estimatedLandDate()
-  )
-  const openNRI = openSettings(
-    'investments_no_recent_interactions',
-    qsParams,
-    INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
-    urls.reminders.investments.noRecentInteraction()
-  )
-  const openENRI = openSettings(
-    'companies_no_recent_interactions',
-    qsParams,
-    COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
-    urls.reminders.exports.noRecentInteractions()
-  )
-  const openENI = openSettings(
-    'companies_new_interactions',
-    qsParams,
-    COMPANIES_NEW_INTERACTIONS_LABEL,
-    urls.reminders.exports.newInteractions()
-  )
-
-  const openSettingsBreadCrumb = [openENI, openENRI, openESL, openNRI].find(
-    (setting) => setting.isOpen
-  )
-
-  const breadcrumbs = generateBreadcrumbs(openSettingsBreadCrumb)
+  const openSettingsSections = getOpenSettings(qsParams)
+  const breadcrumbs = generateBreadcrumbs(openSettingsSections)
 
   return (
     <DefaultLayout
@@ -129,71 +194,20 @@ const RemindersSettings = ({
           exportNewInteractions,
         }) => (
           <>
-            {hasInvestmentFeatureGroup && (
-              <>
-                <H2 size={LEVEL_SIZE[3]}>Investment</H2>
-                <ToggleSectionContainer>
-                  <RemindersToggleSection
-                    label={INVESTMENTS_ESTIMATED_LAND_DATES_LABEL}
-                    id="estimated-land-dates-toggle"
-                    data-test="estimated-land-dates-toggle"
-                    isOpen={openESL.isOpen}
-                  >
-                    <RemindersSettingsTable
-                      dataName={'estimated-land-dates'}
-                      data={estimatedLandDate}
-                      to={urls.reminders.settings.investments.estimatedLandDate()}
-                    />
-                  </RemindersToggleSection>
-                  <RemindersToggleSection
-                    label={INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL}
-                    id="no-recent-interactions-toggle"
-                    data-test="no-recent-interactions-toggle"
-                    isOpen={openNRI.isOpen}
-                    borderBottom={true}
-                  >
-                    <RemindersSettingsTable
-                      dataName={'no-recent-interactions'}
-                      data={noRecentInteraction}
-                      to={urls.reminders.settings.investments.noRecentInteraction()}
-                    />
-                  </RemindersToggleSection>
-                </ToggleSectionContainer>
-              </>
-            )}
-            {hasExportFeatureGroup && (
-              <>
-                <H2 size={LEVEL_SIZE[3]}>Export</H2>
-                <ToggleSectionContainer>
-                  <RemindersToggleSection
-                    label={COMPANIES_NO_RECENT_INTERACTIONS_LABEL}
-                    id="companies-no-recent-interactions-toggle"
-                    data-test="companies-no-recent-interactions-toggle"
-                    isOpen={openENRI.isOpen}
-                    borderBottom={true}
-                  >
-                    <RemindersSettingsTable
-                      dataName={'companies-no-recent-interactions'}
-                      data={exportNoRecentInteractions}
-                      to={urls.reminders.settings.exports.noRecentInteraction()}
-                    />
-                  </RemindersToggleSection>
-                  <RemindersToggleSection
-                    label={COMPANIES_NEW_INTERACTIONS_LABEL}
-                    id="companies-new-interactions-toggle"
-                    data-test="companies-new-interactions-toggle"
-                    isOpen={openENI.isOpen}
-                    borderBottom={true}
-                  >
-                    <RemindersSettingsTable
-                      dataName={'companies-new-interactions'}
-                      data={exportNewInteractions}
-                      to={urls.reminders.settings.exports.newInteraction()}
-                    />
-                  </RemindersToggleSection>
-                </ToggleSectionContainer>
-              </>
-            )}
+            <InvestmentReminderSettings
+              hasInvestmentFeatureGroup={hasInvestmentFeatureGroup}
+              estimatedLandDate={estimatedLandDate}
+              noRecentInteraction={noRecentInteraction}
+              openSettingsSections={openSettingsSections}
+            />
+
+            <ExportReminderSettings
+              hasExportFeatureGroup={hasExportFeatureGroup}
+              exportNoRecentInteractions={exportNoRecentInteractions}
+              exportNewInteractions={exportNewInteractions}
+              openSettingsSections={openSettingsSections}
+            />
+
             <FooterLink
               headingText="Need Help?"
               linkUrl={urls.external.reminderAndSettings}

--- a/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
@@ -23,22 +23,41 @@ const StyledRouterLink = styled(RouterLink)({
   display: 'block',
 })
 
-const RemindersSettingsTable = ({ dataName, data, to }) => (
+const SettingsTable = ({ dataName, to, children }) => (
   <>
-    <StyledTable data-test={`${dataName}-table`}>
-      <Table.Row>
-        <StyledCellHeader>Reminders</StyledCellHeader>
-        <Table.Cell>{data.formattedReminderDays}</Table.Cell>
-      </Table.Row>
-      <Table.Row>
-        <StyledCellHeader>Email notifications</StyledCellHeader>
-        <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
-      </Table.Row>
-    </StyledTable>
-    <StyledRouterLink data-test={`${dataName}-link`} to={to} aria-label="edit">
-      Edit
-    </StyledRouterLink>
+    <StyledTable data-test={`${dataName}-table`}>{children}</StyledTable>
+    {to && (
+      <StyledRouterLink
+        data-test={`${dataName}-link`}
+        to={to}
+        aria-label="edit"
+      >
+        Edit
+      </StyledRouterLink>
+    )}
   </>
+)
+
+export const RemindersSettingsTable = ({ dataName, data, to }) => (
+  <SettingsTable dataName={dataName} to={to}>
+    <Table.Row>
+      <StyledCellHeader>Reminders</StyledCellHeader>
+      <Table.Cell>{data.formattedReminderDays}</Table.Cell>
+    </Table.Row>
+    <Table.Row>
+      <StyledCellHeader>Email notifications</StyledCellHeader>
+      <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+    </Table.Row>
+  </SettingsTable>
+)
+
+export const EmailRemindersSettingsTable = ({ dataName, data, to }) => (
+  <SettingsTable dataName={dataName} to={to}>
+    <Table.Row>
+      <StyledCellHeader>Email notifications</StyledCellHeader>
+      <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+    </Table.Row>
+  </SettingsTable>
 )
 
 export default RemindersSettingsTable

--- a/src/client/modules/Reminders/constants.js
+++ b/src/client/modules/Reminders/constants.js
@@ -1,3 +1,7 @@
+import { snakeCase } from 'lodash'
+
+import urls from '../../../lib/urls'
+
 export const settings = {
   OFF: 'Off',
   ON: 'On',
@@ -44,6 +48,39 @@ export const COMPANIES_NEW_INTERACTIONS_LABEL =
   'Companies with new interactions'
 
 export const MY_TASKS_DUE_DATE_APPROACHING_LABEL = 'Due date approaching'
+
+export const REMINDERS_SETTINGS = [
+  {
+    id: INVESTMENTS_ESTIMATED_LAND_DATES,
+    label: INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+    settingsQSParam: snakeCase(INVESTMENTS_ESTIMATED_LAND_DATES),
+    url: urls.reminders.investments.estimatedLandDate(),
+  },
+  {
+    id: INVESTMENTS_NO_RECENT_INTERACTIONS,
+    label: INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+    settingsQSParam: snakeCase(INVESTMENTS_NO_RECENT_INTERACTIONS),
+    url: urls.reminders.investments.noRecentInteraction(),
+  },
+  {
+    id: INVESTMENTS_OUTSTANDING_PROPOSITIONS,
+    label: INVESTMENTS_OUTSTANDING_PROPOSITIONS_LABEL,
+    settingsQSParam: snakeCase(INVESTMENTS_OUTSTANDING_PROPOSITIONS),
+    url: urls.reminders.investments.outstandingPropositions(),
+  },
+  {
+    id: COMPANIES_NO_RECENT_INTERACTIONS,
+    label: COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+    settingsQSParam: snakeCase(COMPANIES_NO_RECENT_INTERACTIONS),
+    url: urls.reminders.exports.noRecentInteractions(),
+  },
+  {
+    id: COMPANIES_NEW_INTERACTIONS,
+    label: COMPANIES_NEW_INTERACTIONS_LABEL,
+    settingsQSParam: snakeCase(COMPANIES_NEW_INTERACTIONS),
+    url: urls.reminders.exports.newInteractions(),
+  },
+]
 
 export const reminderTypeToLabel = {
   [INVESTMENTS_ESTIMATED_LAND_DATES]: INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -179,46 +179,50 @@ export const deleteMyTasksDueDateApproachingReminder = ({ id } = {}) =>
 
 // ********************** Summary ***************************
 
+const defaultDaysSort = (a, b) => a - b
+const reversedDaysSort = (a, b) => b - a
+
 const transformSubscriptionSummary = ({ data }) => ({
-  estimatedLandDate: {
-    formattedReminderDays: formatDays(
-      data.estimated_land_date.reminder_days.sort((a, b) => a - b).reverse(),
-      'days before the estimated land date'
-    ),
-    emailRemindersOnOff: data.estimated_land_date.email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
-  noRecentInteraction: {
-    formattedReminderDays: formatDays(
-      data.no_recent_investment_interaction.reminder_days.sort((a, b) => a - b),
-      'days after the last interaction'
-    ),
-    emailRemindersOnOff: data.no_recent_investment_interaction
-      .email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
-  exportNoRecentInteractions: {
-    formattedReminderDays: formatDays(
-      data.no_recent_export_interaction.reminder_days.sort((a, b) => a - b),
-      'days after the last interaction'
-    ),
-    emailRemindersOnOff: data.no_recent_export_interaction
-      .email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
-  exportNewInteractions: {
-    formattedReminderDays: formatDays(
-      data.new_export_interaction.reminder_days.sort((a, b) => a - b),
-      'days after a new interaction was posted'
-    ),
-    emailRemindersOnOff: data.new_export_interaction.email_reminders_enabled
-      ? settings.ON
-      : settings.OFF,
-  },
+  estimatedLandDate: transformDaysAndEmailReminders(
+    data.estimated_land_date,
+    'days before the estimated land date',
+    reversedDaysSort
+  ),
+  noRecentInteraction: transformDaysAndEmailReminders(
+    data.no_recent_investment_interaction,
+    'days after the last interaction'
+  ),
+  exportNoRecentInteractions: transformDaysAndEmailReminders(
+    data.no_recent_export_interaction,
+    'days after the last interaction'
+  ),
+  exportNewInteractions: transformDaysAndEmailReminders(
+    data.new_export_interaction,
+    'days after a new interaction was posted'
+  ),
 })
+
+const transformDaysAndEmailReminders = (
+  data,
+  suffixLabel,
+  daysSort = defaultDaysSort
+) => ({
+  formattedReminderDays: transformFormattedReminderDays(
+    data,
+    suffixLabel,
+    daysSort
+  ),
+  emailRemindersOnOff: transformEmailReminders(data),
+})
+
+const transformFormattedReminderDays = (
+  data,
+  suffixLabel,
+  sort = defaultDaysSort
+) => formatDays(data.reminder_days.sort(sort), suffixLabel)
+
+const transformEmailReminders = (data) =>
+  data.email_reminders_enabled ? settings.ON : settings.OFF
 
 export const getSubscriptionSummary = () =>
   apiProxyAxios

--- a/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
+++ b/test/component/cypress/specs/Reminders/ReminderSettings.cy.jsx
@@ -1,0 +1,229 @@
+import React from 'react'
+
+import {
+  InvestmentReminderSettings,
+  ExportReminderSettings,
+} from '../../../../../src/client/modules/Reminders/Settings/RemindersSettings.jsx'
+import DataHubProvider from '../provider'
+import {
+  COMPANIES_NEW_INTERACTIONS,
+  COMPANIES_NEW_INTERACTIONS_LABEL,
+  COMPANIES_NO_RECENT_INTERACTIONS,
+  COMPANIES_NO_RECENT_INTERACTIONS_LABEL,
+  INVESTMENTS_ESTIMATED_LAND_DATES,
+  INVESTMENTS_ESTIMATED_LAND_DATES_LABEL,
+  INVESTMENTS_NO_RECENT_INTERACTIONS,
+  INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
+} from '../../../../../src/client/modules/Reminders/constants.js'
+import { assertKeyValueTable } from '../../../../functional/cypress/support/assertions.js'
+
+const getToggle = (dataTest) => `[data-test="${dataTest}-toggle"]`
+const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
+const getLink = (dataTest) => `[data-test="${dataTest}-link"]`
+
+const setting = {
+  formattedReminderDays: 'a',
+  emailRemindersOnOff: 'b',
+}
+
+const assertSettingsSectionExpanded = (dataTest) => {
+  it('should show the expanded settings section', () => {
+    cy.get(getTable(dataTest)).should('be.visible')
+  })
+}
+
+const assertReminderAndEmailTableData = (dataTest, setting) => {
+  it('should show the table with expected data', () => {
+    assertKeyValueTable(`${dataTest}-table`, {
+      Reminders: setting.formattedReminderDays,
+      'Email notifications': setting.emailRemindersOnOff,
+    })
+  })
+}
+
+const assertEditLink = (dataTest) => {
+  it('should show the edit link', () => {
+    cy.get(getLink(dataTest)).should('be.visible')
+  })
+}
+
+const assertToggleSection = (dataTest, label) => {
+  it(`should hide the settings table on toggle`, () => {
+    cy.get(getToggle(dataTest))
+      .find('button')
+      .contains(label)
+      .click()
+      .get(getTable(dataTest))
+      .should('not.be.visible')
+  })
+}
+
+describe('InvestmentReminderSettings', () => {
+  const Component = (props) => <InvestmentReminderSettings {...props} />
+
+  context('When feature flag is disabled', () => {
+    beforeEach(() => {
+      cy.mount(<Component hasInvestmentFeatureGroup={false} />)
+    })
+
+    it('should return an empty component', () => {
+      cy.get('h2').should('not.exist')
+    })
+  })
+
+  context('When feature flag is enabled', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasInvestmentFeatureGroup={true}
+            estimatedLandDate={{}}
+            noRecentInteraction={{}}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    it('should return all investment reminder setting sections', () => {
+      cy.get(getToggle(INVESTMENTS_ESTIMATED_LAND_DATES)).should('be.visible')
+      cy.get(getToggle(INVESTMENTS_NO_RECENT_INTERACTIONS)).should('be.visible')
+    })
+  })
+
+  context('When estimated land dates setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasInvestmentFeatureGroup={true}
+            openSettingsSections={[{ id: INVESTMENTS_ESTIMATED_LAND_DATES }]}
+            estimatedLandDate={setting}
+            noRecentInteraction={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(INVESTMENTS_ESTIMATED_LAND_DATES)
+
+    assertReminderAndEmailTableData(INVESTMENTS_ESTIMATED_LAND_DATES, setting)
+
+    assertEditLink(INVESTMENTS_ESTIMATED_LAND_DATES)
+
+    assertToggleSection(
+      INVESTMENTS_ESTIMATED_LAND_DATES,
+      INVESTMENTS_ESTIMATED_LAND_DATES_LABEL
+    )
+  })
+
+  context('When no recent interactions setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasInvestmentFeatureGroup={true}
+            openSettingsSections={[{ id: INVESTMENTS_NO_RECENT_INTERACTIONS }]}
+            estimatedLandDate={setting}
+            noRecentInteraction={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(INVESTMENTS_NO_RECENT_INTERACTIONS)
+
+    assertReminderAndEmailTableData(INVESTMENTS_NO_RECENT_INTERACTIONS, setting)
+
+    assertEditLink(INVESTMENTS_NO_RECENT_INTERACTIONS)
+
+    assertToggleSection(
+      INVESTMENTS_NO_RECENT_INTERACTIONS,
+      INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL
+    )
+  })
+})
+
+describe('ExportReminderSettings', () => {
+  const Component = (props) => <ExportReminderSettings {...props} />
+
+  context('When feature flag is disabled', () => {
+    beforeEach(() => {
+      cy.mount(<Component hasExportFeatureGroup={false} />)
+    })
+
+    it('should return an empty component', () => {
+      cy.get('h2').should('not.exist')
+    })
+  })
+
+  context('When feature flag is enabled', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasExportFeatureGroup={true}
+            exportNoRecentInteractions={{}}
+            exportNewInteractions={{}}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    it('should return all investment reminder setting sections', () => {
+      cy.get(getToggle(COMPANIES_NO_RECENT_INTERACTIONS)).should('be.visible')
+      cy.get(getToggle(COMPANIES_NEW_INTERACTIONS)).should('be.visible')
+    })
+  })
+
+  context('When companies with no recent interactions setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasExportFeatureGroup={true}
+            openSettingsSections={[{ id: COMPANIES_NO_RECENT_INTERACTIONS }]}
+            exportNoRecentInteractions={setting}
+            exportNewInteractions={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(COMPANIES_NO_RECENT_INTERACTIONS)
+
+    assertReminderAndEmailTableData(COMPANIES_NO_RECENT_INTERACTIONS, setting)
+
+    assertEditLink(COMPANIES_NO_RECENT_INTERACTIONS)
+
+    assertToggleSection(
+      COMPANIES_NO_RECENT_INTERACTIONS,
+      COMPANIES_NO_RECENT_INTERACTIONS_LABEL
+    )
+  })
+
+  context('When companies with new interactions setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            hasExportFeatureGroup={true}
+            openSettingsSections={[{ id: COMPANIES_NEW_INTERACTIONS }]}
+            exportNoRecentInteractions={setting}
+            exportNewInteractions={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(COMPANIES_NEW_INTERACTIONS)
+
+    assertReminderAndEmailTableData(COMPANIES_NEW_INTERACTIONS, setting)
+
+    assertEditLink(COMPANIES_NEW_INTERACTIONS)
+
+    assertToggleSection(
+      COMPANIES_NEW_INTERACTIONS,
+      COMPANIES_NEW_INTERACTIONS_LABEL
+    )
+  })
+})

--- a/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/notifcation-settings-spec.js
@@ -1,14 +1,18 @@
+import {
+  INVESTMENTS_ESTIMATED_LAND_DATES,
+  INVESTMENTS_NO_RECENT_INTERACTIONS,
+} from '../../../../../../src/client/modules/Reminders/constants'
 import urls from '../../../../../../src/lib/urls'
 
 const selectors = {
   collectionItem: '[data-test="item-content"]',
   remindersSettings: 'a[data-test="reminders-settings-link"]',
-  ELDSettingsClose: '#estimated-land-dates-toggle-toggle-button-close',
-  ELDSettingsOpen: '#estimated-land-dates-toggle-toggle-button-open',
-  ELDEdit: '[data-test="estimated-land-dates-link"]',
-  NRISettingsClose: '#no-recent-interactions-toggle-toggle-button-close',
-  NRISettingsOpen: '#no-recent-interactions-toggle-toggle-button-open',
-  NRIEdit: '[data-test="no-recent-interactions-link"]',
+  ELDSettingsClose: `#${INVESTMENTS_ESTIMATED_LAND_DATES}-toggle-toggle-button-close`,
+  ELDSettingsOpen: `#${INVESTMENTS_ESTIMATED_LAND_DATES}-toggle-toggle-button-open`,
+  ELDEdit: `[data-test="${INVESTMENTS_ESTIMATED_LAND_DATES}-link"]`,
+  NRISettingsClose: `#${INVESTMENTS_NO_RECENT_INTERACTIONS}-toggle-toggle-button-close`,
+  NRISettingsOpen: `#${INVESTMENTS_NO_RECENT_INTERACTIONS}-toggle-toggle-button-open`,
+  NRIEdit: `[data-test="${INVESTMENTS_NO_RECENT_INTERACTIONS}-link"]`,
 }
 
 describe('Notification settings', () => {

--- a/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
@@ -1,17 +1,19 @@
-import {
-  assertBreadcrumbs,
-  assertKeyValueTable,
-} from '../../../support/assertions'
+import { assertBreadcrumbs } from '../../../support/assertions'
 import urls from '../../../../../../src/lib/urls'
+import {
+  INVESTMENTS_ESTIMATED_LAND_DATES,
+  INVESTMENTS_NO_RECENT_INTERACTIONS,
+  COMPANIES_NO_RECENT_INTERACTIONS,
+  COMPANIES_NEW_INTERACTIONS,
+} from '../../../../../../src/client/modules/Reminders/constants'
 
 const summaryEndpoint = '/api-proxy/v4/reminder/subscription/summary'
 
-const eslDataTest = 'estimated-land-dates'
-const nriDataTest = 'no-recent-interactions'
-const enriDataTest = 'companies-no-recent-interactions'
-const eniDataTest = 'companies-new-interactions'
+const eslDataTest = INVESTMENTS_ESTIMATED_LAND_DATES
+const nriDataTest = INVESTMENTS_NO_RECENT_INTERACTIONS
+const enriDataTest = COMPANIES_NO_RECENT_INTERACTIONS
+const eniDataTest = COMPANIES_NEW_INTERACTIONS
 
-const getToggle = (dataTest) => `[data-test="${dataTest}-toggle"]`
 const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
 const getLink = (dataTest) => `[data-test="${dataTest}-link"]`
 
@@ -51,55 +53,27 @@ const waitForAPICalls = () => {
   cy.wait('@summaryRequest')
 }
 
-const assertSettingsTableVisible = (title, dataTest) => {
+const assertSettingsTableVisible = (title, dataTest, includeLink = true) => {
   it(`should show the ${title} settings table and edit link`, () => {
     cy.get(getTable(dataTest)).should('be.visible')
-    cy.get(getLink(dataTest)).should('be.visible')
-  })
-}
-const assertSettingsTableNotVisible = (title, dataTest) => {
-  it(`should hide the ${title} settings table and edit link`, () => {
-    cy.get(getTable(dataTest)).should('not.be.visible')
-    cy.get(getLink(dataTest)).should('not.be.visible')
-  })
-}
-
-const assertSettingsTableToggles = ({
-  title,
-  dataTest,
-  reminderText,
-  buttonText,
-}) => {
-  it(`should render the ${title} settings table`, () => {
-    assertKeyValueTable(`${dataTest}-table`, {
-      Reminders: reminderText,
-      'Email notifications': 'On',
-    })
-  })
-
-  it(`should hide the ${title} settings table on toggle`, () => {
-    cy.get(getToggle(dataTest))
-      .find('button')
-      .contains(buttonText)
-      .click()
-      .get(getTable(dataTest))
-      .should('not.be.visible')
-      .get(getLink(dataTest))
-      .should('not.be.visible')
+    includeLink && cy.get(getLink(dataTest)).should('be.visible')
   })
 }
 
 describe('Settings: reminders and email notifications', () => {
+  before(() => {
+    cy.setUserFeatureGroups([
+      'export-notifications',
+      'investment-notifications',
+    ])
+  })
+
   after(() => {
     cy.resetUser()
   })
 
   context('Breadcrumbs and title', () => {
     before(() => {
-      cy.setUserFeatureGroups([
-        'export-notifications',
-        'investment-notifications',
-      ])
       interceptAPICalls()
       cy.visit(urls.reminders.settings.index())
       waitForAPICalls()
@@ -121,111 +95,9 @@ describe('Settings: reminders and email notifications', () => {
     })
   })
 
-  context('When all settings are hidden', () => {
-    before(() => {
-      interceptAPICalls()
-      cy.visit(urls.reminders.settings.index())
-      waitForAPICalls()
-    })
-
-    assertSettingsTableNotVisible('ELD', eslDataTest)
-    assertSettingsTableNotVisible('NRI', nriDataTest)
-    assertSettingsTableNotVisible('ENRI', enriDataTest)
-    assertSettingsTableNotVisible('ENI', eniDataTest)
-  })
-
-  context(
-    'When estimated land settings are visible and no recent interaction settings are hidden',
-    () => {
-      const queryParams = 'investments_estimated_land_dates=true'
-      before(() => {
-        interceptAPICalls()
-        cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
-        waitForAPICalls()
-      })
-
-      assertSettingsTableVisible('ELD', eslDataTest)
-      assertSettingsTableNotVisible('NRI', nriDataTest)
-      assertSettingsTableNotVisible('ENRI', enriDataTest)
-      assertSettingsTableNotVisible('ENI', eniDataTest)
-
-      assertSettingsTableToggles({
-        title: 'ELD',
-        dataTest: eslDataTest,
-        reminderText: '60 and 30 days before the estimated land date',
-        buttonText: 'Approaching estimated land date',
-      })
-    }
-  )
-
-  context(
-    'When only no recent investment interaction settings are visible',
-    () => {
-      const queryParams = 'investments_no_recent_interactions=true'
-      before(() => {
-        interceptAPICalls()
-        cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
-        waitForAPICalls()
-      })
-
-      assertSettingsTableNotVisible('ELD', eslDataTest)
-      assertSettingsTableVisible('NRI', nriDataTest)
-      assertSettingsTableNotVisible('ENRI', enriDataTest)
-
-      assertSettingsTableToggles({
-        title: 'NRI',
-        dataTest: nriDataTest,
-        reminderText: '30, 50 and 70 days after the last interaction',
-        buttonText: 'Projects with no recent interaction',
-      })
-    }
-  )
-
-  context('When only no recent export interaction settings are visible', () => {
-    const queryParams = 'companies_no_recent_interactions=true'
-    before(() => {
-      interceptAPICalls()
-      cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
-      waitForAPICalls()
-    })
-
-    assertSettingsTableNotVisible('ELD', eslDataTest)
-    assertSettingsTableNotVisible('NRI', nriDataTest)
-    assertSettingsTableVisible('ENRI', enriDataTest)
-    assertSettingsTableNotVisible('ENI', eniDataTest)
-
-    assertSettingsTableToggles({
-      title: 'ENRI',
-      dataTest: enriDataTest,
-      reminderText: '10, 30 and 40 days after the last interaction',
-      buttonText: 'Companies with no recent interaction',
-    })
-  })
-
-  context('When only new export interaction settings are visible', () => {
-    const queryParams = 'companies_new_interactions=true'
-    before(() => {
-      interceptAPICalls()
-      cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
-      waitForAPICalls()
-    })
-
-    assertSettingsTableNotVisible('ELD', eslDataTest)
-    assertSettingsTableNotVisible('NRI', nriDataTest)
-    assertSettingsTableNotVisible('ENRI', enriDataTest)
-    assertSettingsTableVisible('ENI', eniDataTest)
-
-    assertSettingsTableToggles({
-      title: 'ENI',
-      dataTest: eniDataTest,
-      reminderText: '2, 4 and 7 days after a new interaction was posted',
-      buttonText: 'Companies with new interactions',
-    })
-  })
-
   context('When all settings are visible', () => {
     const queryParams =
-      'investments_estimated_land_dates=true&investments_no_recent_interactions=true&companies_no_recent_interactions=true&companies_new_interactions=true'
+      'investments_estimated_land_dates=true&investments_no_recent_interactions=true&companies_no_recent_interactions=true&companies_new_interactions=true&my_tasks_due_date_approaching=true'
     before(() => {
       interceptAPICalls()
       cy.visit(`${urls.reminders.settings.index()}?${queryParams}`)
@@ -236,50 +108,5 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableVisible('NRI', nriDataTest)
     assertSettingsTableVisible('ENRI', enriDataTest)
     assertSettingsTableVisible('ENI', eniDataTest)
-  })
-
-  context('When no settings have been set - the default', () => {
-    before(() => {
-      interceptAPICalls({
-        esl_reminder_days: [],
-        esl_email_reminders_enabled: false,
-        nri_reminder_days: [],
-        nri_email_reminders_enabled: false,
-        enri_reminder_days: [],
-        enri_email_reminders_enabled: false,
-        eni_reminder_days: [],
-        eni_email_reminders_enabled: false,
-      })
-      cy.visit(urls.reminders.settings.index())
-      waitForAPICalls()
-    })
-
-    it('should render the ELD settings table with Off', () => {
-      assertKeyValueTable('estimated-land-dates-table', {
-        Reminders: 'Off',
-        'Email notifications': 'Off',
-      })
-    })
-
-    it('should render the NRI settings table with Off', () => {
-      assertKeyValueTable('no-recent-interactions-table', {
-        Reminders: 'Off',
-        'Email notifications': 'Off',
-      })
-    })
-
-    it('should render the ENRI settings table with Off', () => {
-      assertKeyValueTable('companies-no-recent-interactions-table', {
-        Reminders: 'Off',
-        'Email notifications': 'Off',
-      })
-    })
-
-    it('should render the ENI settings table with Off', () => {
-      assertKeyValueTable('companies-new-interactions-table', {
-        Reminders: 'Off',
-        'Email notifications': 'Off',
-      })
-    })
   })
 })

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -44,6 +44,10 @@ exports.getReminderSubscriptionsSummary = function (req, res) {
       email_reminders_enabled: true,
       reminder_days: [2, 4, 7],
     },
+    upcoming_task_reminder: {
+      email_reminders_enabled: true,
+      reminder_days: [10],
+    },
   })
 }
 


### PR DESCRIPTION
## Description of change

- Moved a large amount of tests from functional to component
- Separated the reminder sections into individual components to allow them to be component tested easier
- Updated the data test id's us the constant value instead of a different one

## Test instructions

No code changes added, all existing tests should pass

## Screenshots

NA

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
