### PR TITLE
Fix bugs in Resource/Paginated component

### DIFF
--- a/src/client/components/Resource/Paginated.js
+++ b/src/client/components/Resource/Paginated.js
@@ -93,6 +93,7 @@ const PaginatedResource = multiInstance({
       {({ location }) => {
         const qsParams = qs.parse(location.search.slice(1))
         const routePage = parseInt(qsParams.page, 10) || 1
+        const totalPages = result ? Math.ceil(result.count / pageSize) : 0
 
         return (
           <Task>
@@ -127,12 +128,10 @@ const PaginatedResource = multiInstance({
                         totalItems={result.count}
                         collectionName={name}
                       />
-                      <StyledCollectionSort
-                        totalPages={Math.floor(result.count / pageSize)}
-                      />
+                      <StyledCollectionSort totalPages={totalPages} />
                       {result ? children(result.results) : null}
                       <Pagination
-                        totalPages={Math.ceil(result.count / pageSize)}
+                        totalPages={totalPages}
                         activePage={routePage}
                         onPageClick={(clickedPage) => {
                           onPageClick(clickedPage)

--- a/src/client/components/Resource/Paginated.js
+++ b/src/client/components/Resource/Paginated.js
@@ -100,6 +100,16 @@ const PaginatedResource = multiInstance({
               const task = getTask(name, id)
               return (
                 <>
+                  <Task.StartOnRender
+                    name={name}
+                    id={id}
+                    payload={{
+                      ...payload,
+                      limit: pageSize,
+                      offset: (routePage - 1) * pageSize,
+                    }}
+                    onSuccessDispatch={PAGINATED_RESOURCE__ON_SUCCESS}
+                  />
                   {currentPage && (
                     <Redirect
                       to={{
@@ -138,18 +148,7 @@ const PaginatedResource = multiInstance({
                       />
                     </LoadingBox>
                   ) : (
-                    <Task.Status
-                      name={name}
-                      id={id}
-                      startOnRender={{
-                        payload: {
-                          ...payload,
-                          limit: pageSize,
-                          offset: (routePage - 1) * pageSize,
-                        },
-                        onSuccessDispatch: PAGINATED_RESOURCE__ON_SUCCESS,
-                      }}
-                    />
+                    <Task.Status name={name} id={id} />
                   )}
                 </>
               )

--- a/test/component/cypress/specs/Resource/Paginated.cy.jsx
+++ b/test/component/cypress/specs/Resource/Paginated.cy.jsx
@@ -1,0 +1,111 @@
+import _ from 'lodash'
+import React from 'react'
+
+import DataHubProvider from '../provider'
+import PaginatedResource from '../../../../../src/client/components/Resource/Paginated'
+import TabNav from '../../../../../src/client/components/TabNav'
+
+const PAGE_SIZE = 10
+const COUNT = 35
+const DB = _.range(COUNT)
+const PAGES = _.chunk(DB, PAGE_SIZE)
+
+describe('Resource/Paginated', () => {
+  it('Should inject only the current page of results to children', () => {
+    cy.mount(
+      <DataHubProvider
+        resetTasks={true}
+        tasks={{
+          foo: (payload) => ({
+            count: COUNT,
+            results: DB.slice(payload.offset, payload.offset + payload.limit),
+          }),
+        }}
+      >
+        <PaginatedResource name="foo" id="whatever" pageSize={PAGE_SIZE}>
+          {(page) => <pre>{JSON.stringify(page)}</pre>}
+        </PaginatedResource>
+      </DataHubProvider>
+    )
+
+    cy.get('pre').as('page').should('have.text', JSON.stringify(PAGES[0]))
+
+    cy.get('[data-test="pagination-summary"]')
+      .as('summary')
+      .should('have.text', `Page 1 of ${PAGES.length}`)
+
+    // Click on page numbers from highest to smallest
+    PAGES.toReversed().forEach((page, i) => {
+      const pageNumber = PAGES.length - i
+      cy.get(`[data-page-number="${pageNumber}"]`).click()
+      cy.get('@summary').should(
+        'have.text',
+        `Page ${pageNumber} of ${PAGES.length}`
+      )
+      cy.get('@page').should('have.text', JSON.stringify(page))
+    })
+
+    // Go through pages forwards by clicking Next
+    PAGES.slice(1).forEach((page) => {
+      cy.get(`[data-test="next"]`).click()
+      cy.get('@page').should('have.text', JSON.stringify(page))
+    })
+
+    // Go through pages backwards by clicking Previous
+    PAGES.slice(0, -1)
+      .toReversed()
+      .forEach((page) => {
+        cy.get(`[data-test="prev"]`).click()
+        cy.get('@page').should('have.text', JSON.stringify(page))
+      })
+  })
+
+  it('Should load when mounted, even if the resource already has data', () => {
+    cy.mount(
+      <DataHubProvider
+        resetTasks={true}
+        tasks={{
+          bar: async (payload) => ({
+            count: COUNT,
+            results: DB.slice(payload.offset, payload.offset + payload.limit),
+          }),
+        }}
+      >
+        <TabNav
+          id="tab-nav"
+          selectedIndex="1"
+          label="Tab nav"
+          tabs={[
+            {
+              label: 'Foo tab',
+              content: 'Fooooo',
+            },
+            {
+              label: 'Bar tab',
+              content: (
+                <PaginatedResource
+                  name="bar"
+                  id="whatever"
+                  pageSize={PAGE_SIZE}
+                >
+                  {(page) => <pre>{JSON.stringify(page)}</pre>}
+                </PaginatedResource>
+              ),
+            },
+          ]}
+        />
+      </DataHubProvider>
+    )
+
+    cy.contains('Loading')
+    cy.get('pre').as('page').should('have.text', JSON.stringify(PAGES[0]))
+
+    // When we go to a different tab and back...
+    cy.contains('Foo tab').click()
+    cy.contains('Bar tab').click()
+
+    // The resource should reload
+    cy.contains('Loading')
+    cy.get('pre').as('page').should('have.text', JSON.stringify(PAGES[0]))
+  })
+})


### PR DESCRIPTION
## Description of change

This PR fixes these two bugs in the `Resource/Paginated` component and also adds tests.

* The resource didn't start its _task_ when the component was remounted if the resource already had a _result_
* The component's heading was showing wrong number of total pages

## Test instructions

1. Use the component and...
2. ...ensure that the resource starts a task when re-mounted. Have look at the tests in this PR where this is done
3. ...ensure that the heading shows correct number of total pages

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
