### PR TITLE
bugfix/task-reminder-rendering-error

### DIFF
--- a/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
@@ -14,16 +14,15 @@ const ItemHint = styled('span')({
 
 const ItemContent = ({ item }) => (
   <ul>
-    <li>
-      <ItemHint>Company: </ItemHint>
-      <Link
-        href={urls.companies.detail(
-          item.task.investment_project.investor_company.id
-        )}
-      >
-        {item.task.investment_project.investor_company.name}
-      </Link>
-    </li>
+    {item.task.company && (
+      <li>
+        <ItemHint>Company: </ItemHint>
+        <Link href={urls.companies.detail(item.task.company.id)}>
+          {item.task.company.name}
+        </Link>
+      </li>
+    )}
+
     <li>
       <ItemHint>Date due: </ItemHint>
       {format(item.task.due_date, DATE_LONG_FORMAT_1)}
@@ -36,7 +35,7 @@ const MyTasksItemRenderer = (item, onDeleteReminder, disableDelete) => (
     item={item}
     onDeleteReminder={onDeleteReminder}
     disableDelete={disableDelete}
-    deletedText={`${item.event} for ${item.task.investment_project.name}`}
+    deletedText={`${item.event} for ${item.task.title}`}
     headerLinkHref={urls.tasks.details(item.task.id)}
     headerLinkTitle={item.event}
     itemContent={<ItemContent item={item} />}

--- a/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
@@ -35,7 +35,9 @@ const MyTasksItemRenderer = (item, onDeleteReminder, disableDelete) => (
     item={item}
     onDeleteReminder={onDeleteReminder}
     disableDelete={disableDelete}
-    deletedText={`${item.event} for ${item.task.title}`}
+    deletedText={`${item.event} for ${
+      item.task.company ? item.task.company.name : item.task.title
+    }`}
     headerLinkHref={urls.tasks.details(item.task.id)}
     headerLinkTitle={item.event}
     itemContent={<ItemContent item={item} />}

--- a/test/functional/cypress/fakers/reminders.js
+++ b/test/functional/cypress/fakers/reminders.js
@@ -57,6 +57,7 @@ export const exportReminderFaker = (overrides = {}) => ({
   ...overrides,
 })
 
+const taskCompany = nestedCompanyFaker()
 export const myTasksReminderFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
   created_on: faker.date.past({ years: 1 }),
@@ -64,11 +65,13 @@ export const myTasksReminderFaker = (overrides = {}) => ({
   task: {
     id: faker.string.uuid(),
     due_date: faker.date.future({ years: 1 }),
+    title: faker.lorem.word(),
+    company: taskCompany,
     investment_project: {
       id: faker.string.uuid(),
       name: faker.lorem.words(),
       project_code: investmentProjectCodeFaker(),
-      investor_company: nestedCompanyFaker(),
+      investor_company: taskCompany,
     },
   },
   ...overrides,

--- a/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
@@ -264,7 +264,7 @@ describe('My Tasks Due Date Approaching Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${reminders[4].event} for ${reminders[4].task.investment_project.name}`
+          `${reminders[4].event} for ${reminders[4].task.company.name}`
         )
         .find('a')
         .should('not.exist')
@@ -283,17 +283,12 @@ describe('My Tasks Due Date Approaching Reminders', () => {
             DATE_LONG_FORMAT_1
           )}`
         )
-        .should(
-          'contain',
-          `Company: ${nextReminder.task.investment_project.investor_company.name}`
-        )
+        .should('contain', `Company: ${nextReminder.task.company.name}`)
         .find('a')
         .should(
           'have.attr',
           'href',
-          urls.companies.detail(
-            nextReminder.task.investment_project.investor_company.id
-          )
+          urls.companies.detail(nextReminder.task.company.id)
         )
     })
   })

--- a/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
@@ -261,7 +261,7 @@ describe('My Tasks Task Overdue Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${reminders[4].event} for ${reminders[4].task.investment_project.name}`
+          `${reminders[4].event} for ${reminders[4].task.company.name}`
         )
         .find('a')
         .should('not.exist')
@@ -280,17 +280,12 @@ describe('My Tasks Task Overdue Reminders', () => {
             DATE_LONG_FORMAT_1
           )}`
         )
-        .should(
-          'contain',
-          `Company: ${nextReminder.task.investment_project.investor_company.name}`
-        )
+        .should('contain', `Company: ${nextReminder.task.company.name}`)
         .find('a')
         .should(
           'have.attr',
           'href',
-          urls.companies.detail(
-            nextReminder.task.investment_project.investor_company.id
-          )
+          urls.companies.detail(nextReminder.task.company.id)
         )
     })
   })

--- a/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
@@ -265,7 +265,7 @@ describe('Task Amended By Others Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${reminders[4].event} for ${reminders[4].task.investment_project.name}`
+          `${reminders[4].event} for ${reminders[4].task.company.name}`
         )
         .find('a')
         .should('not.exist')
@@ -284,17 +284,12 @@ describe('Task Amended By Others Reminders', () => {
             DATE_LONG_FORMAT_1
           )}`
         )
-        .should(
-          'contain',
-          `Company: ${nextReminder.task.investment_project.investor_company.name}`
-        )
+        .should('contain', `Company: ${nextReminder.task.company.name}`)
         .find('a')
         .should(
           'have.attr',
           'href',
-          urls.companies.detail(
-            nextReminder.task.investment_project.investor_company.id
-          )
+          urls.companies.detail(nextReminder.task.company.id)
         )
     })
   })

--- a/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
@@ -265,7 +265,7 @@ describe('My Tasks Task Assigned To Me From Others Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${reminders[4].event} for ${reminders[4].task.investment_project.name}`
+          `${reminders[4].event} for ${reminders[4].task.company.name}`
         )
         .find('a')
         .should('not.exist')
@@ -284,17 +284,12 @@ describe('My Tasks Task Assigned To Me From Others Reminders', () => {
             DATE_LONG_FORMAT_1
           )}`
         )
-        .should(
-          'contain',
-          `Company: ${nextReminder.task.investment_project.investor_company.name}`
-        )
+        .should('contain', `Company: ${nextReminder.task.company.name}`)
         .find('a')
         .should(
           'have.attr',
           'href',
-          urls.companies.detail(
-            nextReminder.task.investment_project.investor_company.id
-          )
+          urls.companies.detail(nextReminder.task.company.id)
         )
     })
   })

--- a/test/functional/cypress/specs/reminders/task-completed-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-completed-list-spec.js
@@ -261,7 +261,7 @@ describe('My Tasks Task Completed Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${reminders[4].event} for ${reminders[4].task.investment_project.name}`
+          `${reminders[4].event} for ${reminders[4].task.company.name}`
         )
         .find('a')
         .should('not.exist')
@@ -280,17 +280,12 @@ describe('My Tasks Task Completed Reminders', () => {
             DATE_LONG_FORMAT_1
           )}`
         )
-        .should(
-          'contain',
-          `Company: ${nextReminder.task.investment_project.investor_company.name}`
-        )
+        .should('contain', `Company: ${nextReminder.task.company.name}`)
         .find('a')
         .should(
           'have.attr',
           'href',
-          urls.companies.detail(
-            nextReminder.task.investment_project.investor_company.id
-          )
+          urls.companies.detail(nextReminder.task.company.id)
         )
     })
   })


### PR DESCRIPTION
## Description of change

With the addition of company and generic tasks, the reminders page is erroring as it's accessing the `investment_project` prop that is missing for these new types of tasks

## Test instructions

Go to http://localhost:3000/reminders/my-tasks-task-assigned-to-me-from-others or any of the reminder pages, there will not be any errors. Do the same test of the dev site and the page will error


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
