### PR TITLE
Work order branch cleanup

### DIFF
--- a/src/client/modules/Omis/OMISLocalHeader.jsx
+++ b/src/client/modules/Omis/OMISLocalHeader.jsx
@@ -51,6 +51,7 @@ const setHeaderItems = (order, quote) => {
         <Link
           href={urls.companies.details(order.company.id)}
           data-test="company-link"
+          noVisitedState={true}
         >
           {order.company.name}
         </Link>
@@ -78,19 +79,31 @@ const setHeaderItems = (order, quote) => {
 }
 
 const CancelLink = ({ orderId }) => (
-  <StyledLink href={urls.omis.cancel(orderId)} data-test="cancel-link">
+  <StyledLink
+    href={urls.omis.cancel(orderId)}
+    data-test="cancel-link"
+    noVisitedState={true}
+  >
     Cancel order
   </StyledLink>
 )
 
 const ViewQuoteLink = ({ orderId }) => (
-  <StyledLink href={urls.omis.quote(orderId)} data-test="quote-link">
+  <StyledLink
+    href={urls.omis.quote(orderId)}
+    data-test="quote-link"
+    noVisitedState={true}
+  >
     View quote
   </StyledLink>
 )
 
 const ViewReceiptLink = ({ orderId }) => (
-  <StyledLink href={urls.omis.paymentReceipt(orderId)} data-test="receipt-link">
+  <StyledLink
+    href={urls.omis.paymentReceipt(orderId)}
+    data-test="receipt-link"
+    noVisitedState={true}
+  >
     View payment receipt
   </StyledLink>
 )

--- a/src/client/modules/Omis/WorkOrderTables/AssigneesTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/AssigneesTable.jsx
@@ -70,6 +70,7 @@ const buildAssigneeRows = (assignees, order) =>
             <Link
               href={urls.omis.edit.setLeadAssignee(order.id, adviser.id)}
               data-test={`set-lead-adviser-link-${adviser.id}`}
+              noVisitedState={true}
             >
               Set as lead adviser
             </Link>
@@ -96,6 +97,7 @@ const AssigneesTable = ({ assignees, order }) => (
               canEditOrder(order)
             )} advisers in the market`}
             data-test="add-assignees-link"
+            noVisitedState={true}
           >
             {setAdviserEditText(assignees, canEditOrder(order))}
           </Link>
@@ -104,6 +106,7 @@ const AssigneesTable = ({ assignees, order }) => (
           <Link
             href={urls.omis.edit.assigneeTime(order.id)}
             data-test="assignee-time-link"
+            noVisitedState={true}
           >
             Estimate hours
           </Link>

--- a/src/client/modules/Omis/WorkOrderTables/ContactTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/ContactTable.jsx
@@ -24,6 +24,7 @@ const ContactTable = ({ order, contact }) => (
         <Link
           href={urls.omis.edit.contact(order.id)}
           data-test="edit-contact-link"
+          noVisitedState={true}
         >
           Edit
         </Link>
@@ -32,7 +33,11 @@ const ContactTable = ({ order, contact }) => (
   >
     <SummaryTable.Row heading="Name">
       <>
-        <Link href={urls.contacts.contact(contact.id)} data-test="contact-link">
+        <Link
+          href={urls.contacts.contact(contact.id)}
+          data-test="contact-link"
+          noVisitedState={true}
+        >
           {contact.name}
         </Link>
         {setJobTitle(contact.jobTitle)}

--- a/src/client/modules/Omis/WorkOrderTables/InternalUseTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/InternalUseTable.jsx
@@ -14,6 +14,7 @@ const InternalUseTable = ({ order }) => (
         <Link
           href={urls.omis.edit.internalInfo(order.id)}
           data-test="edit-internal-info-link"
+          noVisitedState={true}
         >
           Edit
         </Link>

--- a/src/client/modules/Omis/WorkOrderTables/InvoiceDetailsTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/InvoiceDetailsTable.jsx
@@ -63,6 +63,7 @@ const InvoiceDetailsTable = ({ order, company }) => (
         <Link
           href={urls.omis.edit.invoiceDetails(order.id)}
           data-test="edit-invoice-details-link"
+          noVisitedState={true}
         >
           Edit
         </Link>

--- a/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
@@ -15,6 +15,7 @@ const QuoteInformationTable = ({ order }) => (
         <Link
           href={urls.omis.edit.quote(order.id)}
           data-test="edit-quote-info-link"
+          noVisitedState={true}
         >
           Edit
         </Link>

--- a/src/client/modules/Omis/WorkOrderTables/SubscribersTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/SubscribersTable.jsx
@@ -24,6 +24,7 @@ const SubscribersTable = ({ subscribers, order }) => (
           href={urls.omis.edit.subscribers(order.id)}
           aria-label="Add or remove advisers in the UK"
           data-test="add-subscribers-link"
+          noVisitedState={true}
         >
           Add or remove
         </Link>


### PR DESCRIPTION
## Description of change

Cleanup for the work order `feature-merge` branch, containing the following changes:
- A redirect has been set up for the `omis/:orderId` URL, which will now direct to the work order page.
- The `noVisitedState` prop has been set to `true` for all the links on the page

## Test instructions

Search for an order using the main page search. It should take you to the work order page

Click one of the edit links on an order's work order page. The link should remain in the 'unvisited' state when returning to the work order page.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
