### PR TITLE
Add a max word count to the FieldTextArea component

### DIFF
--- a/src/client/components/Form/elements/FieldTextarea/index.jsx
+++ b/src/client/components/Form/elements/FieldTextarea/index.jsx
@@ -1,16 +1,37 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { TextAreaField } from '@govuk-react/text-area'
 import ErrorText from '@govuk-react/error-text'
+
 import {
   BORDER_WIDTH_FORM_ELEMENT_ERROR,
   SPACING,
 } from '@govuk-react/constants'
+import pluralize from 'pluralize'
 
-import { ERROR_COLOUR } from '../../../../../client/utils/colours'
+import { ERROR_COLOUR, BLACK } from '../../../../../client/utils/colours'
 import { useField } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
+
+const WORD_REGEX = /\b\w+(?:-\w+)*\b/g
+
+const getWordCountFromString = (str) => {
+  const words = str.trim().match(WORD_REGEX)
+  return words ? words.length : 0
+}
+
+const getMaxWordValidator = (maxWords, required, invalid) => (value) => {
+  const wordCount = getWordCountFromString(value)
+  return wordCount === 0 ? required : wordCount > maxWords ? invalid : null
+}
+
+const updateMaxWordsDescription = (maxWords, wordCount) => {
+  const delta = maxWords - wordCount
+  const count = Math.abs(delta)
+  const word = pluralize('word', count)
+  return `You have ${count} ${word} ${delta >= 0 ? 'remaining.' : 'too many.'}`
+}
 
 const StyledTextareaWrapper = styled('div')`
   ${(props) =>
@@ -25,6 +46,10 @@ const StyledTextareaWrapper = styled('div')`
   }
 `
 
+const StyledParagraph = styled('p')({
+  color: ({ color }) => color,
+})
+
 const FieldTextarea = ({
   name,
   validate,
@@ -32,31 +57,52 @@ const FieldTextarea = ({
   label,
   legend,
   hint,
+  maxWords,
+  invalid,
   initialValue,
   ...rest
 }) => {
   const { value, error, touched, onChange, onBlur } = useField({
     name,
-    validate,
+    validate:
+      maxWords > 0
+        ? getMaxWordValidator(maxWords, required, invalid)
+        : validate,
     required,
     initialValue,
   })
 
+  const [wordCount, setWordCount] = useState(0)
+
   return (
     <FieldWrapper {...{ name, label, legend, hint, error }}>
       <StyledTextareaWrapper error={error}>
-        {touched && error && <ErrorText>{error}</ErrorText>}
+        {touched && error && (
+          <ErrorText data-test="textarea-error">{error}</ErrorText>
+        )}
         <TextAreaField
+          data-test="textarea"
           id={name}
           key={name}
           error={touched && error}
           name={name}
           value={value}
-          onChange={onChange}
+          onChange={(e) => {
+            onChange(e)
+            maxWords > 0 && setWordCount(getWordCountFromString(e.target.value))
+          }}
           onBlur={onBlur}
           rows="5"
           {...rest}
         />
+        {maxWords > 0 && (
+          <StyledParagraph
+            data-test="word-count"
+            color={wordCount > maxWords ? ERROR_COLOUR : BLACK}
+          >
+            {updateMaxWordsDescription(maxWords, wordCount)}
+          </StyledParagraph>
+        )}
       </StyledTextareaWrapper>
     </FieldWrapper>
   )
@@ -73,6 +119,7 @@ FieldTextarea.propTypes = {
   legend: PropTypes.node,
   hint: PropTypes.node,
   initialValue: PropTypes.string,
+  maxWords: PropTypes.number,
 }
 
 FieldTextarea.defaultProps = {
@@ -82,6 +129,7 @@ FieldTextarea.defaultProps = {
   legend: null,
   hint: null,
   initialValue: '',
+  maxWords: null,
 }
 
 export default FieldTextarea

--- a/test/component/cypress/specs/components/Form/FieldTextArea.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldTextArea.cy.jsx
@@ -1,0 +1,142 @@
+import React from 'react'
+
+import FieldTextarea from '../../../../../../src/client/components/Form/elements/FieldTextarea'
+import { ERROR_COLOUR, BLACK } from '../../../../../../src/client/utils/colours'
+import { Form } from '../../../../../../src/client/components'
+import DataHubProvider from '../../provider'
+
+describe('FieldTextArea', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form
+        id="any-form"
+        analyticsFormName="any-form"
+        cancelRedirectTo={() => '/'}
+        submissionTaskName="TASK_SAVE"
+      >
+        <FieldTextarea name="notes" {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+
+  context('When providing default props', () => {
+    it('should display a label', () => {
+      cy.mount(<Component label="Summary of the support given" />)
+      cy.get('[data-test=field-notes] label').should(
+        'have.text',
+        'Summary of the support given'
+      )
+    })
+    it('should display a hint text', () => {
+      cy.mount(<Component hint="Outline something in 100 words" />)
+      cy.get('[data-test=hint-text]').should(
+        'have.text',
+        'Outline something in 100 words'
+      )
+    })
+    it('should display a textarea without a word count', () => {
+      cy.mount(<Component />)
+      cy.get('[data-test=textarea]').should('exist')
+      cy.get('[data-test=textarea]').should('be.visible')
+      cy.get('[data-test=word-count]').should('not.exist')
+      cy.get('[data-test=submit-button]').click()
+    })
+  })
+
+  context('When setting the maxWords prop', () => {
+    beforeEach(() => {
+      const MAX_WORDS = 3
+      cy.mount(<Component maxWords={MAX_WORDS} />)
+    })
+    it('should display a small paragraph of text', () => {
+      cy.get('[data-test=word-count]').should('exist')
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 3 words remaining.'
+      )
+    })
+    it('should update the paragraph of text after typing one word', () => {
+      cy.get('[data-test=textarea]').type('foo')
+      cy.get('[data-test=word-count]').should('have.colour', BLACK)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 2 words remaining.'
+      )
+    })
+    it('should update the paragraph of text after typing two words', () => {
+      cy.get('[data-test=textarea]').type('foo bar')
+      cy.get('[data-test=word-count]').should('have.colour', BLACK)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 1 word remaining.'
+      )
+    })
+    it('should update the paragraph of text after typing three words', () => {
+      cy.get('[data-test=textarea]').type('foo bar baz')
+      cy.get('[data-test=word-count]').should('have.colour', BLACK)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 0 words remaining.'
+      )
+    })
+    it('should update the paragraph of text after typing four words', () => {
+      cy.get('[data-test=textarea]').type('foo bar baz foo')
+      cy.get('[data-test=word-count]').should('have.colour', ERROR_COLOUR)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 1 word too many.'
+      )
+    })
+    it('should update the paragraph of text after typing five words', () => {
+      cy.get('[data-test=textarea]').type('foo bar baz foo bar')
+      cy.get('[data-test=word-count]').should('have.colour', ERROR_COLOUR)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 2 words too many.'
+      )
+    })
+    it('should update the paragraph of text after typing six words', () => {
+      cy.get('[data-test=textarea]').type('foo bar baz foo bar baz')
+      cy.get('[data-test=word-count]').should('have.colour', ERROR_COLOUR)
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 3 words too many.'
+      )
+    })
+    it('should count hyphenated words as a single word', () => {
+      cy.get('[data-test=textarea]').type('editor-in-chief')
+      cy.get('[data-test=word-count]').should(
+        'have.text',
+        'You have 2 words remaining.'
+      )
+    })
+  })
+
+  context('When setting the maxWords prop and error handling', () => {
+    beforeEach(() => {
+      const MAX_WORDS = 3
+      cy.mount(
+        <Component
+          maxWords={MAX_WORDS}
+          required="Enter a summary"
+          invalid={`Summary must be ${MAX_WORDS} words or less`}
+        />
+      )
+    })
+    it('should display an error when the user submits without entering a word', () => {
+      cy.get('[data-test=submit-button]').click()
+      cy.get('[data-test=textarea-error]').should(
+        'have.text',
+        'Enter a summary'
+      )
+    })
+    it('should display an error when the user submits with too many words', () => {
+      cy.get('[data-test=textarea]').type('foo bar baz foo')
+      cy.get('[data-test=submit-button]').click()
+      cy.get('[data-test=textarea-error]').should(
+        'have.text',
+        'Summary must be 3 words or less'
+      )
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Adds an optional `maxWords` prop to our `FieldTextArea` component that aligns with the GDS standards found [here](https://design-system.service.gov.uk/components/character-count/). 

For demonstrable purposes, the example below has the `maxWords` prop set to `3` meaning users can paste or type what they like into the `textarea`, however, only three words will be accepted (when saving or moving to the next form step). Typically `maxWords` would be set to `100`.

As you would expect, hyphenated words are counted as a single word.

## Test instructions
https://github.com/uktrade/data-hub-frontend/assets/964268/1be802f4-ba18-46e0-a9da-46578d7d6cf8

## Checklist
[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
