### PR TITLE
Add Export Win - Win details (step 4 of 6)

### DIFF
--- a/src/client/modules/ExportWins/Form/AddExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/AddExportWinForm.jsx
@@ -20,7 +20,7 @@ import OfficerDetailsStep from './OfficerDetailsStep'
 import CreditForThisWinStep from './CreditForThisWinStep'
 import CustomerDetailsStep from './CustomerDetailsStep'
 import WinDetailsStep from './WinDetailsStep'
-import SupportGivenStep from './SupportGivenStep'
+import SupportProvidedStep from './SupportProvidedStep'
 import CheckBeforeSendingStep from './CheckBeforeSending'
 
 const StyledLoadingBox = styled(LoadingBox)({
@@ -87,7 +87,7 @@ const AddExportWinForm = ({ isEditing, csrfToken, currentAdviserId }) => {
                 <CreditForThisWinStep {...stepProps} />
                 <CustomerDetailsStep {...stepProps} />
                 <WinDetailsStep {...stepProps} />
-                <SupportGivenStep {...stepProps} />
+                <SupportProvidedStep {...stepProps} />
                 <CheckBeforeSendingStep {...stepProps} />
                 <pre>{JSON.stringify(values, null, 2)}</pre>
               </>

--- a/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
+++ b/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
@@ -1,8 +1,13 @@
 import React from 'react'
+import styled from 'styled-components'
 
 import { useFormContext } from '../../../components/Form/hooks'
-import { Step } from '../../../components'
+import { Step, FieldInput } from '../../../components'
 import { steps } from './constants'
+
+const StyledFieldInput = styled(FieldInput)({
+  display: 'none',
+})
 
 const SupportProvidedStep = () => {
   // eslint-disable-next-line no-unused-vars
@@ -10,6 +15,7 @@ const SupportProvidedStep = () => {
   return (
     <Step name={steps.SUPPORT_PROVIDED}>
       <h1>Support provided</h1>
+      <StyledFieldInput name="hidden" type="text" />
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -189,7 +189,7 @@ const WinDetailsStep = () => {
       />
 
       {values?.win_type?.length > 1 && (
-        <StyledExportTotal>
+        <StyledExportTotal data-test="total-export-value">
           Total export value:{' '}
           {formatValue(sumAllWinTypeYearlyValues(values?.win_type, values))}
         </StyledExportTotal>

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -1,21 +1,225 @@
 import React from 'react'
+import { Details, ListItem, UnorderedList } from 'govuk-react'
+import { H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 
+import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { Step, FieldInput } from '../../../components'
-import { steps } from './constants'
+import CountriesResource from '../../../components/Resource/Countries'
+import { BLACK, WHITE } from '../../../../client/utils/colours'
+import { SectorResource } from '../../../components/Resource'
+import { OPTION_YES } from '../../../../common/constants'
+import { WinTypeValues } from './WinTypeValues'
+import { StyledHintParagraph } from './styled'
+import {
+  Step,
+  FieldDate,
+  FieldInput,
+  FieldTextarea,
+  FieldTypeahead,
+  FieldCheckboxes,
+} from '../../../components'
+import {
+  steps,
+  winTypes,
+  winTypeOptions,
+  goodsServicesOptions,
+} from './constants'
+import {
+  formatValue,
+  getTwelveMonthsAgo,
+  sumAllWinTypeYearlyValues,
+} from './utils'
 
-const StyledFieldInput = styled(FieldInput)({
-  display: 'none',
+const MAX_WORDS = 100
+
+const StyledDetails = styled(Details)({
+  margin: 0,
+})
+
+const StyledExportTotal = styled('p')({
+  padding: 10,
+  color: WHITE,
+  backgroundColor: BLACK,
 })
 
 const WinDetailsStep = () => {
-  // eslint-disable-next-line no-unused-vars
   const { values } = useFormContext()
+  const twelveMonthsAgo = getTwelveMonthsAgo()
+  const month = twelveMonthsAgo.getMonth() + 1
+  const year = twelveMonthsAgo.getFullYear()
+
   return (
     <Step name={steps.WIN_DETAILS}>
-      <h1>Win details</h1>
-      <StyledFieldInput name="hidden" type="text" />
+      <H3 data-test="step-heading">Win details</H3>
+      <StyledHintParagraph data-test="hint">
+        The customer will be asked to confirm this infomation.
+      </StyledHintParagraph>
+      <ResourceOptionsField
+        name="country"
+        id="country"
+        label="Destination country"
+        required="Choose a destination country"
+        resource={CountriesResource}
+        field={FieldTypeahead}
+      />
+      <FieldDate
+        name="date"
+        format="short"
+        label="Date won"
+        hint={`For example ${month} ${year}, date of win must be in the last 12 months.`}
+        required="Enter the win date"
+        invalid="Enter a valid date"
+      />
+      <FieldTextarea
+        name="description"
+        label="Summary of the support given"
+        hint="Outline what had the most impact or would be memorable to the customer in less than 100 words."
+        required="Enter a summary"
+        invalid={`Summary must be ${MAX_WORDS} words or less`}
+        maxWords={MAX_WORDS}
+      />
+
+      <FieldInput
+        type="text"
+        name="name_of_customer"
+        label="Overseas customer"
+        required="Enter the name of the overseas customer"
+        placeholder="Add name"
+      />
+
+      <FieldCheckboxes
+        name="name_of_customer_confidential"
+        hint="Check this box if your customer has asked for this not to be public (optional)."
+        options={[
+          {
+            value: OPTION_YES,
+            label: 'Confidential',
+          },
+        ]}
+      />
+
+      <FieldInput
+        type="text"
+        name="business_type"
+        label="Type of business deal"
+        required="Enter the type of business deal"
+        hint="For example: export sales, contract, order, distributor, tender / competition win, joint venture, outward investment."
+        placeholder="Enter a type of business deal"
+      />
+
+      <FieldCheckboxes
+        name="win_type"
+        legend="Type of win"
+        required="Choose at least one type of win"
+        options={winTypeOptions.map((option) => ({
+          ...option,
+          ...(option.value === winTypes.EXPORT && {
+            children: (
+              <WinTypeValues
+                label="Export value over the next 5 years"
+                name="export_win"
+                values={values}
+              />
+            ),
+          }),
+          ...(option.value === winTypes.BUSINESS_SUCCESS && {
+            link: (
+              <StyledDetails
+                summary="What is business success?"
+                data-test="business-success-details"
+              >
+                <p>Business success is defined as:</p>
+                <UnorderedList listStyleType="bullet">
+                  <ListItem>
+                    the exchange of ownership of goods/services from a
+                    subsidiary of an eligible UK company to a non_UK resident.
+                  </ListItem>
+                  <ListItem>
+                    in financial services, the value of assets under management
+                    or the value of a listing.
+                  </ListItem>
+                  <ListItem>
+                    the collection of cash from an overdue invoice.
+                  </ListItem>
+                  <ListItem>
+                    reduced tax burden on a customer achieved by lobbying.
+                  </ListItem>
+                  <ListItem>repatriation of profits to the UK.</ListItem>
+                </UnorderedList>
+              </StyledDetails>
+            ),
+            children: (
+              <WinTypeValues
+                label="Business success over the next 5 years"
+                name="business_success_win"
+                values={values}
+              />
+            ),
+          }),
+          ...(option.value === winTypes.ODI && {
+            link: (
+              <StyledDetails summary="What is an ODI?" data-test="odi-details">
+                <p>
+                  An ODI is a cross-border investment from the UK into another
+                  country, where the source of the money is the UK.
+                </p>
+                <p>
+                  The aim of the investment is to set up a lasting interest in a
+                  company, where the investor has a genuine influence in the
+                  management. This may involve providing capital for vehicles,
+                  machinery, buildings, and running costs to:
+                </p>
+                <UnorderedList listStyleType="bullet">
+                  <ListItem>set up an overseas subsidiary.</ListItem>
+                  <ListItem>enter into a joint venture.</ListItem>
+                  <ListItem>expand current overseas operations.</ListItem>
+                </UnorderedList>
+              </StyledDetails>
+            ),
+            children: (
+              <WinTypeValues
+                label="Outward Direct Investment over the next 5 years"
+                name="odi_win"
+                values={values}
+              />
+            ),
+          }),
+        }))}
+      />
+
+      {values?.win_type?.length > 1 && (
+        <StyledExportTotal>
+          Total export value:{' '}
+          {formatValue(sumAllWinTypeYearlyValues(values?.win_type, values))}
+        </StyledExportTotal>
+      )}
+
+      <FieldCheckboxes
+        name="goods_vs_services"
+        legend="What does the value relate to?"
+        hint="Select goods or services"
+        required="Select at least one option"
+        options={goodsServicesOptions}
+      />
+
+      <FieldInput
+        type="text"
+        name="name_of_export"
+        label="Name of goods or services"
+        required="Enter the name of goods or services"
+        hint="For instance 'shortbread biscuits'."
+        placeholder="Enter a name for goods or services"
+      />
+
+      <ResourceOptionsField
+        id="sector"
+        name="sector"
+        label="Sector"
+        required="Enter a sector"
+        resource={SectorResource}
+        field={FieldTypeahead}
+      />
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/WinTypeValues.jsx
+++ b/src/client/modules/ExportWins/Form/WinTypeValues.jsx
@@ -34,7 +34,7 @@ const StyledParagraph = styled('p')({
 export const WinTypeValues = ({ label, name, years = 5, values }) => {
   const year = getYearFromWinType(name, values)
   return (
-    <WinTypeContainer>
+    <WinTypeContainer data-test={`win-type-values-${name}`}>
       <StyledLabel data-test="label">{label}</StyledLabel>
       <StyledHintParagraph data-test="hint">
         (round to nearest £)

--- a/src/client/modules/ExportWins/Form/WinTypeValues.jsx
+++ b/src/client/modules/ExportWins/Form/WinTypeValues.jsx
@@ -35,8 +35,10 @@ export const WinTypeValues = ({ label, name, years = 5, values }) => {
   const year = getYearFromWinType(name, values)
   return (
     <WinTypeContainer>
-      <StyledLabel>{label}</StyledLabel>
-      <StyledHintParagraph>(round to nearest £)</StyledHintParagraph>
+      <StyledLabel data-test="label">{label}</StyledLabel>
+      <StyledHintParagraph data-test="hint">
+        (round to nearest £)
+      </StyledHintParagraph>
       <FieldCurrencyContainer>
         {[...Array(years).keys()].map((index) => (
           <FieldCurrency
@@ -48,7 +50,7 @@ export const WinTypeValues = ({ label, name, years = 5, values }) => {
           />
         ))}
       </FieldCurrencyContainer>
-      <StyledParagraph>
+      <StyledParagraph data-test="total">
         Totalling over {year} {pluralize('year', year)}:{' '}
         {formatValue(sumWinTypeYearlyValues(name, values))}
       </StyledParagraph>

--- a/src/client/modules/ExportWins/Form/WinTypeValues.jsx
+++ b/src/client/modules/ExportWins/Form/WinTypeValues.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import Label from '@govuk-react/label'
+import pluralize from 'pluralize'
+import styled from 'styled-components'
+
+import { LIGHT_GREY } from '../../../../client/utils/colours'
+import { FieldCurrency } from '../../../components'
+import { StyledHintParagraph } from './styled'
+import {
+  formatValue,
+  getYearFromWinType,
+  sumWinTypeYearlyValues,
+} from './utils'
+
+const WinTypeContainer = styled('div')({
+  marginLeft: 56,
+})
+
+const FieldCurrencyContainer = styled('div')({
+  display: 'flex',
+  gap: 5,
+})
+
+const StyledLabel = styled(Label)({
+  fontWeight: 'bold',
+})
+
+const StyledParagraph = styled('p')({
+  padding: 10,
+  fontWeight: 'bold',
+  backgroundColor: LIGHT_GREY,
+})
+
+export const WinTypeValues = ({ label, name, years = 5, values }) => {
+  const year = getYearFromWinType(name, values)
+  return (
+    <WinTypeContainer>
+      <StyledLabel>{label}</StyledLabel>
+      <StyledHintParagraph>(round to nearest £)</StyledHintParagraph>
+      <FieldCurrencyContainer>
+        {[...Array(years).keys()].map((index) => (
+          <FieldCurrency
+            type="text"
+            name={`${name}_${index}`}
+            key={`${name}_${index}`}
+            label={`Year ${index + 1}`}
+            boldLabel={true}
+          />
+        ))}
+      </FieldCurrencyContainer>
+      <StyledParagraph>
+        Totalling over {year} {pluralize('year', year)}:{' '}
+        {formatValue(sumWinTypeYearlyValues(name, values))}
+      </StyledParagraph>
+    </WinTypeContainer>
+  )
+}

--- a/test/component/cypress/specs/ExportWins/WinTypeValues.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinTypeValues.cy.jsx
@@ -1,0 +1,241 @@
+import React from 'react'
+
+import { WinTypeValues } from '../../../../../src/client/modules/ExportWins/Form/WinTypeValues'
+import { Form } from '../../../../../src/client/components'
+import DataHubProvider from '../provider'
+
+describe('WinTypeValues', () => {
+  const Component = (props) => (
+    <DataHubProvider>
+      <Form id="exportwin-form" initialValues={{ ...props.values }}>
+        <WinTypeValues {...props} />
+      </Form>
+    </DataHubProvider>
+  )
+
+  context('when rendering an export win - sequential years', () => {
+    it('should render all elements of the component', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{}}
+        />
+      )
+      cy.get('[data-test="label"]').should(
+        'have.text',
+        'Export value over the next 5 years'
+      )
+      cy.get('[data-test="hint"]').should('have.text', '(round to nearest £)')
+      cy.get('input[type="text"]').should('have.length', 5)
+      const expected = ['Year 1', 'Year 2', 'Year 3', 'Year 4', 'Year 5']
+      expected.forEach((year, index) => {
+        cy.get(`[data-test="field-export_win_${index}"]`)
+          .find('label')
+          .should('have.text', year)
+      })
+    })
+
+    it('should render an export win value over 5 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '1000000',
+            export_win_2: '1000000',
+            export_win_3: '1000000',
+            export_win_4: '1000000',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 5 years: £5,000,000'
+      )
+    })
+
+    it('should render an export win value over 4 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '1000000',
+            export_win_2: '1000000',
+            export_win_3: '1000000',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 4 years: £4,000,000'
+      )
+    })
+
+    it('should render an export win value over 3 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '1000000',
+            export_win_2: '1000000',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 3 years: £3,000,000'
+      )
+    })
+
+    it('should render an export win value over 2 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '1000000',
+            export_win_2: '',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 2 years: £2,000,000'
+      )
+    })
+
+    it('should render an export win value over 1 year', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '',
+            export_win_2: '',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 1 year: £1,000,000'
+      )
+    })
+
+    it('should render an export win value over 0 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '',
+            export_win_1: '',
+            export_win_2: '',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 0 years: £0'
+      )
+    })
+  })
+
+  context('when rendering an export win - sporadic years', () => {
+    it('should render an export win value over 5 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '',
+            export_win_2: '1000000',
+            export_win_3: '',
+            export_win_4: '1000000',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 5 years: £3,000,000'
+      )
+    })
+
+    it('should render an export win value over 4 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '',
+            export_win_1: '1000000',
+            export_win_2: '',
+            export_win_3: '1000000',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 4 years: £2,000,000'
+      )
+    })
+
+    it('should render an export win value over 3 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '1000000',
+            export_win_1: '',
+            export_win_2: '1000000',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 3 years: £2,000,000'
+      )
+    })
+
+    it('should render an export win value over 2 years', () => {
+      cy.mount(
+        <Component
+          label="Export value over the next 5 years"
+          name="export_win"
+          values={{
+            export_win_0: '',
+            export_win_1: '1000000',
+            export_win_2: '',
+            export_win_3: '',
+            export_win_4: '',
+          }}
+        />
+      )
+      cy.get('[data-test="total"]').should(
+        'have.text',
+        'Totalling over 2 years: £1,000,000'
+      )
+    })
+  })
+})

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -1,17 +1,22 @@
-import {
-  assertUrl,
-  assertFieldError,
-  assertLocalHeader,
-  assertErrorSummary,
-  assertFieldTypeahead,
-  assertFieldRadiosWithLegend,
-} from '../../support/assertions'
+import { getTwelveMonthsAgo } from '../../../../../src/client/modules/ExportWins/Form/utils'
 import { clickContinueButton } from '../../support/actions'
 import { companyFaker } from '../../fakers/companies'
 import { advisersListFaker } from '../../fakers/advisers'
 import { teamTypeListFaker } from '../../fakers/team-type'
 import { hqTeamListFaker } from '../../fakers/hq-team'
 import urls from '../../../../../src/lib/urls'
+import {
+  assertUrl,
+  assertFieldInput,
+  assertFieldError,
+  assertLocalHeader,
+  assertErrorSummary,
+  assertFieldTextarea,
+  assertFieldTypeahead,
+  assertFieldDateShort,
+  assertFieldCheckboxes,
+  assertFieldRadiosWithLegend,
+} from '../../support/assertions'
 
 const clickContinueAndAssertUrl = (url) => {
   clickContinueButton()
@@ -365,8 +370,212 @@ describe('Adding an export win', () => {
   })
 
   context('Win details', () => {
-    it('should complete this step and continue to "Support provided"', () => {
+    // Helpers
+    const twelveMonthsAgo = getTwelveMonthsAgo()
+    const month = twelveMonthsAgo.getMonth() + 1
+    const year = twelveMonthsAgo.getFullYear()
+
+    // Fields
+    const country = '[data-test="field-country"]'
+    const date = '[data-test="field-date"]'
+    const description = '[data-test="field-description"]'
+    const nameOfCustomer = '[data-test="field-name_of_customer"]'
+    const confidential = '[data-test="field-name_of_customer_confidential"]'
+    const businessType = '[data-test="field-business_type"]'
+    const winType = '[data-test="field-win_type"]'
+    const goodsVsServices = '[data-test="field-goods_vs_services"]'
+    const nameOfExport = '[data-test="field-name_of_export"]'
+    const sector = '[data-test="field-sector"]'
+
+    beforeEach(() =>
       cy.visit(`${urls.companies.exportWins.create()}${winDetails}`)
+    )
+
+    it('should render a step heading', () => {
+      cy.get('[data-test="step-heading"]').should('have.text', 'Win details')
+    })
+
+    it('should render a hint', () => {
+      cy.get('[data-test="hint"]').should(
+        'have.text',
+        'The customer will be asked to confirm this infomation.'
+      )
+    })
+
+    it('should render Destination country label and a Typeahead', () => {
+      cy.get(country).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Destination country',
+        })
+      })
+    })
+
+    it('should render the Win date', () => {
+      cy.get(date).then((element) => {
+        // Both Month and Year labels are tested within the assertion
+        assertFieldDateShort({
+          element,
+          label: 'Date won',
+          hint: `For example ${month} ${year}, date of win must be in the last 12 months.`,
+        })
+      })
+    })
+
+    it('should render Summary of the support given', () => {
+      cy.get(description).then((element) => {
+        assertFieldTextarea({
+          element,
+          label: 'Summary of the support given',
+          hint: 'Outline what had the most impact or would be memorable to the customer in less than 100 words.',
+          wordCount: 'You have 100 words remaining.',
+        })
+      })
+    })
+
+    it('should renderer Overseas customer', () => {
+      cy.get(nameOfCustomer).then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Overseas customer',
+          placeholder: 'Add name',
+        })
+      })
+    })
+
+    it('should render a Confidential checkbox', () => {
+      assertFieldCheckboxes({
+        element: confidential,
+        hint: 'Check this box if your customer has asked for this not to be public (optional).',
+        options: [
+          {
+            label: 'Confidential',
+            checked: false,
+          },
+        ],
+      })
+    })
+
+    it('should renderer a type of business deal', () => {
+      cy.get(businessType).then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Type of business deal',
+          hint: 'For example: export sales, contract, order, distributor, tender / competition win, joint venture, outward investment.',
+          placeholder: 'Enter a type of business deal',
+        })
+      })
+    })
+
+    it('should render Type of win ', () => {
+      assertFieldCheckboxes({
+        element: winType,
+        legend: 'Type of win',
+        options: [
+          {
+            label: 'Export',
+            checked: false,
+          },
+          {
+            label: 'Business success',
+            checked: false,
+          },
+          {
+            label: 'Outward Direct Investment (ODI)',
+            checked: false,
+          },
+        ],
+      })
+    })
+
+    it('should render Goods and Services', () => {
+      assertFieldCheckboxes({
+        element: goodsVsServices,
+        legend: 'What does the value relate to?',
+        hint: 'Select goods or services',
+        options: [
+          {
+            label: 'Goods',
+            checked: false,
+          },
+          {
+            label: 'Services',
+            checked: false,
+          },
+        ],
+      })
+    })
+
+    it('should renderer name of goods or services', () => {
+      cy.get(nameOfExport).then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Name of goods or services',
+          hint: "For instance 'shortbread biscuits'.",
+          placeholder: 'Enter a name for goods or services',
+        })
+      })
+    })
+
+    it('should render a sector label and typeahead', () => {
+      cy.get(sector).then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'Sector',
+        })
+      })
+    })
+
+    it('should display validation error messages on mandatory fields', () => {
+      clickContinueButton()
+      assertErrorSummary([
+        'Choose a destination country',
+        'Enter the win date',
+        'Enter a summary',
+        'Enter the name of the overseas customer',
+        'Enter the type of business deal',
+        'Choose at least one type of win',
+        'Select at least one option',
+        'Enter the name of goods or services',
+        'Enter a sector',
+      ])
+      assertFieldError(cy.get(country), 'Choose a destination country', false)
+      assertFieldError(cy.get(date), 'Enter the win date', true)
+      assertFieldError(cy.get(description), 'Enter a summary', true)
+      assertFieldError(
+        cy.get(nameOfCustomer),
+        'Enter the name of the overseas customer',
+        false
+      )
+      assertFieldError(
+        cy.get(businessType),
+        'Enter the type of business deal',
+        true
+      )
+      assertFieldError(cy.get(winType), 'Choose at least one type of win', true)
+      // We can't use assertFieldError here as it picks up the wrong span
+      cy.get(goodsVsServices).should('contain', 'Select at least one option')
+      assertFieldError(
+        cy.get(nameOfExport),
+        'Enter the name of goods or services',
+        true
+      )
+      assertFieldError(cy.get(sector), 'Enter a sector', false)
+    })
+
+    it('should complete this step and continue to "Support provided"', () => {
+      cy.get(country).selectTypeaheadOption('United states')
+      cy.get(date).as('winDate')
+      cy.get('@winDate').find('[data-test="date-month"]').type('03')
+      cy.get('@winDate').find('[data-test="date-year"]').type('2023')
+      cy.get(description).find('textarea').type('Foo bar baz')
+      cy.get(nameOfCustomer).find('input').type('David French')
+      cy.get(confidential).find('input[type="checkbox"]').check()
+      cy.get(businessType).find('input').type('Contract')
+      cy.get(winType).find('[data-test="checkbox-export_win"]').check()
+      cy.get(goodsVsServices).find('input[type="checkbox"]').eq(0).check()
+      cy.get(nameOfExport).find('input').type('Biscuits')
+      cy.get(sector).selectTypeaheadOption('Advanced Engineering')
       clickContinueAndAssertUrl(supportProvided)
     })
   })

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -488,6 +488,106 @@ describe('Adding an export win', () => {
       })
     })
 
+    it('should render the WinTypeValues component for each win type', () => {
+      const exportWinCheckbox = '[data-test="checkbox-export_win"]'
+      const exportWinTypeValues = '[data-test="win-type-values-export_win"]'
+      const businessSuccessCheckbox =
+        '[data-test="checkbox-business_success_win"]'
+      const businessSuccessTypeValues =
+        '[data-test="win-type-values-business_success_win"]'
+      const odiCheckbox = '[data-test="checkbox-odi_win"]'
+      const odiWinTypeValues = '[data-test="win-type-values-odi_win"]'
+
+      cy.get(winType).as('winType')
+
+      // Export win
+      cy.get('@winType')
+        .find(exportWinTypeValues)
+        .should('not.exist')
+        .get('@winType')
+        .find(exportWinCheckbox)
+        .check()
+        .next()
+        .get(exportWinTypeValues)
+        .should('exist')
+
+      // Business type
+      cy.get('@winType')
+        .find(businessSuccessTypeValues)
+        .should('not.exist')
+        .get('@winType')
+        .find(businessSuccessCheckbox)
+        .check()
+        .next()
+        .get(businessSuccessTypeValues)
+        .should('exist')
+
+      // ODI
+      cy.get('@winType')
+        .find(odiWinTypeValues)
+        .should('not.exist')
+        .get('@winType')
+        .find(odiCheckbox)
+        .check()
+        .next()
+        .get(odiWinTypeValues)
+        .should('exist')
+    })
+
+    it('should render the total export value across all 3 win types', () => {
+      cy.get(winType).as('winType')
+
+      // Check the Export checkbox to render the input fields
+      cy.get('@winType').find('[data-test="checkbox-export_win"]').check()
+
+      const exportWinFields = [
+        '[data-test="export-win-0-input"]',
+        '[data-test="export-win-1-input"]',
+        '[data-test="export-win-2-input"]',
+        '[data-test="export-win-3-input"]',
+        '[data-test="export-win-4-input"]',
+      ]
+      exportWinFields.forEach((dataTest) =>
+        cy.get('@winType').find(dataTest).type('1000000')
+      )
+
+      // Check the Business success checkbox to render the input fields
+      cy.get('@winType')
+        .find('[data-test="checkbox-business_success_win"]')
+        .check()
+
+      const businessSuccessFields = [
+        '[data-test="business-success-win-0-input"]',
+        '[data-test="business-success-win-1-input"]',
+        '[data-test="business-success-win-2-input"]',
+        '[data-test="business-success-win-3-input"]',
+        '[data-test="business-success-win-4-input"]',
+      ]
+      businessSuccessFields.forEach((dataTest) =>
+        cy.get('@winType').find(dataTest).type('1000000')
+      )
+
+      // Check the ODI checkbox to render the input fields
+      cy.get('@winType').find('[data-test="checkbox-odi_win"]').check()
+
+      const odiFields = [
+        '[data-test="odi-win-0-input"]',
+        '[data-test="odi-win-1-input"]',
+        '[data-test="odi-win-2-input"]',
+        '[data-test="odi-win-3-input"]',
+        '[data-test="odi-win-4-input"]',
+      ]
+      odiFields.forEach((dataTest) =>
+        cy.get('@winType').find(dataTest).type('1000000')
+      )
+
+      // Assert the total export value
+      cy.get('[data-test="total-export-value"]').should(
+        'have.text',
+        'Total export value: £15,000,000'
+      )
+    })
+
     it('should render Goods and Services', () => {
       assertFieldCheckboxes({
         element: goodsVsServices,

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -368,7 +368,6 @@ const assertFieldInput = ({
   hint = undefined,
   value = undefined,
   ignoreHint = false,
-  placeholder,
 }) =>
   cy
     .wrap(element)
@@ -390,15 +389,9 @@ const assertFieldInput = ({
       ($el) => (ignoreHint && value ? cy.wrap($el).next() : undefined)
     )
     .find('input')
-    .then(
-      ($el) =>
-        value && cy.wrap($el).should('have.attr', 'value', String(value) || '')
-    )
-    .then(
-      ($el) =>
-        placeholder &&
-        cy.wrap($el).should('have.attr', 'placeholder', placeholder)
-    )
+    .then(($el) => {
+      value && cy.wrap($el).should('have.attr', 'value', String(value) || '')
+    })
 
 const assertFieldInputNoLabel = ({ element, value = undefined }) =>
   cy

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -412,9 +412,8 @@ const assertFieldInputNoLabel = ({ element, value = undefined }) =>
 const assertFieldHidden = ({ element, name, value }) =>
   cy.wrap(element).should('have.attr', 'name', name).should('have.value', value)
 
-const assertFieldTextarea = ({ element, label, hint, value, wordCount }) =>
-  cy
-    .wrap(element)
+const assertFieldTextarea = ({ element, label, hint, value, wordCount }) => {
+  cy.wrap(element)
     .find('label')
     .should('contain', label)
     .parent()
@@ -430,9 +429,9 @@ const assertFieldTextarea = ({ element, label, hint, value, wordCount }) =>
     .parent()
     .find('textarea')
     .then(($el) => value ?? cy.wrap($el).should('have.text', value || ''))
-    .parent()
-    .find('p')
-    .then(($el) => wordCount && cy.wrap($el).should('have.text', wordCount))
+
+  wordCount && cy.wrap(element).find('p').should('have.text', wordCount)
+}
 
 const assertFieldTextareaNoLabel = ({ element, value = undefined }) =>
   cy


### PR DESCRIPTION
## Description of change

This is step 4 of 6 of the Export Win user journey that enables Lead Officers to add an Export Win to Data Hub.

## Test instructions

Go to `/exportwins/create?step=win_details&company=<company-uuid>`

1. Enter values for all fields (there are lots)
2. Click continue
3. Click back
4. Ensure all data entered from 1. has persisted.

## Screenshots
<img width="545" alt="Screenshot 2024-01-23 at 12 57 10" src="https://github.com/uktrade/data-hub-frontend/assets/964268/6166b3d3-cba4-4f41-aa24-aacca89e4d29">

## Validation
<img width="545" alt="Screenshot 2024-01-23 at 12 59 12" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b8b17dca-9b85-49e5-93b9-f6af5193aea8">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
