### PR TITLE
Company name and status added to Tasks table

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
@@ -19,16 +19,18 @@ const header = (
   <Table.Row>
     <StyledTableCellHeader>Date due</StyledTableCellHeader>
     <StyledTableCellHeader>Task title</StyledTableCellHeader>
+    <StyledTableCellHeader>Company name</StyledTableCellHeader>
     <StyledTableCellHeader>Project</StyledTableCellHeader>
     <StyledTableCellHeader>Assigned to</StyledTableCellHeader>
+    <StyledTableCellHeader>Status</StyledTableCellHeader>
   </Table.Row>
 )
 
 const rows = ({ results }) => {
   return results.map((task) => (
     <Table.Row>
-      <Table.Cell setWidth="15%">{formatMediumDate(task.due_date)}</Table.Cell>
-      <Table.Cell setWidth="40%">
+      <Table.Cell setWidth="12%">{formatMediumDate(task.due_date)}</Table.Cell>
+      <Table.Cell setWidth="23%">
         <Link
           href={urls.tasks.details(task.id)}
           data-test={`${task.id}-task-link`}
@@ -36,9 +38,13 @@ const rows = ({ results }) => {
           {task.title}
         </Link>
       </Table.Cell>
+      <Table.Cell setWidth="20%">{task.company?.name}</Table.Cell>
       <Table.Cell setWidth="20%">{task.investment_project?.name}</Table.Cell>
-      <Table.Cell setWidth="25%">
+      <Table.Cell setWidth="15%">
         <ul>{transformAdvisersListItem(task.advisers)}</ul>
+      </Table.Cell>
+      <Table.Cell setWidth="10%">
+        {task.archived ? 'Completed' : 'Active'}
       </Table.Cell>
     </Table.Row>
   ))

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -14,7 +14,10 @@ import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
 
 describe('My Tasks on the Dashboard', () => {
   const Component = (props) => <MyTasksContent {...props} />
+  // Create 3 tasks of which one is Archived
   const myTasksList = taskWithInvestmentProjectListFaker()
+  myTasksList[1].archived = true
+
   const myTaskResults = myTasksList.map((task) => keysToSnakeCase(task))
   const myTasks = {
     count: 3,
@@ -23,6 +26,7 @@ describe('My Tasks on the Dashboard', () => {
 
   context('When the logged in adviser has three tasks', () => {
     beforeEach(() => {
+      cy.viewport(1024, 768)
       cy.mount(<Component myTasks={myTasks} />)
     })
 
@@ -30,33 +34,39 @@ describe('My Tasks on the Dashboard', () => {
       cy.get('h3').should('contain', '3 tasks')
     })
 
-    it('should render three table rows in due date ascending order as this is the default', () => {
+    it('should render three table rows in due date in default ascending order', () => {
       assertGovReactTable({
         element: '[data-test="my-tasks-table"]',
         rows: [
           [
             formatMediumDate(myTaskResults[0].due_date),
             myTaskResults[0].title,
+            myTaskResults[0].company.name,
             myTaskResults[0].investment_project.name,
             myTaskResults[0].advisers[0].name +
               myTaskResults[0].advisers[1].name +
               myTaskResults[0].advisers[2].name,
+            'Active',
           ],
           [
             formatMediumDate(myTaskResults[1].due_date),
             myTaskResults[1].title,
+            myTaskResults[1].company.name,
             myTaskResults[1].investment_project.name,
             myTaskResults[1].advisers[0].name +
               myTaskResults[1].advisers[1].name +
               myTaskResults[1].advisers[2].name,
+            'Completed',
           ],
           [
             formatMediumDate(myTaskResults[2].due_date),
             myTaskResults[2].title,
+            myTaskResults[2].company.name,
             myTaskResults[2].investment_project.name,
             myTaskResults[2].advisers[0].name +
               myTaskResults[2].advisers[1].name +
               myTaskResults[2].advisers[2].name,
+            'Active',
           ],
         ],
       })
@@ -88,6 +98,7 @@ describe('My Tasks on the Dashboard', () => {
 
   context('When the logged in adviser has no tasks', () => {
     beforeEach(() => {
+      cy.viewport(1024, 768)
       cy.mount(<Component myTasks={myTasks} />)
     })
     it('should display the heading 0 tasks', () => {
@@ -116,6 +127,7 @@ describe('My Tasks on the Dashboard', () => {
 
   context('When the logged in adviser has three tasks', () => {
     beforeEach(() => {
+      cy.viewport(1024, 768)
       cy.mount(<Component myTasks={myTasks} />)
     })
 

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
@@ -1,9 +1,6 @@
 import React from 'react'
 
-import {
-  taskWithInvestmentProjectFaker,
-  taskWithInvestmentProjectNotCompleteFaker,
-} from '../../../../../functional/cypress/fakers/task'
+import { taskWithInvestmentProjectFaker } from '../../../../../functional/cypress/fakers/task'
 import DataHubProvider from '../../provider'
 import { TaskButtons } from '../../../../../../src/client/modules/Tasks/TaskDetails/TaskButtons'
 import { assertLink } from '../../../../../functional/cypress/support/assertions'
@@ -16,7 +13,7 @@ describe('Task buttons', () => {
   )
 
   context('When a task is not completed', () => {
-    const investmentProjectTask = taskWithInvestmentProjectNotCompleteFaker()
+    const investmentProjectTask = taskWithInvestmentProjectFaker()
 
     beforeEach(() => {
       cy.mount(<Component task={investmentProjectTask} editUrl={'/1/2/3'} />)

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -17,7 +17,7 @@ describe('Task details table', () => {
 
   context('When a task has all optional fields set', () => {
     const investmentProjectTask = taskWithInvestmentProjectFaker()
-    const company = investmentProjectTask.investmentProject.investorCompany
+    const company = investmentProjectTask.company
 
     it('the table should show all expected values', () => {
       cy.mount(<Component task={investmentProjectTask} company={company} />)
@@ -50,7 +50,7 @@ describe('Task details table', () => {
       description: undefined,
       emailRemindersEnabled: false,
     })
-    const company = investmentProjectTask.investmentProject.investorCompany
+    const company = investmentProjectTask.company
 
     it('the table should show all expected values', () => {
       cy.mount(<Component task={investmentProjectTask} company={company} />)

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -22,7 +22,7 @@ const taskFaker = (overrides = {}) => ({
   reminderDays: faker.helpers.rangeToNumber({ min: 0, max: 365 }),
   emailRemindersEnabled: true,
   advisers: [...Array(3)].map(() => basicAdviserFaker()),
-  archived: true,
+  archived: false,
   archivedBy: null,
   createdBy: basicAdviserFaker(),
   modifiedBy: basicAdviserFaker(),
@@ -44,7 +44,6 @@ const taskWithInvestmentProjectFaker = (overrides = {}) =>
         name: faker.word.adjective(),
       },
       company: company,
-      archived: false,
       ...overrides,
     })
   )

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -36,15 +36,20 @@ const taskWithInvestmentProjectFaker = (overrides = {}) =>
   taskFaker(
     (overrides = {
       investmentProject: {
-        investorCompany: {
-          name: faker.company.name(),
-          id: faker.string.uuid(),
-        },
         id: faker.string.uuid(),
         name: faker.word.adjective(),
       },
       id: faker.string.uuid(),
       name: faker.word.adjective(),
+      company: {
+        name: faker.company.name(),
+        id: faker.string.uuid(),
+      },
+      company: {
+        name: faker.company.name(),
+        id: faker.string.uuid(),
+      },
+      archived: false,
       ...overrides,
     })
   )

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -49,15 +49,6 @@ const taskWithInvestmentProjectFaker = (overrides = {}) =>
     })
   )
 
-const taskWithInvestmentProjectNotCompleteFaker = (overrides = {}) =>
-  taskWithInvestmentProjectFaker(
-    (overrides = {
-      archived: false,
-
-      ...overrides,
-    })
-  )
-
 const investmentProjectTaskFaker = (overrides = {}) =>
   taskFaker(
     (overrides = {
@@ -93,7 +84,6 @@ export {
   taskListFaker,
   investmentProjectTaskFaker,
   taskWithInvestmentProjectFaker,
-  taskWithInvestmentProjectNotCompleteFaker,
   taskWithInvestmentProjectListFaker,
   investmentProjectTaskListFaker,
   basicAdviserFaker,

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -3,6 +3,7 @@ import { pick } from 'lodash'
 
 import { listFaker } from './utils'
 import { investmentProjectFaker } from './investment-projects'
+import { companyFaker } from './companies'
 
 const basicAdviserFaker = (overrides = {}) => ({
   name: faker.person.fullName(),
@@ -32,23 +33,17 @@ const taskFaker = (overrides = {}) => ({
   ...overrides,
 })
 
+const company = pick(companyFaker(), ['id', 'name'])
+
 const taskWithInvestmentProjectFaker = (overrides = {}) =>
   taskFaker(
     (overrides = {
       investmentProject: {
+        investorCompany: company,
         id: faker.string.uuid(),
         name: faker.word.adjective(),
       },
-      id: faker.string.uuid(),
-      name: faker.word.adjective(),
-      company: {
-        name: faker.company.name(),
-        id: faker.string.uuid(),
-      },
-      company: {
-        name: faker.company.name(),
-        id: faker.string.uuid(),
-      },
+      company: company,
       archived: false,
       ...overrides,
     })

--- a/test/functional/cypress/specs/tasks/details-spec.js
+++ b/test/functional/cypress/specs/tasks/details-spec.js
@@ -16,9 +16,6 @@ describe('View details for task that is assigned to an investment project', () =
   const investmentProjectNotCompleteTask =
     taskWithInvestmentProjectNotCompleteFaker()
 
-  const expectedCompany =
-    investmentProjectTask.investmentProject.investorCompany
-
   context('When visiting a completed task details', () => {
     before(() => {
       cy.intercept(
@@ -34,7 +31,9 @@ describe('View details for task that is assigned to an investment project', () =
       assertBreadcrumbs({
         Home: dashboard.index(),
         Companies: companies.index(),
-        [expectedCompany.name]: companies.detail(expectedCompany.id),
+        [investmentProjectTask.company.name]: companies.detail(
+          investmentProjectTask.company.id
+        ),
         [investmentProjectTask.title]: null,
       })
     })

--- a/test/functional/cypress/specs/tasks/details-spec.js
+++ b/test/functional/cypress/specs/tasks/details-spec.js
@@ -1,8 +1,5 @@
 import { tasks, dashboard, companies } from '../../../../../src/lib/urls'
-import {
-  taskWithInvestmentProjectFaker,
-  taskWithInvestmentProjectNotCompleteFaker,
-} from '../../fakers/task'
+import { taskWithInvestmentProjectFaker } from '../../fakers/task'
 import {
   assertSummaryTable,
   assertBreadcrumbs,
@@ -16,8 +13,6 @@ describe('View details for task that is assigned to an investment project', () =
   const investmentProjectTaskCompleted = taskWithInvestmentProjectFaker({
     archived: true,
   })
-
-  taskWithInvestmentProjectNotCompleteFaker()
 
   context('When visiting a completed task details', () => {
     before(() => {

--- a/test/functional/cypress/specs/tasks/details-spec.js
+++ b/test/functional/cypress/specs/tasks/details-spec.js
@@ -13,17 +13,20 @@ import { clickButton } from '../../support/actions'
 
 describe('View details for task that is assigned to an investment project', () => {
   const investmentProjectTask = taskWithInvestmentProjectFaker()
-  const investmentProjectNotCompleteTask =
-    taskWithInvestmentProjectNotCompleteFaker()
+  const investmentProjectTaskCompleted = taskWithInvestmentProjectFaker({
+    archived: true,
+  })
+
+  taskWithInvestmentProjectNotCompleteFaker()
 
   context('When visiting a completed task details', () => {
     before(() => {
       cy.intercept(
         'GET',
-        `/api-proxy/v4/task/${investmentProjectTask.id}`,
-        investmentProjectTask
+        `/api-proxy/v4/task/${investmentProjectTaskCompleted.id}`,
+        investmentProjectTaskCompleted
       ).as('apiRequest')
-      cy.visit(tasks.details(investmentProjectTask.id))
+      cy.visit(tasks.details(investmentProjectTaskCompleted.id))
       cy.wait('@apiRequest')
     })
 
@@ -31,17 +34,17 @@ describe('View details for task that is assigned to an investment project', () =
       assertBreadcrumbs({
         Home: dashboard.index(),
         Companies: companies.index(),
-        [investmentProjectTask.company.name]: companies.detail(
-          investmentProjectTask.company.id
+        [investmentProjectTaskCompleted.company.name]: companies.detail(
+          investmentProjectTaskCompleted.company.id
         ),
-        [investmentProjectTask.title]: null,
+        [investmentProjectTaskCompleted.title]: null,
       })
     })
 
     it('should display the title of the investment project task and completed tag', () => {
       cy.get('[data-test="heading"]').should(
         'contain',
-        investmentProjectTask.title
+        investmentProjectTaskCompleted.title
       )
 
       cy.get('[data-test="activity-kind-label"]').should('contain', 'COMPLETED')
@@ -58,23 +61,23 @@ describe('View details for task that is assigned to an investment project', () =
     before(() => {
       cy.intercept(
         'GET',
-        `/api-proxy/v4/task/${investmentProjectNotCompleteTask.id}`,
-        investmentProjectNotCompleteTask
+        `/api-proxy/v4/task/${investmentProjectTask.id}`,
+        investmentProjectTask
       ).as('apiRequest')
-      cy.visit(tasks.details(investmentProjectNotCompleteTask.id))
+      cy.visit(tasks.details(investmentProjectTask.id))
       cy.wait('@apiRequest')
     })
 
     it('should redirect to the investment project and show the Flash message after marking as complete', () => {
       cy.intercept(
         'POST',
-        `/api-proxy/v4/task/${investmentProjectNotCompleteTask.id}/archive`,
+        `/api-proxy/v4/task/${investmentProjectTask.id}/archive`,
         {}
       ).as('postTaskArchiveApiRequest')
       clickButton('Mark as complete')
       assertPayload('@postTaskArchiveApiRequest', { reason: 'completed' })
       assertUrl(
-        `/investments/projects/${investmentProjectNotCompleteTask.investmentProject.id}/tasks`
+        `/investments/projects/${investmentProjectTask.investmentProject.id}/tasks`
       )
     })
   })


### PR DESCRIPTION
## Description of change

Add Company name and status columns to Tasks table

## Test instructions

Download this branch. Run against Dev. Ensure you have two tasks assigned to yourself with one completed and the other not. View that the tasks table has the additional columns and that the status of the tasks displays correctly.

## Screenshots

### Before
![Screenshot 2023-12-08 at 13 56 35](https://github.com/uktrade/data-hub-frontend/assets/72826129/568ad26f-569b-45e6-b16f-6b839eb78a32)

### After
![Screenshot 2023-12-08 at 13 59 10](https://github.com/uktrade/data-hub-frontend/assets/72826129/0195f245-f576-418c-aa0e-53b860707871)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
