### PR TITLE
Temporarily skip tests reliant on ActivityStream

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -114,7 +114,7 @@ describe('Event', () => {
       createEvent()
     })
 
-    it('should create an attendee on a event', () => {
+    it.skip('should create an attendee on a event', () => {
       createEvent()
       // This is here to allow the activity stream to poll the event api and detect the new event.
       //TODO once the activity stream poll is made customisable remove this wait
@@ -142,7 +142,7 @@ describe('Event', () => {
     })
   })
 
-  describe('edit', () => {
+  describe.skip('edit', () => {
     beforeEach(() => {
       cy.visit(urls.events.index())
     })


### PR DESCRIPTION
## Description of change

The integrated version of `ActivityStream` we use in our e2e tests has been broken since a dependency upgrade on Friday. This means that all FE PRs will contain failing tests and can only be merged with admin permissions.

To unblock everyone I've disabled the tests that are reliant on `ActivityStream` until this is fixed. Once the AS issues are fixed this PR should be reverted.

## Test instructions

All tests should pass.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
