### PR TITLE
ProgressIndicator.Inline component

### DIFF
--- a/src/client/components/ProgressIndicator.jsx
+++ b/src/client/components/ProgressIndicator.jsx
@@ -1,7 +1,10 @@
 import React from 'react'
 import LoadingBox from '@govuk-react/loading-box'
 import { SPACING } from '@govuk-react/constants'
+import { Spinner } from '@govuk-react/icons'
 import styled from 'styled-components'
+
+import InlineIcon from './InlineIcon'
 
 const StyledRoot = styled.div({
   textAlign: 'center',
@@ -12,12 +15,39 @@ const StyledLoadingBox = styled(LoadingBox)({
   marginTop: SPACING.SCALE_5,
   marginBottom: SPACING.SCALE_3,
 })
-
-const ProgressIndicator = ({ message }) => (
+/**
+ * @function ProgressIndicator
+ * @description A progress indicator
+ * @param {Object} props
+ * @param {string} props.noun - A noun describing the thing in progress
+ * @param {string} [props.message = `Loading ${noun}`] - The message
+ * rendered underneath the spinner icon.
+ * @returns {JSX.Element}
+ */
+const ProgressIndicator = ({ noun, message = `Loading ${noun}` }) => (
   <StyledRoot>
     <StyledLoadingBox loading={true} />
     {message && <p>{message}</p>}
   </StyledRoot>
+)
+
+/**
+ * @function ProgressIndicator.Inline
+ * @description A progress indicator designed to be rendered nicely in any
+ * inline context.
+ * @param {Object} props
+ * @param {string} props.noun - A noun describing the thing in progress
+ * @param {string} [props.message = `Loading ${noun}`] - The message
+ * rendered next to the spinner icon.
+ * @returns {JSX.Element}
+ */
+ProgressIndicator.Inline = ({ noun, message = `Loading ${noun}` }) => (
+  <>
+    <InlineIcon>
+      <Spinner />
+    </InlineIcon>{' '}
+    <span style={{ opacity: 0.3 }}>{message}</span>
+  </>
 )
 
 export default ProgressIndicator

--- a/src/client/components/Task/__stories__/ProgressIndicator.stories.jsx
+++ b/src/client/components/Task/__stories__/ProgressIndicator.stories.jsx
@@ -1,0 +1,20 @@
+import { InlineTemplate } from './utils'
+import ProgressIndicator from '../../ProgressIndicator'
+
+export default {
+  title: 'Task/ProgressIndicator',
+  component: ProgressIndicator,
+}
+
+export const Noun = () => <ProgressIndicator noun="stuff" />
+
+export const Message = () => (
+  <ProgressIndicator message="something is in progress" />
+)
+
+export const Inline = () => (
+  <InlineTemplate
+    dismissable={<ProgressIndicator.Inline noun="stuff" />}
+    noRetry={<ProgressIndicator.Inline noun="stuff" />}
+  />
+)


### PR DESCRIPTION
## Description of change

Adds the `Task/Error.Inline` and also the `SecondaryButton.Inline` and `InlineIcon` components.

## Test instructions

1. Start storybook
2. Go to _Task > ProgressIndicator > Inline_ or `/?path=/story/task-progressindicator--inline`
3. You should see a demo of appearance of the new `Task/Error.Inline` component in various contexts

## Screenshots

<img width="1044" alt="Screenshot 2023-12-07 at 17 07 42" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/433de340-b80b-457a-ae61-c131f14e059a">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
