### PR TITLE
feature/CLS2-489-mark-as-read-sandbox

### DIFF
--- a/test/sandbox/routes/v4/reminders/index.js
+++ b/test/sandbox/routes/v4/reminders/index.js
@@ -1,3 +1,7 @@
+exports.deleteReminder = function (req, res) {
+  res.sendStatus(204)
+}
+
 exports.getEstimatedLandDateSubscriptions = function (req, res) {
   res.json({
     reminder_days: [30, 60],

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -582,23 +582,42 @@ app.get(
   '/v4/reminder/estimated-land-date',
   v4Reminders.getEstimatedLandDateReminders
 )
+app.delete('/v4/reminder/estimated-land-date/:id', v4Reminders.deleteReminder)
+
 app.get(
   '/v4/reminder/no-recent-export-interaction',
   v4Reminders.getNoRecentExportInteractionReminders
 )
+app.delete(
+  '/v4/reminder/no-recent-export-interaction/:id',
+  v4Reminders.deleteReminder
+)
+
 app.get(
   '/v4/reminder/no-recent-investment-interaction',
   v4Reminders.getNoRecentInvestmentInteractionReminders
+)
+app.delete(
+  '/v4/reminder/no-recent-investment-interaction/:id',
+  v4Reminders.deleteReminder
 )
 
 app.get(
   '/v4/reminder/new-export-interaction',
   v4Reminders.getNewExportInteractionReminders
 )
+app.delete(
+  '/v4/reminder/new-export-interaction/:id',
+  v4Reminders.deleteReminder
+)
 
 app.get(
   '/v4/reminder/my-tasks-due-date-approaching',
   v4Reminder.myTasksDueDateApproaching
+)
+app.delete(
+  '/v4/reminder/my-tasks-due-date-approaching/:id',
+  v4Reminders.deleteReminder
 )
 
 // V4 Investment


### PR DESCRIPTION
## Description of change

Add empty sandbox endpoint to get rid of console errors when using sandbox locally

## Test instructions

Run the frontend connected to the sandbox api, go to http://localhost:3000/reminders/my-tasks-due-date-approaching, and delete any reminder. You will see the message Reminder deleted, instead of nothing happening

## Screenshots

### Before

Nothing happens

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/05ee504e-c902-40b4-8dc3-ae4d933e618f)
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
