### PR TITLE
Adjusting positioning of sort by and my tasks filters in filters dashboard

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import { SITE_WIDTH, SPACING } from '@govuk-react/constants'
 
 import { HintText } from 'govuk-react'
 
@@ -13,18 +13,22 @@ import MyTasksTable from './MyTasksTable'
 import TaskListSelect from './TaskListSelect'
 import SpacedSectionBreak from '../../SpacedSectionBreak'
 
-const FiltersContainer = styled('div')({
-  display: 'grid',
-  rowGap: 15,
-  [MEDIA_QUERIES.TABLET]: {
-    columnGap: 2,
-    gridTemplateColumns: '50% 50%',
-  },
-  [MEDIA_QUERIES.DESKTOP]: {
-    gridTemplateColumns: '25% 25% 25% 25%',
-  },
-  marginBottom: SPACING.SCALE_3,
-})
+const SELECT_WIDTH = `16%`
+
+const FiltersContainer = styled.div`
+  display: grid;
+  row-gap: 15px;
+  column-gap: 2px;
+  margin-bottom: ${SPACING.SCALE_3};
+
+  grid-template-columns: repeat(3, ${SELECT_WIDTH}) 35.5% ${SELECT_WIDTH};
+  @media (max-width: ${SITE_WIDTH}) {
+    grid-template-columns: repeat(2, 50%);
+    span.task-select-spacer {
+      display: none;
+    }
+  }
+`
 
 export const MyTasksContent = ({ myTasks, filters }) => (
   <>
@@ -44,6 +48,7 @@ export const MyTasksContent = ({ myTasks, filters }) => (
         qsParam="created_by"
         options={filters?.createdBy?.options}
       />
+      <span class="task-select-spacer" id="task-select-spacer" />
       <TaskListSelect
         label="Sort by"
         qsParam="sortby"


### PR DESCRIPTION
## Description of change

The PR adjusts the positioning of filters + sort_by dropdowns in my tasks dashboards

See screenshots for resulting layout

NOTE: every time a filter is added, this needs adjusting, till we have the full design (5 filters + sort by dropdown)
 
### After

![Screenshot 2023-12-19 at 10 21 41](https://github.com/uktrade/data-hub-frontend/assets/1381563/33a09816-1808-40f2-96b8-f529488fb9f4)

![Screenshot 2023-12-19 at 10 21 53](https://github.com/uktrade/data-hub-frontend/assets/1381563/602d545c-1910-49cb-bbae-bce1e1946f40)

## Checklist


- [x] Has the branch been rebased to feature branch?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
