### PR TITLE
Add incomplete fields message to OMIS work order page

### DIFF
--- a/src/client/components/ArchivePanel/index.jsx
+++ b/src/client/components/ArchivePanel/index.jsx
@@ -6,8 +6,7 @@ import { SPACING, FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import Link from '@govuk-react/link'
 
 import StatusMessage from '../../../client/components/StatusMessage'
-
-const { format } = require('../../utils/date')
+import { format } from '../../utils/date'
 
 const negativeSpacing = '-' + SPACING.SCALE_4
 
@@ -25,6 +24,14 @@ const StyledMessage = styled('p')`
 const StyledReason = styled(StyledMessage)`
   margin-top: ${negativeSpacing};
 `
+
+const checkArchiverFormat = (archivedBy) =>
+  typeof archivedBy === 'string'
+    ? archivedBy
+    : `${archivedBy.first_name || archivedBy.firstName} ${
+        archivedBy.last_name || archivedBy.lastName
+      }`
+
 /**
  * An extension of `StatusMessage` that is used to denote whether a record has been archived.
  */
@@ -36,39 +43,31 @@ const ArchivePanel = ({
   onClick = null,
   type,
   archiveMessage = 'archived',
-}) => {
-  return (
-    <StyledMain data-test="archive-panel">
-      <StatusMessage>
-        <StyledMessage data-test="archive-message">
-          {archivedBy
-            ? `This ${type} was ${archiveMessage} on ${format(archivedOn)} by ${
-                archivedBy.first_name || archivedBy.firstName
-              } ${archivedBy.last_name || archivedBy.lastName}.`
-            : `This ${type} was automatically archived on ${format(
-                archivedOn
-              )}.`}
-        </StyledMessage>
-        <StyledReason data-test="archive-reason">{`Reason: ${archiveReason}`}</StyledReason>
-        {unarchiveUrl && (
-          <Link
-            data-test="unarchive-link"
-            onClick={onClick}
-            href={unarchiveUrl}
-          >
-            Unarchive
-          </Link>
-        )}
-      </StatusMessage>
-    </StyledMain>
-  )
-}
+}) => (
+  <StyledMain data-test="archive-panel">
+    <StatusMessage>
+      <StyledMessage data-test="archive-message">
+        {archivedBy
+          ? `This ${type} was ${archiveMessage} on ${format(
+              archivedOn
+            )} by ${checkArchiverFormat(archivedBy)}.`
+          : `This ${type} was automatically archived on ${format(archivedOn)}.`}
+      </StyledMessage>
+      <StyledReason data-test="archive-reason">{`Reason: ${archiveReason}`}</StyledReason>
+      {unarchiveUrl && (
+        <Link data-test="unarchive-link" onClick={onClick} href={unarchiveUrl}>
+          Unarchive
+        </Link>
+      )}
+    </StatusMessage>
+  </StyledMain>
+)
 
 ArchivePanel.propTypes = {
   /**
    * An object containg the first and last name of the person who archived the record. If this is not defined, the automatic archive text will appear.
    */
-  archivedBy: PropTypes.object,
+  archivedBy: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   /**
    * The date the record was archived.
    */

--- a/src/client/modules/Omis/OMISLocalHeader.jsx
+++ b/src/client/modules/Omis/OMISLocalHeader.jsx
@@ -108,16 +108,26 @@ const ViewReceiptLink = ({ orderId }) => (
   </StyledLink>
 )
 
-const DraftActions = ({ orderId }) => (
+const DraftActions = ({ orderId, incompleteFields }) => (
   <StyledWrapper>
     <StyledButtonWrapper>
-      <Button
-        as={Link}
-        href={urls.omis.quote(orderId)}
-        data-test="preview-quote-button"
-      >
-        Preview quote
-      </Button>
+      {incompleteFields.length === 0 ? (
+        <Button
+          as={Link}
+          href={urls.omis.quote(orderId)}
+          data-test="preview-quote-button"
+        >
+          Preview quote
+        </Button>
+      ) : (
+        <Button
+          href={urls.omis.quote(orderId)}
+          data-test="preview-quote-button-disabled"
+          disabled={true}
+        >
+          Preview quote
+        </Button>
+      )}
     </StyledButtonWrapper>
     <br />
     <CancelLink orderId={orderId} />
@@ -173,13 +183,15 @@ const CancelledActions = ({ orderId }) => (
   </StyledWrapper>
 )
 
-const OMISLocalHeader = ({ order, quote }) => (
+const OMISLocalHeader = ({ order, quote, incompleteFields }) => (
   <GridRow>
     <GridCol setWidth="75%">
       <LocalHeaderDetails items={setHeaderItems(order, quote)} />
     </GridCol>
     <GridCol>
-      {order.status === STATUS.DRAFT && <DraftActions orderId={order.id} />}
+      {order.status === STATUS.DRAFT && (
+        <DraftActions orderId={order.id} incompleteFields={incompleteFields} />
+      )}
       {order.status === STATUS.QUOTE_AWAITING_ACCEPTANCE && (
         <QuoteAwaitingAcceptanceActions orderId={order.id} />
       )}

--- a/src/client/modules/Omis/OrderIncompleteFields.jsx
+++ b/src/client/modules/Omis/OrderIncompleteFields.jsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import styled from 'styled-components'
+import { Link, ListItem, UnorderedList } from 'govuk-react'
+import { kebabCase } from 'lodash'
+
+import { StatusMessage } from '../../components'
+import ArchivePanel from '../../components/ArchivePanel'
+import { INCOMPLETE_FIELD_MESSAGES, STATUS } from './constants'
+import urls from '../../../lib/urls'
+import { BLUE } from '../../utils/colours'
+import { getIncompleteFields, mapFieldToUrl } from './transformers'
+
+const StyledListItem = styled(ListItem)`
+  color: ${BLUE};
+  font-weight: bold;
+  line-height: 1.5;
+`
+
+const OrderIncompleteFields = ({ order, assignees }) => (
+  <>
+    {order.status === STATUS.QUOTE_AWAITING_ACCEPTANCE && (
+      <StatusMessage data-test="withdraw-quote-message">
+        You cannot edit the order once a quote has been sent.
+        <br />
+        <br />
+        <Link href={urls.omis.quote(order.id)} data-test="withdraw-quote-link">
+          Withdraw the quote
+        </Link>{' '}
+        to edit the order.
+      </StatusMessage>
+    )}
+    {order.status === STATUS.CANCELLED && (
+      <ArchivePanel
+        archivedBy={order.cancelledBy?.name}
+        archivedOn={order.cancelledOn}
+        archiveReason={order.cancellationReason?.name}
+        type="order"
+        archiveMessage="cancelled"
+      />
+    )}
+    {order.status === STATUS.DRAFT &&
+    getIncompleteFields(order, assignees).length > 0 ? (
+      <StatusMessage data-test="incomplete-fields-message">
+        To preview the quote you must complete the following:
+        <UnorderedList listStyleType="bullet">
+          {getIncompleteFields(order, assignees).map((field, i) => (
+            <StyledListItem key={i}>
+              {field === INCOMPLETE_FIELD_MESSAGES.LEAD_ASSIGNEE ? (
+                field
+              ) : (
+                <Link
+                  href={mapFieldToUrl(field, order.id)}
+                  data-test={`${kebabCase(field)}-link`}
+                >
+                  {field}
+                </Link>
+              )}
+            </StyledListItem>
+          ))}
+        </UnorderedList>
+      </StatusMessage>
+    ) : null}
+  </>
+)
+
+export default OrderIncompleteFields

--- a/src/client/modules/Omis/WorkOrder.jsx
+++ b/src/client/modules/Omis/WorkOrder.jsx
@@ -13,6 +13,7 @@ import {
 import urls from '../../../lib/urls'
 import { STATUS } from './constants'
 import OMISLocalHeader from './OMISLocalHeader'
+import { getIncompleteFields } from './transformers'
 
 import ContactTable from './WorkOrderTables/ContactTable'
 import AssigneesTable from './WorkOrderTables/AssigneesTable'
@@ -20,66 +21,75 @@ import SubscribersTable from './WorkOrderTables/SubscribersTable'
 import QuoteInformationTable from './WorkOrderTables/QuoteInformationTable'
 import InternalUseTable from './WorkOrderTables/InternalUseTable'
 import InvoiceDetailsTable from './WorkOrderTables/InvoiceDetailsTable'
+import OrderIncompleteFields from './OrderIncompleteFields'
 
 const WorkOrder = () => {
   const { orderId } = useParams()
   return (
     <OrderResource id={orderId}>
       {(order) => (
-        <DefaultLayout
-          heading={order.reference}
-          pageTitle={`${order.reference} - Orders (OMIS)`}
-          breadcrumbs={[
-            {
-              link: urls.dashboard.index(),
-              text: 'Home',
-            },
-            {
-              link: urls.omis.index(),
-              text: 'Orders (OMIS)',
-            },
-            {
-              text: order.reference,
-            },
-          ]}
-          localHeaderChildren={
-            order.status === STATUS.QUOTE_AWAITING_ACCEPTANCE ? (
-              <OrderQuoteResource id={order.id}>
-                {(quote) => <OMISLocalHeader order={order} quote={quote} />}
-              </OrderQuoteResource>
-            ) : (
-              <OMISLocalHeader order={order} quote={null} />
-            )
-          }
-        >
-          <>
-            <ContactResource id={order.contact.id}>
-              {(contact) => <ContactTable order={order} contact={contact} />}
-            </ContactResource>
+        <OrderAssigneesResource id={order.id}>
+          {(assignees) => (
+            <DefaultLayout
+              heading={order.reference}
+              pageTitle={`${order.reference} - Orders (OMIS)`}
+              breadcrumbs={[
+                {
+                  link: urls.dashboard.index(),
+                  text: 'Home',
+                },
+                {
+                  link: urls.omis.index(),
+                  text: 'Orders (OMIS)',
+                },
+                {
+                  text: order.reference,
+                },
+              ]}
+              localHeaderChildren={
+                order.status === STATUS.QUOTE_AWAITING_ACCEPTANCE ? (
+                  <OrderQuoteResource id={order.id}>
+                    {(quote) => <OMISLocalHeader order={order} quote={quote} />}
+                  </OrderQuoteResource>
+                ) : (
+                  <OMISLocalHeader
+                    order={order}
+                    quote={null}
+                    incompleteFields={getIncompleteFields(order, assignees)}
+                  />
+                )
+              }
+            >
+              <>
+                <OrderIncompleteFields order={order} assignees={assignees} />
 
-            <OrderAssigneesResource id={order.id}>
-              {(assignees) => (
+                <ContactResource id={order.contact.id}>
+                  {(contact) => (
+                    <ContactTable order={order} contact={contact} />
+                  )}
+                </ContactResource>
+
                 <AssigneesTable assignees={assignees} order={order} />
-              )}
-            </OrderAssigneesResource>
 
-            <OrderSubscribersResource id={order.id}>
-              {(subscribers) => (
-                <SubscribersTable subscribers={subscribers} order={order} />
-              )}
-            </OrderSubscribersResource>
+                <OrderSubscribersResource id={order.id}>
+                  {(subscribers) => (
+                    <SubscribersTable subscribers={subscribers} order={order} />
+                  )}
+                </OrderSubscribersResource>
 
-            <QuoteInformationTable order={order} />
+                <QuoteInformationTable order={order} />
 
-            <InternalUseTable order={order} />
+                <InternalUseTable order={order} />
 
-            <CompanyResource id={order.company.id}>
-              {(company) => (
-                <InvoiceDetailsTable order={order} company={company} />
-              )}
-            </CompanyResource>
-          </>
-        </DefaultLayout>
+                <CompanyResource id={order.company.id}>
+                  {(company) => (
+                    <InvoiceDetailsTable order={order} company={company} />
+                  )}
+                </CompanyResource>
+              </>
+            </DefaultLayout>
+          )}
+        </OrderAssigneesResource>
       )}
     </OrderResource>
   )

--- a/src/client/modules/Omis/constants.js
+++ b/src/client/modules/Omis/constants.js
@@ -15,3 +15,15 @@ export const VAT_STATUS = {
 
 export const EU_VAT_NUMBER_REGEX =
   /^(ATU[0-9]{8}|BE0[0-9]{9}|BG[0-9]{9,10}|HR[0-9]{11}|CY[0-9]{8}L|CZ[0-9]{8,10}|DE[0-9]{9}|DK[0-9]{8}|EE[0-9]{9}|(EL|GR)[0-9]{9}|ES[0-9A-Z][0-9]{7}[0-9A-Z]|FI[0-9]{8}|FR[0-9A-Z]{2}[0-9]{9}|GB([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})|HU[0-9]{8}|IE[0-9]{7}[A-Z]{1,2}|IE[0-9]{1}[A-Z]{1}[0-9]{5}[A-Z]{1}|IT[0-9]{11}|LT([0-9]{9}|[0-9]{12})|LU[0-9]{8}|LV[0-9]{11}|MT[0-9]{8}|NL[0-9]{9}B[0-9]{2}|PL[0-9]{10}|PT[0-9]{9}|RO[0-9]{2,10}|SE[0-9]{12}|SI[0-9]{8}|SK[0-9]{10})$/
+
+export const INCOMPLETE_FIELD_MESSAGES = {
+  SERVICE_TYPES: 'Choose at least one service type the order covers',
+  DESCRIPTION: 'Add a description of the work or activity',
+  DELIVERY_DATE: 'Set a delivery date of at least 21 days from now',
+  ASSIGNEES: 'Add at least one adviser in the market',
+  ASSIGNEE_TIME: 'Allocate hours to at least one adviser in the market',
+  LEAD_ASSIGNEE: 'Set a lead adviser',
+  VAT_STATUS: 'Choose a VAT category',
+  VAT_NUMBER: 'Enter the EU company’s VAT number',
+  VAT_VERIFIED: 'Verify the EU company’s VAT number',
+}

--- a/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
@@ -148,7 +148,7 @@ describe('OMISLocalHeader', () => {
         heading="TMY947/21"
         breadcrumbs={[{ link: '/', text: 'Home' }, { text: 'This is a test' }]}
       >
-        <OMISLocalHeader {...props} />
+        <OMISLocalHeader incompleteFields={[]} {...props} />
       </LocalHeader>
     </DataHubProvider>
   )
@@ -175,6 +175,40 @@ describe('OMISLocalHeader', () => {
         .should('exist')
         .should('have.text', 'Preview quote')
         .should('have.attr', 'href', urls.omis.quote(draftOrder.id))
+    })
+
+    assertCancelLink(draftOrder.id), 'Cancel order'
+  })
+
+  context('When the order status is draft and has incomplete fields', () => {
+    beforeEach(() => {
+      cy.viewport(1024, 768)
+      dispatchResetAction()
+      cy.mount(
+        <Component
+          order={draftOrder}
+          quote={null}
+          incompleteFields={['test']}
+        />
+      )
+    })
+
+    it('should render the order details', () => {
+      assertCompany(draftOrder.company.name)
+      assertMarket(draftOrder.primaryMarket.name)
+      assertUkRegion(draftOrder.ukRegion.name)
+      assertCreatedOn(3, draftOrder.createdOn)
+      assertUpdatedOn(4, draftOrder.modifiedOn)
+      assertStatus(5, 'Draft')
+    })
+
+    assertCompanyLink(draftOrder.company.id)
+
+    it('should render the disabled preview quote button', () => {
+      cy.get('[data-test="preview-quote-button-disabled"]')
+        .should('exist')
+        .should('have.text', 'Preview quote')
+        .should('have.attr', 'disabled', 'disabled')
     })
 
     assertCancelLink(draftOrder.id), 'Cancel order'

--- a/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
@@ -1,0 +1,235 @@
+import React from 'react'
+
+import OrderIncompleteFields from '../../../../../../src/client/modules/Omis/OrderIncompleteFields'
+import {
+  INCOMPLETE_FIELD_MESSAGES,
+  STATUS,
+  VAT_STATUS,
+} from '../../../../../../src/client/modules/Omis/constants'
+import urls from '../../../../../../src/lib/urls'
+import { format } from '../../../../../../src/client/utils/date'
+
+const quoteAwaitingOrder = {
+  id: '123',
+  status: STATUS.QUOTE_AWAITING_ACCEPTANCE,
+}
+
+const cancelledOrder = {
+  id: '123',
+  status: STATUS.CANCELLED,
+  cancelledBy: {
+    name: 'Andreas Test',
+  },
+  cancelledOn: '2018-07-26T14:08:36.380979',
+  cancellationReason: {
+    name: 'Work transferred to Overseas Partner',
+  },
+}
+
+const draftOrder = {
+  id: '123',
+  status: STATUS.DRAFT,
+  serviceTypes: [],
+}
+
+const draftBaseEUOrder = {
+  id: '123',
+  status: STATUS.DRAFT,
+  description: 'test',
+  deliveryDate: '2108-07-26T14:08:36.380979',
+  serviceTypes: ['test service type'],
+  vatStatus: VAT_STATUS.EU_COMPANY,
+}
+
+const draftEUOrder = { ...draftBaseEUOrder, ...{ vatVerified: false } }
+
+const draftOrderAllFields = {
+  ...draftBaseEUOrder,
+  ...{ vatNumber: 'test', vatVerified: true },
+}
+
+const assignees = [{ estimatedHours: 60, isLead: true }]
+
+describe('OrderIncompleteFields', () => {
+  context('When the order status is quote awaiting acceptance', () => {
+    beforeEach(() => {
+      cy.mount(<OrderIncompleteFields order={quoteAwaitingOrder} />)
+    })
+
+    it('should render the correct status message', () => {
+      cy.get('[data-test="withdraw-quote-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'You cannot edit the order once a quote has been sent.Withdraw the quote to edit the order.'
+        )
+    })
+
+    it('should render the withdraw quote link', () => {
+      cy.get('[data-test="withdraw-quote-link"]')
+        .should('exist')
+        .should('have.attr', 'href', urls.omis.quote(quoteAwaitingOrder.id))
+    })
+  })
+
+  context('When the order status is cancelled', () => {
+    beforeEach(() => {
+      cy.mount(<OrderIncompleteFields order={cancelledOrder} />)
+    })
+
+    it('should render the correct status message', () => {
+      cy.get('[data-test="archive-panel"]').should('exist')
+      cy.get('[data-test="archive-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          `This order was cancelled on ${format(
+            cancelledOrder.cancelledOn
+          )} by ${cancelledOrder.cancelledBy.name}.`
+        )
+      cy.get('[data-test="archive-reason"]')
+        .should('exist')
+        .should(
+          'have.text',
+          `Reason: ${cancelledOrder.cancellationReason.name}`
+        )
+    })
+  })
+
+  context('When the order status is draft and has no fields', () => {
+    beforeEach(() => {
+      cy.mount(<OrderIncompleteFields order={draftOrder} assignees={[]} />)
+    })
+
+    it('should render the description message', () => {
+      cy.get('[data-test="add-a-description-of-the-work-or-activity-link"]')
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.DESCRIPTION)
+        .should('have.attr', 'href', urls.omis.edit.quote(draftOrder.id))
+    })
+
+    it('should render the delivery date message', () => {
+      cy.get(
+        '[data-test="set-a-delivery-date-of-at-least-21-days-from-now-link"]'
+      )
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.DELIVERY_DATE)
+        .should('have.attr', 'href', urls.omis.edit.quote(draftOrder.id))
+    })
+
+    it('should render the service types message', () => {
+      cy.get(
+        '[data-test="choose-at-least-one-service-type-the-order-covers-link"]'
+      )
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.SERVICE_TYPES)
+        .should('have.attr', 'href', urls.omis.edit.internalInfo(draftOrder.id))
+    })
+
+    it('should render the VAT category message', () => {
+      cy.get('[data-test="choose-a-vat-category-link"]')
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.VAT_STATUS)
+        .should(
+          'have.attr',
+          'href',
+          urls.omis.edit.invoiceDetails(draftOrder.id)
+        )
+    })
+
+    it('should render the assignees message', () => {
+      cy.get('[data-test="add-at-least-one-adviser-in-the-market-link"]')
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.ASSIGNEES)
+        .should('have.attr', 'href', urls.omis.edit.assignees(draftOrder.id))
+    })
+
+    it('should render the assignee time message', () => {
+      cy.get(
+        '[data-test="allocate-hours-to-at-least-one-adviser-in-the-market-link"]'
+      )
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.ASSIGNEE_TIME)
+        .should('have.attr', 'href', urls.omis.edit.assigneeTime(draftOrder.id))
+    })
+
+    it('should render the lead adviser message', () => {
+      cy.get('[data-test="incomplete-fields-message"]').should(
+        'contain',
+        INCOMPLETE_FIELD_MESSAGES.LEAD_ASSIGNEE
+      )
+    })
+  })
+
+  context('When the order status is draft and has the EU VAT status', () => {
+    beforeEach(() => {
+      cy.mount(
+        <OrderIncompleteFields order={draftEUOrder} assignees={assignees} />
+      )
+    })
+
+    it('should render the VAT number message', () => {
+      cy.get('[data-test="enter-the-eu-companys-vat-number-link"]')
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.VAT_NUMBER)
+        .should(
+          'have.attr',
+          'href',
+          urls.omis.edit.invoiceDetails(draftEUOrder.id)
+        )
+    })
+
+    it('should render the VAT verified message', () => {
+      cy.get('[data-test="verify-the-eu-companys-vat-number-link"]')
+        .should('exist')
+        .should('have.text', INCOMPLETE_FIELD_MESSAGES.VAT_VERIFIED)
+        .should(
+          'have.attr',
+          'href',
+          urls.omis.edit.invoiceDetails(draftEUOrder.id)
+        )
+    })
+
+    it('should not render any other messages', () => {
+      cy.get(
+        '[data-test="add-a-description-of-the-work-or-activity-link"]'
+      ).should('not.exist')
+
+      cy.get(
+        '[data-test="set-a-delivery-date-of-at-least-21-days-from-now-link"]'
+      ).should('not.exist')
+      cy.get(
+        '[data-test="choose-at-least-one-service-type-the-order-covers-link"]'
+      ).should('not.exist')
+      cy.get('[data-test="choose-a-vat-category-link"]').should('not.exist')
+
+      cy.get(
+        '[data-test="add-at-least-one-adviser-in-the-market-link"]'
+      ).should('not.exist')
+
+      cy.get(
+        '[data-test="allocate-hours-to-at-least-one-adviser-in-the-market-link"]'
+      ).should('not.exist')
+
+      cy.get('[data-test="incomplete-fields-message"]').should(
+        'not.contain',
+        INCOMPLETE_FIELD_MESSAGES.LEAD_ASSIGNEE
+      )
+    })
+  })
+
+  context('When the order status is draft and has all the fields', () => {
+    beforeEach(() => {
+      cy.mount(
+        <OrderIncompleteFields
+          order={draftOrderAllFields}
+          assignees={assignees}
+        />
+      )
+    })
+
+    it('should not render anything', () => {
+      cy.get('[data-test="incomplete-fields-message"]').should('not.exist')
+    })
+  })
+})

--- a/test/component/cypress/specs/components/ArchivePanel.cy.jsx
+++ b/test/component/cypress/specs/components/ArchivePanel.cy.jsx
@@ -9,6 +9,8 @@ const archivist = {
   last_name: 'Archivist',
 }
 
+const archivistString = 'String Archivist'
+
 const archivistWithAlternateKey = {
   firstName: 'Inter',
   lastName: 'Action',
@@ -49,6 +51,26 @@ describe('ArchivePanel', () => {
     it('should render the panel with the archivist name visible', () => {
       assertArchiveMessage(
         'This company was archived on 10 Dec 2019 by Example Archivist.'
+      )
+    })
+
+    it('should render the archive reason', () => {
+      assertArchiveReason()
+    })
+
+    it('should render the unarchive link', () => {
+      assertUnarchiveLink()
+    })
+  })
+
+  context('When the archived record uses a string for the name', () => {
+    beforeEach(() => {
+      cy.mount(<Component type="order" archivedBy={archivistString} />)
+    })
+
+    it('should render the panel with the archivist name visible', () => {
+      assertArchiveMessage(
+        'This order was archived on 10 Dec 2019 by String Archivist.'
       )
     })
 


### PR DESCRIPTION
## Description of change

Currently if an OMIS order doesn't have values for all the fields required to build the quote, the user is not notified of this until they try to view the quote itself (by clicking the 'Preview quote' button).

This isn't ideal, as if the user needs to fill in multiple forms they will need to repeatedly go back to the preview quote page in order to see what else is needed. In addition to this, there are some fields that are required (mostly related to assignees) but don't appear on the preview quote page. In these situations, the user will only see an empty status message with no indication of how to resolve the issue.

<img width="990" alt="Screenshot 2023-11-14 at 14 18 49" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/a9de2306-328f-4ee4-8438-76048a66664a">

In order to resolve this issue, I have followed the approach used for investment projects, where all required fields are outlined to the user on the main project page. The messages that appear at the top of `quote_awaiting_acceptance` and `cancelled` orders have also been included here.

## Test instructions

Create a new OMIS order. You should see the fields required for the quote. You should not be able to click the 'Preview quote' button until all these fields have been filled in. Set the VAT category to EU in order to view all fields.

Go to an order with the status `quote_awating_acceptance`. You should see a message about the quote.

Go to an order with the status `cancelled`. You should see a standard `ArchivePanel` with the cancellation data.

## Screenshots

### Before

<img width="991" alt="Screenshot 2023-11-14 at 14 18 10" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/2e47690d-0457-41dd-bf51-6e02610f8770">

<img width="990" alt="Screenshot 2023-11-14 at 14 18 49" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/cc058892-e094-404d-bd59-97e05d7bd122">

### After

<img width="995" alt="Screenshot 2023-11-14 at 14 13 12" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/78153708-e800-4202-9932-23b6b3b303ef">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
