### PR TITLE
Update export wins endpoint to use a hyphen instead of an underscore

### DIFF
--- a/src/client/modules/ExportWins/Confirmed/ConfirmedWinsTable.jsx
+++ b/src/client/modules/ExportWins/Confirmed/ConfirmedWinsTable.jsx
@@ -44,7 +44,7 @@ export const ExportWinsTable = ({ exportWins }) => (
           <Table.Cell>{currencyGBP(total_expected_export_value)}</Table.Cell>
           <NoWrapCell>{formatMediumDate(date)}</NoWrapCell>
           <NoWrapCell>
-            {formatMediumDate(customer_response.created_on)}
+            {formatMediumDate(customer_response?.created_on)}
           </NoWrapCell>
           <NoWrapCell>
             {/* TODO: Add target to the link once the path is decided */}

--- a/src/client/modules/ExportWins/Form/tasks.js
+++ b/src/client/modules/ExportWins/Form/tasks.js
@@ -5,6 +5,8 @@ import {
   transformExportProjectForForm,
 } from './transformers'
 
+const exportWinEndpoint = '/v4/export-win'
+
 export const getExportProject = ({ id }) =>
   apiProxyAxios
     .get(`/v4/export/${id}`)
@@ -12,14 +14,14 @@ export const getExportProject = ({ id }) =>
 
 export const getExportWin = ({ id }) =>
   apiProxyAxios
-    .get(`/v4/export_win/${id}`)
+    .get(`${exportWinEndpoint}/${id}`)
     .then(({ data }) => transformExportWinForForm(data))
 
 export const saveExportWin = ({ exportWinId, payload }) => {
   const request = exportWinId ? apiProxyAxios.patch : apiProxyAxios.post
   const endpoint = exportWinId
-    ? `/v4/export_win/${exportWinId}`
-    : '/v4/export_win'
+    ? `${exportWinEndpoint}/${exportWinId}`
+    : exportWinEndpoint
 
   return request(endpoint, payload)
 }

--- a/src/client/modules/ExportWins/Unconfirmed/UnconfirmedWinsList.jsx
+++ b/src/client/modules/ExportWins/Unconfirmed/UnconfirmedWinsList.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { Button } from 'govuk-react'
 
-import { SecondaryButton, CollectionItem } from '../../../components'
+import { CollectionItem } from '../../../components'
 import { formatMediumDate } from '../../../utils/date'
 import { currencyGBP } from '../../../utils/number-utils'
 import ExportWinsResource from '../../../components/Resource/ExportWins'
+
+import urls from '../../../../lib/urls'
 
 export default () => (
   <ExportWinsResource.Paginated
@@ -17,7 +19,7 @@ export default () => (
           <li key={item.id}>
             <CollectionItem
               headingText={item.company.name}
-              headingUrl={`company-url/${item.company.id}`}
+              headingUrl={`${urls.companies.detail(item.company.id)}`}
               metadata={[
                 { label: 'Destination', value: item.country.name },
                 { label: 'Contact name', value: item.customer_name },
@@ -33,9 +35,6 @@ export default () => (
                   <Button as="a" href={`review/${item.id}`}>
                     Review export win
                   </Button>
-                  <SecondaryButton as="a" href={`edit/${item.id}`}>
-                    Edit export win
-                  </SecondaryButton>
                 </div>
               }
             />

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -57,7 +57,6 @@ const ALLOWLIST = [
   '/v3/event/',
   '/v4/event/',
   '/v4/export-win/',
-  '/v4/export_win',
   '/v4/event/:id',
   '/v3/omis/order/:id/assignee',
   '/v3/omis/order/:id/subscriber-list',

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -1006,7 +1006,7 @@ describe('Adding an export win', () => {
         'have.text',
         'Confirm and send to customer'
       )
-      cy.intercept('POST', '/api-proxy/v4/export_win', {
+      cy.intercept('POST', '/api-proxy/v4/export-win', {
         statusCode: 201,
       }).as('apiRequest')
       cy.get('[data-test="confirm-and-send-to-customer"]').click()


### PR DESCRIPTION
## Description of change
1. Updated the export wins endpoint to use a hyphen instead of an underscore.
2. Update the company url so when clicking the company name when on the unconfirmed tab the user will be taken to the company details page.

## Test instructions
In the dev environment go to `/exportwins/unconfirmed` where the page should load unconfirmed export wins.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
