### PR TITLE
Correct value for assignee time check

### DIFF
--- a/src/client/modules/Omis/transformers.js
+++ b/src/client/modules/Omis/transformers.js
@@ -202,7 +202,7 @@ export const transformLeadAdviserForApi = (values) => {
 }
 
 const checkIfAssigneeHasHours = (assignees) =>
-  assignees.some((assignee) => assignee.estimatedHours != 0)
+  assignees.some((assignee) => assignee.estimatedTime != 0)
 
 const checkIfLeadAssigneeExists = (assignees) =>
   assignees.some((assignee) => assignee.isLead)

--- a/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
@@ -48,7 +48,7 @@ const draftOrderAllFields = {
   ...{ vatNumber: 'test', vatVerified: true },
 }
 
-const assignees = [{ estimatedHours: 60, isLead: true }]
+const assignees = [{ estimatedTime: 60, isLead: true }]
 
 describe('OrderIncompleteFields', () => {
   context('When the order status is quote awaiting acceptance', () => {


### PR DESCRIPTION
## Description of change

The `assigneeTime` message in the OMIS incomplete fields component wasn't showing up properly. This has been fixed.

## Test instructions

Go to a draft OMIS order and remove any assignees (advisers in the market). You should see a message about estimated hours in the incomplete fields box.

Add some assignees without adding estimated hours. The message should still appear.

Edit the estimated hours for an assignee. The message should not appear anymore.

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
