### PR TITLE
Add Export Win - Credit for this win (2 of 6 steps)

### DIFF
--- a/src/client/components/Resource/Resource.jsx
+++ b/src/client/components/Resource/Resource.jsx
@@ -265,7 +265,7 @@ export const createMetadataResource = (name, endpoint) => {
     rawResult,
   ]
   const Component = (props) => (
-    <EntityResource transformer={transformer} {...props} id="__METADATA__" />
+    <EntityResource transformer={transformer} id="__METADATA__" {...props} />
   )
 
   Component.propTypes = _.omit(Component.propTypes, 'id')

--- a/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
+++ b/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
@@ -1,21 +1,111 @@
 import React from 'react'
+import { H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 
+import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { Step, FieldInput } from '../../../components'
+import { OPTION_YES, OPTIONS_YES_NO } from '../../../../common/constants'
+import { MID_GREY } from '../../../../client/utils/colours'
+import { StyledHintParagraph } from './styled'
 import { steps } from './constants'
+import {
+  TeamTypeResource,
+  HQTeamRegionOrPostsResource,
+} from '../../../components/Resource'
+import {
+  Step,
+  FieldRadios,
+  FieldTypeahead,
+  FieldAddAnother,
+  FieldAdvisersTypeahead,
+} from '../../../components'
 
-const StyledFieldInput = styled(FieldInput)({
-  display: 'none',
+const Container = styled('div')({
+  borderLeft: `3px solid ${MID_GREY}`,
+  marginLeft: 18,
+  paddingLeft: 34,
+})
+
+const StyledFieldRadios = styled(FieldRadios)({
+  marginBottom: 0,
 })
 
 const CreditForThisWinStep = () => {
-  // eslint-disable-next-line no-unused-vars
   const { values } = useFormContext()
+
+  // Determine the child group count by selecting any field
+  const officerCount = Object.keys(values).filter((key) =>
+    key.startsWith('contributing_officer')
+  ).length
+
   return (
     <Step name={steps.CREDIT_FOR_THIS_WIN}>
-      <h1>Credit for this win</h1>
-      <StyledFieldInput name="hidden" type="text" />
+      <H3 data-test="step-heading">Credit for this win</H3>
+      <StyledHintParagraph data-test="hint">
+        Other teams that helped with this win should be added so they can be
+        credited, this will not reduce your credit for this win.
+      </StyledHintParagraph>
+      <StyledFieldRadios
+        name="credit_for_win"
+        label="Did any other teams help with this win?"
+        inline={true}
+        options={OPTIONS_YES_NO}
+        required="Select Yes or No"
+      />
+      {values.credit_for_win === OPTION_YES && (
+        <Container>
+          <FieldAddAnother
+            name="addAnother"
+            label="Contributing advisers"
+            hint="Up to 5 advisers can be added."
+            itemName="contributing-adviser"
+            buttonText="Add another"
+            limitChildGroupCount={5}
+            dataTestPrefix="contributing-advisers-"
+            initialChildGroupCount={officerCount || 1}
+          >
+            {({ groupIndex }) => (
+              <>
+                <FieldAdvisersTypeahead
+                  name={`contributing_officer_${groupIndex}`}
+                  label="Contributing officer"
+                  required="Enter a contributing officer"
+                />
+                <ResourceOptionsField
+                  name={`team_type_${groupIndex}`}
+                  id={`contributors-${groupIndex}`}
+                  resource={TeamTypeResource}
+                  field={FieldTypeahead}
+                  fullWidth={true}
+                  label="Team type"
+                  required="Enter a team type"
+                />
+                {values[`team_type_${groupIndex}`] && (
+                  // Should a user choose a team type, then choose a HQ team, region or post
+                  // then change their mind and change the team type for a second time we
+                  // want the component below to rerender and display 'Start typing'. We don't
+                  // want the previous selection displayed after they've changed the team type.
+                  // To ensure this happens we've added a key prop and set it to the team type
+                  // id, when the id changes the component updates.
+                  <ResourceOptionsField
+                    key={values[`team_type_${groupIndex}`].value}
+                    name={`hq_team_${groupIndex}`}
+                    id={`contributors-${groupIndex}`}
+                    resource={HQTeamRegionOrPostsResource}
+                    field={FieldTypeahead}
+                    fullWidth={true}
+                    label="HQ team, region or post"
+                    required="Enter a HQ team, region or post"
+                    payload={{
+                      team_type: values[`team_type_${groupIndex}`].value,
+                    }}
+                  />
+                )}
+              </>
+            )}
+          </FieldAddAnother>
+        </Container>
+      )}
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { Step } from '../../../components'
+import { Step, FieldInput } from '../../../components'
 import { steps } from './constants'
+
+const StyledFieldInput = styled(FieldInput)({
+  display: 'none',
+})
 
 const CustomerDetailsStep = () => {
   // eslint-disable-next-line no-unused-vars
@@ -10,6 +15,7 @@ const CustomerDetailsStep = () => {
   return (
     <Step name={steps.CUSTOMER_DETAILS}>
       <h1>Customer details</h1>
+      <StyledFieldInput name="hidden" type="text" />
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/styled.jsx
+++ b/src/client/modules/ExportWins/Form/styled.jsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+import { DARK_GREY } from '../../../utils/colours'
+
+export const StyledHintParagraph = styled('p')({
+  color: DARK_GREY,
+})

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -4,6 +4,7 @@ import {
   assertLocalHeader,
   assertErrorSummary,
   assertFieldTypeahead,
+  assertFieldRadiosWithLegend,
 } from '../../support/assertions'
 import { clickContinueButton } from '../../support/actions'
 import { companyFaker } from '../../fakers/companies'
@@ -145,8 +146,128 @@ describe('Adding an export win', () => {
   })
 
   context('Credit for this win', () => {
-    it('should complete this step and continue to "Customer details"', () => {
+    beforeEach(() =>
       cy.visit(`${urls.companies.exportWins.create()}${creditForThisWin}`)
+    )
+
+    it('should render a step heading', () => {
+      cy.get('[data-test="step-heading"]').should(
+        'have.text',
+        'Credit for this win'
+      )
+    })
+
+    it('should render a hint', () => {
+      cy.get('[data-test="hint"]').should(
+        'have.text',
+        'Other teams that helped with this win should be added so they can be credited, this will not reduce your credit for this win.'
+      )
+    })
+
+    it('should render two unselected radio buttons', () => {
+      cy.get('[data-test="field-credit_for_win"]').then((element) => {
+        assertFieldRadiosWithLegend({
+          element,
+          legend: 'Did any other teams help with this win?',
+          optionsCount: 2,
+        })
+      })
+      cy.get('[data-test="credit-for-win-yes"]').should('not.be.checked')
+      cy.get('[data-test="credit-for-win-no"]').should('not.be.checked')
+    })
+
+    it('should go to the next step when selecting "No" and then "Continue"', () => {
+      cy.get('[data-test="credit-for-win-no"]').check()
+      clickContinueAndAssertUrl(customerDetails)
+    })
+
+    it('should render a legend and hint text', () => {
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      cy.get('[data-test="field-addAnother"]')
+        .find('legend')
+        .eq(0)
+        .should('have.text', 'Contributing advisers')
+      cy.get('[data-test="hint-text"]').should(
+        'have.text',
+        'Up to 5 advisers can be added.'
+      )
+    })
+
+    it('should render a Typeahead for the contributing officer', () => {
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      cy.get('[data-test="field-contributing_officer_0"]').then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Contributing officer',
+        })
+      })
+    })
+
+    it('should render a Typeahead for the team type', () => {
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      cy.get('[data-test="field-team_type_0"]').then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Team type',
+        })
+      })
+    })
+
+    it('should render an "Add another" button', () => {
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      cy.get('[data-test="add-another"]').should('exist')
+    })
+
+    it('should display validation error messages on mandatory fields', () => {
+      clickContinueButton()
+      // Assert Yes and No radio buttons
+      assertErrorSummary(['Select Yes or No'])
+      assertFieldError(
+        cy.get('[data-test="field-credit_for_win"]'),
+        'Select Yes or No',
+        true
+      )
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      clickContinueButton()
+      // Assert Contributing officer and Team type
+      assertErrorSummary(['Enter a contributing officer', 'Enter a team type'])
+      assertFieldError(
+        cy.get('[data-test="field-contributing_officer_0"]'),
+        'Enter a contributing officer',
+        false
+      )
+      assertFieldError(
+        cy.get('[data-test="field-team_type_0"]'),
+        'Enter a team type',
+        false
+      )
+      // Select a team type to render the HQ team, region or post field
+      cy.get('[data-test="field-team_type_0"]')
+        .find('input')
+        .as('teamTypeInput')
+      cy.get('@teamTypeInput').type('Inv')
+      cy.get('@teamTypeInput').type('{downarrow}{enter}{esc}')
+      clickContinueButton()
+      // Assert HQ team, region or post
+      assertErrorSummary([
+        'Enter a contributing officer',
+        'Enter a HQ team, region or post',
+      ])
+      assertFieldError(
+        cy.get('[data-test="field-hq_team_0"]'),
+        'Enter a HQ team, region or post',
+        false
+      )
+    })
+
+    it('should complete this step and continue to "Credit for this win"', () => {
+      const contributingOfficer = '[data-test="field-contributing_officer_0"]'
+      const teamType = '[data-test="field-team_type_0"]'
+      const hqTeam = '[data-test="field-hq_team_0"]'
+      cy.get('[data-test="credit-for-win-yes"]').check()
+      cy.get(contributingOfficer).selectTypeaheadOption('David')
+      cy.get(teamType).selectTypeaheadOption('Investment (ITFG or IG)')
+      cy.get(hqTeam).selectTypeaheadOption('DIT Education')
       clickContinueAndAssertUrl(customerDetails)
     })
   })

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -172,8 +172,14 @@ describe('Adding an export win', () => {
           optionsCount: 2,
         })
       })
-      cy.get('[data-test="credit-for-win-yes"]').should('not.be.checked')
-      cy.get('[data-test="credit-for-win-no"]').should('not.be.checked')
+      cy.get('[data-test="credit-for-win-yes"]')
+        .should('not.be.checked')
+        .parent()
+        .should('have.text', 'Yes')
+      cy.get('[data-test="credit-for-win-no"]')
+        .should('not.be.checked')
+        .parent()
+        .should('have.text', 'No')
     })
 
     it('should go to the next step when selecting "No" and then "Continue"', () => {
@@ -260,7 +266,7 @@ describe('Adding an export win', () => {
       )
     })
 
-    it('should complete this step and continue to "Credit for this win"', () => {
+    it('should complete this step and continue to "Customer details"', () => {
       const contributingOfficer = '[data-test="field-contributing_officer_0"]'
       const teamType = '[data-test="field-team_type_0"]'
       const hqTeam = '[data-test="field-hq_team_0"]'

--- a/test/sandbox/fixtures/v4/metadata/team-type.json
+++ b/test/sandbox/fixtures/v4/metadata/team-type.json
@@ -1,0 +1,42 @@
+[
+  {
+    "id": "a4839e09-e30e-492c-93b5-8ab2ef90b891",
+    "name": "Trade (TD or ST)",
+    "disabled_on": null
+  },
+  {
+    "id": "42bdaf2e-ae19-4589-9840-5dbb67b50add",
+    "name": "Investment (ITFG or IG)",
+    "disabled_on": null
+  },
+  {
+    "id": "c2d215e2-d564-4c50-b209-ec838eef761d",
+    "name": "DSO",
+    "disabled_on": null
+  },
+  {
+    "id": "bbb7fad4-417c-411e-a40a-11184b0c635d",
+    "name": "Other HQ Team",
+    "disabled_on": null
+  },
+  {
+    "id": "1f6eccf9-289a-450b-a4af-b75600ea521b",
+    "name": "International Trade Team",
+    "disabled_on": null
+  },
+  {
+    "id": "17f95045-63b4-489d-9af8-7246e6ab370e",
+    "name": "Overseas Business Network",
+    "disabled_on": null
+  },
+  {
+    "id": "6e798633-83da-4597-8e9a-9bb033ca06a4",
+    "name": "Overseas Post",
+    "disabled_on": null
+  },
+  {
+    "id": "f7006548-9ef0-4c4e-bc60-1b7ca40ff75b",
+    "name": "Trade Challenge Partners (TCP)",
+    "disabled_on": null
+  }
+]

--- a/test/sandbox/routes/v4/metadata/index.js
+++ b/test/sandbox/routes/v4/metadata/index.js
@@ -33,6 +33,7 @@ import headquarterType from '../../../fixtures/v4/metadata/headquarter-type.json
 import service from '../../../fixtures/v4/metadata/service.json' assert { type: 'json' }
 import communicationChannel from '../../../fixtures/v4/metadata/communication-channel.json' assert { type: 'json' }
 import team from '../../../fixtures/v4/metadata/team.json' assert { type: 'json' }
+import teamType from '../../../fixtures/v4/metadata/team-type.json' assert { type: 'json' }
 import policyArea from '../../../fixtures/v4/metadata/policy-area.json' assert { type: 'json' }
 import policyIssueType from '../../../fixtures/v4/metadata/policy-issue-type.json' assert { type: 'json' }
 import exportBarrier from '../../../fixtures/v4/metadata/export-barrier.json' assert { type: 'json' }
@@ -198,6 +199,10 @@ export const getCommunicationChannel = function (req, res) {
 
 export const getTeam = function (req, res) {
   res.json(team)
+}
+
+export const getTeamType = function (req, res) {
+  res.json(teamType)
 }
 
 export const getPolicyArea = function (req, res) {

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -218,6 +218,7 @@ import {
   getService as _service,
   getCommunicationChannel as _communicationChannel,
   getTeam as _team,
+  getTeamType as _teamType,
   getPolicyArea as _policyArea,
   getPolicyIssueType as _policyIssueType,
   getExportBarrier,
@@ -395,6 +396,7 @@ app.get(
 app.get('/metadata/one-list-tier/', getOneListTier)
 
 // V4 Metadata endpoints
+app.get('/v4/metadata/team-type/', _teamType)
 app.get('/v4/metadata/likelihood-to-land', _likelihoodToLand)
 app.get('/v4/metadata/export-experience-category', _exportExperienceCategory)
 app.get('/v4/metadata/investment-investor-type', _investmentInvestorType)


### PR DESCRIPTION
## Description of change

This is step 2 of 6 of the Export Win user journey that enables Lead Officers to add an Export Win to Data Hub.

## Test instructions

Go to `/exportwins/create?step=credit_for_this_win&company=<company-uuid>`

1. Enter all fields and add another (up to a max of 5)
2. Click continue
3. Click back
4. Ensure all data entered from 1. has persisted.

## Screenshots
<img width="1002" alt="Screenshot 2024-01-18 at 13 45 07" src="https://github.com/uktrade/data-hub-frontend/assets/964268/be25513f-27e8-46d0-bc2e-bc089d058be5">

<img width="996" alt="Screenshot 2024-01-18 at 13 38 26" src="https://github.com/uktrade/data-hub-frontend/assets/964268/bd0d863d-13e3-4abc-b363-94c3a083b357">

<img width="1002" alt="Screenshot 2024-01-18 at 13 38 45" src="https://github.com/uktrade/data-hub-frontend/assets/964268/a28f484c-ac1c-4b34-9be6-5218279bafb8">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
