### PR TITLE
bugfix/revert-width-percentages

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
@@ -29,8 +29,8 @@ const header = (
 const rows = ({ results }) => {
   return results.map((task) => (
     <Table.Row data-test="task-item">
-      <Table.Cell setWidth="15%">{formatMediumDate(task.due_date)}</Table.Cell>
-      <Table.Cell setWidth="40%">
+      <Table.Cell setWidth="12%">{formatMediumDate(task.due_date)}</Table.Cell>
+      <Table.Cell setWidth="23%">
         <Link
           href={urls.tasks.details(task.id)}
           data-test={`${task.id}-task-link`}


### PR DESCRIPTION
## Description of change

The increase of the first 2 columns puts the total width of the row at 120%. This PR puts the widths back to the values that equal 100% over the entire row


## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/a99bafb0-d7c9-4b9f-aa01-52273028425a)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/734e761a-437d-4a72-9e10-6ab0cc844c9b)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
