### PR TITLE
Cls2 539 tasks mvp add back button

### DIFF
--- a/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
@@ -14,10 +14,18 @@ import urls from '../../../../lib/urls'
 import { TASK_ARCHIVE_TASK, buttonState2props } from './state'
 import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 
-const GreyButton = styled(Button)`
-  background-color: ${GREY_3};
-  color: ${TEXT_COLOUR};
-  margin-left: ${SPACING.SCALE_5};
+// const GreyButton = styled(Button)`
+//   background-color: ${GREY_3};
+//   color: ${TEXT_COLOUR};
+//   margin-left: ${SPACING.SCALE_5};
+// `
+
+const NestedButton = styled(Button)`
+  ${Link} {
+    background-color: ${GREY_3};
+    color: ${TEXT_COLOUR};
+    margin-left: ${SPACING.SCALE_5};
+  }
 `
 
 export const TaskButtons = ({ task, editUrl }) => (
@@ -67,13 +75,13 @@ export const TaskButtons = ({ task, editUrl }) => (
         Back
       </Button>
 
-      <GreyButton
+      <NestedButton
         as={Link}
         buttonColour={GREY_3}
         buttonTextColour={TEXT_COLOUR}
       >
         Messin' Button
-      </GreyButton>
+      </NestedButton>
     </GridRow>
   </>
 )

--- a/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
@@ -2,48 +2,49 @@ import React from 'react'
 import Link from '@govuk-react/link'
 import Button from '@govuk-react/button'
 import { connect } from 'react-redux'
-import { GridCol, GridRow } from 'govuk-react'
+import { GridRow } from 'govuk-react'
+
+import { SPACING } from '@govuk-react/constants'
+
 import styled from 'styled-components'
 
-import { Form, FormLayout } from '../../../components'
+import { Form } from '../../../components'
 
 import urls from '../../../../lib/urls'
 import { TASK_ARCHIVE_TASK, buttonState2props } from './state'
-import { FORM_LAYOUT } from '../../../../common/constants'
 import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 
-const StyledGridCol = styled(GridCol)`
-  margin-left: -75px;
+const GreyButton = styled(Button)`
+  background-color: ${GREY_3};
+  color: ${TEXT_COLOUR};
+  margin-left: ${SPACING.SCALE_5};
 `
 
 export const TaskButtons = ({ task, editUrl }) => (
-  <GridRow>
-    <GridCol setWidth={'28%'}>
+  <>
+    <GridRow>
       {!task.archived && (
-        <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
-          <Form
-            id="archive-task-form"
-            analyticsFormName="archiveTaskForm"
-            redirectTo={() =>
-              urls.investments.projects.tasks.index(
-                task.investmentProjectTask.investmentProject.id
-              )
-            }
-            cancelRedirectTo={false}
-            submissionTaskName={TASK_ARCHIVE_TASK}
-            transformPayload={() => ({
-              taskId: task.id,
-            })}
-            flashMessage={() => 'Task marked as complete'}
-            submitButtonLabel="Mark as complete"
-            initialValues={task}
-          >
-            {() => <></>}
-          </Form>
-        </FormLayout>
+        <Form
+          id="archive-task-form"
+          analyticsFormName="archiveTaskForm"
+          redirectTo={() =>
+            urls.investments.projects.tasks.index(
+              task.investmentProjectTask.investmentProject.id
+            )
+          }
+          cancelRedirectTo={false}
+          submissionTaskName={TASK_ARCHIVE_TASK}
+          transformPayload={() => ({
+            taskId: task.id,
+          })}
+          flashMessage={() => 'Task marked as complete'}
+          submitButtonLabel="Mark as complete"
+          initialValues={task}
+        >
+          {() => <></>}
+        </Form>
       )}
-    </GridCol>
-    <StyledGridCol setWidth={'20%'}>
+
       <Button
         buttonColour={GREY_3}
         buttonTextColour={TEXT_COLOUR}
@@ -53,8 +54,28 @@ export const TaskButtons = ({ task, editUrl }) => (
       >
         Edit
       </Button>
-    </StyledGridCol>
-  </GridRow>
+
+      <Button
+        buttonColour={GREY_3}
+        buttonTextColour={TEXT_COLOUR}
+        as={Link}
+        href={urls.investments.projects.tasks.index(
+          task.investmentProjectTask.investmentProject.id
+        )}
+        data-test="back-button"
+      >
+        Back
+      </Button>
+
+      <GreyButton
+        as={Link}
+        buttonColour={GREY_3}
+        buttonTextColour={TEXT_COLOUR}
+      >
+        Messin' Button
+      </GreyButton>
+    </GridRow>
+  </>
 )
 
 export default connect(buttonState2props)(TaskButtons)

--- a/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
@@ -14,17 +14,9 @@ import urls from '../../../../lib/urls'
 import { TASK_ARCHIVE_TASK, buttonState2props } from './state'
 import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 
-// const GreyButton = styled(Button)`
-//   background-color: ${GREY_3};
-//   color: ${TEXT_COLOUR};
-//   margin-left: ${SPACING.SCALE_5};
-// `
-
-const NestedButton = styled(Button)`
-  ${Link} {
-    background-color: ${GREY_3};
-    color: ${TEXT_COLOUR};
-    margin-left: ${SPACING.SCALE_5};
+const ButtonWrapper = styled.div`
+  * {
+    margin-left: ${SPACING.SCALE_4};
   }
 `
 
@@ -52,36 +44,29 @@ export const TaskButtons = ({ task, editUrl }) => (
           {() => <></>}
         </Form>
       )}
+      <ButtonWrapper>
+        <Button
+          buttonColour={GREY_3}
+          buttonTextColour={TEXT_COLOUR}
+          as={Link}
+          href={editUrl}
+          data-test="edit-form-button"
+        >
+          Edit
+        </Button>
 
-      <Button
-        buttonColour={GREY_3}
-        buttonTextColour={TEXT_COLOUR}
-        as={Link}
-        href={editUrl}
-        data-test="edit-form-button"
-      >
-        Edit
-      </Button>
-
-      <Button
-        buttonColour={GREY_3}
-        buttonTextColour={TEXT_COLOUR}
-        as={Link}
-        href={urls.investments.projects.tasks.index(
-          task.investmentProjectTask.investmentProject.id
-        )}
-        data-test="back-button"
-      >
-        Back
-      </Button>
-
-      <NestedButton
-        as={Link}
-        buttonColour={GREY_3}
-        buttonTextColour={TEXT_COLOUR}
-      >
-        Messin' Button
-      </NestedButton>
+        <Button
+          buttonColour={GREY_3}
+          buttonTextColour={TEXT_COLOUR}
+          as={Link}
+          href={urls.investments.projects.tasks.index(
+            task.investmentProjectTask.investmentProject.id
+          )} //TODO - when the my tasks dashboard is added this url needs to be more intelligent as there will be multiple entry points to this page
+          data-test="back-button"
+        >
+          Back
+        </Button>
+      </ButtonWrapper>
     </GridRow>
   </>
 )

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
@@ -29,6 +29,12 @@ describe('Task buttons', () => {
     it('should show the Edit link with expected url', () => {
       assertLink('edit-form-button', '/1/2/3')
     })
+    it('should show the Back link with expected url', () => {
+      assertLink(
+        'back-button',
+        `/investments/projects/${investmentProjectTask.investmentProjectTask.investmentProject.id}/tasks?sortby=-task__created_on`
+      )
+    })
   })
 
   context('When a task is completed', () => {
@@ -46,6 +52,12 @@ describe('Task buttons', () => {
 
     it('should show the Edit link with expected url', () => {
       assertLink('edit-form-button', '/1/2/3')
+    })
+    it('should show the Back link with expected url', () => {
+      assertLink(
+        'back-button',
+        `/investments/projects/${investmentProjectTask.investmentProjectTask.investmentProject.id}/tasks?sortby=-task__created_on`
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change

Add a back button to the task view page

## Test instructions

Go to any task, for example http://localhost:3000/tasks/d500cef5-5718-4a98-9e6c-f5a179b094e3. You will now see a back button that will take you back to the investment project page

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/50d8ec15-7de7-485d-85fb-037916fba1a1)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/b667050c-2756-4f66-b21f-e5c7b117d0c9)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
