### PR TITLE
Reactify OMIS invoice details table

### DIFF
--- a/src/client/modules/Omis/WorkOrder.jsx
+++ b/src/client/modules/Omis/WorkOrder.jsx
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom'
 
 import { DefaultLayout } from '../../components'
 import {
+  CompanyResource,
   ContactResource,
   OrderResource,
   OrderQuoteResource,
@@ -16,6 +17,7 @@ import ContactTable from './WorkOrderTables/ContactTable'
 import SubscribersTable from './WorkOrderTables/SubscribersTable'
 import QuoteInformationTable from './WorkOrderTables/QuoteInformationTable'
 import InternalUseTable from './WorkOrderTables/InternalUseTable'
+import InvoiceDetailsTable from './WorkOrderTables/InvoiceDetailsTable'
 
 const WorkOrder = () => {
   const { orderId } = useParams()
@@ -62,6 +64,12 @@ const WorkOrder = () => {
             <QuoteInformationTable order={order} />
 
             <InternalUseTable order={order} />
+
+            <CompanyResource id={order.company.id}>
+              {(company) => (
+                <InvoiceDetailsTable order={order} company={company} />
+              )}
+            </CompanyResource>
           </>
         </DefaultLayout>
       )}

--- a/src/client/modules/Omis/WorkOrderTables/InvoiceDetailsTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/InvoiceDetailsTable.jsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import styled from 'styled-components'
+import { InsetText, Link } from 'govuk-react'
+
+import { SummaryTable } from '../../../components'
+import {
+  canEditOrder,
+  getAddress,
+  isOrderActive,
+  transformAddress,
+} from '../transformers'
+import { VAT_STATUS } from '../constants'
+import urls from '../../../../lib/urls'
+import { currencyGBP } from '../../../utils/number-utils'
+
+const StyledInset = styled(InsetText)`
+  margin-top: -10px;
+  font-size: 16px;
+`
+
+const setPrice = (order) => {
+  const formattedPrice = currencyGBP(order.totalCost / 100)
+  return order.vatCost > 0
+    ? `${formattedPrice} (${currencyGBP(
+        order.subtotalCost / 100
+      )} excluding VAT)`
+    : order.discountValue
+    ? `${formattedPrice} (includes a net discount of ${currencyGBP(
+        order.discountValue
+      )})`
+    : `${formattedPrice} (No VAT applies)`
+}
+
+const transformVATStatus = (vatStatus) =>
+  vatStatus === VAT_STATUS.EU_COMPANY
+    ? 'Inside EU'
+    : vatStatus === VAT_STATUS.UK_COMPANY
+    ? 'Inside UK'
+    : 'Outside EU'
+
+const transformOrderAddress = (company, order) => {
+  const address = getAddress(order, company)
+  const transformedAddress = transformAddress(address).join(', ')
+  return address === company.address ||
+    address === company.registeredAddress ? (
+    <>
+      <p>{transformedAddress}</p>
+      <StyledInset data-test="company-address-inset">
+        The company's address is currently being used for the invoice.
+      </StyledInset>
+    </>
+  ) : (
+    transformedAddress
+  )
+}
+
+const InvoiceDetailsTable = ({ order, company }) => (
+  <SummaryTable
+    caption="Invoice details"
+    data-test="invoice-details-table"
+    actions={
+      (canEditOrder(order) || isOrderActive(order)) && (
+        <Link
+          href={urls.omis.edit.invoiceDetails(order.id)}
+          data-test="edit-invoice-details-link"
+        >
+          Edit
+        </Link>
+      )
+    }
+  >
+    <SummaryTable.Row heading="Price">
+      {order.totalCost
+        ? setPrice(order)
+        : 'Estimated hours and VAT category must be set to calculate price'}
+    </SummaryTable.Row>
+    <SummaryTable.Row heading="Billing address">
+      {transformOrderAddress(company, order)}
+    </SummaryTable.Row>
+    <SummaryTable.Row heading="VAT category">
+      {order.vatStatus ? transformVATStatus(order.vatStatus) : 'Not set'}
+    </SummaryTable.Row>
+    <SummaryTable.Row heading="VAT number" hideWhenEmpty={true}>
+      {order.vatNumber
+        ? order.vatVerified
+          ? `${order.vatNumber} (Valid)`
+          : `${order.vatNumber} (Invalid)`
+        : null}
+    </SummaryTable.Row>
+    <SummaryTable.Row heading="Purchase Order (PO) number">
+      {order.poNumber || 'Not added'}
+    </SummaryTable.Row>
+  </SummaryTable>
+)
+
+export default InvoiceDetailsTable

--- a/test/component/cypress/specs/Omis/WorkOrder/InvoiceDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/InvoiceDetailsTable.cy.jsx
@@ -1,0 +1,315 @@
+import React from 'react'
+
+import InvoiceDetailsTable from '../../../../../../src/client/modules/Omis/WorkOrderTables/InvoiceDetailsTable'
+import {
+  assertLink,
+  assertSummaryTable,
+} from '../../../../../functional/cypress/support/assertions'
+import {
+  STATUS,
+  VAT_STATUS,
+} from '../../../../../../src/client/modules/Omis/constants'
+import urls from '../../../../../../src/lib/urls'
+import { COMPANY_ADDRESS, COMPANY_REGISTERED_ADDRESS } from '../constants'
+
+const order = {
+  id: '123',
+  status: STATUS.DRAFT,
+}
+
+const billingAddress = {
+  billingAddress1: 'OMIS line 1',
+  billingAddress2: '',
+  billingAddressTown: 'OMIS town',
+  billingAddressCounty: 'OMIS county',
+  billingAddressPostcode: 'OMIS postcode',
+  billingAddressCountry: {
+    name: 'OMIS Country',
+  },
+}
+
+const outsideEUFields = {
+  totalCost: 10000,
+  vatStatus: VAT_STATUS.OUTSIDE_EU,
+}
+
+const insideUKFields = {
+  totalCost: 1158000,
+  subtotalCost: 965000,
+  vatCost: 193000,
+  vatStatus: VAT_STATUS.UK_COMPANY,
+}
+
+const insideEUFields = {
+  vatStatus: VAT_STATUS.EU_COMPANY,
+  vatNumber: 'IT12345678901',
+  poNumber: 'PO number',
+}
+
+const verified = {
+  totalCost: 965000,
+  subtotalCost: 965000,
+  vatVerified: true,
+}
+
+const notVerified = {
+  totalCost: 1158000,
+  subtotalCost: 965000,
+  vatCost: 193000,
+  vatVerified: false,
+}
+
+const inactiveOrder = {
+  status: STATUS.COMPLETE,
+}
+
+const orderWithAddress = { ...order, ...billingAddress }
+const orderOutsideEU = { ...order, ...outsideEUFields }
+const orderInsideUK = { ...order, ...insideUKFields }
+const orderInsideEU = { ...order, ...insideEUFields, ...verified }
+const unverifiedOrderInsideEU = { ...order, ...insideEUFields, ...notVerified }
+
+describe('InternalUseTable', () => {
+  context(
+    'When viewing an order with no invoice details and that uses the company address',
+    () => {
+      beforeEach(() => {
+        cy.mount(
+          <InvoiceDetailsTable order={order} company={COMPANY_ADDRESS} />
+        )
+      })
+
+      it('should display the Not Set messages', () => {
+        assertSummaryTable({
+          dataTest: 'invoice-details-table',
+          heading: 'Invoice details',
+          showEditLink: true,
+          content: {
+            Price:
+              'Estimated hours and VAT category must be set to calculate price',
+            'Billing address':
+              "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+            'VAT category': 'Not set',
+            'Purchase Order (PO) number': 'Not added',
+          },
+        })
+
+        cy.get('[data-test="company-address-inset"]').should('exist')
+      })
+
+      it('should display the edit link', () => {
+        assertLink(
+          'edit-invoice-details-link',
+          urls.omis.edit.invoiceDetails(order.id)
+        )
+      })
+    }
+  )
+
+  context(
+    'When viewing an order with no invoice details and that uses the company registered address',
+    () => {
+      beforeEach(() => {
+        cy.mount(
+          <InvoiceDetailsTable
+            order={order}
+            company={COMPANY_REGISTERED_ADDRESS}
+          />
+        )
+      })
+
+      it('should display the company registered adddress', () => {
+        assertSummaryTable({
+          dataTest: 'invoice-details-table',
+          heading: 'Invoice details',
+          showEditLink: true,
+          content: {
+            Price:
+              'Estimated hours and VAT category must be set to calculate price',
+            'Billing address':
+              "Registered Address line 1, Registered Address line 2, Registered town, Test Registered County, Registered postcode, Test Registered CountryThe company's address is currently being used for the invoice.",
+            'VAT category': 'Not set',
+            'Purchase Order (PO) number': 'Not added',
+          },
+        })
+
+        cy.get('[data-test="company-address-inset"]').should('exist')
+      })
+
+      it('should display the edit link', () => {
+        assertLink(
+          'edit-invoice-details-link',
+          urls.omis.edit.invoiceDetails(order.id)
+        )
+      })
+    }
+  )
+
+  context('When viewing an order with a specified billing address', () => {
+    beforeEach(() => {
+      cy.mount(
+        <InvoiceDetailsTable
+          order={orderWithAddress}
+          company={COMPANY_REGISTERED_ADDRESS}
+        />
+      )
+    })
+
+    it('should display the order address over the company one', () => {
+      assertSummaryTable({
+        dataTest: 'invoice-details-table',
+        heading: 'Invoice details',
+        showEditLink: true,
+        content: {
+          Price:
+            'Estimated hours and VAT category must be set to calculate price',
+          'Billing address':
+            'OMIS line 1, OMIS town, OMIS county, OMIS postcode, OMIS Country',
+          'VAT category': 'Not set',
+          'Purchase Order (PO) number': 'Not added',
+        },
+      })
+
+      cy.get('[data-test="company-address-inset"]').should('not.exist')
+    })
+
+    it('should display the edit link', () => {
+      assertLink(
+        'edit-invoice-details-link',
+        urls.omis.edit.invoiceDetails(order.id)
+      )
+    })
+  })
+
+  context('When viewing an order with the Outside EU VAT category', () => {
+    beforeEach(() => {
+      cy.mount(
+        <InvoiceDetailsTable order={orderOutsideEU} company={COMPANY_ADDRESS} />
+      )
+    })
+
+    it('should display the correct VAT category and price', () => {
+      assertSummaryTable({
+        dataTest: 'invoice-details-table',
+        heading: 'Invoice details',
+        showEditLink: true,
+        content: {
+          Price: '£100 (No VAT applies)',
+          'Billing address':
+            "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+          'VAT category': 'Outside EU',
+          'Purchase Order (PO) number': 'Not added',
+        },
+      })
+    })
+  })
+
+  context('When viewing an order with the Inside UK VAT category', () => {
+    beforeEach(() => {
+      cy.mount(
+        <InvoiceDetailsTable order={orderInsideUK} company={COMPANY_ADDRESS} />
+      )
+    })
+
+    it('should display the correct VAT category and price', () => {
+      assertSummaryTable({
+        dataTest: 'invoice-details-table',
+        heading: 'Invoice details',
+        showEditLink: true,
+        content: {
+          Price: '£11,580 (£9,650 excluding VAT)',
+          'Billing address':
+            "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+          'VAT category': 'Inside UK',
+          'Purchase Order (PO) number': 'Not added',
+        },
+      })
+    })
+  })
+
+  context(
+    'When viewing an order with the Inside EU VAT category and an unverified VAT number',
+    () => {
+      beforeEach(() => {
+        cy.mount(
+          <InvoiceDetailsTable
+            order={unverifiedOrderInsideEU}
+            company={COMPANY_ADDRESS}
+          />
+        )
+      })
+
+      it('should display the correct VAT category and price', () => {
+        assertSummaryTable({
+          dataTest: 'invoice-details-table',
+          heading: 'Invoice details',
+          showEditLink: true,
+          content: {
+            Price: '£11,580 (£9,650 excluding VAT)',
+            'Billing address':
+              "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+            'VAT category': 'Inside EU',
+            'VAT number': 'IT12345678901 (Invalid)',
+            'Purchase Order (PO) number': orderInsideEU.poNumber,
+          },
+        })
+      })
+    }
+  )
+
+  context(
+    'When viewing an order with the Inside EU VAT category and a verified VAT number',
+    () => {
+      beforeEach(() => {
+        cy.mount(
+          <InvoiceDetailsTable
+            order={orderInsideEU}
+            company={COMPANY_ADDRESS}
+          />
+        )
+      })
+
+      it('should display the correct VAT category and price', () => {
+        assertSummaryTable({
+          dataTest: 'invoice-details-table',
+          heading: 'Invoice details',
+          showEditLink: true,
+          content: {
+            Price: '£9,650 (No VAT applies)',
+            'Billing address':
+              "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+            'VAT category': 'Inside EU',
+            'VAT number': 'IT12345678901 (Valid)',
+            'Purchase Order (PO) number': orderInsideEU.poNumber,
+          },
+        })
+      })
+    }
+  )
+
+  context('When viewing an inactive order', () => {
+    beforeEach(() => {
+      cy.mount(
+        <InvoiceDetailsTable order={inactiveOrder} company={COMPANY_ADDRESS} />
+      )
+    })
+
+    it('should display the Not Set messages', () => {
+      assertSummaryTable({
+        dataTest: 'invoice-details-table',
+        heading: 'Invoice details',
+        showEditLink: false,
+        content: {
+          Price:
+            'Estimated hours and VAT category must be set to calculate price',
+          'Billing address':
+            "Address line 1, Address line 2, town, Test County, postcode, Test CountryThe company's address is currently being used for the invoice.",
+          'VAT category': 'Not set',
+          'Purchase Order (PO) number': 'Not added',
+        },
+      })
+
+      cy.get('[data-test="company-address-inset"]').should('exist')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

The invoice details table shown on the OMIS work order page has been reactified.

## Test instructions

The invoice details table should display as previously.

## Screenshots

<img width="998" alt="Screenshot 2023-11-13 at 11 55 33" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/75313eb4-1fb6-46d9-a2f7-ed840ee1561d">

<img width="995" alt="Screenshot 2023-11-13 at 11 56 03" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/e1f3dc86-c37a-4c91-9a41-1fab1b86c89e">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
