### PR TITLE
Add Export Win - Customer details (3 of 6 steps)

### DIFF
--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -80,7 +80,7 @@ const CustomerDetailsStep = () => {
         id="export-experience"
         label="Export experience"
         required="Select export experience"
-        hint="You customer will be asked to confirm this information."
+        hint="Your customer will be asked to confirm this information."
         field={FieldTypeahead}
         resource={ExportExperienceResource}
       />

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -1,21 +1,89 @@
 import React from 'react'
-import styled from 'styled-components'
+import { useLocation } from 'react-router-dom'
+import { H3 } from '@govuk-react/heading'
 
+import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
+import { TASK_REDIRECT_TO_CONTACT_FORM } from '../../../components/ContactForm/state'
+import { Step, FieldTypeahead, ContactInformation } from '../../../components'
+import { getQueryParamsFromLocation } from '../../../../client/utils/url'
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { Step, FieldInput } from '../../../components'
+import { idNameToValueLabel } from '../../../../client/utils'
+import Task from '../../../components/Task'
+import { ID } from './state'
 import { steps } from './constants'
-
-const StyledFieldInput = styled(FieldInput)({
-  display: 'none',
-})
+import {
+  UKRegionsResource,
+  CompanyContactsResource,
+  ExportExperienceResource,
+  BusinessPotentialResource,
+} from '../../../components/Resource'
 
 const CustomerDetailsStep = () => {
-  // eslint-disable-next-line no-unused-vars
   const { values } = useFormContext()
+  const location = useLocation()
+  const queryParams = getQueryParamsFromLocation(location)
+  const companyId = queryParams.company
+
   return (
     <Step name={steps.CUSTOMER_DETAILS}>
-      <h1>Customer details</h1>
-      <StyledFieldInput name="hidden" type="text" />
+      <H3 data-test="step-heading">Customer details</H3>
+      <ResourceOptionsField
+        name="company_contacts"
+        id={companyId}
+        label="Company contacts"
+        hint="This contact will be emailed to approve the win."
+        required="Select a contact"
+        placeholder="Select contact"
+        resource={CompanyContactsResource}
+        field={FieldTypeahead}
+        autoScroll={true}
+        resultToOptions={({ results }) => results.map(idNameToValueLabel)}
+      />
+      <Task>
+        {(getTask) => {
+          const openContactFormTask = getTask(TASK_REDIRECT_TO_CONTACT_FORM, ID)
+          return (
+            <ContactInformation
+              companyId={companyId}
+              onOpenContactForm={({ redirectUrl }) => {
+                openContactFormTask.start({
+                  payload: {
+                    values,
+                    url: redirectUrl,
+                    storeId: ID,
+                  },
+                })
+              }}
+            />
+          )
+        }}
+      </Task>
+      <ResourceOptionsField
+        name="customer_location"
+        id="customer-location"
+        label="HQ location"
+        required="Select HQ location"
+        field={FieldTypeahead}
+        resource={UKRegionsResource}
+        fullWidth={true}
+      />
+      <ResourceOptionsField
+        name="business_potential"
+        id="business-potential"
+        label="Export potential"
+        required="Select export potential"
+        field={FieldTypeahead}
+        resource={BusinessPotentialResource}
+      />
+      <ResourceOptionsField
+        name="export_experience"
+        id="export-experience"
+        label="Export experience"
+        required="Select export experience"
+        hint="You customer will be asked to confirm this information."
+        field={FieldTypeahead}
+        resource={ExportExperienceResource}
+      />
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { Step } from '../../../components'
+import { Step, FieldInput } from '../../../components'
 import { steps } from './constants'
+
+const StyledFieldInput = styled(FieldInput)({
+  display: 'none',
+})
 
 const WinDetailsStep = () => {
   // eslint-disable-next-line no-unused-vars
@@ -10,6 +15,7 @@ const WinDetailsStep = () => {
   return (
     <Step name={steps.WIN_DETAILS}>
       <h1>Win details</h1>
+      <StyledFieldInput name="hidden" type="text" />
     </Step>
   )
 }

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -279,8 +279,87 @@ describe('Adding an export win', () => {
   })
 
   context('Customer details', () => {
-    it('should complete this step and continue to "Win details"', () => {
+    // The 4 typeaheads on the form step
+    const contacts = '[data-test="field-company_contacts"]'
+    const location = '[data-test="field-customer_location"]'
+    const potential = '[data-test="field-business_potential"]'
+    const experience = '[data-test="field-export_experience"]'
+
+    beforeEach(() =>
       cy.visit(`${urls.companies.exportWins.create()}${customerDetails}`)
+    )
+
+    it('should render a step heading', () => {
+      cy.get('[data-test="step-heading"]').should(
+        'have.text',
+        'Customer details'
+      )
+    })
+
+    it('should show a contact link and details', () => {
+      cy.get('[data-test="add-a-new-contact-link"]').should('be.visible')
+      cy.get('[data-test="contact-information-details"]').should('be.visible')
+    })
+
+    it('should render Company contacts label and a Typeahead', () => {
+      cy.get(contacts).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Company contacts',
+          hint: 'This contact will be emailed to approve the win.',
+        })
+      })
+    })
+
+    it('should render HQ location label and a Typeahead', () => {
+      cy.get(location).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'HQ location',
+        })
+      })
+    })
+
+    it('should render Export potential label and a Typeahead', () => {
+      cy.get(potential).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Export potential',
+        })
+      })
+    })
+
+    it('should render Export potential label and a Typeahead', () => {
+      cy.get(experience).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Export experience',
+          hint: 'You customer will be asked to confirm this information.',
+        })
+      })
+    })
+
+    it('should display validation error messages on mandatory fields', () => {
+      clickContinueButton()
+      assertErrorSummary([
+        'Select a contact',
+        'Select HQ location',
+        'Select export potential',
+        'Select export experience',
+      ])
+      assertFieldError(cy.get(contacts), 'Select a contact', true)
+      assertFieldError(cy.get(location), 'Select HQ location', false)
+      assertFieldError(cy.get(potential), 'Select export potential', false)
+      assertFieldError(cy.get(experience), 'Select export experience', true)
+    })
+
+    it('should complete this step and continue to "Win details"', () => {
+      cy.get(contacts).selectTypeaheadOption('Joseph Woof')
+      cy.get(location).selectTypeaheadOption('Scotland')
+      cy.get(potential).selectTypeaheadOption(
+        'The company is a Medium Sized Business'
+      )
+      cy.get(experience).selectTypeaheadOption('Never exported')
       clickContinueAndAssertUrl(winDetails)
     })
   })

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -334,7 +334,7 @@ describe('Adding an export win', () => {
         assertFieldTypeahead({
           element,
           label: 'Export experience',
-          hint: 'You customer will be asked to confirm this information.',
+          hint: 'Your customer will be asked to confirm this information.',
         })
       })
     })

--- a/test/sandbox/fixtures/v4/metadata/business-potential.json
+++ b/test/sandbox/fixtures/v4/metadata/business-potential.json
@@ -1,0 +1,17 @@
+[
+  {
+    "id": "0e6f1d69-e9c3-4460-a74b-3881930fe3e9",
+    "name": "The company is an exporter with High Export Potential",
+    "disabled_on": null
+  },
+  {
+    "id": "e4d74957-60a4-4eab-a17b-d4c7b792ad25",
+    "name": "The company is a Medium Sized Business",
+    "disabled_on": null
+  },
+  {
+    "id": "97f5e000-37a6-4452-b2be-25ccc94e5bd3",
+    "name": "The company is not an exporter with High Export Potential or a Medium Sized Business",
+    "disabled_on": null
+  }
+]

--- a/test/sandbox/routes/v4/metadata/index.js
+++ b/test/sandbox/routes/v4/metadata/index.js
@@ -21,6 +21,7 @@ import locationType from '../../../fixtures/v4/metadata/location-type.json' asse
 import eventType from '../../../fixtures/v4/metadata/event-type.json' assert { type: 'json' }
 import programme from '../../../fixtures/v4/metadata/programme.json' assert { type: 'json' }
 import businessType from '../../../fixtures/v4/metadata/business-type.json' assert { type: 'json' }
+import businessPotential from '../../../fixtures/v4/metadata/business-potential.json' assert { type: 'json' }
 import evidenceTag from '../../../fixtures/v4/metadata/evidence-tag.json' assert { type: 'json' }
 import employeeRange from '../../../fixtures/v4/metadata/employee-range.json' assert { type: 'json' }
 import country from '../../../fixtures/v4/metadata/country.json' assert { type: 'json' }
@@ -145,6 +146,10 @@ export const getProgramme = function (req, res) {
 
 export const getBusinessType = function (req, res) {
   res.json(businessType)
+}
+
+export const getBusinessPotential = function (req, res) {
+  res.json(businessPotential)
 }
 
 export const getEvidenceTag = function (req, res) {

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -206,6 +206,7 @@ import {
   getEventType as _eventType,
   getProgramme as _programme,
   getBusinessType as _businessType,
+  getBusinessPotential as _businessPotential,
   getEvidenceTag as _evidenceTag,
   getEmployeeRange as _employeeRange,
   getCountry as _country,
@@ -397,6 +398,7 @@ app.get('/metadata/one-list-tier/', getOneListTier)
 
 // V4 Metadata endpoints
 app.get('/v4/metadata/team-type/', _teamType)
+app.get('/v4/metadata/business-potential/', _businessPotential)
 app.get('/v4/metadata/likelihood-to-land', _likelihoodToLand)
 app.get('/v4/metadata/export-experience-category', _exportExperienceCategory)
 app.get('/v4/metadata/investment-investor-type', _investmentInvestorType)


### PR DESCRIPTION
## Description of change

This is step 3 of 6 of the Export Win user journey that enables Lead Officers to add an Export Win to Data Hub.

## Test instructions

Go to `/exportwins/create?step=customer_details&company=<company-uuid>`

1. Enter values for all 4 fields
2. Click continue
3. Click back
4. Ensure all data entered from 1. has persisted.

## Screenshots
<img width="998" alt="Screenshot 2024-01-19 at 14 40 09" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d40477dc-767b-4ce2-97cc-891744337f28">

<img width="986" alt="Screenshot 2024-01-19 at 14 41 27" src="https://github.com/uktrade/data-hub-frontend/assets/964268/caa4121c-64e5-4e85-af25-a1a1593cbb43">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
