### PR TITLE
Resize no-tasks image to 460/380px

### DIFF
--- a/src/client/components/Dashboard/my-tasks/NoTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/NoTasks.jsx
@@ -34,11 +34,11 @@ const StyledImage = styled('img')`
   display: none;
   ${MEDIA_QUERIES.TABLET} {
     display: block;
-    width: 655px;
+    width: 380px;
     margin-bottom: ${SPACING.SCALE_3};
   }
   ${MEDIA_QUERIES.DESKTOP} {
-    width: 760px;
+    width: 460px;
     margin: ${SPACING.SCALE_3} 0 35px 0;
   }
 `


### PR DESCRIPTION
## Description of change

Resizes the my tasks placeholder image (when no tasks are present) down to `460px` (`380px` for tablets) so it's not too big

## Screenshots

### Before

![Screenshot 2024-01-05 at 13 46 50](https://github.com/uktrade/data-hub-frontend/assets/1381563/9ef8a199-a1c1-472e-8c70-9734663ad55c)

### After

![Screenshot 2024-01-05 at 13 46 34](https://github.com/uktrade/data-hub-frontend/assets/1381563/0e9c2035-a7f6-4895-8bbb-35d976671ca7)

## Checklist


- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
