### PR TITLE
Rename task-assigned-to-me-from-others: add my-tasks prefix

### DIFF
--- a/src/client/components/Resource/TaskAssignedToMeFromOthersSettings.js
+++ b/src/client/components/Resource/TaskAssignedToMeFromOthersSettings.js
@@ -2,5 +2,5 @@ import { createEntityResource } from './Resource'
 
 export default createEntityResource(
   'TaskAssignedToMeFromOthersSettings',
-  () => `v4/reminder/subscription/task-assigned-to-me-from-others`
+  () => `v4/reminder/subscription/my-tasks-task-assigned-to-me-from-others`
 )

--- a/src/client/modules/Reminders/Settings/tasks.js
+++ b/src/client/modules/Reminders/Settings/tasks.js
@@ -151,7 +151,7 @@ export const saveUpcomingDueDateExportSubscriptions = (payload) =>
 
 export const saveTaskAssignedToMeFromOthersExportSubscriptions = (payload) =>
   apiProxyAxios.patch(
-    '/v4/reminder/subscription/task-assigned-to-me-from-others',
+    '/v4/reminder/subscription/my-tasks-task-assigned-to-me-from-others',
     payload
   )
 

--- a/src/client/modules/Reminders/tasks.js
+++ b/src/client/modules/Reminders/tasks.js
@@ -143,7 +143,9 @@ export const getNextTaskAssignedToMeFromOthersReminder = ({
   getNextReminder(sortby, page, limit, 'task-assigned-to-me-from-others')
 
 export const deleteTaskAssignedToMeFromOthersReminder = ({ id } = {}) =>
-  apiProxyAxios.delete(`/v4/reminder/task-assigned-to-me-from-others/${id}`)
+  apiProxyAxios.delete(
+    `/v4/reminder/my-tasks-task-assigned-to-me-from-others/${id}`
+  )
 
 export const getTaskAmendedByOthersReminders = ({
   sortby = '-created_on',

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -29,7 +29,7 @@ const ALLOWLIST = [
   '/v4/reminder/no-recent-investment-interaction',
   '/v4/reminder/new-export-interaction',
   '/v4/reminder/my-tasks-due-date-approaching',
-  '/v4/reminder/task-assigned-to-me-from-others',
+  '/v4/reminder/my-tasks-task-assigned-to-me-from-others',
   '/v4/reminder/my-tasks-task-amended-by-others',
   '/v4/reminder/my-tasks-task-overdue',
   '/v4/reminder/my-tasks-task-completed',

--- a/test/functional/cypress/specs/reminders/settings/task-assigned-to-me-from-others-spec.js
+++ b/test/functional/cypress/specs/reminders/settings/task-assigned-to-me-from-others-spec.js
@@ -2,7 +2,7 @@ import { assertBreadcrumbs, assertPayload } from '../../../support/assertions'
 import urls from '../../../../../../src/lib/urls'
 
 const endpoint =
-  '/api-proxy/v4/reminder/subscription/task-assigned-to-me-from-others'
+  '/api-proxy/v4/reminder/subscription/my-tasks-task-assigned-to-me-from-others'
 
 describe('Settings - task assigned to me from others', () => {
   context('Page breadcrumbs and title', () => {

--- a/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
@@ -5,7 +5,7 @@ import { formatWithoutParsing } from '../../../../../src/client/utils/date'
 import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
 
 const remindersEndpoint =
-  '/api-proxy/v4/reminder/task-assigned-to-me-from-others'
+  '/api-proxy/v4/reminder/my-tasks-task-assigned-to-me-from-others'
 
 describe('My Tasks Task Assigned To Me From Others Reminders', () => {
   after(() => {

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -574,12 +574,12 @@ app.patch(
 )
 
 app.get(
-  '/v4/reminder/subscription/task-assigned-to-me-from-others',
+  '/v4/reminder/subscription/my-tasks-task-assigned-to-me-from-others',
   v4Reminders.getSubscriptions
 )
 
 app.patch(
-  '/v4/reminder/subscription/task-assigned-to-me-from-others',
+  '/v4/reminder/subscription/my-tasks-task-assigned-to-me-from-others',
   v4Reminders.saveSubscriptions
 )
 
@@ -655,10 +655,13 @@ app.delete(
   v4Reminders.deleteReminder
 )
 
-app.get('/v4/reminder/task-assigned-to-me-from-others', v4Reminder.myTasks)
+app.get(
+  '/v4/reminder/my-tasks-task-assigned-to-me-from-others',
+  v4Reminder.myTasks
+)
 
 app.delete(
-  '/v4/reminder/task-assigned-to-me-from-others/:id',
+  '/v4/reminder/my-tasks-task-assigned-to-me-from-others/:id',
   v4Reminders.deleteReminder
 )
 


### PR DESCRIPTION
## Description of change

Update the front end to use new API urls:

- reminder/subscription/task-assigned-to-me-from-others

- reminder/task-assigned-to-me-from-others

- reminder/task-assigned-to-me-from-others

All of the above need to be prefixed by `my-tasks-...`

## Checklist

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
