### PR TITLE
Added related interaction to task details

### DIFF
--- a/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
@@ -32,6 +32,16 @@ const TaskDetailsTable = ({ task, company, project }) => (
           }
         />
       )}
+      {task.interaction && (
+        <SummaryTable.Row
+          heading="Related interaction"
+          children={
+            <Link href={urls.interactions.detail(task.interaction.id)}>
+              {task.interaction.subject}
+            </Link>
+          }
+        />
+      )}
       <SummaryTable.Row
         heading="Date due"
         children={task.dueDate ? formatLongDate(task.dueDate) : NOT_SET_TEXT}

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -6,6 +6,7 @@ import { assertSummaryTable } from '../../../../../functional/cypress/support/as
 import {
   taskFaker,
   taskWithInvestmentProjectFaker,
+  taskWithInteractionFaker,
 } from '../../../../../functional/cypress/fakers/task'
 import urls from '../../../../../../src/lib/urls'
 import { formatLongDate } from '../../../../../../src/client/utils/date'
@@ -99,6 +100,39 @@ describe('Task details table', () => {
           'Reminders set': NOT_SET_TEXT,
           'Date created': formatLongDate(taskWithNoInvestmentProject.createdOn),
           'Created by': taskWithNoInvestmentProject.createdBy.name,
+        },
+      })
+    })
+  })
+
+  context('When a task is linked to an interaction', () => {
+    const taskWithInteraction = taskWithInteractionFaker()
+    const company = taskWithInteraction.company
+
+    it('the table should show all expected values', () => {
+      cy.mount(<Component task={taskWithInteraction} company={company} />)
+
+      assertSummaryTable({
+        dataTest: 'task-details-table',
+        heading: null,
+        showEditLink: false,
+        content: {
+          Company: {
+            href: urls.companies.detail(company.id),
+            name: company.name,
+          },
+          'Related interaction': {
+            href: urls.interactions.detail(taskWithInteraction.interaction.id),
+            name: taskWithInteraction.interaction.subject,
+          },
+          ['Date due']: formatLongDate(taskWithInteraction.dueDate),
+          'Assigned to': taskWithInteraction.advisers
+            .map((adviser) => adviser.name)
+            .join(''),
+          'Task description': taskWithInteraction.description,
+          'Reminders set': `${taskWithInteraction.reminderDays} days before due date`,
+          'Date created': formatLongDate(taskWithInteraction.createdOn),
+          'Created by': taskWithInteraction.createdBy.name,
         },
       })
     })

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -3,6 +3,7 @@ import { pick } from 'lodash'
 
 import { listFaker } from './utils'
 import { companyFaker } from './companies'
+import { interactionFaker } from './interactions'
 
 const basicAdviserFaker = (overrides = {}) => ({
   name: faker.person.fullName(),
@@ -21,6 +22,7 @@ const taskFaker = (overrides = {}) => ({
   reminderDays: faker.helpers.rangeToNumber({ min: 0, max: 365 }),
   emailRemindersEnabled: true,
   advisers: [...Array(3)].map(() => basicAdviserFaker()),
+  interaction: null,
   archived: false,
   archivedBy: null,
   createdBy: basicAdviserFaker(),
@@ -46,6 +48,29 @@ const taskWithInvestmentProjectFaker = (
         ...investmentProjectOverrides,
       },
       company: company,
+      ...overrides,
+    })
+  )
+}
+
+const taskWithInteractionFaker = (overrides = {}) => {
+  const company = pick(companyFaker(), ['id', 'name'])
+  const interaction = pick(
+    interactionFaker({
+      companies: [
+        {
+          name: company.name,
+          id: company.id,
+        },
+      ],
+    }),
+    ['subject', 'id']
+  )
+
+  return taskFaker(
+    (overrides = {
+      company: company,
+      interaction: interaction,
       ...overrides,
     })
   )
@@ -78,6 +103,7 @@ export {
   taskListFaker,
   taskWithInvestmentProjectFaker,
   taskWithInvestmentProjectListFaker,
+  taskWithInteractionFaker,
   basicAdviserFaker,
   taskWithCompanyFaker,
 }

--- a/test/functional/cypress/specs/tasks/details-spec.js
+++ b/test/functional/cypress/specs/tasks/details-spec.js
@@ -11,6 +11,7 @@ import {
   assertUrl,
 } from '../../support/assertions'
 import { clickButton } from '../../support/actions'
+import interactionsListFaker from '../../fakers/interactions'
 
 describe('View details for a generic task', () => {
   const genericTaskCompleted = taskFaker({ archived: true })
@@ -136,6 +137,29 @@ describe('View details for task that is assigned to a company', () => {
       clickButton('Mark as complete')
       assertPayload('@postTaskArchiveApiRequest', { reason: 'completed' })
       assertUrl(dashboard.myTasks())
+    })
+  })
+})
+
+describe('View details for task that is assigned to an interaction', () => {
+  const interaction = interactionsListFaker((length = 3))
+  const task = taskWithCompanyFaker({
+    interaction: { subject: interaction[0].subject, id: interaction[0].id },
+  })
+
+  context('When visiting a completed task details', () => {
+    before(() => {
+      cy.intercept('GET', `/api-proxy/v4/task/${task.id}`, task).as(
+        'apiRequest'
+      )
+      cy.visit(tasks.details(task.id))
+      cy.wait('@apiRequest')
+    })
+
+    it('should display the summary table', () => {
+      assertSummaryTable({
+        dataTest: 'task-details-table',
+      })
     })
   })
 })


### PR DESCRIPTION
Show the interaction title on a task

## Description of change

This ticket is to add a row with title: ‘Related interaction’ that will show the interaction title with a clickable link to the interaction detail page. 

## Test instructions

Pull this branch.
1. Create a an interaction then create task from that interaction.
2. Go to the tasks homepage.
3. Click on the task you just created.
4. View the title of the interaction you created.
5. Click on this and you will be directed to the interaction

## Screenshots

### Before
![Screenshot 2024-01-11 at 13 52 22](https://github.com/uktrade/data-hub-frontend/assets/72826129/5cd0109e-74fd-46f1-b888-6a171ea2110e)


### Af
![Screenshot 2024-01-11 at 13 52 04](https://github.com/uktrade/data-hub-frontend/assets/72826129/29c327dd-b2e0-4a4f-9353-bc82a3d558b1)
ter


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
