### PR TITLE
feature/CLS2-632-remove-adviser-feature-flag-from-FE

### DIFF
--- a/src/client/modules/AdviserTasks/constants.js
+++ b/src/client/modules/AdviserTasks/constants.js
@@ -1,1 +1,0 @@
-export const adviserTasksFeatureFlag = 'adviser-tasks'

--- a/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskAdd.jsx
+++ b/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskAdd.jsx
@@ -10,7 +10,7 @@ import Task from '../../../../components/Task'
 import { DefaultLayout } from '../../../../components'
 import TaskForm from '../../../Tasks/TaskForm'
 
-const TaskAdd = ({ currentAdviserId, investmentProject, activeFeatures }) => {
+const TaskAdd = ({ currentAdviserId, investmentProject }) => {
   const { projectId } = useParams()
   const investorCompanyName = investmentProject?.investorCompany?.name || ''
   return (
@@ -49,7 +49,6 @@ const TaskAdd = ({ currentAdviserId, investmentProject, activeFeatures }) => {
               )}
               submissionTaskName={TASK_SAVE_INVESTMENT_PROJECT_TASK}
               additionalPayloadData={{ investmentProject: investmentProject }}
-              activeFeatures={activeFeatures}
             />
           )
         }

--- a/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskEdit.jsx
+++ b/src/client/modules/Investments/Projects/Tasks/InvestmentProjectTaskEdit.jsx
@@ -15,7 +15,7 @@ import { DefaultLayout } from '../../../../components'
 import TaskForm from '../../../Tasks/TaskForm'
 import { TASK_SAVE_TASK_DETAILS } from '../../../Tasks/TaskForm/state'
 
-const TaskEdit = ({ currentAdviserId, task, activeFeatures }) => {
+const TaskEdit = ({ currentAdviserId, task }) => {
   const { taskId } = useParams()
   const investmentProject = task?.investmentProject
   const investorCompanyName = investmentProject?.investorCompany.name || ''
@@ -53,7 +53,6 @@ const TaskEdit = ({ currentAdviserId, task, activeFeatures }) => {
                 investmentProject.id
               )}
               submissionTaskName={TASK_SAVE_TASK_DETAILS}
-              activeFeatures={activeFeatures}
             />
           )
         }

--- a/src/client/modules/Investments/Projects/Tasks/state.js
+++ b/src/client/modules/Investments/Projects/Tasks/state.js
@@ -9,12 +9,10 @@ export const state2props = (state) => {
   const { project } = state[INVESTMENT_PROJECT_ID]
   const { task } = state[TASK_ID]
   const currentAdviserId = state.currentAdviserId
-  const activeFeatures = state.activeFeatures
 
   return {
     investmentProject: project,
     currentAdviserId,
     task: task && transformAPIValuesForForm(task, currentAdviserId),
-    activeFeatures: activeFeatures,
   }
 }

--- a/src/client/modules/Tasks/TaskForm/index.jsx
+++ b/src/client/modules/Tasks/TaskForm/index.jsx
@@ -17,7 +17,6 @@ import { validateDaysRange, validateIfDateInFuture } from './validators'
 import { FORM_LAYOUT, OPTIONS_YES_NO } from '../../../../common/constants'
 import { OPTIONS } from './constants'
 import urls from '../../../../lib/urls'
-import { adviserTasksFeatureFlag } from '../../AdviserTasks/constants'
 
 const StyledFieldInput = styled(FieldInput)`
   text-align: center;
@@ -36,9 +35,6 @@ const taskDueDateOptions = [
   { label: 'No due date', value: 'none' },
 ]
 
-const userCanViewTaskReminders = (activeFeatures) =>
-  activeFeatures.includes(adviserTasksFeatureFlag)
-
 const TaskForm = ({
   currentAdviserId,
   task,
@@ -47,7 +43,6 @@ const TaskForm = ({
   redirectToUrl,
   submissionTaskName,
   additionalPayloadData,
-  activeFeatures,
 }) => {
   return (
     <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
@@ -124,19 +119,17 @@ const TaskForm = ({
                 }),
               }))}
             />
-            {userCanViewTaskReminders(activeFeatures) && (
-              <FieldRadios
-                name="taskRemindersEnabled"
-                legend="Do you want to set a reminder for this task?"
-                required="Select reminder"
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                  ...(option.label === 'Yes' && {
-                    children: <FieldReminder />,
-                  }),
-                }))}
-              />
-            )}
+            <FieldRadios
+              name="taskRemindersEnabled"
+              legend="Do you want to set a reminder for this task?"
+              required="Select reminder"
+              options={OPTIONS_YES_NO.map((option) => ({
+                ...option,
+                ...(option.label === 'Yes' && {
+                  children: <FieldReminder />,
+                }),
+              }))}
+            />
             <Details summary="Find out more about task reminders">
               <p>
                 By default reminders are sent at 8am, on the specified date by:

--- a/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskForm/TaskForm.cy.jsx
@@ -20,7 +20,6 @@ import advisersListFaker, {
 } from '../../../../../functional/cypress/fakers/advisers'
 import { OPTION_NO, OPTION_YES } from '../../../../../../src/common/constants'
 import { convertDateToFieldDateObject } from '../../../../../../src/client/utils/date'
-import { adviserTasksFeatureFlag } from '../../../../../../src/client/modules/AdviserTasks/constants'
 
 describe('Task form', () => {
   const Component = (props) => (
@@ -31,12 +30,7 @@ describe('Task form', () => {
 
   context('When a task form renders without initial values', () => {
     beforeEach(() => {
-      cy.mount(
-        <Component
-          cancelRedirectUrl={urls.companies.index()}
-          activeFeatures={[adviserTasksFeatureFlag]}
-        />
-      )
+      cy.mount(<Component cancelRedirectUrl={urls.companies.index()} />)
     })
 
     it('should display the task title field', () => {
@@ -101,7 +95,6 @@ describe('Task form', () => {
         <Component
           cancelRedirectUrl={urls.companies.index()}
           task={transformAPIValuesForForm(investmentProjectTask)}
-          activeFeatures={[adviserTasksFeatureFlag]}
         />
       )
     })
@@ -181,7 +174,6 @@ describe('Task form', () => {
               investmentProjectTask,
               currentAdviser.id
             )}
-            activeFeatures={[adviserTasksFeatureFlag]}
           />
         )
       })
@@ -216,7 +208,6 @@ describe('Task form', () => {
               investmentProjectTask,
               currentAdviser.id
             )}
-            activeFeatures={[adviserTasksFeatureFlag]}
           />
         )
       })
@@ -256,7 +247,6 @@ describe('Task form', () => {
             <Component
               cancelRedirectUrl={urls.companies.index()}
               task={transformAPIValuesForForm(investmentProjectTask)}
-              activeFeatures={[adviserTasksFeatureFlag]}
             />
           )
         })
@@ -276,7 +266,7 @@ describe('Task form', () => {
 
   context('When a task is missing all mandatory fields', () => {
     beforeEach(() => {
-      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
+      cy.mount(<Component />)
       clickButton('Save task')
     })
 
@@ -306,7 +296,7 @@ describe('Task form', () => {
 
   context('When creating a task assigned to someone else', () => {
     beforeEach(() => {
-      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
+      cy.mount(<Component />)
 
       cy.get('[data-test=task-assigned-to-someone-else]').click()
     })
@@ -323,7 +313,7 @@ describe('Task form', () => {
 
   context('When a task is created a task with a custom date', () => {
     beforeEach(() => {
-      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
+      cy.mount(<Component />)
       cy.get('[data-test=task-due-date-custom-date]').click()
     })
 
@@ -365,7 +355,7 @@ describe('Task form', () => {
 
   context('When creating a task with task reminders', () => {
     beforeEach(() => {
-      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
+      cy.mount(<Component />)
 
       cy.get('[data-test=field-taskRemindersEnabled]').click()
     })
@@ -397,34 +387,6 @@ describe('Task form', () => {
         'contain.text',
         'Enter a number between 1 and 365'
       )
-    })
-  })
-})
-
-describe('Task form feature flag', () => {
-  const Component = (props) => (
-    <DataHubProvider>
-      <TaskForm {...props} />
-    </DataHubProvider>
-  )
-
-  context('When advisers-task feature flag is disabled', () => {
-    beforeEach(() => {
-      cy.mount(<Component activeFeatures={[]} />)
-    })
-
-    it('should not display the task reminder field radios', () => {
-      cy.get('[data-test="field-taskRemindersEnabled"]').should('not.exist')
-    })
-  })
-
-  context('When advisers-task feature flag is enabled', () => {
-    beforeEach(() => {
-      cy.mount(<Component activeFeatures={[adviserTasksFeatureFlag]} />)
-    })
-
-    it('should display the task reminder field radios', () => {
-      cy.get('[data-test="field-taskRemindersEnabled"]').should('exist')
     })
   })
 })

--- a/test/functional/cypress/specs/investments/project-add-task-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-task-spec.js
@@ -12,7 +12,6 @@ import {
 } from '../../support/assertions'
 import { fill, fillMultiOptionTypeahead } from '../../support/form-fillers'
 import { clickButton } from '../../../../functional/cypress/support/actions'
-import { adviserTasksFeatureFlag } from '../../../../../src/client/modules/AdviserTasks/constants'
 
 const autoCompleteAdvisers =
   require('../../../../sandbox/fixtures/autocomplete-adviser-list.json').results
@@ -48,14 +47,9 @@ describe('Add investment project task', () => {
 
   context('When creating a task for me', () => {
     before(() => {
-      cy.setUserFeatures([adviserTasksFeatureFlag])
       cy.visit(
         investments.projects.tasks.create(investment.investmentWithDetails.id)
       )
-    })
-
-    after(() => {
-      cy.resetUser()
     })
 
     it('add task button should send expected values to the api', () => {
@@ -67,14 +61,9 @@ describe('Add investment project task', () => {
 
   context('When creating a task for someone else', () => {
     before(() => {
-      cy.setUserFeatures([adviserTasksFeatureFlag])
       cy.visit(
         investments.projects.tasks.create(investment.investmentWithDetails.id)
       )
-    })
-
-    after(() => {
-      cy.resetUser()
     })
 
     it('add task button should send expected values to the api', () => {


### PR DESCRIPTION
## Description of change

Removed the adviser tasks feature flag

## Test instructions

Make sure your user doesn't have the `adviser-tasks` feature flag and view a task. You will now be able to view the set a reminder option without having the feature flag

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/661618e9-918f-4d77-a697-e2bd5a6e7401)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/9ed7ea68-9d6c-4879-a354-5673179744d8)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
