### PR TITLE
Display project on task details

### DIFF
--- a/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
@@ -9,7 +9,7 @@ import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 import urls from '../../../../lib/urls'
 import TaskButtons from './TaskButtons'
 
-const TaskDetailsTable = ({ task, company }) => (
+const TaskDetailsTable = ({ task, company, project }) => (
   <>
     <SummaryTable data-test="task-details-table">
       <SummaryTable.Row
@@ -22,6 +22,16 @@ const TaskDetailsTable = ({ task, company }) => (
           )
         }
       />
+      {project && (
+        <SummaryTable.Row
+          heading="Investment project"
+          children={
+            <Link href={urls.investments.projects.details(project.id)}>
+              {project.name}
+            </Link>
+          }
+        />
+      )}
       <SummaryTable.Row
         heading="Date due"
         children={task.dueDate ? formatLongDate(task.dueDate) : NOT_SET_TEXT}

--- a/src/client/modules/Tasks/TaskDetails/index.jsx
+++ b/src/client/modules/Tasks/TaskDetails/index.jsx
@@ -43,7 +43,15 @@ const TaskDetails = ({ task, breadcrumbs }) => {
           onSuccessDispatch: TASK_DETAILS_LOADED,
         }}
       >
-        {() => task && <TaskDetailsTable task={task} company={task?.company} />}
+        {() =>
+          task && (
+            <TaskDetailsTable
+              task={task}
+              company={task?.company}
+              project={task?.investmentProject}
+            />
+          )
+        }
       </Task.Status>
     </DefaultLayout>
   )

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -1,12 +1,18 @@
 import React from 'react'
 
+import { pick } from 'lodash'
+
 import { assertSummaryTable } from '../../../../../functional/cypress/support/assertions'
-import { taskWithInvestmentProjectFaker } from '../../../../../functional/cypress/fakers/task'
+import {
+  taskFaker,
+  taskWithInvestmentProjectFaker,
+} from '../../../../../functional/cypress/fakers/task'
 import urls from '../../../../../../src/lib/urls'
 import { formatLongDate } from '../../../../../../src/client/utils/date'
 import { NOT_SET_TEXT } from '../../../../../../src/apps/companies/constants'
 import TaskDetailsTable from '../../../../../../src/client/modules/Tasks/TaskDetails/TaskDetailsTable'
 import DataHubProvider from '../../provider'
+import { companyFaker } from '../../../../../functional/cypress/fakers/companies'
 
 describe('Task details table', () => {
   const Component = (props) => (
@@ -56,17 +62,21 @@ describe('Task details table', () => {
   })
 
   context('When a task is missing all optional fields', () => {
-    const investmentProjectTask = taskWithInvestmentProjectFaker({
+    const company = pick(companyFaker(), ['id', 'name'])
+    const project = null
+
+    const taskNoInvestmentProject = taskFaker({
       dueDate: undefined,
       description: undefined,
       emailRemindersEnabled: false,
+      company: company,
+      investmentProject: project,
     })
-    const company = investmentProjectTask.company
 
     it('the table should show all expected values', () => {
       cy.mount(
         <Component
-          task={investmentProjectTask}
+          task={taskNoInvestmentProject}
           company={company}
           project={project}
         />
@@ -82,13 +92,13 @@ describe('Task details table', () => {
             name: company.name,
           },
           ['Date due']: NOT_SET_TEXT,
-          'Assigned to': investmentProjectTask.advisers
+          'Assigned to': taskNoInvestmentProject.advisers
             .map((adviser) => adviser.name)
             .join(''),
           'Task description': NOT_SET_TEXT,
           'Reminders set': NOT_SET_TEXT,
-          'Date created': formatLongDate(investmentProjectTask.createdOn),
-          'Created by': investmentProjectTask.createdBy.name,
+          'Date created': formatLongDate(taskNoInvestmentProject.createdOn),
+          'Created by': taskNoInvestmentProject.createdBy.name,
         },
       })
     })

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -65,7 +65,7 @@ describe('Task details table', () => {
     const company = pick(companyFaker(), ['id', 'name'])
     const project = null
 
-    const taskNoInvestmentProject = taskFaker({
+    const taskWithNoInvestmentProject = taskFaker({
       dueDate: undefined,
       description: undefined,
       emailRemindersEnabled: false,
@@ -76,7 +76,7 @@ describe('Task details table', () => {
     it('the table should show all expected values', () => {
       cy.mount(
         <Component
-          task={taskNoInvestmentProject}
+          task={taskWithNoInvestmentProject}
           company={company}
           project={project}
         />
@@ -92,13 +92,13 @@ describe('Task details table', () => {
             name: company.name,
           },
           ['Date due']: NOT_SET_TEXT,
-          'Assigned to': taskNoInvestmentProject.advisers
+          'Assigned to': taskWithNoInvestmentProject.advisers
             .map((adviser) => adviser.name)
             .join(''),
           'Task description': NOT_SET_TEXT,
           'Reminders set': NOT_SET_TEXT,
-          'Date created': formatLongDate(taskNoInvestmentProject.createdOn),
-          'Created by': taskNoInvestmentProject.createdBy.name,
+          'Date created': formatLongDate(taskWithNoInvestmentProject.createdOn),
+          'Created by': taskWithNoInvestmentProject.createdBy.name,
         },
       })
     })

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -18,9 +18,16 @@ describe('Task details table', () => {
   context('When a task has all optional fields set', () => {
     const investmentProjectTask = taskWithInvestmentProjectFaker()
     const company = investmentProjectTask.company
+    const project = investmentProjectTask.investmentProject
 
     it('the table should show all expected values', () => {
-      cy.mount(<Component task={investmentProjectTask} company={company} />)
+      cy.mount(
+        <Component
+          task={investmentProjectTask}
+          company={company}
+          project={project}
+        />
+      )
 
       assertSummaryTable({
         dataTest: 'task-details-table',
@@ -30,6 +37,10 @@ describe('Task details table', () => {
           Company: {
             href: urls.companies.detail(company.id),
             name: company.name,
+          },
+          ['Investment project']: {
+            href: urls.investments.projects.details(project.id),
+            name: project.name,
           },
           ['Date due']: formatLongDate(investmentProjectTask.dueDate),
           'Assigned to': investmentProjectTask.advisers
@@ -53,7 +64,13 @@ describe('Task details table', () => {
     const company = investmentProjectTask.company
 
     it('the table should show all expected values', () => {
-      cy.mount(<Component task={investmentProjectTask} company={company} />)
+      cy.mount(
+        <Component
+          task={investmentProjectTask}
+          company={company}
+          project={project}
+        />
+      )
 
       assertSummaryTable({
         dataTest: 'task-details-table',


### PR DESCRIPTION
## Description of change

Display Project on task details page if one is assigned. The field will not display if there is no project.

## Test instructions

Go to a task with an investment project. You should see the investment project listed and clicking the name will redirect to the investment projects details.

## Screenshots

<img width="978" alt="Screenshot 2023-12-28 at 14 59 33" src="https://github.com/uktrade/data-hub-frontend/assets/54268863/129ee14e-f5fb-48c5-8e33-ab083dddcdde">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
