### PR TITLE
Enable status active/complete filter

### DIFF
--- a/src/client/components/Dashboard/my-tasks/state.js
+++ b/src/client/components/Dashboard/my-tasks/state.js
@@ -30,9 +30,10 @@ const sortbyMapping = {
   company_ascending: 'company.name:asc',
   project_ascending: 'investment_project.name:asc',
 }
+
 const statusMapping = {
-  active: { archived: false },
-  completed: { archived: true },
+  active: { status: 'active' },
+  completed: { status: 'complete' },
 }
 
 export const state2props = ({ router, ...state }) => {
@@ -50,6 +51,7 @@ export const state2props = ({ router, ...state }) => {
     sortby: 'due_date:asc',
     company: undefined,
     project: undefined,
+    status: undefined,
   }
 
   const assignedToMapping = {

--- a/src/client/components/Dashboard/my-tasks/tasks.js
+++ b/src/client/components/Dashboard/my-tasks/tasks.js
@@ -10,6 +10,7 @@ export const getMyTasks = ({
   sortby = 'due_date:asc',
   company,
   project,
+  status,
 }) =>
   apiProxyAxios
     .post('/v4/search/task', {
@@ -24,5 +25,6 @@ export const getMyTasks = ({
       sortby,
       company,
       investment_project: project,
+      status,
     })
     .then(({ data }) => data)

--- a/test/functional/cypress/fakers/task.js
+++ b/test/functional/cypress/fakers/task.js
@@ -29,6 +29,7 @@ const taskFaker = (overrides = {}) => ({
   modifiedBy: basicAdviserFaker(),
   modifiedOn: faker.date.past().toISOString(),
   createdOn: faker.date.past().toISOString(),
+  status: 'active',
 
   ...overrides,
 })

--- a/test/functional/cypress/specs/dashboard/filter-spec.js
+++ b/test/functional/cypress/specs/dashboard/filter-spec.js
@@ -300,24 +300,29 @@ describe('Task filters', () => {
     })
 
     it('should filter active status from the url', () => {
-      testFilterFromUrl(element, 'status=active', { archived: false }, 'Active')
+      testFilterFromUrl(
+        element,
+        'status=active',
+        { status: 'active' },
+        'Active'
+      )
     })
 
     it('should filter completed status from the url', () => {
       testFilterFromUrl(
         element,
         'status=completed',
-        { archived: true },
+        { status: 'complete' },
         'Completed'
       )
     })
 
     it('should filter active status from user input', () => {
-      testFilterFromUserInput(element, { archived: false }, 'Active')
+      testFilterFromUserInput(element, { status: 'active' }, 'Active')
     })
 
     it('should filter completed status from user input', () => {
-      testFilterFromUserInput(element, { archived: true }, 'Completed')
+      testFilterFromUserInput(element, { status: 'complete' }, 'Completed')
     })
   })
 


### PR DESCRIPTION
## Description of change

This PR enables Statuses on the Tasks filter to be Either Active or Complete


### After

<img width="1447" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/74972011/82ed945e-48da-4de8-ae8a-1c168416c5fa">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
