### PR TITLE
Cls2 493 link to dw account plan

### DIFF
--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -63,7 +63,7 @@ const canEditOneList = (permissions) =>
     'company.change_one_list_tier_and_global_account_manager'
   )
 
-const Plan = ({ company }) => (
+const DataWorkspaceAccountPlan = ({ company }) => (
   <SectionGridRow data-test="account-plan-row">
     <GridCol>
       <GridRow>
@@ -264,7 +264,7 @@ const AccountManagement = ({
           flashMessages={flashMessages}
           csrfToken={csrfToken}
         >
-          <Plan company={company} />
+          <DataWorkspaceAccountPlan company={company} />
           <Strategy company={company} />
           <Objectives company={company} />
           {!company.oneListGroupTier ||

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -63,6 +63,29 @@ const canEditOneList = (permissions) =>
     'company.change_one_list_tier_and_global_account_manager'
   )
 
+const Plan = ({ company }) => (
+  <SectionGridRow data-test="account-plan-row">
+    <GridCol>
+      <GridRow>
+        <GridCol>
+          <H3>Account plan</H3>
+        </GridCol>
+      </GridRow>
+      <GridCol>
+        <GridRow>
+          An account plan is a forward thinking dashboard of the company,
+          summarising the wider company's scale, their investment and export
+          ambitions alongside DBT's relationships and progress with them.
+        </GridRow>
+      </GridCol>
+      <br />
+      <NewWindowLink href={urls.external.dataWorkspace(company.id)}>
+        View {company.name}'s account plan
+      </NewWindowLink>
+    </GridCol>
+  </SectionGridRow>
+)
+
 const Strategy = ({ company }) => (
   <SectionGridRow data-test="strategy-row">
     <GridCol>
@@ -241,6 +264,7 @@ const AccountManagement = ({
           flashMessages={flashMessages}
           csrfToken={csrfToken}
         >
+          <Plan company={company} />
           <Strategy company={company} />
           <Objectives company={company} />
           {!company.oneListGroupTier ||

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -85,6 +85,8 @@ module.exports = {
     findExporters: () =>
       'https://data.trade.gov.uk/datasets/4a0da123-a933-4250-90b5-df5cde34930b',
     exportWins: () => 'https://www.exportwins.service.trade.gov.uk/',
+    dataWorkspace: (id) =>
+      `https://data.trade.gov.uk/visualisations/link/e69bbfde-0e68-49d3-ad81-ddffbad6bac6#p.CompanyID=${id}`,
     digitalWorkspace: {
       teams:
         'https://people.trade.gov.uk/teams/department-for-international-trade',

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -231,6 +231,24 @@ describe('Company account management', () => {
       })
     }
   )
+
+  context('When visiting the account management page', () => {
+    before(() => {
+      cy.intercept('GET', `/api-proxy/v4/company/${companyId}`).as('companyApi')
+      cy.visit(urls.companies.accountManagement.index(companyId))
+      cy.wait('@companyApi')
+    })
+
+    it('should display the account plan section', () => {
+      cy.get('[data-test="account-plan-row"]').should('be.visible')
+    })
+
+    it('should navigate to the account plan page when the link is clicked', () => {
+      cy.get('[data-test="newWindowLink"]')
+        .should('exist')
+        .should('have.attr', 'href', urls.external.dataWorkspace(companyId))
+    })
+  })
 })
 
 describe('One List core team', () => {


### PR DESCRIPTION
## Description of change

In the account management tab, an account plan section has been added along with a link that takes you to the company's account plan visualisation in Data Workspace.

## Test instructions

Click on a company and navigate from the company overview tab to the account management tab. You will be see the account plan section first.

## Screenshots

### Before
<img width="990" alt="Screenshot 2023-11-29 at 10 42 25" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/8816d9d8-e4c0-4b9f-aff1-9ed2936034dd">



### After
<img width="978" alt="Screenshot 2023-11-29 at 10 47 23" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/9bc30056-e57e-4fcd-8ccf-0d3f7dc01715">



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
