### PR TITLE
Task/Error.Inline component

### DIFF
--- a/src/client/components/DataHubHeader/state.js
+++ b/src/client/components/DataHubHeader/state.js
@@ -1,9 +1,9 @@
 export const state2props = (state) => {
   const activeFeatureGroups = state.activeFeatureGroups
-  const hasInvestmentFeatureGroup = activeFeatureGroups.includes(
+  const hasInvestmentFeatureGroup = activeFeatureGroups?.includes(
     'investment-notifications'
   )
-  const hasExportFeatureGroup = activeFeatureGroups.includes(
+  const hasExportFeatureGroup = activeFeatureGroups?.includes(
     'export-notifications'
   )
 

--- a/src/client/components/InlineIcon/index.js
+++ b/src/client/components/InlineIcon/index.js
@@ -1,5 +1,18 @@
 import styled from 'styled-components'
 
+/**
+ * @function InlineIcon
+ * @description
+ * Allows displaying `@govuk-react/icons` icons inline.
+ * @param {Object} props
+ * @param {React.ReactNode} props.children - A `@govuk-react/icons` element.
+ * @example
+ * import { IconImportant } from '@govuk-react/icons'
+ *
+ * <InlineIcon>
+ *   <IconImportant/>
+ * </InlineIcon>
+ */
 const InlineIcon = styled.span`
   height: 2ex;
   width: 2ex;

--- a/src/client/components/InlineIcon/index.js
+++ b/src/client/components/InlineIcon/index.js
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+const InlineIcon = styled.span`
+  height: 2ex;
+  width: 2ex;
+  vertical-align: -10%;
+  display: inline-block;
+`
+
+export default InlineIcon

--- a/src/client/components/ProgressIndicator.jsx
+++ b/src/client/components/ProgressIndicator.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import LoadingBox from '@govuk-react/loading-box'
 import { SPACING } from '@govuk-react/constants'
+import { Spinner } from '@govuk-react/icons'
 import styled from 'styled-components'
+
+import InlineIcon from './InlineIcon'
 
 const StyledRoot = styled.div({
   textAlign: 'center',
@@ -12,12 +15,39 @@ const StyledLoadingBox = styled(LoadingBox)({
   marginTop: SPACING.SCALE_5,
   marginBottom: SPACING.SCALE_3,
 })
-
-const ProgressIndicator = ({ message }) => (
+/**
+ * @function ProgressIndicator
+ * @description A progress indicator
+ * @param {Object} props
+ * @param {string} props.noun - A noun describing the thing in progress
+ * @param {string} [props.message = `Loading ${noun}`] - The message
+ * rendered underneath the spinner icon.
+ * @returns {JSX.Element}
+ */
+const ProgressIndicator = ({ noun, message = `Loading ${noun}` }) => (
   <StyledRoot>
     <StyledLoadingBox loading={true} />
     {message && <p>{message}</p>}
   </StyledRoot>
+)
+
+/**
+ * @function ProgressIndicator.Inline
+ * @description A progress indicator designed to be rendered nicely in any
+ * inline context.
+ * @param {Object} props
+ * @param {string} props.noun - A noun describing the thing in progress
+ * @param {string} [props.message = `Loading ${noun}`] - The message
+ * rendered next to the spinner icon.
+ * @returns {JSX.Element}
+ */
+ProgressIndicator.Inline = ({ noun, message = `Loading ${noun}` }) => (
+  <>
+    <InlineIcon>
+      <Spinner />
+    </InlineIcon>{' '}
+    <span style={{ opacity: 0.3 }}>{message}</span>
+  </>
 )
 
 export default ProgressIndicator

--- a/src/client/components/SecondaryButton.jsx
+++ b/src/client/components/SecondaryButton.jsx
@@ -13,6 +13,11 @@ const SecondaryButton = React.forwardRef((props, ref) => (
   />
 ))
 
+/**
+ * @function SecondaryButton.Inline
+ * @description {SecondaryButton} which displays inline and inherits the
+ * sizing from the inline context.
+ */
 SecondaryButton.Inline = styled(SecondaryButton)`
   display: inline-block;
   width: auto;

--- a/src/client/components/SecondaryButton.jsx
+++ b/src/client/components/SecondaryButton.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Button from '@govuk-react/button'
+import styled from 'styled-components'
 
 import { TEXT_COLOUR, GREY_3 } from '../../client/utils/colours'
 
@@ -11,5 +12,15 @@ const SecondaryButton = React.forwardRef((props, ref) => (
     {...props}
   />
 ))
+
+SecondaryButton.Inline = styled(SecondaryButton)`
+  display: inline-block;
+  width: auto;
+  font-size: 0.8em;
+  vertical-align: baseline;
+  padding: 0.2em;
+  line-height: 0.5lh;
+  margin: 0;
+`
 
 export default SecondaryButton

--- a/src/client/components/Task/Error.jsx
+++ b/src/client/components/Task/Error.jsx
@@ -11,14 +11,12 @@ import {
 } from '@govuk-react/constants'
 import { spacing } from '@govuk-react/lib'
 import { isString, isArray } from 'lodash'
+import { IconImportant } from '@govuk-react/icons'
 
+import InlineIcon from '../InlineIcon'
 import FormActions from '../Form/elements/FormActions'
 import SecondaryButton from '../SecondaryButton'
-import {
-  TEXT_COLOUR,
-  ERROR_COLOUR,
-  FOCUS_COLOUR,
-} from '../../../client/utils/colours'
+import { TEXT_COLOUR, ERROR_COLOUR, FOCUS_COLOUR } from '../../utils/colours'
 
 const StyledRoot = styled.div(
   {
@@ -43,26 +41,45 @@ const StyledSecondaryButton = styled(SecondaryButton)({
   marginBottom: 0,
 })
 
-const Err = ({ errorMessage, retry, dismiss, noun, dismissable = true }) => (
+const Err = ({ errorMessage, retry, dismiss, noun }) => (
   <StyledRoot data-test="error-dialog">
     <H2 size="MEDIUM">Could not load {noun}</H2>
     {isString(errorMessage) && <p>Error: {errorMessage}</p>}
     {isArray(errorMessage) &&
       errorMessage.map((error) => <p key={error}>{error}</p>)}
-    <FormActions>
-      <StyledSecondaryButton onClick={retry}>Retry</StyledSecondaryButton>
-      {dismissable && (
-        <StyledSecondaryButton onClick={dismiss}>Dismiss</StyledSecondaryButton>
-      )}
-    </FormActions>
+    {retry && (
+      <FormActions>
+        <StyledSecondaryButton onClick={retry}>Retry</StyledSecondaryButton>
+        {dismiss && (
+          <StyledSecondaryButton onClick={dismiss}>
+            Dismiss
+          </StyledSecondaryButton>
+        )}
+      </FormActions>
+    )}
   </StyledRoot>
 )
 
 Err.propTypes = {
   noun: PropTypes.string.isRequired,
   errorMessage: PropTypes.string.isRequired,
-  retry: PropTypes.func.isRequired,
-  clear: PropTypes.func.isRequired,
+  retry: PropTypes.func,
+  dismiss: PropTypes.func,
 }
+
+Err.Inline = ({ retry, noun }) => (
+  <span style={{ color: ERROR_COLOUR }}>
+    <InlineIcon>
+      <IconImportant />
+    </InlineIcon>{' '}
+    Could not load {noun}
+    {retry && (
+      <>
+        {' '}
+        <SecondaryButton.Inline onClick={retry}>Retry</SecondaryButton.Inline>
+      </>
+    )}
+  </span>
+)
 
 export default Err

--- a/src/client/components/Task/__stories__/Error.stories.jsx
+++ b/src/client/components/Task/__stories__/Error.stories.jsx
@@ -1,0 +1,36 @@
+import { actions } from '@storybook/addon-actions'
+
+import { InlineTemplate } from './utils'
+import Err from '../Error'
+
+export default {
+  title: 'Task/Error',
+  component: Err,
+}
+
+export const Dismissable = () => (
+  <Err
+    {...actions('retry', 'dismiss')}
+    errorMessage="Complete meltdown"
+    noun="made up thing"
+  />
+)
+
+export const NonDismissable = () => (
+  <Err
+    {...actions('retry')}
+    errorMessage="Complete meltdown"
+    noun="made up thing"
+  />
+)
+
+const InlineError = (props) => (
+  <Err.Inline errorMessage="Complete meltdown" noun="stuff" {...props} />
+)
+
+export const Inline = () => (
+  <InlineTemplate
+    dismissable={<InlineError {...actions('retry')} />}
+    noRetry={<InlineError />}
+  />
+)

--- a/src/client/components/Task/__stories__/ProgressIndicator.stories.jsx
+++ b/src/client/components/Task/__stories__/ProgressIndicator.stories.jsx
@@ -1,0 +1,20 @@
+import { InlineTemplate } from './utils'
+import ProgressIndicator from '../../ProgressIndicator'
+
+export default {
+  title: 'Task/ProgressIndicator',
+  component: ProgressIndicator,
+}
+
+export const Noun = () => <ProgressIndicator noun="stuff" />
+
+export const Message = () => (
+  <ProgressIndicator message="something is in progress" />
+)
+
+export const Inline = () => (
+  <InlineTemplate
+    dismissable={<ProgressIndicator.Inline noun="stuff" />}
+    noRetry={<ProgressIndicator.Inline noun="stuff" />}
+  />
+)

--- a/src/client/components/Task/__stories__/utils.jsx
+++ b/src/client/components/Task/__stories__/utils.jsx
@@ -1,0 +1,51 @@
+import TabNav from '../../TabNav'
+import DefaultLayout from '../../Layout/DefaultLayout'
+
+export const InlineTemplate = ({ dismissable, noRetry }) => (
+  <DefaultLayout
+    heading={<>In heading {dismissable} foo bar baz</>}
+    localHeaderdismissable={<>In local header {dismissable} foo bar baz</>}
+    breadcrumbs={[
+      {
+        text: 'Foo',
+      },
+      {
+        text: noRetry,
+      },
+      {
+        text: 'Foo',
+      },
+    ]}
+  >
+    <TabNav
+      id="example"
+      label="Tab nav"
+      selectedIndex="bar"
+      tabs={{
+        foo: { label: 'Foo', content: 'Foo content' },
+        bar: {
+          label: <>Inside tab {noRetry}</>,
+          content: 'Bar content',
+        },
+        baz: { label: 'Baz', content: 'Baz content' },
+      }}
+    />
+    <h1>Inside H1 {dismissable} foo bar baz</h1>
+    <h2>Inside H2 {dismissable} foo bar baz</h2>
+    <h3>Inside H3 {dismissable} foo bar baz</h3>
+    <h4>Inside H4 {dismissable} foo bar baz</h4>
+    <h5>Inside H5 {dismissable} foo bar baz</h5>
+    <h6>Inside H6 {dismissable} foo bar baz</h6>
+    <p>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis ultrices{' '}
+      {dismissable} odio at ultricies semper. Sed fermentum tortor quis ante
+      blandit malesuada. Praesent vulputate eget dolor vel luctus. Pellentesque
+      id molestie arcu, a eleifend justo.
+    </p>
+    <ul>
+      <li>Inside list item {dismissable} foo bar baz</li>
+      <li>Inside list item {dismissable} foo bar baz</li>
+      <li>Inside list item {dismissable} foo bar baz</li>
+    </ul>
+  </DefaultLayout>
+)


### PR DESCRIPTION
## Description of change

Adds the `Task/Error.Inline` and also the `SecondaryButton.Inline` and `InlineIcon` components.

## Test instructions

1. Start storybook
2. Go to _Task > Error > Inline_ or `/?path=/story/task-error--inline`
3. You should see a demo of appearance of the new `Task/Error.Inline` component in various contexts

## Screenshots

<img width="831" alt="Screenshot 2023-12-06 at 17 13 53" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/1695e90c-7df4-4de0-92c9-b7d69d313da2">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
