### PR TITLE
Allow pageTitle prop of DefaultLayout to be a JSX expression

### DIFF
--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { createGlobalStyle } from 'styled-components'
 import PropTypes from 'prop-types'
 import GridCol from '@govuk-react/grid-col'
@@ -8,6 +8,7 @@ import Footer from '../Footer'
 import Main from '../Main'
 import LocalHeader from '../LocalHeader/LocalHeader'
 import DataHubHeader from '../DataHubHeader'
+import WatchTextContent from '../WatchTextContent'
 
 const GlobalStyles = createGlobalStyle`
   *, *:before, *:after {
@@ -27,11 +28,17 @@ const DefaultLayout = ({
   localHeaderChildren,
 }) => {
   const [showVerticalNav, setShowVerticalNav] = useState(false)
-  useEffect(() => {
-    document.title = `${pageTitle} - DBT Data Hub`
-  }, [pageTitle])
+
   return (
     <>
+      <WatchTextContent
+        style={{ display: 'none' }}
+        onTextContentChange={(text) => {
+          document.title = text
+        }}
+      >
+        {pageTitle} - DBT Data Hub
+      </WatchTextContent>
       <GlobalStyles />
       <DataHubHeader
         showVerticalNav={showVerticalNav}
@@ -66,7 +73,7 @@ DefaultLayout.propTypes = {
     text: PropTypes.string.isRequired,
   }),
   subheading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  pageTitle: PropTypes.string.isRequired,
+  pageTitle: PropTypes.node.isRequired,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 }
 

--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -32,7 +32,6 @@ const DefaultLayout = ({
   return (
     <>
       <WatchTextContent
-        style={{ display: 'none' }}
         onTextContentChange={(text) => {
           document.title = text
         }}

--- a/src/client/components/WatchTextContent.jsx
+++ b/src/client/components/WatchTextContent.jsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef } from 'react'
+
+/**
+ * @function WatchTextContent
+ * @description Calls {onTextContentChange} anytime the `textContent`
+ * of this component changes.
+ * @param {Object} props
+ * @param {React.Children} props.children - Children
+ * @param {(textContent: string) => void} props.onTextContentChange - A callback that will
+ * be called anytime the `textContent` of this component changes with the value
+ * of the current `textContent`.
+ * @param {string} [props.as = 'div'] - What should be the wrapping element
+ */
+const WatchTextContent = ({
+  onTextContentChange,
+  as: As = 'div',
+  ...props
+}) => {
+  const ref = useRef()
+  const previousTextContent = useRef()
+
+  useEffect(() => {
+    previousTextContent.current = ref.current.textContent
+
+    const observer = new MutationObserver(() => {
+      if (ref.current.textContent !== previousTextContent.current) {
+        onTextContentChange(ref.current.textContent)
+        previousTextContent.current = ref.current.textContent
+      }
+    })
+
+    if (ref.current) {
+      observer.observe(ref.current, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      })
+    }
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  return <As {...props} ref={ref} />
+}
+
+export default WatchTextContent

--- a/src/client/components/WatchTextContent.jsx
+++ b/src/client/components/WatchTextContent.jsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef } from 'react'
+import { useEffect, useRef } from 'react'
+import ReactDOM from 'react-dom'
 
 /**
  * @function WatchTextContent
@@ -15,34 +16,24 @@ const WatchTextContent = ({ onTextContentChange, ...props }) => {
   const previousTextContent = useRef()
 
   useEffect(() => {
-    previousTextContent.current = ref.current.textContent
+    ref.current = document.createElement('div')
+    return () => {
+      ref.current.remove()
+    }
+  }, [])
 
-    // Detach the element so that the content is not searchable by Cypress tests.
-    // This is the only way to make an element really hidden from Cypress.
-    ref.current?.remove()
-
-    const observer = new MutationObserver(() => {
+  useEffect(() => {
+    ReactDOM.render(props.children, ref.current)
+    // The most recent update only takes effect in the next event tick
+    setTimeout(() => {
       if (ref.current.textContent !== previousTextContent.current) {
         onTextContentChange(ref.current.textContent)
         previousTextContent.current = ref.current.textContent
       }
-    })
+    }, 0)
+  })
 
-    if (ref.current) {
-      observer.observe(ref.current, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        characterData: true,
-      })
-    }
-
-    return () => {
-      observer.disconnect()
-    }
-  }, [])
-
-  return <div ref={ref} {...props} hidden={true} />
+  return null
 }
 
 export default WatchTextContent

--- a/src/client/components/WatchTextContent.jsx
+++ b/src/client/components/WatchTextContent.jsx
@@ -3,24 +3,23 @@ import React, { useEffect, useRef } from 'react'
 /**
  * @function WatchTextContent
  * @description Calls {onTextContentChange} anytime the `textContent`
- * of this component changes.
+ * of {children} changes. The {children} won't be rendered.
  * @param {Object} props
  * @param {React.Children} props.children - Children
  * @param {(textContent: string) => void} props.onTextContentChange - A callback that will
  * be called anytime the `textContent` of this component changes with the value
  * of the current `textContent`.
- * @param {string} [props.as = 'div'] - What should be the wrapping element
  */
-const WatchTextContent = ({
-  onTextContentChange,
-  as: As = 'div',
-  ...props
-}) => {
+const WatchTextContent = ({ onTextContentChange, ...props }) => {
   const ref = useRef()
   const previousTextContent = useRef()
 
   useEffect(() => {
     previousTextContent.current = ref.current.textContent
+
+    // Detach the element so that the content is not searchable by Cypress tests.
+    // This is the only way to make an element really hidden from Cypress.
+    ref.current?.remove()
 
     const observer = new MutationObserver(() => {
       if (ref.current.textContent !== previousTextContent.current) {
@@ -43,7 +42,7 @@ const WatchTextContent = ({
     }
   }, [])
 
-  return <As {...props} ref={ref} />
+  return <div ref={ref} {...props} hidden={true} />
 }
 
 export default WatchTextContent

--- a/test/component/cypress/specs/WatchTextContent.cy.jsx
+++ b/test/component/cypress/specs/WatchTextContent.cy.jsx
@@ -2,12 +2,15 @@ import React, { useState } from 'react'
 
 import WatchTextContent from '../../../../src/client/components/WatchTextContent.jsx'
 
-const Counter = () => {
+const Counter = ({ children }) => {
   const [count, setCount] = useState(0)
   return (
-    <button className="counter" onClick={() => setCount((x) => x + 1)}>
-      {count}
-    </button>
+    <>
+      <button className="counter" onClick={() => setCount((x) => x + 1)}>
+        increase
+      </button>
+      {children(count)}
+    </>
   )
 }
 
@@ -16,17 +19,19 @@ describe('WatchTextContent', () => {
     const onTextContentChange = cy.stub()
 
     cy.mount(
-      <WatchTextContent onTextContentChange={onTextContentChange}>
-        <h1>Heading</h1>
-        <ul>
-          <li>foo</li>
-          <li>bar</li>
-          <li>
-            <Counter />
-          </li>
-          <li>baz</li>
-        </ul>
-      </WatchTextContent>
+      <Counter>
+        {(count) => (
+          <WatchTextContent onTextContentChange={onTextContentChange}>
+            <h1>Heading</h1>
+            <ul>
+              <li>foo</li>
+              <li>bar</li>
+              <li>{count}</li>
+              <li>baz</li>
+            </ul>
+          </WatchTextContent>
+        )}
+      </Counter>
     )
 
     cy.get('.counter').click()

--- a/test/component/cypress/specs/WatchTextContent.cy.jsx
+++ b/test/component/cypress/specs/WatchTextContent.cy.jsx
@@ -21,15 +21,18 @@ describe('WatchTextContent', () => {
     cy.mount(
       <Counter>
         {(count) => (
-          <WatchTextContent onTextContentChange={onTextContentChange}>
-            <h1>Heading</h1>
-            <ul>
-              <li>foo</li>
-              <li>bar</li>
-              <li>{count}</li>
-              <li>baz</li>
-            </ul>
-          </WatchTextContent>
+          <>
+            count: {count}
+            <WatchTextContent onTextContentChange={onTextContentChange}>
+              <h1>Heading</h1>
+              <ul>
+                <li>foo</li>
+                <li>bar</li>
+                <li>{count}</li>
+                <li>baz</li>
+              </ul>
+            </WatchTextContent>
+          </>
         )}
       </Counter>
     )
@@ -40,6 +43,7 @@ describe('WatchTextContent', () => {
       .click()
       .then(() => {
         expect(onTextContentChange.args).to.deep.eq([
+          ['Headingfoobar0baz'],
           ['Headingfoobar1baz'],
           ['Headingfoobar2baz'],
           ['Headingfoobar3baz'],

--- a/test/component/cypress/specs/WatchTextContent.cy.jsx
+++ b/test/component/cypress/specs/WatchTextContent.cy.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react'
+
+import WatchTextContent from '../../../../src/client/components/WatchTextContent.jsx'
+
+const Counter = () => {
+  const [count, setCount] = useState(0)
+  return (
+    <button className="counter" onClick={() => setCount((x) => x + 1)}>
+      {count}
+    </button>
+  )
+}
+
+describe('WatchTextContent', () => {
+  it("calls onTextContentChange when it's text content changes", () => {
+    const onTextContentChange = cy.stub()
+
+    cy.mount(
+      <WatchTextContent onTextContentChange={onTextContentChange}>
+        <h1>Heading</h1>
+        <ul>
+          <li>foo</li>
+          <li>bar</li>
+          <li>
+            <Counter />
+          </li>
+          <li>baz</li>
+        </ul>
+      </WatchTextContent>
+    )
+
+    cy.get('.counter').click()
+    cy.get('.counter').click()
+    cy.get('.counter')
+      .click()
+      .then(() => {
+        expect(onTextContentChange.args).to.deep.eq([
+          ['Headingfoobar1baz'],
+          ['Headingfoobar2baz'],
+          ['Headingfoobar3baz'],
+        ])
+      })
+  })
+})


### PR DESCRIPTION
## Description of change

Fixes a shortcoming of the `DefaultLayout` component, when if its `pageTitle` was a JSX expression, the `document.title` was set to `'[object Object]'`. This PR fixes this using the new `WatchTextContent` component which provides a way how to convert React vdom to string.

## Test instructions

1. Use the `DefaultLayout` component with its `pageTitle` prop set to a JSX expression
2. The `document.title` should not be `'[object Object]'`, but the _text content_ of the JSX expression passed as `pageTitle`.

```jsx
  <DefaultLayout
    heading="Bla bla"
    pageTitle={<div>foo <span>bar</span> baz</div>} // should make document.title 'foo bar baz'
  />
```

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
