### PR TITLE
Fixes a bug around the optional HVC field

### DIFF
--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -212,7 +212,7 @@ export const transformFormValuesForAPI = (values) => ({
   name_of_export: values.name_of_export,
   sector: values.sector.value,
   // Support given
-  hvc: values.hvc.value,
+  ...(values.hvc && { hvc: values.hvc.value }), // optional field
   type_of_support: values.type_of_support.map((support) => support.value),
   associated_programme: values.associated_programme.map((c) => c.value),
   is_personally_confirmed: values.is_personally_confirmed[0] === OPTION_YES,


### PR DESCRIPTION
## Description of change
If a user enters an optional HVC value then there's not a problem, the user can create an export win, however, if they omit the field then the UI errors. This fix addresses that bug.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
