### PR TITLE
Update sectors used by SectorFaker

### DIFF
--- a/test/functional/cypress/fakers/sectors.js
+++ b/test/functional/cypress/fakers/sectors.js
@@ -2,11 +2,7 @@ import { faker } from '@faker-js/faker'
 
 import { listFaker } from './utils'
 
-const sectors = [
-  'Advanced Engineering',
-  'Biotechnology and Pharmaceuticals',
-  'Creative and Media',
-]
+const sectors = ['Aerospace', 'Mining', 'Railways']
 
 export const sectorFaker = (overrides = {}) => ({
   ancestors: [],


### PR DESCRIPTION
## Description of change

Since the sectors were changed in the API some of the e2e tests have become flaky. This is because the `sectorFaker` was set to use sectors that had been removed. I have replaced these with sectors that still exist, and in order to reduce test runtimes slightly I've chosen sectors with short names (as these are typed by Cypress).

## Test instructions

All e2e tests should pass

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
