### PR TITLE
Refactor company account management tab

### DIFF
--- a/src/apps/companies/apps/account-management/controllers.js
+++ b/src/apps/companies/apps/account-management/controllers.js
@@ -11,23 +11,6 @@ const companyToLeadITA = ({ one_list_group_global_account_manager: leadITA }) =>
     team: get(leadITA, 'dit_team.name'),
   }
 
-async function renderAccountManagement(req, res) {
-  const { company, dnbRelatedCompaniesCount, localNavItems, returnUrl } =
-    res.locals
-  const permissions = res.locals.user.permissions
-
-  res.render('companies/apps/account-management/views/client-container', {
-    props: {
-      dnbRelatedCompaniesCount,
-      permissions,
-      localNavItems: localNavItems,
-      flashMessages: res.locals.getMessages(),
-      companyId: company.id,
-      returnUrl: returnUrl,
-    },
-  })
-}
-
 // istanbul ignore next: Covered by functional tests
 const form = (req, res) => {
   const {
@@ -66,7 +49,6 @@ async function submit(req, res, next) {
 }
 
 module.exports = {
-  renderAccountManagement,
   submit,
   form,
 }

--- a/src/apps/companies/apps/account-management/router.js
+++ b/src/apps/companies/apps/account-management/router.js
@@ -1,13 +1,8 @@
 const router = require('express').Router()
 
 const urls = require('../../../../lib/urls')
-const { submit, renderAccountManagement, form } = require('./controllers')
+const { submit, form } = require('./controllers')
 const { allPermissionsOr403 } = require('../../../../middleware/conditionals')
-
-router.get(
-  urls.companies.accountManagement.index.route,
-  renderAccountManagement
-)
 
 router
   .route([

--- a/src/apps/companies/apps/account-management/views/client-container.njk
+++ b/src/apps/companies/apps/account-management/views/client-container.njk
@@ -1,9 +1,0 @@
-{% extends "_layouts/template-no-local-header.njk" %}
-
-{% block body %}
-  {% component 'react-slot', {
-    id: 'account-management',
-    props: props
-  } %}
-
-{% endblock %}

--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -116,6 +116,7 @@ const reactRoutes = [
   '/companies/:companyId/activity',
   '/companies/:companyId/contacts',
   '/companies/:companyId/orders',
+  '/companies/:companyId/account-management',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/index.jsx
+++ b/src/client/index.jsx
@@ -39,7 +39,6 @@ import LargeCapitalProfile from './modules/Companies/CompanyInvestments/LargeCap
 import PropositionDetails from './modules/Investments/Projects/Propositions/PropositionDetails'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
 import CompanyProjectsCollection from './modules/Companies/CompanyInvestments/CompanyProjectsCollection'
-import AccountManagement from './modules/Companies/AccountManagement'
 
 import Footer from '../client/components/Footer'
 
@@ -254,11 +253,6 @@ function App() {
         </Mount>
         <Mount selector="#proposition-details">
           {(props) => <PropositionDetails {...props} />}
-        </Mount>
-        <Mount selector="#account-management">
-          {(props) => (
-            <AccountManagement csrfToken={globalProps.csrfToken} {...props} />
-          )}
         </Mount>
 
         <Mount selector="#react-app">

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -4,9 +4,11 @@ import { FONT_SIZE, SPACING } from '@govuk-react/constants'
 import Button from '@govuk-react/button'
 import Details from '@govuk-react/details'
 import styled from 'styled-components'
+import { useParams } from 'react-router-dom'
+import { connect } from 'react-redux'
 
 import { Metadata, NewWindowLink } from '../../../components'
-import CompanyLayout from '../../../components/Layout/CompanyLayout'
+import CompanyLayoutNew from '../../../components/Layout/CompanyLayoutNew'
 import {
   CompanyObjectivesCountResource,
   CompanyObjectivesResource,
@@ -19,6 +21,8 @@ import { LeadITA } from './LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
 import { isItaTierDAccount } from '../utils'
 import { ONE_LIST_EMAIL } from './constants'
+import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
+import { state2propsMainTab } from './state'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -245,63 +249,64 @@ const objectiveMetadata = (objective) => {
   return rows
 }
 
-const AccountManagement = ({
-  companyId,
-  flashMessages,
-  csrfToken,
-  permissions,
-}) => {
+const AccountManagement = ({ flashMessages, csrfToken, permissions }) => {
+  const { companyId } = useParams()
+
   return (
-    <CompanyResource id={companyId}>
-      {(company) => (
-        <CompanyLayout
-          company={company}
-          breadcrumbs={[{ text: 'Account management' }]}
-          flashMessages={flashMessages}
-          csrfToken={csrfToken}
-        >
-          <DataWorkspaceAccountPlan company={company} />
-          <Strategy company={company} />
-          <Objectives company={company} />
-          {!company.oneListGroupTier ||
-          isItaTierDAccount(company.oneListGroupTier) ? (
-            <LeadITA company={company} permissions={permissions} />
-          ) : (
-            <div>
-              <CoreTeamAdvisers
-                company={company}
-                oneListEmail={ONE_LIST_EMAIL}
-              />
-              {canEditOneList(permissions) && (
-                <div>
-                  <Button
-                    data-test="edit-core-team-button"
-                    as={Link}
-                    href={urls.companies.editVirtualTeam(companyId)}
-                  >
-                    Edit core team
-                  </Button>
-                </div>
-              )}
-            </div>
-          )}
-          <Details
-            summary="Need to find out more, or edit the One List tier information?"
-            data-test="core-team-details"
+    <DefaultLayoutBase>
+      <CompanyResource id={companyId}>
+        {(company) => (
+          <CompanyLayoutNew
+            company={company}
+            breadcrumbs={[{ text: 'Account management' }]}
+            flashMessages={flashMessages}
+            csrfToken={csrfToken}
+            pageTitle="Account management"
           >
-            For more information, or if you need to change the One List tier or
-            account management team for this company, go to the{' '}
-            <NewWindowLink
-              href={urls.external.digitalWorkspace.accountManagement}
+            <DataWorkspaceAccountPlan company={company} />
+            <Strategy company={company} />
+            <Objectives company={company} />
+            {!company.oneListGroupTier ||
+            isItaTierDAccount(company.oneListGroupTier) ? (
+              <LeadITA company={company} permissions={permissions} />
+            ) : (
+              <div>
+                <CoreTeamAdvisers
+                  company={company}
+                  oneListEmail={ONE_LIST_EMAIL}
+                />
+                {canEditOneList(permissions) && (
+                  <div>
+                    <Button
+                      data-test="edit-core-team-button"
+                      as={Link}
+                      href={urls.companies.editVirtualTeam(companyId)}
+                    >
+                      Edit core team
+                    </Button>
+                  </div>
+                )}
+              </div>
+            )}
+            <Details
+              summary="Need to find out more, or edit the One List tier information?"
+              data-test="core-team-details"
             >
-              Digital Workspace
-            </NewWindowLink>{' '}
-            or email <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
-          </Details>
-        </CompanyLayout>
-      )}
-    </CompanyResource>
+              For more information, or if you need to change the One List tier
+              or account management team for this company, go to the{' '}
+              <NewWindowLink
+                href={urls.external.digitalWorkspace.accountManagement}
+              >
+                Digital Workspace
+              </NewWindowLink>{' '}
+              or email{' '}
+              <Link href={`mailto:${oneListEmail}`}>{oneListEmail}</Link>
+            </Details>
+          </CompanyLayoutNew>
+        )}
+      </CompanyResource>
+    </DefaultLayoutBase>
   )
 }
 
-export default AccountManagement
+export default connect(state2propsMainTab)(AccountManagement)

--- a/src/client/modules/Companies/AccountManagement/state.js
+++ b/src/client/modules/Companies/AccountManagement/state.js
@@ -14,3 +14,8 @@ export const state2props = (state) => {
   }
   return { objectiveItem }
 }
+
+export const state2propsMainTab = (state) => ({
+  csrfToken: state.csrfToken,
+  permissions: state.userPermissions,
+})

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -88,6 +88,7 @@ import RemoveGlobalHQ from './modules/Companies/CompanyBusinessDetails/LinkGloba
 import CompanyActivityCollection from './components/ActivityFeed/CollectionList/index'
 import CompanyContactsCollection from './modules/Contacts/CollectionList/CompanyContactsCollection'
 import CompanyOrdersCollection from './modules/Omis/CollectionList/CompanyOrdersCollection'
+import AccountManagement from './modules/Companies/AccountManagement'
 
 const routes = {
   companies: [
@@ -205,6 +206,11 @@ const routes = {
       path: '/companies/:companyId/orders',
       module: 'datahub:companies',
       component: CompanyOrdersCollection,
+    },
+    {
+      path: '/companies/:companyId/account-management',
+      module: 'datahub:companies',
+      component: AccountManagement,
     },
   ],
   contacts: [

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -13,7 +13,10 @@ describe('Lead advisers', () => {
     })
 
     it('should render a meta title', () => {
-      cy.title().should('eq', 'Companies - DBT Data Hub')
+      cy.title().should(
+        'eq',
+        'Account management - Mars Exports Ltd - Companies - DBT Data Hub'
+      )
     })
 
     it('should display a header with the company name', () => {


### PR DESCRIPTION
## Description of change

The company account management tab has been migrated to React Router.

## Test instructions

The account management tab should still work.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
