### PR TITLE
Task assigned to me from others reminder settings

### DIFF
--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -11,6 +11,7 @@ import { DefaultLayout, RemindersToggleSection } from '../../../components'
 import {
   RemindersSettingsTable,
   EmailRemindersSettingsTable,
+  NoEditEmailRemindersSettingsTable,
 } from './RemindersSettingsTable'
 import Resource from '../../../components/Resource/Resource'
 import urls from '../../../../lib/urls'
@@ -28,6 +29,8 @@ import {
   MY_TASKS_DUE_DATE_APPROACHING,
   COMPANIES_NO_RECENT_INTERACTIONS,
   COMPANIES_NEW_INTERACTIONS,
+  TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL,
+  TASK_ASSIGNED_TO_ME_FROM_OTHERS,
 } from '../constants'
 
 import FooterLink from '../FooterLink'
@@ -174,6 +177,7 @@ export const ExportReminderSettings = ({
 
 export const TasksAssignedToMeSettings = ({
   upcomingTaskReminder,
+  taskAssignedToMeFromOthers,
   openSettingsSections,
 }) => (
   <>
@@ -194,6 +198,18 @@ export const TasksAssignedToMeSettings = ({
           data={upcomingTaskReminder}
           to={urls.reminders.settings.myTasks.dueDateApproaching()}
         />
+      </RemindersToggleSection>
+      <RemindersToggleSection
+        label={TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL}
+        id={`${TASK_ASSIGNED_TO_ME_FROM_OTHERS}-toggle`}
+        data-test={`${TASK_ASSIGNED_TO_ME_FROM_OTHERS}-toggle`}
+        isOpen={isSettingOpen(
+          openSettingsSections,
+          TASK_ASSIGNED_TO_ME_FROM_OTHERS
+        )}
+        borderBottom={true}
+      >
+        <NoEditEmailRemindersSettingsTable data={taskAssignedToMeFromOthers} />
       </RemindersToggleSection>
     </ToggleSectionContainer>
   </>
@@ -225,6 +241,7 @@ export const RemindersSettings = ({
           exportNoRecentInteractions,
           exportNewInteractions,
           upcomingTaskReminder,
+          taskAssignedToMeFromOthers,
         }) => (
           <>
             <InvestmentReminderSettings
@@ -243,6 +260,7 @@ export const RemindersSettings = ({
 
             <TasksAssignedToMeSettings
               upcomingTaskReminder={upcomingTaskReminder}
+              taskAssignedToMeFromOthers={taskAssignedToMeFromOthers}
               openSettingsSections={openSettingsSections}
             />
 

--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -11,7 +11,6 @@ import { DefaultLayout, RemindersToggleSection } from '../../../components'
 import {
   RemindersSettingsTable,
   EmailRemindersSettingsTable,
-  NoEditEmailRemindersSettingsTable,
 } from './RemindersSettingsTable'
 import Resource from '../../../components/Resource/Resource'
 import urls from '../../../../lib/urls'
@@ -207,9 +206,9 @@ export const TasksAssignedToMeSettings = ({
           openSettingsSections,
           TASK_ASSIGNED_TO_ME_FROM_OTHERS
         )}
-        borderBottom={true}
+        borderBottom={false}
       >
-        <NoEditEmailRemindersSettingsTable
+        <EmailRemindersSettingsTable
           dataName={TASK_ASSIGNED_TO_ME_FROM_OTHERS}
           data={taskAssignedToMeFromOthers}
         />

--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -209,7 +209,10 @@ export const TasksAssignedToMeSettings = ({
         )}
         borderBottom={true}
       >
-        <NoEditEmailRemindersSettingsTable data={taskAssignedToMeFromOthers} />
+        <NoEditEmailRemindersSettingsTable
+          dataName={TASK_ASSIGNED_TO_ME_FROM_OTHERS}
+          data={taskAssignedToMeFromOthers}
+        />
       </RemindersToggleSection>
     </ToggleSectionContainer>
   </>

--- a/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
@@ -60,4 +60,12 @@ export const EmailRemindersSettingsTable = ({ dataName, data, to }) => (
   </SettingsTable>
 )
 
+// This will be removed once the edit functionality is added
+export const NoEditEmailRemindersSettingsTable = ({ data }) => (
+  <Table.Row>
+    <StyledCellHeader>Email notifications</StyledCellHeader>
+    <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
+  </Table.Row>
+)
+
 export default RemindersSettingsTable

--- a/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettingsTable.jsx
@@ -60,12 +60,4 @@ export const EmailRemindersSettingsTable = ({ dataName, data, to }) => (
   </SettingsTable>
 )
 
-// This will be removed once the edit functionality is added
-export const NoEditEmailRemindersSettingsTable = ({ data }) => (
-  <Table.Row>
-    <StyledCellHeader>Email notifications</StyledCellHeader>
-    <Table.Cell>{data.emailRemindersOnOff}</Table.Cell>
-  </Table.Row>
-)
-
 export default RemindersSettingsTable

--- a/src/client/modules/Reminders/Settings/tasks.js
+++ b/src/client/modules/Reminders/Settings/tasks.js
@@ -30,6 +30,11 @@ const transformSubscriptionSummary = ({ data }) => ({
     data.upcoming_task_reminder,
     'days before the task due date'
   ),
+  taskAssignedToMeFromOthers: {
+    emailRemindersOnOff: transformEmailReminders(
+      data.task_assigned_to_me_from_others
+    ),
+  },
 })
 
 const transformDaysAndEmailReminders = (

--- a/src/client/modules/Reminders/constants.js
+++ b/src/client/modules/Reminders/constants.js
@@ -31,6 +31,7 @@ export const COMPANIES_NO_RECENT_INTERACTIONS =
   'companies-no-recent-interactions'
 export const COMPANIES_NEW_INTERACTIONS = 'companies-new-interactions'
 export const MY_TASKS_DUE_DATE_APPROACHING = 'my-tasks-due-date-approaching'
+export const TASK_ASSIGNED_TO_ME_FROM_OTHERS = 'task-assigned-to-me-from-others'
 
 export const INVESTMENTS_ESTIMATED_LAND_DATES_LABEL =
   'Approaching estimated land dates'
@@ -48,6 +49,9 @@ export const COMPANIES_NEW_INTERACTIONS_LABEL =
   'Companies with new interactions'
 
 export const MY_TASKS_DUE_DATE_APPROACHING_LABEL = 'Due date approaching'
+
+export const TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL =
+  'Task assigned to me from others'
 
 export const REMINDERS_SETTINGS = [
   {
@@ -85,6 +89,12 @@ export const REMINDERS_SETTINGS = [
     label: MY_TASKS_DUE_DATE_APPROACHING_LABEL,
     settingsQSParam: snakeCase(MY_TASKS_DUE_DATE_APPROACHING),
     url: urls.reminders.myTasks.dueDateApproaching(),
+  },
+  {
+    id: TASK_ASSIGNED_TO_ME_FROM_OTHERS,
+    label: TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL,
+    settingsQSParam: snakeCase(TASK_ASSIGNED_TO_ME_FROM_OTHERS),
+    url: urls.reminders.myTasks.taskAssignedToMeFromOthers(),
   },
 ]
 

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -669,7 +669,7 @@ module.exports = {
           '/reminders/settings/my-tasks-due-date-approaching'
         ),
         taskAssignedToMeFromOthers: url(
-          '/reminders/task-assigned-to-me-from-others'
+          '/reminders/settings/task-assigned-to-me-from-others'
         ),
       },
     },

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -644,6 +644,9 @@ module.exports = {
     },
     myTasks: {
       dueDateApproaching: url('/reminders/my-tasks-due-date-approaching'),
+      taskAssignedToMeFromOthers: url(
+        '/reminders/task-assigned-to-me-from-others'
+      ),
     },
     settings: {
       index: url('/reminders/settings'),
@@ -664,6 +667,9 @@ module.exports = {
       myTasks: {
         dueDateApproaching: url(
           '/reminders/settings/my-tasks-due-date-approaching'
+        ),
+        taskAssignedToMeFromOthers: url(
+          '/reminders/task-assigned-to-me-from-others'
         ),
       },
     },

--- a/test/component/cypress/specs/Reminders/Settings/ReminderSettings.cy.jsx
+++ b/test/component/cypress/specs/Reminders/Settings/ReminderSettings.cy.jsx
@@ -18,6 +18,7 @@ import {
   MY_TASKS_DUE_DATE_APPROACHING,
   MY_TASKS_DUE_DATE_APPROACHING_LABEL,
   TASK_ASSIGNED_TO_ME_FROM_OTHERS,
+  TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL,
 } from '../../../../../../src/client/modules/Reminders/constants.js'
 import { assertKeyValueTable } from '../../../../../functional/cypress/support/assertions.js'
 
@@ -282,6 +283,29 @@ describe('TasksAssignedToMeSettings', () => {
     assertToggleSection(
       MY_TASKS_DUE_DATE_APPROACHING,
       MY_TASKS_DUE_DATE_APPROACHING_LABEL
+    )
+  })
+
+  context('When task assigned to me from others setting is open', () => {
+    beforeEach(() => {
+      cy.mount(
+        <DataHubProvider>
+          <Component
+            openSettingsSections={[{ id: TASK_ASSIGNED_TO_ME_FROM_OTHERS }]}
+            upcomingTaskReminder={setting}
+            taskAssignedToMeFromOthers={setting}
+          />
+        </DataHubProvider>
+      )
+    })
+
+    assertSettingsSectionExpanded(TASK_ASSIGNED_TO_ME_FROM_OTHERS)
+
+    assertEmailTableData(TASK_ASSIGNED_TO_ME_FROM_OTHERS, setting)
+
+    assertToggleSection(
+      TASK_ASSIGNED_TO_ME_FROM_OTHERS,
+      TASK_ASSIGNED_TO_ME_FROM_OTHERS_LABEL
     )
   })
 })

--- a/test/component/cypress/specs/Reminders/Settings/ReminderSettings.cy.jsx
+++ b/test/component/cypress/specs/Reminders/Settings/ReminderSettings.cy.jsx
@@ -17,6 +17,7 @@ import {
   INVESTMENTS_NO_RECENT_INTERACTIONS_LABEL,
   MY_TASKS_DUE_DATE_APPROACHING,
   MY_TASKS_DUE_DATE_APPROACHING_LABEL,
+  TASK_ASSIGNED_TO_ME_FROM_OTHERS,
 } from '../../../../../../src/client/modules/Reminders/constants.js'
 import { assertKeyValueTable } from '../../../../../functional/cypress/support/assertions.js'
 
@@ -245,13 +246,17 @@ describe('TasksAssignedToMeSettings', () => {
     beforeEach(() => {
       cy.mount(
         <DataHubProvider>
-          <Component upcomingTaskReminder={{}} />
+          <Component
+            upcomingTaskReminder={{}}
+            taskAssignedToMeFromOthers={{}}
+          />
         </DataHubProvider>
       )
     })
 
     it('should return all my tasks reminder setting sections', () => {
       cy.get(getToggle(MY_TASKS_DUE_DATE_APPROACHING)).should('be.visible')
+      cy.get(getToggle(TASK_ASSIGNED_TO_ME_FROM_OTHERS)).should('be.visible')
     })
   })
 
@@ -262,6 +267,7 @@ describe('TasksAssignedToMeSettings', () => {
           <Component
             openSettingsSections={[{ id: MY_TASKS_DUE_DATE_APPROACHING }]}
             upcomingTaskReminder={setting}
+            taskAssignedToMeFromOthers={setting}
           />
         </DataHubProvider>
       )

--- a/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/summary-settings-spec.js
@@ -15,6 +15,7 @@ const nriDataTest = INVESTMENTS_NO_RECENT_INTERACTIONS
 const enriDataTest = COMPANIES_NO_RECENT_INTERACTIONS
 const eniDataTest = COMPANIES_NEW_INTERACTIONS
 const ddaDataTest = MY_TASKS_DUE_DATE_APPROACHING
+// const tatmfoDataTest = TASK_ASSIGNED_TO_ME_FROM_OTHERS To be added in next ticket (edit functionality)
 
 const getTable = (dataTest) => `[data-test="${dataTest}-table"]`
 const getLink = (dataTest) => `[data-test="${dataTest}-link"]`
@@ -30,6 +31,7 @@ const interceptAPICalls = ({
   eni_email_reminders_enabled = true,
   dda_reminder_days = [10],
   dda_email_reminders_enabled = true,
+  tatmfo_email_reminders_enabled = true,
 } = {}) => {
   cy.intercept('GET', summaryEndpoint, {
     body: {
@@ -52,6 +54,9 @@ const interceptAPICalls = ({
       upcoming_task_reminder: {
         email_reminders_enabled: dda_email_reminders_enabled,
         reminder_days: dda_reminder_days,
+      },
+      task_assigned_to_me_from_others: {
+        email_reminders_enabled: tatmfo_email_reminders_enabled,
       },
     },
   }).as('summaryRequest')
@@ -118,5 +123,6 @@ describe('Settings: reminders and email notifications', () => {
     assertSettingsTableVisible('ENRI', enriDataTest)
     assertSettingsTableVisible('ENI', eniDataTest)
     assertSettingsTableVisible('DDA', ddaDataTest)
+    // assertSettingsTableVisible('TATMFO', tatmfoDataTest) To be added in next ticket (edit functionality)
   })
 })

--- a/test/sandbox/fixtures/v4/reminder/summary.json
+++ b/test/sandbox/fixtures/v4/reminder/summary.json
@@ -1,5 +1,5 @@
 {
-  "count": 307,
+  "count": 309,
   "investment": {
     "estimated_land_date": 230,
     "no_recent_interaction": 10,
@@ -10,6 +10,7 @@
     "new_interaction": 16
   },
   "my_tasks": {
-    "due_date_approaching": 2
+    "due_date_approaching": 2,
+    "task_assigned_to_me_from_others": 2
   }
 }

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -48,6 +48,13 @@ exports.getReminderSubscriptionsSummary = function (req, res) {
       email_reminders_enabled: true,
       reminder_days: [10],
     },
+    my_tasks_due_date_approaching: {
+      email_reminders_enabled: true,
+      reminder_days: [10],
+    },
+    task_assigned_to_me_from_others: {
+      reminder_days: [10],
+    },
   })
 }
 

--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -53,7 +53,7 @@ exports.getReminderSubscriptionsSummary = function (req, res) {
       reminder_days: [10],
     },
     task_assigned_to_me_from_others: {
-      reminder_days: [10],
+      email_reminders_enabled: true,
     },
   })
 }


### PR DESCRIPTION
## Description of change

Task assigned to me from others settings in settings page. Email notifications will either be set to on or off
Some changes are for the edit functionality that will be worked on straight after this.

## Test instructions

Navigate to the notifications page (notification bell icon) and then to. settings. Under the `Tasks assigned to me` section you should see email notification settings for `task assigned to me from others`.

## Screenshots

### After
![Screenshot 2023-11-03 at 11 23 42](https://github.com/uktrade/data-hub-frontend/assets/54268863/48c12a2e-a8cd-4d67-a54a-124679826eb6)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
