### PR TITLE
Cls2 555 create add task button

### DIFF
--- a/src/client/components/ContentWithHeading.jsx
+++ b/src/client/components/ContentWithHeading.jsx
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { H3 } from 'govuk-react'
+import { Button, H3 } from 'govuk-react'
 import styled from 'styled-components'
 
 import SpacedSectionBreak from './SpacedSectionBreak'
+import { BLUE } from '../utils/colours'
+import urls from '../../lib/urls'
 
 const StyledHeading = styled(H3)({
   flexGrow: 1,
@@ -19,6 +21,14 @@ const ContentWithHeading = ({ heading, children, headingActions }) => (
     <StyledHeader>
       <StyledHeading size={24}>{heading}</StyledHeading>
       {headingActions}
+      <Button
+        buttonColour={BLUE}
+        href={urls.tasks.create()}
+        as="a"
+        data-test="add-task"
+      >
+        Add task
+      </Button>
     </StyledHeader>
     <SpacedSectionBreak />
     {children}

--- a/src/client/components/ContentWithHeading.jsx
+++ b/src/client/components/ContentWithHeading.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Button, H3 } from 'govuk-react'
+import { Button, H3, Link } from 'govuk-react'
 import styled from 'styled-components'
 
 import SpacedSectionBreak from './SpacedSectionBreak'
@@ -24,7 +24,7 @@ const ContentWithHeading = ({ heading, children, headingActions }) => (
       <Button
         buttonColour={BLUE}
         href={urls.tasks.create()}
-        as="a"
+        as={Link}
         data-test="add-task"
       >
         Add task

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -17,6 +17,7 @@ import {
 } from '../../../../../../src/client/components/Dashboard/my-tasks/constants'
 
 import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
+import urls from '../../../../../../src/lib/urls'
 
 describe('My Tasks on the Dashboard', () => {
   const Component = (props) => (
@@ -167,6 +168,12 @@ describe('My Tasks on the Dashboard', () => {
 
     it('should display the heading 1 task (singular) and not 1 tasks (plural)', () => {
       cy.get('h3').should('contain', '1 task').should('not.contain', '1 tasks')
+    })
+
+    it('should contain a button to add task', () => {
+      cy.get('[data-test="add-task"]')
+        .should('have.text', 'Add task')
+        .should('have.attr', 'href', urls.tasks.create())
     })
   })
 })

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -17,7 +17,6 @@ import {
 } from '../../../../../../src/client/components/Dashboard/my-tasks/constants'
 
 import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
-import urls from '../../../../../../src/lib/urls'
 
 describe('My Tasks on the Dashboard', () => {
   const Component = (props) => (


### PR DESCRIPTION
## Description of change

Added an 'Add task' button in the Task dashboard that links to the add task form. 

## Test instructions

Go to the Task dashboard, in the right hand corner of the table you will the the 'Add task' button. 

## Screenshots

### Before

<img width="1208" alt="Screenshot 2023-12-19 at 09 47 05" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/59e7b1c4-e4d9-4556-9c13-b730f04db661">


### After

<img width="1197" alt="Screenshot 2023-12-19 at 09 47 29" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/0e98de04-d25c-4498-b8b6-29625f241079">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
