### PR TITLE
Ensure Add Tasks button only appears in my tasks dashboard

### DIFF
--- a/src/client/components/ContentWithHeading.jsx
+++ b/src/client/components/ContentWithHeading.jsx
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import { Button, H3, Link } from 'govuk-react'
+import { H3 } from 'govuk-react'
 import styled from 'styled-components'
 
 import SpacedSectionBreak from './SpacedSectionBreak'
-import { BLUE } from '../utils/colours'
-import urls from '../../lib/urls'
 
 const StyledHeading = styled(H3)({
   flexGrow: 1,
@@ -21,14 +19,6 @@ const ContentWithHeading = ({ heading, children, headingActions }) => (
     <StyledHeader>
       <StyledHeading size={24}>{heading}</StyledHeading>
       {headingActions}
-      <Button
-        buttonColour={BLUE}
-        href={urls.tasks.create()}
-        as={Link}
-        data-test="add-task"
-      >
-        Add task
-      </Button>
     </StyledHeader>
     <SpacedSectionBreak />
     {children}

--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -67,7 +67,7 @@ export const MyTasksContent = ({ myTasks, filters }) => (
           as={Link}
           data-test="add-task"
         >
-          Add tasks
+          Add task
         </Button>
       }
       data-test="my-tasks-heading"

--- a/src/client/components/Dashboard/my-tasks/MyTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasks.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import styled from 'styled-components'
 import { SITE_WIDTH, SPACING } from '@govuk-react/constants'
 
-import { HintText } from 'govuk-react'
+import { HintText, Button, Link } from 'govuk-react'
 
 import { ID as GET_MY_TASKS_ID, TASK_GET_MY_TASKS, state2props } from './state'
 import { MY_TASKS_LOADED } from '../../../actions'
@@ -12,6 +12,8 @@ import ContentWithHeading from '../../ContentWithHeading'
 import MyTasksTable from './MyTasksTable'
 import TaskListSelect from './TaskListSelect'
 import SpacedSectionBreak from '../../SpacedSectionBreak'
+import { BLUE } from '../../../utils/colours'
+import urls from '../../../../lib/urls'
 
 const SELECT_WIDTH = `16%`
 
@@ -58,6 +60,16 @@ export const MyTasksContent = ({ myTasks, filters }) => (
     <SpacedSectionBreak />
     <ContentWithHeading
       heading={`${myTasks?.count} ${myTasks?.count == 1 ? 'task' : 'tasks'}`}
+      headingActions={
+        <Button
+          buttonColour={BLUE}
+          href={urls.tasks.create()}
+          as={Link}
+          data-test="add-task"
+        >
+          Add tasks
+        </Button>
+      }
       data-test="my-tasks-heading"
     >
       {myTasks?.count ? (


### PR DESCRIPTION
## Description of change

The "Add Task" component is currently being loaded in every tab, including unrelated ones, of a user's dashboard.
This PR moves where the button is being loaded to ensure it's only in the correct place.


## Screenshots

### Before
![Screenshot 2024-01-05 at 11 15 13](https://github.com/uktrade/data-hub-frontend/assets/1381563/39bf4b04-9f44-4873-92b8-994969a66762)

![Screenshot 2024-01-05 at 11 15 09](https://github.com/uktrade/data-hub-frontend/assets/1381563/09ff3c74-7a91-420b-bf24-bd11edc649e3)

![Screenshot 2024-01-05 at 11 15 05](https://github.com/uktrade/data-hub-frontend/assets/1381563/6ecd2fe4-b67f-4abc-aa3a-c663b1ffb184)

![Screenshot 2024-01-05 at 11 15 01](https://github.com/uktrade/data-hub-frontend/assets/1381563/a6716635-632f-48af-807f-a413f7ee48c3)

### After

![Screenshot 2024-01-05 at 11 12 08](https://github.com/uktrade/data-hub-frontend/assets/1381563/9a8ceb25-598a-4fcf-bb11-6593f7ad5dbb)

![Screenshot 2024-01-05 at 11 12 13](https://github.com/uktrade/data-hub-frontend/assets/1381563/b14d2ccf-0cc0-485e-8276-b14206f353c1)

![Screenshot 2024-01-05 at 11 12 1
8](https://github.com/uktrade/data-hub-frontend/assets/1381563/1ee63894-9248-410b-b4a4-93451074a0d5)

![Screenshot 2024-01-05 at 11 12 23](https://github.com/uktrade/data-hub-frontend/assets/1381563/f01aee84-8e9d-467b-a70a-62f117615462)

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
