### PR TITLE
Fix OMIS assignees form

### DIFF
--- a/src/client/modules/Omis/EditAssignees.jsx
+++ b/src/client/modules/Omis/EditAssignees.jsx
@@ -2,7 +2,10 @@ import React from 'react'
 import { useParams } from 'react-router-dom'
 
 import { TASK_SAVE_ORDER_ASSIGNEES } from './state'
-import { transformAdvisersForTypeahead } from './transformers'
+import {
+  transformAdvisersForTypeahead,
+  transformAssignees,
+} from './transformers'
 import {
   OrderAssigneesResource,
   OrderResource,
@@ -29,11 +32,13 @@ const EditAssignees = () => {
                   assignees: transformAdvisersForTypeahead(orderAssignees),
                 }}
                 submissionTaskName={TASK_SAVE_ORDER_ASSIGNEES}
-                transformPayload={(values) => ({
-                  values,
-                  orderId,
-                  canRemoveAssignees: order.status === STATUS.DRAFT,
-                })}
+                transformPayload={(values) =>
+                  transformAssignees({
+                    values,
+                    orderId: order.id,
+                    canRemoveAssignees: order.status === STATUS.DRAFT,
+                  })
+                }
                 orderId={order.id}
                 orderAdvisers={orderAssignees}
                 typeaheadName="assignees"

--- a/src/client/modules/Omis/tasks.js
+++ b/src/client/modules/Omis/tasks.js
@@ -24,11 +24,11 @@ export const completeOrder = (values) =>
     values.assignees
   ) && apiProxyAxios.post(`v3/omis/order/${values.id}/complete`)
 
-export function saveOrderAssignees({ values, id, canRemoveAssignees }) {
-  const url = canRemoveAssignees
-    ? `/v3/omis/order/${id}/assignee?force-delete=1`
-    : `/v3/omis/order/${id}/assignee`
-  return apiProxyAxios.patch(url, transformAdvisersForAPI(values))
+export const saveOrderAssignees = (values) => {
+  const url = values.canRemove
+    ? `/v3/omis/order/${values.id}/assignee?force-delete=1`
+    : `/v3/omis/order/${values.id}/assignee`
+  return apiProxyAxios.patch(url, transformAdvisersForAPI(values.assignees))
 }
 
 export function saveOrderSubscribers({ values, id, canRemoveSubscribers }) {

--- a/src/client/modules/Omis/transformers.js
+++ b/src/client/modules/Omis/transformers.js
@@ -132,8 +132,8 @@ export const transformAdvisersForTypeahead = (advisers) =>
     value: value.adviser.id,
   }))
 
-export const transformAdvisersForAPI = (values) =>
-  values.assignees.map((assignee) => ({
+export const transformAdvisersForAPI = (assignees) =>
+  assignees.map((assignee) => ({
     adviser: {
       id: assignee.value,
     },
@@ -149,3 +149,9 @@ export const transformSubscribersForAPI = (values) =>
   values.subscribers.map((subscriber) => ({
     id: subscriber.value,
   }))
+
+export const transformAssignees = (values) => ({
+  id: values.orderId,
+  assignees: values.values.assignees,
+  canRemove: values.canRemoveAssignees,
+})


### PR DESCRIPTION
## Description of change

There is a bug in the OMIS assignees form where it would not save properly. This has been fixed.

## Test instructions
Go to an OMIS order and edit the Advisers in the market. You should be able to edit the assignees.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
