### PR TITLE
bugfix/investment-project-urls

### DIFF
--- a/src/client/components/CompanyTabbedLocalNavigation/constants.js
+++ b/src/client/components/CompanyTabbedLocalNavigation/constants.js
@@ -40,7 +40,6 @@ export const localNavItems = (companyId) => {
         companyId
       ),
       label: 'Investment',
-      search: '/projects?page=1&sortby=created_on%3Adesc',
       permissions: [
         'investment.view_all_investmentproject',
         'investment.view_associated_investmentproject',


### PR DESCRIPTION
## Description of change

The search portion of the investment project url is duplicated, both in the urls.js file and the constants.js file. Only one is required as it is causing an issue with the search endpoints

## Test instructions

Go to any company on dev and click the Investments tab, you will get an error. Do the same on this branch and it will work



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
