### PR TITLE
Fix Refer Button when loading company page lists

### DIFF
--- a/src/client/components/CompanyLocalHeader/LocalHeaderCompanyLists.jsx
+++ b/src/client/components/CompanyLocalHeader/LocalHeaderCompanyLists.jsx
@@ -14,6 +14,7 @@ import {
 import Task from '../Task'
 import { COMPANY_LISTS__COMPANY_IN_LOADED } from '../../actions'
 import { ID, TASK_GET_LISTS_COMPANY_IS_IN, state2props } from './state'
+import LocalHeaderCompanyRefer from './LocalHeaderCompanyRefer'
 
 const StyledCompanyListButton = styled('button')`
   display: inline-table;
@@ -75,6 +76,7 @@ export const LocalHeaderCompanyLists = ({ results, company, returnUrl }) => {
             >
               <span>+</span> Add to list
             </StyledAddButton>
+            <LocalHeaderCompanyRefer companyId={company.id} />
           </>
         )
       }

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -14,7 +14,6 @@ import { GREY_3, TEXT_COLOUR } from '../../utils/colours'
 import LocalHeader from '../LocalHeader/LocalHeader'
 import LocalHeaderHeading from '../LocalHeader/LocalHeaderHeading'
 import LocalHeaderCompanyLists from './LocalHeaderCompanyLists'
-import LocalHeaderCompanyRefer from './LocalHeaderCompanyRefer'
 import Badge from '../../../client/components/Badge'
 import StatusMessage from '../../../client/components/StatusMessage'
 import { addressToStringResource } from '../../../client/utils/addresses'
@@ -193,7 +192,6 @@ const CompanyLocalHeader = ({
         </GridRow>
         <StyledList>
           <LocalHeaderCompanyLists company={company} returnUrl={returnUrl} />
-          <LocalHeaderCompanyRefer companyId={company.id} />
         </StyledList>
         {(isUltimate(company) || isGlobalHQ(company)) && (
           <TypeWrapper>


### PR DESCRIPTION
## Description of change

The `refer this company` button now loads once the lists task has finished loading. This prevents the button stretching whilst the loading symbol is present.

## Test instructions

When viewing a company page, you should no longer see the refer company button until the lists have loaded

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
