### PR TITLE
Cls2 602 fe task filter assigned to

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -30,6 +30,11 @@ export const MyTasksContent = ({ myTasks, filters }) => (
   <>
     <FiltersContainer>
       <TaskListSelect
+        label="Assigned to"
+        qsParam="assigned_to"
+        options={filters?.assignedTo?.options}
+      />
+      <TaskListSelect
         label="Created by"
         qsParam="created_by"
         options={filters?.createdBy?.options}

--- a/src/client/components/Dashboard/my-tasks/constants.js
+++ b/src/client/components/Dashboard/my-tasks/constants.js
@@ -1,3 +1,14 @@
+export const ASSIGNED_TO_OPTIONS = [
+  {
+    label: 'Me',
+    value: 'me',
+  },
+  {
+    label: 'Others',
+    value: 'others',
+  },
+]
+
 export const CREATED_BY_OPTIONS = [
   {
     label: 'Me',
@@ -38,3 +49,8 @@ export const SHOW_ALL_OPTION = {
 }
 
 export const CREATED_BY_LIST_OPTIONS = [SHOW_ALL_OPTION, ...CREATED_BY_OPTIONS]
+
+export const ASSIGNED_TO_LIST_OPTIONS = [
+  SHOW_ALL_OPTION,
+  ...ASSIGNED_TO_OPTIONS,
+]

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -37,19 +37,11 @@ export const state2props = ({ router, ...state }) => {
     ...queryParams,
     page: parsePage(queryParams.page),
     created_by: undefined,
-    advisers: undefined,
     not_created_by: undefined,
+    advisers: undefined,
     not_advisers: undefined,
     adviser: [currentAdviserId],
     sortby: 'due_date:asc',
-  }
-
-  if (queryParams.created_by === 'me') {
-    payload.created_by = currentAdviserId
-  }
-
-  if (queryParams.created_by === 'others') {
-    payload.not_created_by = currentAdviserId
   }
 
   if (queryParams.assigned_to === 'me') {
@@ -58,6 +50,14 @@ export const state2props = ({ router, ...state }) => {
 
   if (queryParams.assigned_to === 'others') {
     payload.not_advisers = [currentAdviserId]
+  }
+
+  if (queryParams.created_by === 'me') {
+    payload.created_by = currentAdviserId
+  }
+
+  if (queryParams.created_by === 'others') {
+    payload.not_created_by = currentAdviserId
   }
 
   if (queryParams.sortby in sortbyMapping) {

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -3,7 +3,11 @@ import { omitBy, isEmpty } from 'lodash'
 import { getQueryParamsFromLocation } from '../../../../client/utils/url'
 import { parsePage } from '../../../../client/utils/pagination'
 
-import { CREATED_BY_LIST_OPTIONS, SORT_BY_LIST_OPTIONS } from './constants'
+import {
+  ASSIGNED_TO_LIST_OPTIONS,
+  CREATED_BY_LIST_OPTIONS,
+  SORT_BY_LIST_OPTIONS,
+} from './constants'
 
 export const ID = 'getMyTasks'
 export const TASK_GET_MY_TASKS = 'TASK_GET_MY_TASKS'
@@ -33,7 +37,9 @@ export const state2props = ({ router, ...state }) => {
     ...queryParams,
     page: parsePage(queryParams.page),
     created_by: undefined,
+    advisers: undefined,
     not_created_by: undefined,
+    not_advisers: undefined,
     adviser: [currentAdviserId],
     sortby: 'due_date:asc',
   }
@@ -46,6 +52,14 @@ export const state2props = ({ router, ...state }) => {
     payload.not_created_by = currentAdviserId
   }
 
+  if (queryParams.assigned_to === 'me') {
+    payload.advisers = [currentAdviserId]
+  }
+
+  if (queryParams.assigned_to === 'others') {
+    payload.not_advisers = [currentAdviserId]
+  }
+
   if (queryParams.sortby in sortbyMapping) {
     payload.sortby = sortbyMapping[queryParams.sortby]
   }
@@ -55,6 +69,9 @@ export const state2props = ({ router, ...state }) => {
     payload: payload,
     filters: {
       areActive: areFiltersActive(queryParams),
+      assignedTo: {
+        options: ASSIGNED_TO_LIST_OPTIONS,
+      },
       createdBy: {
         options: CREATED_BY_LIST_OPTIONS,
       },

--- a/src/client/components/Dashboard/my-tasks/tasks.js
+++ b/src/client/components/Dashboard/my-tasks/tasks.js
@@ -4,6 +4,8 @@ export const getMyTasks = ({
   adviser,
   created_by,
   not_created_by,
+  advisers,
+  not_advisers,
   sortby = 'due_date:asc',
 }) =>
   apiProxyAxios
@@ -12,6 +14,8 @@ export const getMyTasks = ({
       offset: 0,
       created_by: created_by,
       not_created_by: not_created_by,
+      advisers: advisers,
+      not_advisers: not_advisers,
       adviser: adviser,
       sortby,
     })

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -10,7 +10,10 @@ import { taskWithInvestmentProjectListFaker } from '../../../../../functional/cy
 import { formatMediumDate } from '../../../../../../src/client/utils/date'
 import { MyTasksContent } from '../../../../../../src/client/components/Dashboard/my-tasks/MyTasks'
 import urls from '../../../../../../src/lib/urls'
-import { CREATED_BY_LIST_OPTIONS } from '../../../../../../src/client/components/Dashboard/my-tasks/constants'
+import {
+  ASSIGNED_TO_LIST_OPTIONS,
+  CREATED_BY_LIST_OPTIONS,
+} from '../../../../../../src/client/components/Dashboard/my-tasks/constants'
 
 import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
 
@@ -32,6 +35,9 @@ describe('My Tasks on the Dashboard', () => {
 
   const filtersList = {
     areActive: false,
+    assignedTo: {
+      options: [ASSIGNED_TO_LIST_OPTIONS],
+    },
     createdBy: {
       options: [CREATED_BY_LIST_OPTIONS],
     },

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -40,7 +40,7 @@ describe('Task filters', () => {
       })
     })
 
-    it('should filter from the url', () => {
+    it('should filter created by me from the url', () => {
       cy.intercept('POST', endpoint, {
         body: {
           count: 1,
@@ -63,7 +63,30 @@ describe('Task filters', () => {
       cy.get(`${element} select`).find(':selected').contains('Me')
     })
 
-    it('should filter from user input', () => {
+    it('should filter created by others from the url', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestCreatedBy')
+      cy.visit(`${tasksTab}?created_by=others&page=1`)
+
+      // This ignores the checkForMyTasks API call which happens on page load
+      cy.wait('@apiRequestCreatedBy')
+
+      assertPayload('@apiRequestCreatedBy', {
+        not_created_by: myAdviserId,
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+      cy.get(`${element} select`).find(':selected').contains('Others')
+    })
+
+    it('should filter created by me from user input', () => {
       cy.intercept('POST', endpoint, {
         body: {
           count: 3,
@@ -89,7 +112,35 @@ describe('Task filters', () => {
       })
       assertListItems({ length: 1 })
     })
+
+    it('should filter created by others from user input', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 3,
+          results: TaskList,
+        },
+      })
+      cy.visit(tasksTab)
+      assertListItems({ length: 3 })
+
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestCreatedBy')
+      cy.get(`${element} select`).select('Others')
+      assertPayload('@apiRequestCreatedBy', {
+        not_created_by: myAdviserId,
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
   })
+
   context('Sort by', () => {
     const element = '[data-test="sortby-select"]'
 
@@ -198,6 +249,7 @@ describe('Task filters', () => {
       })
     })
   })
+
   context('Assigned to', () => {
     const element = '[data-test="assigned-to-select"]'
 
@@ -220,7 +272,7 @@ describe('Task filters', () => {
       })
     })
 
-    it('should filter from the url', () => {
+    it('should filter assigned to me from the url', () => {
       cy.intercept('POST', endpoint, {
         body: {
           count: 1,
@@ -243,7 +295,30 @@ describe('Task filters', () => {
       cy.get(`${element} select`).find(':selected').contains('Me')
     })
 
-    it('should filter from user input', () => {
+    it('should filter assigned to others from the url', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestassignedTo')
+      cy.visit(`${tasksTab}?assigned_to=others&page=1`)
+
+      // This ignores the checkForMyTasks API call which happens on page load
+      cy.wait('@apiRequestassignedTo')
+
+      assertPayload('@apiRequestassignedTo', {
+        not_advisers: [myAdviserId],
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+      cy.get(`${element} select`).find(':selected').contains('Others')
+    })
+
+    it('should filter assigned to me from user input', () => {
       cy.intercept('POST', endpoint, {
         body: {
           count: 3,
@@ -262,6 +337,33 @@ describe('Task filters', () => {
       cy.get(`${element} select`).select('Me')
       assertPayload('@apiRequestassignedTo', {
         advisers: [myAdviserId],
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
+
+    it('should filter assigned to others from user input', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 3,
+          results: TaskList,
+        },
+      })
+      cy.visit(tasksTab)
+      assertListItems({ length: 3 })
+
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestassignedTo')
+      cy.get(`${element} select`).select('Others')
+      assertPayload('@apiRequestassignedTo', {
+        not_advisers: [myAdviserId],
         limit: 50,
         offset: 0,
         adviser: [myAdviserId],


### PR DESCRIPTION
## Description of change

This PR adds an `Assigned to` dropdown filter to the new My Tasks dashboard. The filter should allow users to select tasks that have been assigned to themselves or others, or both.

Jira ticket [here](https://uktrade.atlassian.net/browse/CLS2-602)

## Test instructions

- Assign a task in the API to the logged in FE user
- The `Tasks` tab will then appear in the dashboard
- It should default to `Show all`
- Select `Me` -> it should only display the tasks assigned to the currently logged in adviser
- Select `Others` -> it should only display the tasks not assigned to the currently logged in adviser

## Screenshots

![Screenshot 2023-12-15 at 09 16 34](https://github.com/uktrade/data-hub-frontend/assets/1381563/33297666-ad6f-4636-861b-f79ab58f7e22)
![Screenshot 2023-12-15 at 09 16 47](https://github.com/uktrade/data-hub-frontend/assets/1381563/d1773611-22bf-441b-8ca5-69b7af56db14)
![Screenshot 2023-12-15 at 09 16 41](https://github.com/uktrade/data-hub-frontend/assets/1381563/4931f981-429e-4304-b7b0-569ff34772c0)


## Checklist

- [ ] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
