### PR TITLE
Cls2 588 sort by filter

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -38,6 +38,13 @@ export const MyTasksContent = ({ myTasks, filters }) => (
             options={filters?.createdBy?.options}
           />
         </StyledGridCol>
+        <StyledGridCol>
+          <TaskListSelect
+            label="Sort by"
+            qsParam="sortby"
+            options={filters?.sortby?.options}
+          />
+        </StyledGridCol>
       </GridRow>
     </StyledHeader>
     <SpacedSectionBreak />

--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
-import { HintText, GridCol, GridRow } from 'govuk-react'
+import { HintText } from 'govuk-react'
 
 import { GET_MY_TASKS_ID, TASK_GET_MY_TASKS, state2props } from './state'
 import { MY_TASKS_LOADED } from '../../../actions'
@@ -13,40 +13,33 @@ import MyTasksTable from './MyTasksTable'
 import TaskListSelect from './TaskListSelect'
 import SpacedSectionBreak from '../../SpacedSectionBreak'
 
-const StyledHeader = styled('header')({
-  [MEDIA_QUERIES.DESKTOP]: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    margin: `-${SPACING.SCALE_1} -${SPACING.SCALE_2}`,
+const FiltersContainer = styled('div')({
+  display: 'grid',
+  rowGap: 15,
+  [MEDIA_QUERIES.TABLET]: {
+    columnGap: 2,
+    gridTemplateColumns: '50% 50%',
   },
-})
-
-const StyledGridCol = styled(GridCol)({
+  [MEDIA_QUERIES.DESKTOP]: {
+    gridTemplateColumns: '25% 25% 25% 25%',
+  },
   marginBottom: SPACING.SCALE_3,
-  paddingBottom: SPACING.SCALE_3,
-  paddingLeft: '25px',
 })
 
 export const MyTasksContent = ({ myTasks, filters }) => (
   <>
-    <StyledHeader>
-      <GridRow>
-        <StyledGridCol>
-          <TaskListSelect
-            label="Created by"
-            qsParam="created_by"
-            options={filters?.createdBy?.options}
-          />
-        </StyledGridCol>
-        <StyledGridCol>
-          <TaskListSelect
-            label="Sort by"
-            qsParam="sortby"
-            options={filters?.sortby?.options}
-          />
-        </StyledGridCol>
-      </GridRow>
-    </StyledHeader>
+    <FiltersContainer>
+      <TaskListSelect
+        label="Created by"
+        qsParam="created_by"
+        options={filters?.createdBy?.options}
+      />
+      <TaskListSelect
+        label="Sort by"
+        qsParam="sortby"
+        options={filters?.sortby?.options}
+      />
+    </FiltersContainer>
     <SpacedSectionBreak />
     <ContentWithHeading
       heading={`${myTasks?.count} ${myTasks?.count == 1 ? 'task' : 'tasks'}`}

--- a/src/client/components/Dashboard/my-tasks/TaskListSelect.jsx
+++ b/src/client/components/Dashboard/my-tasks/TaskListSelect.jsx
@@ -4,25 +4,16 @@ import { Select } from 'govuk-react'
 import styled from 'styled-components'
 import { get, kebabCase } from 'lodash'
 import qs from 'qs'
-import { BREAKPOINTS } from '@govuk-react/constants'
 
-const StyledSelect = styled(Select)`
-  select {
-    @media (min-width: ${BREAKPOINTS.SMALLSCREEN}) {
-      width: auto;
-    }
-    @media (min-width: ${BREAKPOINTS.TABLET}) {
-      width: auto;
-    }
-    @media (min-width: ${BREAKPOINTS.DESKTOP}) {
-      width: 150%;
-    }
-  }
-  span {
-    font-weight: bold;
-    font-size: 17px;
-  }
-`
+const StyledSelect = styled(Select)({
+  select: {
+    width: '100%',
+  },
+  span: {
+    fontWeight: 'bold',
+    fontSize: '17px',
+  },
+})
 
 const TaskSelect = ({ label, options = [], qsParam }) => {
   const history = useHistory()

--- a/src/client/components/Dashboard/my-tasks/TaskListSelect.jsx
+++ b/src/client/components/Dashboard/my-tasks/TaskListSelect.jsx
@@ -4,14 +4,15 @@ import { Select } from 'govuk-react'
 import styled from 'styled-components'
 import { get, kebabCase } from 'lodash'
 import qs from 'qs'
+import { FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 
 const StyledSelect = styled(Select)({
   select: {
     width: '100%',
   },
   span: {
-    fontWeight: 'bold',
-    fontSize: '17px',
+    fontWeight: FONT_WEIGHTS.bold,
+    fontSize: FONT_SIZE.SIZE_16,
   },
 })
 

--- a/src/client/components/Dashboard/my-tasks/constants.js
+++ b/src/client/components/Dashboard/my-tasks/constants.js
@@ -9,6 +9,29 @@ export const CREATED_BY_OPTIONS = [
   },
 ]
 
+export const SORT_BY_LIST_OPTIONS = [
+  {
+    label: 'Due date',
+    value: 'due_date',
+  },
+  {
+    label: 'Recently updated',
+    value: 'recently_updated',
+  },
+  {
+    label: 'Least recently updated',
+    value: 'least_recently_updated',
+  },
+  {
+    label: 'Company A-Z',
+    value: 'company_ascending',
+  },
+  {
+    label: 'Project A-Z',
+    value: 'project_ascending',
+  },
+]
+
 export const SHOW_ALL_OPTION = {
   label: 'Show all',
   value: 'all-statuses',

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -3,7 +3,7 @@ import { omitBy, isEmpty } from 'lodash'
 import { getQueryParamsFromLocation } from '../../../../client/utils/url'
 import { parsePage } from '../../../../client/utils/pagination'
 
-import { CREATED_BY_LIST_OPTIONS } from './constants'
+import { CREATED_BY_LIST_OPTIONS, SORT_BY_LIST_OPTIONS } from './constants'
 
 export const ID = 'getMyTasks'
 export const TASK_GET_MY_TASKS = 'TASK_GET_MY_TASKS'
@@ -27,6 +27,7 @@ export const state2props = ({ router, ...state }) => {
     created_by: undefined,
     not_created_by: undefined,
     adviser: [currentAdviserId],
+    sortby: 'due_date:asc',
   }
   if (queryParams.created_by === 'me') {
     payload.created_by = currentAdviserId
@@ -35,6 +36,21 @@ export const state2props = ({ router, ...state }) => {
   if (queryParams.created_by === 'others') {
     payload.not_created_by = currentAdviserId
   }
+  if (queryParams.sortby === 'due_date') {
+    payload.sortby = 'due_date:asc'
+  }
+  if (queryParams.sortby === 'recently_updated') {
+    payload.sortby = 'modified_on:desc'
+  }
+  if (queryParams.sortby === 'least_recently_updated') {
+    payload.sortby = 'modified_on:asc'
+  }
+  if (queryParams.sortby === 'company_ascending') {
+    payload.sortby = 'company.name:asc'
+  }
+  if (queryParams.sortby === 'project_ascending') {
+    payload.sortby = 'investment_project.name:asc'
+  }
   return {
     ...state[ID],
     payload: payload,
@@ -42,6 +58,9 @@ export const state2props = ({ router, ...state }) => {
       areActive: areFiltersActive(queryParams),
       createdBy: {
         options: CREATED_BY_LIST_OPTIONS,
+      },
+      sortby: {
+        options: SORT_BY_LIST_OPTIONS,
       },
     },
   }

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -18,6 +18,14 @@ const areFiltersActive = (queryParams) => {
   return !isEmpty(filters)
 }
 
+const sortbyMapping = {
+  due_date: 'due_date:asc',
+  recently_updated: 'modified_on:desc',
+  least_recently_updated: 'modified_on:asc',
+  company_ascending: 'company.name:asc',
+  project_ascending: 'investment_project.name:asc',
+}
+
 export const state2props = ({ router, ...state }) => {
   const queryParams = getQueryParamsFromLocation(router.location)
   const { currentAdviserId } = state
@@ -29,6 +37,7 @@ export const state2props = ({ router, ...state }) => {
     adviser: [currentAdviserId],
     sortby: 'due_date:asc',
   }
+
   if (queryParams.created_by === 'me') {
     payload.created_by = currentAdviserId
   }
@@ -36,21 +45,11 @@ export const state2props = ({ router, ...state }) => {
   if (queryParams.created_by === 'others') {
     payload.not_created_by = currentAdviserId
   }
-  if (queryParams.sortby === 'due_date') {
-    payload.sortby = 'due_date:asc'
+
+  if (queryParams.sortby in sortbyMapping) {
+    payload.sortby = sortbyMapping[queryParams.sortby]
   }
-  if (queryParams.sortby === 'recently_updated') {
-    payload.sortby = 'modified_on:desc'
-  }
-  if (queryParams.sortby === 'least_recently_updated') {
-    payload.sortby = 'modified_on:asc'
-  }
-  if (queryParams.sortby === 'company_ascending') {
-    payload.sortby = 'company.name:asc'
-  }
-  if (queryParams.sortby === 'project_ascending') {
-    payload.sortby = 'investment_project.name:asc'
-  }
+
   return {
     ...state[ID],
     payload: payload,

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -160,9 +160,7 @@ describe('Task filters', () => {
         assertListItems({ length: 1 })
         cy.get(`${element} select`).find(':selected').contains(label)
       })
-    })
 
-    sortbyOptionsData.forEach(({ label, sortBy }) => {
       it(`should filter ${label} from user input`, () => {
         cy.intercept('POST', endpoint, {
           body: {

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -171,7 +171,7 @@ describe('Task filters', () => {
         cy.visit(tasksTab)
         assertListItems({ length: 3 })
 
-        // Select a different option so the API is called for when testing Due Date
+        // Select a different option so the API is called when testing Due Date
         if (label === 'Due date') {
           cy.get(`${element} select`).select('Recently updated')
         }

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -93,6 +93,34 @@ describe('Task filters', () => {
   context('Sort by', () => {
     const element = '[data-test="sortby-select"]'
 
+    const sortbyOptionsData = [
+      {
+        label: 'Due date',
+        value: 'due_date',
+        sortBy: 'due_date:asc',
+      },
+      {
+        label: 'Recently updated',
+        value: 'recently_updated',
+        sortBy: 'modified_on:desc',
+      },
+      {
+        label: 'Least recently updated',
+        value: 'least_recently_updated',
+        sortBy: 'modified_on:asc',
+      },
+      {
+        label: 'Company A-Z',
+        value: 'company_ascending',
+        sortBy: 'company.name:asc',
+      },
+      {
+        label: 'Project A-Z',
+        value: 'project_ascending',
+        sortBy: 'investment_project.name:asc',
+      },
+    ]
+
     it('should have a "Sort by" filter', () => {
       cy.intercept('POST', endpoint, {
         body: {
@@ -104,13 +132,9 @@ describe('Task filters', () => {
 
       cy.get(element).find('span').should('have.text', 'Sort by')
       cy.get(`${element} option`).then((sortByOptions) => {
-        expect(transformOptions(sortByOptions)).to.deep.eq([
-          { value: 'due_date', label: 'Due date' },
-          { value: 'recently_updated', label: 'Recently updated' },
-          { value: 'least_recently_updated', label: 'Least recently updated' },
-          { value: 'company_ascending', label: 'Company A-Z' },
-          { value: 'project_ascending', label: 'Project A-Z' },
-        ])
+        expect(transformOptions(sortByOptions)).to.deep.eq(
+          transformOptions(sortbyOptionsData)
+        )
       })
     })
 
@@ -136,30 +160,7 @@ describe('Task filters', () => {
       cy.get(`${element} select`).find(':selected').contains('Due date')
     })
 
-    const testData = [
-      {
-        label: 'Due date',
-        sortBy: 'due_date:asc',
-      },
-      {
-        label: 'Recently updated',
-        sortBy: 'modified_on:desc',
-      },
-      {
-        label: 'Least recently updated',
-        sortBy: 'modified_on:asc',
-      },
-      {
-        label: 'Company A-Z',
-        sortBy: 'company.name:asc',
-      },
-      {
-        label: 'Project A-Z',
-        sortBy: 'investment_project.name:asc',
-      },
-    ]
-
-    testData.forEach(({ label, sortBy }) => {
+    sortbyOptionsData.forEach(({ label, sortBy }) => {
       it(`should filter ${label} from user input`, () => {
         cy.intercept('POST', endpoint, {
           body: {

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -138,26 +138,28 @@ describe('Task filters', () => {
       })
     })
 
-    it('should filter from the url', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestSortBy')
-      cy.visit(`${tasksTab}?sortby=due_date&page=1`)
+    sortbyOptionsData.forEach(({ label, value, sortBy }) => {
+      it(`should filter ${label} from the url`, () => {
+        cy.intercept('POST', endpoint, {
+          body: {
+            count: 1,
+            results: [TaskList[0]],
+          },
+        }).as('apiRequestSortBy')
+        cy.visit(`${tasksTab}?sortby=${value}&page=1`)
 
-      // This ignores the checkForMyTasks API call which happens on page load
-      cy.wait('@apiRequestSortBy')
+        // This ignores the checkForMyTasks API call which happens on page load
+        cy.wait('@apiRequestSortBy')
 
-      assertPayload('@apiRequestSortBy', {
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        sortby: 'due_date:asc',
+        assertPayload('@apiRequestSortBy', {
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          sortby: sortBy,
+        })
+        assertListItems({ length: 1 })
+        cy.get(`${element} select`).find(':selected').contains(label)
       })
-      assertListItems({ length: 1 })
-      cy.get(`${element} select`).find(':selected').contains('Due date')
     })
 
     sortbyOptionsData.forEach(({ label, sortBy }) => {


### PR DESCRIPTION
## Description of change

Add `sort by` filter to Tasks tab. Can filter on due date, recently updated, least recently updated, Company A-Z and investment project A-Z

## Test instructions

Go to the `/my-tasks` page. Select the sort by filter. Results should change based on your selection

### After

![Screenshot 2023-12-13 at 14 23 10](https://github.com/uktrade/data-hub-frontend/assets/54268863/f50d38a6-33c8-4964-9a00-8caef9185d8f)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
