### PR TITLE
feature/CLS2-662-back-button-as-link

### DIFF
--- a/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskButtons.jsx
@@ -12,8 +12,12 @@ import { TASK_ARCHIVE_TASK, buttonState2props } from './state'
 import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 
 const ButtonWrapper = styled.div`
+  min-height: 71px;
   * {
     margin-left: ${SPACING.SCALE_4};
+  }
+  * {
+    vertical-align: baseline;
   }
 `
 
@@ -49,15 +53,12 @@ export const TaskButtons = ({ task, returnUrl }) => (
             Edit
           </Button>
         )}
-        <Button
-          buttonColour={GREY_3}
-          buttonTextColour={TEXT_COLOUR}
-          as={Link}
+        <Link
+          data-test="task-back-link"
           href={returnUrl ?? urls.dashboard.myTasks()}
-          data-test="back-button"
         >
           Back
-        </Button>
+        </Link>
       </ButtonWrapper>
     </GridRow>
   </>

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskButtons.cy.jsx
@@ -32,7 +32,7 @@ describe('Task buttons', () => {
     })
 
     it('should show the Back link to dashboard when no return url exists', () => {
-      assertLink('back-button', urls.dashboard.myTasks())
+      assertLink('task-back-link', urls.dashboard.myTasks())
     })
   })
 
@@ -52,7 +52,7 @@ describe('Task buttons', () => {
     })
 
     it('should show the Back link to dashboard when no return url exists', () => {
-      assertLink('back-button', urls.dashboard.myTasks())
+      assertLink('task-back-link', urls.dashboard.myTasks())
     })
   })
 
@@ -64,7 +64,7 @@ describe('Task buttons', () => {
     })
 
     it('should the back button with the returnUrl as the href', () => {
-      assertLink('back-button', 'a/b/c')
+      assertLink('task-back-link', 'a/b/c')
     })
   })
 })


### PR DESCRIPTION
## Description of change

The back button on the task details page should be a link to match the rest of datahub

## Test instructions

Go to the details page of any task, the back button will now render as a link

## Screenshots

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/5bfcc97f-3422-4a86-9235-4405c61f6d3d)


### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/6178d784-ca4e-40f1-97b1-959f242c368c)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
