### PR TITLE
Task component will now ignore starts of tasks which are already in

### DIFF
--- a/src/client/components/Task/saga.js
+++ b/src/client/components/Task/saga.js
@@ -102,9 +102,7 @@ function* subscribeToStart(registry) {
       get(state, ['tasks', name, id, 'status'])
     )
     if (status === 'progress') {
-      throw Error(
-        `Cannot start task "${name}.${id}" because it is already in progress. Cancel it first!`
-      )
+      continue
     }
     yield spawn(manageTask, task, action)
   }


### PR DESCRIPTION
## Description of change

Changes the logic of starting a `Task` so that if when a task with the same `name` and `id` is already in progress, it will ignore requests to start the task again, as opposed to the current behavior when an 'Cannot start task "<name>.<id>" because it is already in progress. Cancel it first!' error is thrown.

## Test instructions

This change should not have any effect on the app's logic.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
