### PR TITLE
Cls2 603 status filter

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -30,6 +30,11 @@ export const MyTasksContent = ({ myTasks, filters }) => (
   <>
     <FiltersContainer>
       <TaskListSelect
+        label="Status"
+        qsParam="status"
+        options={filters?.status?.options}
+      />
+      <TaskListSelect
         label="Assigned to"
         qsParam="assigned_to"
         options={filters?.assignedTo?.options}

--- a/src/client/components/Dashboard/my-tasks/constants.js
+++ b/src/client/components/Dashboard/my-tasks/constants.js
@@ -1,15 +1,4 @@
-const ASSIGNED_TO_OPTIONS = [
-  {
-    label: 'Me',
-    value: 'me',
-  },
-  {
-    label: 'Others',
-    value: 'others',
-  },
-]
-
-const CREATED_BY_OPTIONS = [
+const ME_OTHERS_OPTIONS = [
   {
     label: 'Me',
     value: 'me',
@@ -59,11 +48,6 @@ export const SHOW_ALL_OPTION = {
   value: 'all-statuses',
 }
 
-export const CREATED_BY_LIST_OPTIONS = [SHOW_ALL_OPTION, ...CREATED_BY_OPTIONS]
-
-export const ASSIGNED_TO_LIST_OPTIONS = [
-  SHOW_ALL_OPTION,
-  ...ASSIGNED_TO_OPTIONS,
-]
+export const ME_OTHERS_LIST_OPTIONS = [SHOW_ALL_OPTION, ...ME_OTHERS_OPTIONS]
 
 export const STATUS_LIST_OPTIONS = [SHOW_ALL_OPTION, ...STATUS_OPTIONS]

--- a/src/client/components/Dashboard/my-tasks/constants.js
+++ b/src/client/components/Dashboard/my-tasks/constants.js
@@ -1,4 +1,4 @@
-export const ASSIGNED_TO_OPTIONS = [
+const ASSIGNED_TO_OPTIONS = [
   {
     label: 'Me',
     value: 'me',
@@ -9,7 +9,7 @@ export const ASSIGNED_TO_OPTIONS = [
   },
 ]
 
-export const CREATED_BY_OPTIONS = [
+const CREATED_BY_OPTIONS = [
   {
     label: 'Me',
     value: 'me',
@@ -43,6 +43,17 @@ export const SORT_BY_LIST_OPTIONS = [
   },
 ]
 
+const STATUS_OPTIONS = [
+  {
+    label: 'Active',
+    value: 'active',
+  },
+  {
+    label: 'Completed',
+    value: 'completed',
+  },
+]
+
 export const SHOW_ALL_OPTION = {
   label: 'Show all',
   value: 'all-statuses',
@@ -54,3 +65,5 @@ export const ASSIGNED_TO_LIST_OPTIONS = [
   SHOW_ALL_OPTION,
   ...ASSIGNED_TO_OPTIONS,
 ]
+
+export const STATUS_LIST_OPTIONS = [SHOW_ALL_OPTION, ...STATUS_OPTIONS]

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -7,6 +7,7 @@ import {
   ASSIGNED_TO_LIST_OPTIONS,
   CREATED_BY_LIST_OPTIONS,
   SORT_BY_LIST_OPTIONS,
+  STATUS_LIST_OPTIONS,
 } from './constants'
 
 export const ID = 'getMyTasks'
@@ -22,14 +23,6 @@ const areFiltersActive = (queryParams) => {
   return !isEmpty(filters)
 }
 
-const sortbyMapping = {
-  due_date: 'due_date:asc',
-  recently_updated: 'modified_on:desc',
-  least_recently_updated: 'modified_on:asc',
-  company_ascending: 'company.name:asc',
-  project_ascending: 'investment_project.name:asc',
-}
-
 export const state2props = ({ router, ...state }) => {
   const queryParams = getQueryParamsFromLocation(router.location)
   const { currentAdviserId } = state
@@ -41,28 +34,37 @@ export const state2props = ({ router, ...state }) => {
     advisers: undefined,
     not_advisers: undefined,
     adviser: [currentAdviserId],
+    archived: undefined,
     sortby: 'due_date:asc',
   }
 
-  if (queryParams.assigned_to === 'me') {
-    payload.advisers = [currentAdviserId]
+  const sortbyMapping = {
+    due_date: 'due_date:asc',
+    recently_updated: 'modified_on:desc',
+    least_recently_updated: 'modified_on:asc',
+    company_ascending: 'company.name:asc',
+    project_ascending: 'investment_project.name:asc',
   }
-
-  if (queryParams.assigned_to === 'others') {
-    payload.not_advisers = [currentAdviserId]
+  const statusMapping = {
+    active: { archived: false },
+    completed: { archived: true },
   }
-
-  if (queryParams.created_by === 'me') {
-    payload.created_by = currentAdviserId
+  const assignedToMapping = {
+    me: { advisers: [currentAdviserId] },
+    others: { not_advisers: [currentAdviserId] },
   }
-
-  if (queryParams.created_by === 'others') {
-    payload.not_created_by = currentAdviserId
+  const createdByMapping = {
+    me: { created_by: currentAdviserId },
+    others: { not_created_by: currentAdviserId },
   }
 
   if (queryParams.sortby in sortbyMapping) {
     payload.sortby = sortbyMapping[queryParams.sortby]
   }
+
+  Object.assign(payload, assignedToMapping[queryParams.assigned_to])
+  Object.assign(payload, createdByMapping[queryParams.created_by])
+  Object.assign(payload, statusMapping[queryParams.status])
 
   return {
     ...state[ID],
@@ -77,6 +79,9 @@ export const state2props = ({ router, ...state }) => {
       },
       sortby: {
         options: SORT_BY_LIST_OPTIONS,
+      },
+      status: {
+        options: STATUS_LIST_OPTIONS,
       },
     },
   }

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -4,10 +4,9 @@ import { getQueryParamsFromLocation } from '../../../../client/utils/url'
 import { parsePage } from '../../../../client/utils/pagination'
 
 import {
-  ASSIGNED_TO_LIST_OPTIONS,
-  CREATED_BY_LIST_OPTIONS,
   SORT_BY_LIST_OPTIONS,
   STATUS_LIST_OPTIONS,
+  ME_OTHERS_LIST_OPTIONS,
 } from './constants'
 
 export const ID = 'getMyTasks'
@@ -72,10 +71,10 @@ export const state2props = ({ router, ...state }) => {
     filters: {
       areActive: areFiltersActive(queryParams),
       assignedTo: {
-        options: ASSIGNED_TO_LIST_OPTIONS,
+        options: ME_OTHERS_LIST_OPTIONS,
       },
       createdBy: {
-        options: CREATED_BY_LIST_OPTIONS,
+        options: ME_OTHERS_LIST_OPTIONS,
       },
       sortby: {
         options: SORT_BY_LIST_OPTIONS,

--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -22,6 +22,18 @@ const areFiltersActive = (queryParams) => {
   return !isEmpty(filters)
 }
 
+const sortbyMapping = {
+  due_date: 'due_date:asc',
+  recently_updated: 'modified_on:desc',
+  least_recently_updated: 'modified_on:asc',
+  company_ascending: 'company.name:asc',
+  project_ascending: 'investment_project.name:asc',
+}
+const statusMapping = {
+  active: { archived: false },
+  completed: { archived: true },
+}
+
 export const state2props = ({ router, ...state }) => {
   const queryParams = getQueryParamsFromLocation(router.location)
   const { currentAdviserId } = state
@@ -37,17 +49,6 @@ export const state2props = ({ router, ...state }) => {
     sortby: 'due_date:asc',
   }
 
-  const sortbyMapping = {
-    due_date: 'due_date:asc',
-    recently_updated: 'modified_on:desc',
-    least_recently_updated: 'modified_on:asc',
-    company_ascending: 'company.name:asc',
-    project_ascending: 'investment_project.name:asc',
-  }
-  const statusMapping = {
-    active: { archived: false },
-    completed: { archived: true },
-  }
   const assignedToMapping = {
     me: { advisers: [currentAdviserId] },
     others: { not_advisers: [currentAdviserId] },

--- a/src/client/components/Dashboard/my-tasks/tasks.js
+++ b/src/client/components/Dashboard/my-tasks/tasks.js
@@ -6,6 +6,7 @@ export const getMyTasks = ({
   not_created_by,
   advisers,
   not_advisers,
+  archived,
   sortby = 'due_date:asc',
 }) =>
   apiProxyAxios
@@ -17,6 +18,7 @@ export const getMyTasks = ({
       advisers: advisers,
       not_advisers: not_advisers,
       adviser: adviser,
+      archived: archived,
       sortby,
     })
     .then(({ data }) => data)

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -11,8 +11,9 @@ import { formatMediumDate } from '../../../../../../src/client/utils/date'
 import { MyTasksContent } from '../../../../../../src/client/components/Dashboard/my-tasks/MyTasks'
 import urls from '../../../../../../src/lib/urls'
 import {
-  ASSIGNED_TO_LIST_OPTIONS,
-  CREATED_BY_LIST_OPTIONS,
+  ME_OTHERS_LIST_OPTIONS,
+  SORT_BY_LIST_OPTIONS,
+  STATUS_LIST_OPTIONS,
 } from '../../../../../../src/client/components/Dashboard/my-tasks/constants'
 
 import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
@@ -36,10 +37,16 @@ describe('My Tasks on the Dashboard', () => {
   const filtersList = {
     areActive: false,
     assignedTo: {
-      options: [ASSIGNED_TO_LIST_OPTIONS],
+      options: [ME_OTHERS_LIST_OPTIONS],
     },
     createdBy: {
-      options: [CREATED_BY_LIST_OPTIONS],
+      options: [ME_OTHERS_LIST_OPTIONS],
+    },
+    status: {
+      options: [STATUS_LIST_OPTIONS],
+    },
+    sortby: {
+      options: [SORT_BY_LIST_OPTIONS],
     },
   }
 

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -17,6 +17,12 @@ describe('Task filters', () => {
   const endpoint = '/api-proxy/v4/search/task'
   const tasksTab = urls.dashboard.myTasks()
   const TaskList = taskListFaker()
+  const basePayload = {
+    limit: 50,
+    offset: 0,
+    adviser: [myAdviserId],
+    sortby: 'due_date:asc',
+  }
 
   function assertFilterName(element, text) {
     cy.intercept('POST', endpoint, {
@@ -42,7 +48,7 @@ describe('Task filters', () => {
     // This ignores the checkForMyTasks API call which happens on page load
     cy.wait('@apiRequest')
 
-    assertPayload('@apiRequest', payload)
+    assertPayload('@apiRequest', { ...basePayload, ...payload })
     assertListItems({ length: 1 })
     cy.get(`${element} select`).find(':selected').contains(selectedOption)
   }
@@ -86,13 +92,7 @@ describe('Task filters', () => {
       testFilterFromUrl(
         element,
         'created_by=me',
-        {
-          created_by: myAdviserId,
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { created_by: myAdviserId },
         'Me'
       )
     })
@@ -101,13 +101,7 @@ describe('Task filters', () => {
       testFilterFromUrl(
         element,
         'created_by=others',
-        {
-          not_created_by: myAdviserId,
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { not_created_by: myAdviserId },
         'Others'
       )
     })
@@ -183,17 +177,7 @@ describe('Task filters', () => {
 
     sortbyOptionsData.forEach(({ label, value, sortBy }) => {
       it(`should filter ${label} from the url`, () => {
-        testFilterFromUrl(
-          element,
-          `sortby=${value}`,
-          {
-            limit: 50,
-            offset: 0,
-            adviser: [myAdviserId],
-            sortby: sortBy,
-          },
-          label
-        )
+        testFilterFromUrl(element, `sortby=${value}`, { sortby: sortBy }, label)
       })
 
       it(`should filter ${label} from user input`, () => {
@@ -252,13 +236,7 @@ describe('Task filters', () => {
       testFilterFromUrl(
         element,
         'assigned_to=me',
-        {
-          advisers: [myAdviserId],
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { advisers: [myAdviserId] },
         'Me'
       )
     })
@@ -267,13 +245,7 @@ describe('Task filters', () => {
       testFilterFromUrl(
         element,
         'assigned_to=others',
-        {
-          not_advisers: [myAdviserId],
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { not_advisers: [myAdviserId] },
         'Others'
       )
     })
@@ -322,31 +294,14 @@ describe('Task filters', () => {
     })
 
     it('should filter active status from the url', () => {
-      testFilterFromUrl(
-        element,
-        'status=active',
-        {
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          archived: false,
-          sortby: 'due_date:asc',
-        },
-        'Active'
-      )
+      testFilterFromUrl(element, 'status=active', { archived: false }, 'Active')
     })
 
     it('should filter completed status from the url', () => {
       testFilterFromUrl(
         element,
         'status=completed',
-        {
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          archived: true,
-          sortby: 'due_date:asc',
-        },
+        { archived: true },
         'Completed'
       )
     })

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -18,19 +18,23 @@ describe('Task filters', () => {
   const tasksTab = urls.dashboard.myTasks()
   const TaskList = taskListFaker()
 
+  function assertFilterName(element, text) {
+    cy.intercept('POST', endpoint, {
+      body: {
+        count: 1,
+        results: [TaskList[0]],
+      },
+    })
+    cy.visit(tasksTab)
+
+    cy.get(element).find('span').should('have.text', text)
+  }
+
   context('Created by', () => {
     const element = '[data-test="created-by-select"]'
 
     it('should have a "Created by" filter', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestCreatedBy')
-      cy.visit(`${tasksTab}?created_by=me&page=1`)
-
-      cy.get(element).find('span').should('have.text', 'Created by')
+      assertFilterName(element, 'Created by')
       cy.get(`${element} option`).then((createdByOptions) => {
         expect(transformOptions(createdByOptions)).to.deep.eq([
           { value: 'all-statuses', label: 'Show all' },
@@ -173,15 +177,7 @@ describe('Task filters', () => {
     ]
 
     it('should have a "Sort by" filter', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestSortBy')
-      cy.visit(tasksTab)
-
-      cy.get(element).find('span').should('have.text', 'Sort by')
+      assertFilterName(element, 'Sort by')
       cy.get(`${element} option`).then((sortByOptions) => {
         expect(transformOptions(sortByOptions)).to.deep.eq(
           transformOptions(sortbyOptionsData)
@@ -254,15 +250,7 @@ describe('Task filters', () => {
     const element = '[data-test="assigned-to-select"]'
 
     it('should have a "Assigned to" filter', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestassignedTo')
-      cy.visit(`${tasksTab}?assigned_to=me&page=1`)
-
-      cy.get(element).find('span').should('have.text', 'Assigned to')
+      assertFilterName(element, 'Assigned to')
       cy.get(`${element} option`).then((assignedToOptions) => {
         expect(transformOptions(assignedToOptions)).to.deep.eq([
           { value: 'all-statuses', label: 'Show all' },
@@ -376,16 +364,8 @@ describe('Task filters', () => {
   context('Status', () => {
     const element = '[data-test="status-select"]'
 
-    it('should have a "status" filter', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestStatus')
-      cy.visit(`${tasksTab}?status=active&page=1`)
-
-      cy.get(element).find('span').should('have.text', 'Status')
+    it('should have a "Status" filter', () => {
+      assertFilterName(element, 'Status')
       cy.get(`${element} option`).then((statusOptions) => {
         expect(transformOptions(statusOptions)).to.deep.eq([
           { value: 'all-statuses', label: 'Show all' },

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -415,6 +415,7 @@ describe('Task filters', () => {
         sortby: 'due_date:asc',
       })
       assertListItems({ length: 1 })
+      cy.get(`${element} select`).find(':selected').contains('Active')
     })
 
     it('should filter completed status from the url', () => {
@@ -437,6 +438,7 @@ describe('Task filters', () => {
         sortby: 'due_date:asc',
       })
       assertListItems({ length: 1 })
+      cy.get(`${element} select`).find(':selected').contains('Completed')
     })
 
     it('should filter active status from user input', () => {

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -70,7 +70,7 @@ describe('Task filters', () => {
       },
     }).as('apiRequest')
     cy.get(`${element} select`).select(selectedOption)
-    assertPayload('@apiRequest', payload)
+    assertPayload('@apiRequest', { ...basePayload, ...payload })
     assertListItems({ length: 1 })
   }
 
@@ -107,29 +107,13 @@ describe('Task filters', () => {
     })
 
     it('should filter created by me from user input', () => {
-      testFilterFromUserInput(
-        element,
-        {
-          created_by: myAdviserId,
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
-        'Me'
-      )
+      testFilterFromUserInput(element, { created_by: myAdviserId }, 'Me')
     })
 
     it('should filter created by others from user input', () => {
       testFilterFromUserInput(
         element,
-        {
-          not_created_by: myAdviserId,
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { not_created_by: myAdviserId },
         'Others'
       )
     })
@@ -251,29 +235,13 @@ describe('Task filters', () => {
     })
 
     it('should filter assigned to me from user input', () => {
-      testFilterFromUserInput(
-        element,
-        {
-          advisers: [myAdviserId],
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
-        'Me'
-      )
+      testFilterFromUserInput(element, { advisers: [myAdviserId] }, 'Me')
     })
 
     it('should filter assigned to others from user input', () => {
       testFilterFromUserInput(
         element,
-        {
-          not_advisers: [myAdviserId],
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          sortby: 'due_date:asc',
-        },
+        { not_advisers: [myAdviserId] },
         'Others'
       )
     })
@@ -307,31 +275,11 @@ describe('Task filters', () => {
     })
 
     it('should filter active status from user input', () => {
-      testFilterFromUserInput(
-        element,
-        {
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          archived: false,
-          sortby: 'due_date:asc',
-        },
-        'Active'
-      )
+      testFilterFromUserInput(element, { archived: false }, 'Active')
     })
 
     it('should filter completed status from user input', () => {
-      testFilterFromUserInput(
-        element,
-        {
-          limit: 50,
-          offset: 0,
-          adviser: [myAdviserId],
-          archived: true,
-          sortby: 'due_date:asc',
-        },
-        'Completed'
-      )
+      testFilterFromUserInput(element, { archived: true }, 'Completed')
     })
   })
 })

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -372,4 +372,125 @@ describe('Task filters', () => {
       assertListItems({ length: 1 })
     })
   })
+
+  context('Status', () => {
+    const element = '[data-test="status-select"]'
+
+    it('should have a "status" filter', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestStatus')
+      cy.visit(`${tasksTab}?status=active&page=1`)
+
+      cy.get(element).find('span').should('have.text', 'Status')
+      cy.get(`${element} option`).then((statusOptions) => {
+        expect(transformOptions(statusOptions)).to.deep.eq([
+          { value: 'all-statuses', label: 'Show all' },
+          { value: 'active', label: 'Active' },
+          { value: 'completed', label: 'Completed' },
+        ])
+      })
+    })
+
+    it('should filter active status from the url', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestStatus')
+      cy.visit(`${tasksTab}?status=active&page=1`)
+
+      // This ignores the checkForMyTasks API call which happens on page load
+      cy.wait('@apiRequestStatus')
+
+      assertPayload('@apiRequestStatus', {
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        archived: false,
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
+
+    it('should filter completed status from the url', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestStatus')
+      cy.visit(`${tasksTab}?status=completed&page=1`)
+
+      // This ignores the checkForMyTasks API call which happens on page load
+      cy.wait('@apiRequestStatus')
+
+      assertPayload('@apiRequestStatus', {
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        archived: true,
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
+
+    it('should filter active status from user input', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 3,
+          results: TaskList,
+        },
+      })
+      cy.visit(tasksTab)
+      assertListItems({ length: 3 })
+
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestStatus')
+      cy.get(`${element} select`).select('Active')
+      assertPayload('@apiRequestStatus', {
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        archived: false,
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
+
+    it('should filter completed status from user input', () => {
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 3,
+          results: TaskList,
+        },
+      })
+      cy.visit(tasksTab)
+      assertListItems({ length: 3 })
+
+      cy.intercept('POST', endpoint, {
+        body: {
+          count: 1,
+          results: [TaskList[0]],
+        },
+      }).as('apiRequestStatus')
+      cy.get(`${element} select`).select('Completed')
+      assertPayload('@apiRequestStatus', {
+        limit: 50,
+        offset: 0,
+        adviser: [myAdviserId],
+        archived: true,
+        sortby: 'due_date:asc',
+      })
+      assertListItems({ length: 1 })
+    })
+  })
 })

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -47,6 +47,27 @@ describe('Task filters', () => {
     cy.get(`${element} select`).find(':selected').contains(selectedOption)
   }
 
+  function testFilterFromUserInput(element, payload, selectedOption) {
+    cy.intercept('POST', endpoint, {
+      body: {
+        count: 3,
+        results: TaskList,
+      },
+    })
+    cy.visit(tasksTab)
+    assertListItems({ length: 3 })
+
+    cy.intercept('POST', endpoint, {
+      body: {
+        count: 1,
+        results: [TaskList[0]],
+      },
+    }).as('apiRequest')
+    cy.get(`${element} select`).select(selectedOption)
+    assertPayload('@apiRequest', payload)
+    assertListItems({ length: 1 })
+  }
+
   context('Created by', () => {
     const element = '[data-test="created-by-select"]'
 
@@ -92,57 +113,31 @@ describe('Task filters', () => {
     })
 
     it('should filter created by me from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          created_by: myAdviserId,
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestCreatedBy')
-      cy.get(`${element} select`).select('Me')
-      assertPayload('@apiRequestCreatedBy', {
-        created_by: myAdviserId,
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Me'
+      )
     })
 
     it('should filter created by others from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          not_created_by: myAdviserId,
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestCreatedBy')
-      cy.get(`${element} select`).select('Others')
-      assertPayload('@apiRequestCreatedBy', {
-        not_created_by: myAdviserId,
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Others'
+      )
     })
   })
 
@@ -284,57 +279,31 @@ describe('Task filters', () => {
     })
 
     it('should filter assigned to me from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          advisers: [myAdviserId],
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestassignedTo')
-      cy.get(`${element} select`).select('Me')
-      assertPayload('@apiRequestassignedTo', {
-        advisers: [myAdviserId],
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Me'
+      )
     })
 
     it('should filter assigned to others from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          not_advisers: [myAdviserId],
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestassignedTo')
-      cy.get(`${element} select`).select('Others')
-      assertPayload('@apiRequestassignedTo', {
-        not_advisers: [myAdviserId],
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Others'
+      )
     })
   })
 
@@ -383,57 +352,31 @@ describe('Task filters', () => {
     })
 
     it('should filter active status from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          archived: false,
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestStatus')
-      cy.get(`${element} select`).select('Active')
-      assertPayload('@apiRequestStatus', {
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        archived: false,
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Active'
+      )
     })
 
     it('should filter completed status from user input', () => {
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 3,
-          results: TaskList,
+      testFilterFromUserInput(
+        element,
+        {
+          limit: 50,
+          offset: 0,
+          adviser: [myAdviserId],
+          archived: true,
+          sortby: 'due_date:asc',
         },
-      })
-      cy.visit(tasksTab)
-      assertListItems({ length: 3 })
-
-      cy.intercept('POST', endpoint, {
-        body: {
-          count: 1,
-          results: [TaskList[0]],
-        },
-      }).as('apiRequestStatus')
-      cy.get(`${element} select`).select('Completed')
-      assertPayload('@apiRequestStatus', {
-        limit: 50,
-        offset: 0,
-        adviser: [myAdviserId],
-        archived: true,
-        sortby: 'due_date:asc',
-      })
-      assertListItems({ length: 1 })
+        'Completed'
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change

- Add Status filter to `/my-tasks` page. Can filter on active or completed tasks
- 
- Refactor how query params are handled in state file for all filters
- Refactor constants and tests

## Test instructions

When navigating to `/my-tasks` page, you should see the Status filter. Changing this will filter active/completed

## Screenshots
![Screenshot 2023-12-18 at 15 45 34](https://github.com/uktrade/data-hub-frontend/assets/54268863/cb92fcc6-d9f6-4958-81ac-4f57e366a5d9)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
