### PR TITLE
bugfix/CLS2-650-dashboard-clears-query-params-on-refresh

### DIFF
--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -79,7 +79,11 @@ const PersonalisedDashboard = ({
   const history = useHistory()
 
   const previouslySelectedTabPath = readFromLocalStorage(DASHBOARD_TAB)
-  if (previouslySelectedTabPath) {
+
+  if (
+    previouslySelectedTabPath &&
+    previouslySelectedTabPath !== window.location.pathname
+  ) {
     history.push(previouslySelectedTabPath)
   }
 

--- a/test/functional/cypress/specs/dashboard/tabs-spec.js
+++ b/test/functional/cypress/specs/dashboard/tabs-spec.js
@@ -27,6 +27,16 @@ describe('Selecting a dashboard tab based on localstorage when the advisers has 
       visit(urls.dashboard.myTasks())
       assertTabSelected(TASKS)
     })
+
+    it('should keep the query params on page refresh', () => {
+      cy.localStorage(LOCAL_STORAGE_KEY, urls.dashboard.myTasks())
+      visit(`${urls.dashboard.myTasks()}?a=1&b=2`)
+      assertTabSelected(TASKS)
+      cy.reload()
+      cy.location().should((loc) => {
+        expect(loc.search).to.include('?a=1&b=2')
+      })
+    })
   })
 
   context('Company lists', () => {

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -733,6 +733,8 @@ app.get('/v4/task/:taskId', v4Task.getTask)
 app.post('/v4/task', v4Task.createTask)
 app.patch('/v4/task/:taskId', v4Task.updateTask)
 
+app.get('/v4/export', (req, res) => res.json({ count: 0, results: [] }))
+
 // Whoami endpoint
 app.get('/whoami', user.whoami)
 app.put('/whoami', user.setWhoami)


### PR DESCRIPTION
## Description of change

- Currently if you use a tab on the personalised dashboard that has filter values stored in the url, when the page is refreshed the selected filters are lost. This change keeps the selected filters during a refresh, but clicking into another tab and coming back will clear them. The upcoming tickets for adding filters to the Tasks tab require this functionality
- Added an empty route for the export pipeline into the sandbox, to avoid 404 errors in the functional tests

## Test instructions

Go to http://localhost:3000/export and choose some filters from the dropdowns. Refresh the page, and the same filters will be retained.

Click into another tab, then click the Export tab again and these filters will be removed

## Screenshots

N/A

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
