### PR TITLE
feature/CLS2-651-add-location-tag-search-results

### DIFF
--- a/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
@@ -30,8 +30,8 @@ const CompanyResultWithTags = ({ option, searchString }) => (
     <GridRow>
       <GridCol>
         <Tag colour={'blue'} data-test="location-tag">
-          {option.uk_region
-            ? `${get(option, 'uk_region.name')}, UK`
+          {option.ukRegion
+            ? `${get(option, 'ukRegion.name')}, UK`
             : get(option, 'address.country.name')}
         </Tag>
       </GridCol>
@@ -74,7 +74,7 @@ const FieldCompaniesTypeahead = ({
                     chipLabel: name,
                     value: id,
                     isInList: is_in_adviser_list,
-                    uk_region,
+                    ukRegion: uk_region,
                     address,
                   })
                 )

--- a/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
@@ -32,7 +32,7 @@ const CompanyResultWithTags = ({ option, searchString }) => (
         <Tag colour={'blue'} data-test="location-tag">
           {option.ukRegion
             ? `${get(option, 'ukRegion.name')}, UK`
-            : get(option, 'address.country.name')}
+            : get(option, 'address.country.name', 'unknown')}
         </Tag>
       </GridCol>
     </GridRow>

--- a/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldCompaniesTypeahead/index.jsx
@@ -1,9 +1,43 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { throttle } from 'lodash'
+import { get, throttle } from 'lodash'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+import { GridCol, GridRow } from 'govuk-react'
 
 import FieldTypeahead from '../FieldTypeahead'
 import { apiProxyAxios } from '../../../Task/utils'
+import Highlighter from '../../../Typeahead/Highlighter'
+import Tag from '../../../Tag'
+
+const getOptionLabel = (option) =>
+  `${option.label}${option.isInList ? ' (in your company lists)' : ''}`
+
+const StyledRow = styled(GridRow)(() => ({
+  paddingBottom: `${SPACING.SCALE_2}`,
+}))
+
+const CompanyResultWithTags = ({ option, searchString }) => (
+  <>
+    <StyledRow>
+      <GridCol>
+        <Highlighter
+          optionLabel={getOptionLabel(option)}
+          searchStr={searchString}
+        />
+      </GridCol>
+    </StyledRow>
+    <GridRow>
+      <GridCol>
+        <Tag colour={'blue'} data-test="location-tag">
+          {option.uk_region
+            ? `${get(option, 'uk_region.name')}, UK`
+            : get(option, 'address.country.name')}
+        </Tag>
+      </GridCol>
+    </GridRow>
+  </>
+)
 
 const FieldCompaniesTypeahead = ({
   name,
@@ -12,6 +46,7 @@ const FieldCompaniesTypeahead = ({
   isMulti,
   onlyShowActiveCompanies = true,
   placeholder = 'Type to search for companies',
+  loadOptions,
   ...props
 }) => {
   return (
@@ -21,25 +56,34 @@ const FieldCompaniesTypeahead = ({
       placeholder={placeholder}
       noOptionsMessage="Type to search for companies"
       required={required}
-      loadOptions={throttle(
-        (searchString) =>
-          apiProxyAxios
-            .get('/v4/company', {
-              params: {
-                autocomplete: searchString,
-                is_active: onlyShowActiveCompanies,
-              },
-            })
-            .then(({ data: { results } }) =>
-              results.map(({ id, name }) => ({
-                label: name,
-                chipLabel: name,
-                value: id,
-              }))
-            ),
-        500
-      )}
+      loadOptions={
+        loadOptions ??
+        throttle(
+          (searchString) =>
+            apiProxyAxios
+              .get('/v4/company', {
+                params: {
+                  autocomplete: searchString,
+                  is_active: onlyShowActiveCompanies,
+                },
+              })
+              .then(({ data: { results } }) =>
+                results.map(
+                  ({ id, name, is_in_adviser_list, uk_region, address }) => ({
+                    label: name,
+                    chipLabel: name,
+                    value: id,
+                    isInList: is_in_adviser_list,
+                    uk_region,
+                    address,
+                  })
+                )
+              ),
+          500
+        )
+      }
       isMulti={isMulti}
+      OptionContent={CompanyResultWithTags}
       {...props}
     />
   )
@@ -51,6 +95,7 @@ FieldCompaniesTypeahead.propTypes = {
   required: PropTypes.string,
   isMulti: PropTypes.bool,
   placeholder: PropTypes.string,
+  loadOptions: PropTypes.func,
 }
 
 export default FieldCompaniesTypeahead

--- a/src/client/components/Form/elements/__stories__/FieldCompaniesTypeahead.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCompaniesTypeahead.stories.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+import FieldCompaniesTypeahead from '../FieldCompaniesTypeahead'
+import Form from '../../../Form'
+
+const options = [
+  {
+    value: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+    label: 'Company A',
+    isInList: true,
+    uk_region: { name: 'Bristol' },
+  },
+  {
+    value: '8dcd2bb8-dc73-4a42-8655-4ae42d4d3c5a',
+    label: 'Company B',
+    uk_region: { name: 'Cardiff' },
+  },
+  {
+    value: 'a6f39399-5bf4-46cb-a686-826f73e9f0ca',
+    label: 'Company C',
+    address: { country: { name: 'France' } },
+  },
+]
+
+export const mockLoadOptions = (query = '') =>
+  new Promise((resolve) =>
+    query && query.length
+      ? setTimeout(
+          resolve,
+          200,
+          options.filter(({ label }) =>
+            label.toLowerCase().includes(query.toLowerCase())
+          )
+        )
+      : resolve([])
+  )
+
+export default {
+  title: 'Form/Form Elements/FieldCompaniesTypeahead',
+  excludeStories: ['mockLoadOptions'],
+  parameters: {
+    component: FieldCompaniesTypeahead,
+  },
+}
+
+export const Default = () => (
+  <Form
+    id="fieldCompaniesTypeaheadExample"
+    analyticsFormName="fieldCompaniesTypeaheadExample"
+    submissionTaskName="Submit Form example"
+  >
+    {() => (
+      <>
+        <FieldCompaniesTypeahead name="company" loadOptions={mockLoadOptions} />
+      </>
+    )}
+  </Form>
+)

--- a/src/client/components/Form/elements/__stories__/FieldCompaniesTypeahead.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCompaniesTypeahead.stories.jsx
@@ -8,12 +8,12 @@ const options = [
     value: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
     label: 'Company A',
     isInList: true,
-    uk_region: { name: 'Bristol' },
+    ukRegion: { name: 'Bristol' },
   },
   {
     value: '8dcd2bb8-dc73-4a42-8655-4ae42d4d3c5a',
     label: 'Company B',
-    uk_region: { name: 'Cardiff' },
+    ukRegion: { name: 'Cardiff' },
   },
   {
     value: 'a6f39399-5bf4-46cb-a686-826f73e9f0ca',

--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -126,6 +126,10 @@ const AutocompleteInput = styled('input')(({ error }) => ({
   ...FOCUSABLE,
 }))
 
+const TypeaheadOptionContent = ({ option, searchString }) => (
+  <Highlighter optionLabel={option.label} searchStr={searchString} />
+)
+
 const Menu = styled('div')(({ open }) => ({
   visibility: open ? 'visible' : 'hidden',
   backgroundColor: WHITE,
@@ -172,6 +176,7 @@ const Typeahead = ({
   onMenuOpen,
   onChange = () => {},
   'data-test': testId,
+  OptionContent = TypeaheadOptionContent,
   ...inputProps
 }) => {
   const closeOnSelect = isMulti ? closeMenuOnSelect : true
@@ -362,10 +367,7 @@ const Typeahead = ({
                       data-test="typeahead-menu-option"
                     >
                       <span>
-                        <Highlighter
-                          optionLabel={option.label}
-                          searchStr={input}
-                        />
+                        <OptionContent option={option} searchString={input} />
                       </span>
                     </ListboxOption>
                   ))}

--- a/test/component/cypress/specs/components/Form/FieldCompaniesTypeahead.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldCompaniesTypeahead.cy.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import {
+  FieldCompaniesTypeahead,
+  Form,
+} from '../../../../../../src/client/components'
+
+import DataHubProvider from '../../provider'
+
+const options = [
+  {
+    value: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+    label: 'Company A',
+    isInList: true,
+    ukRegion: { name: 'Bristol' },
+  },
+  {
+    value: '8dcd2bb8-dc73-4a42-8655-4ae42d4d3c5a',
+    label: 'Company B',
+    ukRegion: { name: 'Cardiff' },
+  },
+  {
+    value: 'a6f39399-5bf4-46cb-a686-826f73e9f0ca',
+    label: 'Company C',
+    address: { country: { name: 'France' } },
+  },
+]
+
+const mockLoadOptions = (query = '') =>
+  new Promise((resolve) =>
+    resolve(
+      options.filter(({ label }) =>
+        label.toLowerCase().includes(query.toLowerCase())
+      )
+    )
+  )
+
+describe('FieldCompaniesTypeahead', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form id="export-form">
+        <FieldCompaniesTypeahead
+          name="companies"
+          loadOptions={mockLoadOptions}
+          {...props}
+        />
+      </Form>
+    </DataHubProvider>
+  )
+
+  beforeEach(() => cy.mount(<Component />))
+
+  const searchForCompany = (name) => {
+    cy.get('[data-test="field-companies"]')
+      .find('input')
+      .click()
+      .clear()
+      .type(name)
+  }
+
+  context('When the company is in a list', () => {
+    it('the label should tell the user this', () => {
+      searchForCompany('Company A')
+      cy.get('[data-test="typeahead-menu-option"]').should(
+        'contain',
+        '(in your company lists)'
+      )
+    })
+  })
+
+  context('When the company is in a uk region', () => {
+    it('the tag should contain the region name and UK', () => {
+      searchForCompany('Company B')
+      cy.get('[data-test="location-tag"]').should('contain', 'Cardiff')
+    })
+  })
+
+  context('When the company is not in a uk region', () => {
+    it('the tag should contain the country name', () => {
+      searchForCompany('Company C')
+      cy.get('[data-test="location-tag"]').should('contain', 'France')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Replace the standard typeahead content with a company typeahead specific one that displays the country and region of a company as a tag. If a company is present in a users list, this is also shown to a user

## Test instructions

- Add any company into one of your lists, then go to http://localhost:3000/tasks/create.
- Search for that company in the company name filter, it will show with the region and country along with a title explaining it is in your list

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/3ef11ab4-3378-442d-bee5-577fd2aaaba7)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/4d8b0ff5-81e1-4c0a-8e1f-d88f349f96b4)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
