### PR TITLE
Check for DUNS number before firing the related company count resource

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -149,22 +149,24 @@ const CompanyLocalHeader = ({
             <StyledAddress data-test="address">
               {addressToStringResource(company.address)}
             </StyledAddress>
-            <RelatedCompaniesCountResource id={company.id}>
-              {({ relatedCompaniesCount }) =>
-                relatedCompaniesCount > 0 && (
-                  <StyledRelatedCompaniesWrapper>
-                    <Link
-                      href={urls.companies.dnbHierarchy.tree(company.id)}
-                      data-test="company-tree-link"
-                    >
-                      {`View company tree: ${
-                        relatedCompaniesCount + 1
-                      } companies`}
-                    </Link>
-                  </StyledRelatedCompaniesWrapper>
-                )
-              }
-            </RelatedCompaniesCountResource>
+            {company.dunsNumber && (
+              <RelatedCompaniesCountResource id={company.id}>
+                {({ relatedCompaniesCount }) =>
+                  relatedCompaniesCount > 0 && (
+                    <StyledRelatedCompaniesWrapper>
+                      <Link
+                        href={urls.companies.dnbHierarchy.tree(company.id)}
+                        data-test="company-tree-link"
+                      >
+                        {`View company tree: ${
+                          relatedCompaniesCount + 1
+                        } companies`}
+                      </Link>
+                    </StyledRelatedCompaniesWrapper>
+                  )
+                }
+              </RelatedCompaniesCountResource>
+            )}
           </GridCol>
           <GridCol setWith="one-third">
             <StyledButtonContainer>


### PR DESCRIPTION
## Description of change

When I did the work for #6394 I forgot to add a check for company DUNS numbers, which meant that all non-DNB companies were showing an error in the header. This has now been fixed.

## Test instructions

Go to a non-DNB company page. There shouldn't be any errors in the header.

## Screenshots

### Before

<img width="827" alt="Screenshot 2024-01-05 at 10 31 13" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/a75c4e18-941d-4b6b-8635-0c76d240879f">


### After

<img width="833" alt="Screenshot 2024-01-05 at 10 31 20" src="https://github.com/uktrade/data-hub-frontend/assets/36161814/c60d9dac-230c-4fd4-8d9d-b8273aae5fb0">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
