### PR TITLE
bugfix/CLS2-672-investment-project-selector

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -48,7 +48,7 @@ export const MyTasksContent = ({ myTasks, filters }) => (
         qsParam="created_by"
         options={filters?.createdBy?.options}
       />
-      <span class="task-select-spacer" id="task-select-spacer" />
+      <span className="task-select-spacer" id="task-select-spacer" />
       <TaskListSelect
         label="Sort by"
         qsParam="sortby"

--- a/src/client/modules/Investments/Projects/state.js
+++ b/src/client/modules/Investments/Projects/state.js
@@ -9,6 +9,7 @@ import {
   PROJECT_STATUS_OPTIONS,
   INVOLVEMENT_LEVEL_OPTIONS,
 } from './constants'
+import { transformInvestmentProjectToListItem } from './transformers'
 
 export const TASK_EDIT_INVESTMENT_PROJECT_STATUS =
   'TASK_EDIT_INVESTMENT_PROJECT_STATUS'
@@ -29,7 +30,7 @@ export const state2props = ({ router, ...state }) => {
   const queryString = router.location.search.slice(1)
 
   const queryParams = parseQueryString(queryString)
-  const { metadata, selectedAdvisers } = state[INVESTMENT_PROJECTS_ID]
+  const { metadata, selectedAdvisers, results } = state[INVESTMENT_PROJECTS_ID]
   const financialYearStart = getFinancialYearStart(new Date())
   const financialYearOptions = [
     {
@@ -61,9 +62,9 @@ export const state2props = ({ router, ...state }) => {
     selectedFilters.includeRelatedCompanies.options.some(
       (f) => f.value === 'include_subsidiary_companies'
     )
-
   return {
     ...state[INVESTMENT_PROJECTS_ID],
+    results: results.map(transformInvestmentProjectToListItem),
     currentAdviserId: state.currentAdviserId,
     payload: { ...queryParams },
     selectedFilters,

--- a/src/client/modules/Investments/Projects/tasks.js
+++ b/src/client/modules/Investments/Projects/tasks.js
@@ -1,6 +1,5 @@
 import { apiProxyAxios } from '../../../components/Task/utils'
 import { getMetadataOptions } from '../../../metadata'
-import { transformInvestmentProjectToListItem } from './transformers'
 import { transformLandDateFilters } from './landDateTransformer'
 
 export const updateInvestmentProject = (values) =>
@@ -23,7 +22,7 @@ export const getProjects = ({ limit = 10, page, companyId, ...rest }) => {
     })
     .then(({ data }) => ({
       count: data.count,
-      results: data.results.map(transformInvestmentProjectToListItem),
+      results: data.results,
     }))
 }
 

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -282,7 +282,6 @@ export const transformInvestmentProjectToListItem = ({
     subheading: `Project code ${project_code}`,
     badges,
     metadata,
-    name: name,
   }
 }
 

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -282,6 +282,7 @@ export const transformInvestmentProjectToListItem = ({
     subheading: `Project code ${project_code}`,
     badges,
     metadata,
+    name: name,
   }
 }
 

--- a/src/client/modules/Tasks/TaskForm/TaskFormAdd.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormAdd.jsx
@@ -44,7 +44,12 @@ const getCancelUrl = (task) => {
   return urls.tasks.details(task.id)
 }
 
-const TaskFormAdd = ({ currentAdviserId, task, breadcrumbs }) => {
+const TaskFormAdd = ({
+  currentAdviserId,
+  task,
+  breadcrumbs,
+  companyInvestmentProjects,
+}) => {
   const { search } = useLocation()
   const { investmentProjectId } = qs.parse(search.slice(1))
   const redirectUrl = getRedirectUrl(task)
@@ -75,6 +80,7 @@ const TaskFormAdd = ({ currentAdviserId, task, breadcrumbs }) => {
         cancelRedirectUrl={cancelUrl}
         redirectToUrl={redirectUrl}
         submissionTaskName={TASK_SAVE_TASK_DETAILS}
+        companyInvestmentProjects={companyInvestmentProjects}
       />
     </DefaultLayout>
   )

--- a/src/client/modules/Tasks/TaskForm/TaskFormEdit.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormEdit.jsx
@@ -21,9 +21,13 @@ const getTitle = (task) => {
   return `Edit task for ${task.company.label}`
 }
 
-const TaskFormEdit = ({ currentAdviserId, task, breadcrumbs }) => {
+const TaskFormEdit = ({
+  currentAdviserId,
+  task,
+  breadcrumbs,
+  companyInvestmentProjects,
+}) => {
   const { taskId } = useParams()
-
   return (
     <DefaultLayout
       heading={getTitle(task)}
@@ -48,6 +52,7 @@ const TaskFormEdit = ({ currentAdviserId, task, breadcrumbs }) => {
               cancelRedirectUrl={urls.tasks.details(taskId)}
               redirectToUrl={urls.tasks.details(taskId)}
               submissionTaskName={TASK_SAVE_TASK_DETAILS}
+              companyInvestmentProjects={companyInvestmentProjects}
             />
           )
         }

--- a/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
@@ -158,7 +158,7 @@ const TaskFormFields = ({
                 name={TASK_GET_PROJECTS_LIST}
                 startOnRender={{
                   payload: {
-                    limit: 150,
+                    limit: 250,
                     companyId: task?.company?.value || values.company.value,
                   },
                   onSuccessDispatch: INVESTMENTS__PROJECTS_LOADED,
@@ -171,6 +171,7 @@ const TaskFormFields = ({
                   label="Investment project (optional)"
                   hint="This will link the task to the project selected. The task will be added to your task list on the homepage."
                   initialValue={task?.investmentProject}
+                  placeholder="Type to search for investment projects"
                 />
               )}
             </>

--- a/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
@@ -151,9 +151,9 @@ const TaskFormFields = ({
             hint="This will link the task to the company selected. The task will be added to your task list on the homepage."
             initialValue={task?.company}
           />
-
           {(task?.company || values.company) && (
             <>
+              {/* todo - this needs to refire the query when the company value changes */}
               <Task.Status
                 name={TASK_GET_PROJECTS_LIST}
                 startOnRender={{
@@ -163,7 +163,8 @@ const TaskFormFields = ({
                   },
                   onSuccessDispatch: INVESTMENTS__PROJECTS_LOADED,
                 }}
-              />
+              ></Task.Status>
+
               {companyInvestmentProjects && (
                 <FieldTypeahead
                   options={companyInvestmentProjects}

--- a/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
@@ -12,7 +12,7 @@ import {
   FieldAdvisersTypeahead,
   NewWindowLink,
   FieldCompaniesTypeahead,
-  FieldInvestmentProjectTypeahead,
+  FieldTypeahead,
 } from '../../../components'
 
 import { validateDaysRange, validateIfDateInFuture } from './validators'
@@ -20,6 +20,9 @@ import { FORM_LAYOUT, OPTIONS_YES_NO } from '../../../../common/constants'
 import { OPTIONS } from './constants'
 import urls from '../../../../lib/urls'
 import { TASK_SAVE_TASK_DETAILS } from './state'
+import Task from '../../../components/Task'
+import { TASK_GET_PROJECTS_LIST } from '../../Investments/Projects/state'
+import { INVESTMENTS__PROJECTS_LOADED } from '../../../actions'
 
 const StyledFieldInput = styled(FieldInput)`
   text-align: center;
@@ -44,6 +47,7 @@ const TaskFormFields = ({
   analyticsFormName,
   cancelRedirectUrl,
   redirectToUrl,
+  companyInvestmentProjects,
 }) => (
   <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
     <Form
@@ -147,14 +151,29 @@ const TaskFormFields = ({
             hint="This will link the task to the company selected. The task will be added to your task list on the homepage."
             initialValue={task?.company}
           />
+
           {(task?.company || values.company) && (
-            <FieldInvestmentProjectTypeahead
-              name="investmentProject"
-              label="Investment project (optional)"
-              hint="This will link the task to the project selected. The task will be added to your task list on the homepage."
-              company={values.company && values.company.value}
-              initialValue={task?.investmentProject}
-            />
+            <>
+              <Task.Status
+                name={TASK_GET_PROJECTS_LIST}
+                startOnRender={{
+                  payload: {
+                    limit: 150,
+                    companyId: task?.company?.value || values.company.value,
+                  },
+                  onSuccessDispatch: INVESTMENTS__PROJECTS_LOADED,
+                }}
+              />
+              {companyInvestmentProjects && (
+                <FieldTypeahead
+                  options={companyInvestmentProjects}
+                  name="investmentProject"
+                  label="Investment project (optional)"
+                  hint="This will link the task to the project selected. The task will be added to your task list on the homepage."
+                  initialValue={task?.investmentProject}
+                />
+              )}
+            </>
           )}
         </>
       )}

--- a/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
@@ -161,16 +161,16 @@ const TaskFormFields = ({
                 )
 
                 const companyId = values.company?.value || task?.company?.value
-
                 return (
                   <>
                     <Effect
                       dependencyList={[companyId]}
                       effect={() => {
-                        setFieldValue('investmentProject', {
-                          value: null,
-                          label: null,
-                        })
+                        companyInvestmentProjects &&
+                          setFieldValue('investmentProject', {
+                            value: null,
+                            label: null,
+                          })
                         getProjectsTask.start({
                           payload: {
                             limit: 250,

--- a/src/client/modules/Tasks/TaskForm/state.js
+++ b/src/client/modules/Tasks/TaskForm/state.js
@@ -1,6 +1,12 @@
 import urls from '../../../../lib/urls'
-import { transformIdNameToValueLabel } from '../../../transformers'
-import { INVESTMENT_PROJECT_ID } from '../../Investments/Projects/state'
+import {
+  transformArrayIdNameToValueLabel,
+  transformIdNameToValueLabel,
+} from '../../../transformers'
+import {
+  INVESTMENT_PROJECTS_ID,
+  INVESTMENT_PROJECT_ID,
+} from '../../Investments/Projects/state'
 import { ID as TASK_DETAILS_ID } from '../TaskDetails/state'
 import { transformAPIValuesForForm } from './transformers'
 
@@ -76,12 +82,20 @@ export const state2props = (state) => {
   const currentAdviserId = state.currentAdviserId
   const { task } = state[TASK_DETAILS_ID]
   const { project } = state[INVESTMENT_PROJECT_ID]
+  const { results } = state[INVESTMENT_PROJECTS_ID]
+
+  const companyInvestmentProjects =
+    Array.isArray(results) && results.length > 0
+      ? transformArrayIdNameToValueLabel(results)
+      : null
+
   if (task) {
     const transformedTask = transformAPIValuesForForm(task, currentAdviserId)
     return {
       task: transformedTask,
       currentAdviserId,
       breadcrumbs: getTaskBreadcrumbs(transformedTask),
+      companyInvestmentProjects: companyInvestmentProjects,
     }
   }
 
@@ -97,6 +111,7 @@ export const state2props = (state) => {
       },
       currentAdviserId,
       breadcrumbs: getInvestmentProjectBreadcumbs(transformedProject),
+      companyInvestmentProjects: companyInvestmentProjects,
     }
   }
 
@@ -104,5 +119,6 @@ export const state2props = (state) => {
     task: null,
     currentAdviserId,
     breadcrumbs: getGenericBreadcumbs(task),
+    companyInvestmentProjects: companyInvestmentProjects,
   }
 }

--- a/src/client/modules/Tasks/TaskForm/transformers.js
+++ b/src/client/modules/Tasks/TaskForm/transformers.js
@@ -36,7 +36,7 @@ export const transformTaskFormValuesForAPI = (
 })
 
 const getUniquePKValue = (formValues) => {
-  if (formValues.investmentProject) {
+  if (formValues?.investmentProject?.value) {
     return {
       investment_project: formValues.investmentProject.value,
       company: null,

--- a/test/component/cypress/specs/Tasks/TaskForm/TaskFormFields.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskForm/TaskFormFields.cy.jsx
@@ -324,17 +324,6 @@ describe('Task form', () => {
           })
         })
       })
-
-      it('should display the investment project typeahead without a selected value', () => {
-        cy.get('[data-test="field-investmentProject"]').then((element) => {
-          assertFieldSingleTypeahead({
-            element,
-            label: 'Investment project (optional)',
-            value: '',
-            placeholder: 'Type to search for investment projects',
-          })
-        })
-      })
     })
 
     context(
@@ -347,6 +336,7 @@ describe('Task form', () => {
             <Component
               cancelRedirectUrl={urls.companies.index()}
               task={transformAPIValuesForForm(task)}
+              companyInvestmentProjects={{ results: [task.investmentProject] }}
             />
           )
         })

--- a/test/functional/cypress/specs/tasks/add-task-spec.js
+++ b/test/functional/cypress/specs/tasks/add-task-spec.js
@@ -10,6 +10,7 @@ import {
   assertExactUrl,
   assertSingleTypeaheadOptionSelected,
   assertVisible,
+  assertNotExists,
 } from '../../support/assertions'
 import {
   fill,
@@ -32,7 +33,7 @@ describe('Add generic task', () => {
       cy.get('h1').should('have.text', 'Add task')
     })
 
-    context('When a company is selected', () => {
+    context('When a company is selected that has investment projects', () => {
       const company = companyFaker()
 
       it('should display the investment project typeahead field', () => {
@@ -42,6 +43,23 @@ describe('Add generic task', () => {
         assertVisible('[data-test="field-investmentProject"]')
       })
     })
+
+    context(
+      'When a company is selected that doesnt have any investment projects',
+      () => {
+        const company = companyFaker()
+
+        it('should not the investment project typeahead field', () => {
+          cy.intercept(`/api-proxy/v4/company?*`, { results: [company] })
+          cy.intercept(`/api-proxy/v3/search/investment_project`, {
+            results: [],
+          })
+          fillTypeahead('[data-test=field-company]', company.name)
+
+          assertNotExists('[data-test="field-investmentProject"]')
+        })
+      }
+    )
   })
 
   context('When creating a task for me', () => {

--- a/test/functional/cypress/specs/tasks/add-task-spec.js
+++ b/test/functional/cypress/specs/tasks/add-task-spec.js
@@ -49,7 +49,7 @@ describe('Add generic task', () => {
       () => {
         const company = companyFaker()
 
-        it('should not the investment project typeahead field', () => {
+        it('should not the show the investment project typeahead field', () => {
           cy.intercept(`/api-proxy/v4/company?*`, { results: [company] })
           cy.intercept(`/api-proxy/v3/search/investment_project`, {
             results: [],

--- a/test/functional/cypress/specs/tasks/edit-task-spec.js
+++ b/test/functional/cypress/specs/tasks/edit-task-spec.js
@@ -86,6 +86,13 @@ describe('Edit investment project task', () => {
       })
     })
 
+    it('should display the investment project typeahead with the value matching the investment project', () => {
+      assertSingleTypeaheadOptionSelected({
+        element: '[data-test="field-investmentProject"]',
+        expectedOption: investmentProjectTask.investmentProject.name,
+      })
+    })
+
     it('changing field values should send new values to the api', () => {
       cy.intercept('PATCH', endpoint, {
         statusCode: 200,


### PR DESCRIPTION
## Description of change

- Change the investment project field in the task form from a typeahead that uses an api call to retrieve matching results, to a field that has all the investment projects matching the selected company already loaded.
- Only show the investment project field when the company selected has at least 1 investment project
- Moved the logic for converting the api response for an investment project search into the state2props, as the reducer should store the raw value for use by other components

## Test instructions

Add a new task or edit an existing one. Choose a company that you know has investment projects and choose that in the company name field. The investment project field will now show, if you click into it you will see all the projects belonging to that company.

Do the same test, but this time choose a company you know has no investment projects. The investment project field will not display

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/7a22a842-d1e4-44cd-b8f1-d677d031b6ec)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/102232401/be20db53-c24d-408c-8104-fa96ca5d25ca)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
