### PR TITLE
Remove references to Heroku

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,6 @@
 - Ensure your branch contains logical atomic commits before sending a pull request
 - Pull requests are automatically tested, where applicable using [CircleCI](https://circleci.com/),
   which will report back on whether the tests still pass on your branch
-- Pull requests deploy a heroku [review app](https://devcenter.heroku.com/articles/github-integration-review-apps)
-  with those changes. Details of the review app will be reported in the pull request.
 - You _may_ rebase your branch after feedback if it's to include relevant
   updates from the main branch. We prefer a rebase here to a merge commit
   as we prefer a clean and straight history on main with discrete merge

--- a/docs/Deployments.md
+++ b/docs/Deployments.md
@@ -2,8 +2,6 @@
 
 Commits to `main` are automatically deployed to dev and staging environments.
 
-Opening a pull request creates a temporary instance on Heroku called [review app](https://devcenter.heroku.com/articles/github-integration-review-apps) which is pointing to the staging API.
-
 Deployments to production are done manually through Jenkins where a Git tag can be used.
 
 ## Deploying to production


### PR DESCRIPTION
## Description of change
The DBT Heroku account is going away. As we will not be using it anymore I've removed the remaining references to it from the docs.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
