### PR TITLE
Refactor building of sector_descends list

### DIFF
--- a/src/client/modules/Companies/CollectionList/tasks.js
+++ b/src/client/modules/Companies/CollectionList/tasks.js
@@ -18,8 +18,8 @@ const getCompanies = ({
   page,
   headquarter_type,
   name,
-  sector_descends,
-  sub_sector_descends,
+  sector_descends = [], // Default to empty array if not provided
+  sub_sector_descends = [], // Default to empty array if not provided
   country,
   uk_postcode,
   uk_region,
@@ -36,24 +36,13 @@ const getCompanies = ({
   sortby = 'modified_on:desc',
 }) => {
   const administrativeAreas = [...us_state, ...canadian_province]
-  const getSectors = (sector_descends, sub_sector_descends) => {
-    if (sector_descends && sub_sector_descends) {
-      return [...sector_descends, ...sub_sector_descends]
-    }
-    if (sub_sector_descends) {
-      return sub_sector_descends
-    }
-    if (sector_descends) {
-      return sector_descends
-    }
-  }
   return apiProxyAxios
     .post('/v4/search/company', {
       limit,
       offset: getPageOffset({ limit, page }),
       headquarter_type,
       name,
-      sector_descends: getSectors(sector_descends, sub_sector_descends),
+      sector_descends: [...sector_descends, ...sub_sector_descends],
       country,
       uk_postcode,
       uk_region,

--- a/src/client/modules/Interactions/CollectionList/tasks.js
+++ b/src/client/modules/Interactions/CollectionList/tasks.js
@@ -63,25 +63,14 @@ const getInteractions = ({
   date_before,
   date_after,
   sortby = 'date:desc',
-  sector_descends,
-  sub_sector_descends,
+  sector_descends = [], // Default to empty array if not provided
+  sub_sector_descends = [], // Default to empty array if not provided
   was_policy_feedback_provided,
   policy_areas,
   policy_issue_types,
   company_one_list_group_tier,
   dit_participants__team,
 }) => {
-  const getSectors = (sector_descends, sub_sector_descends) => {
-    if (sector_descends && sub_sector_descends) {
-      return [...sector_descends, ...sub_sector_descends]
-    }
-    if (sub_sector_descends) {
-      return sub_sector_descends
-    }
-    if (sector_descends) {
-      return sector_descends
-    }
-  }
   return apiProxyAxios
     .post('/v3/search/interaction', {
       limit,
@@ -94,7 +83,7 @@ const getInteractions = ({
       date_before,
       date_after,
       service,
-      sector_descends: getSectors(sector_descends, sub_sector_descends),
+      sector_descends: [...sector_descends, ...sub_sector_descends],
       was_policy_feedback_provided,
       policy_areas,
       policy_issue_types,

--- a/src/client/modules/Omis/CreateOrder/CompanySelect/tasks.js
+++ b/src/client/modules/Omis/CreateOrder/CompanySelect/tasks.js
@@ -7,8 +7,8 @@ export const getOmisCompanies = ({
   page,
   headquarter_type,
   name,
-  sector_descends,
-  sub_sector_descends,
+  sector_descends = [], // Default to empty array if not provided
+  sub_sector_descends = [], // Default to empty array if not provided
   country,
   uk_postcode,
   uk_region,
@@ -17,24 +17,13 @@ export const getOmisCompanies = ({
   sortby = 'modified_on:desc',
 }) => {
   const administrativeAreas = [...us_state, ...canadian_province]
-  const getSectors = (sector_descends, sub_sector_descends) => {
-    if (sector_descends && sub_sector_descends) {
-      return [...sector_descends, ...sub_sector_descends]
-    }
-    if (sub_sector_descends) {
-      return sub_sector_descends
-    }
-    if (sector_descends) {
-      return sector_descends
-    }
-  }
   return apiProxyAxios
     .post('/v4/search/company', {
       limit,
       offset: getPageOffset({ limit, page }),
       headquarter_type,
       name,
-      sector_descends: getSectors(sector_descends, sub_sector_descends),
+      sector_descends: [...sector_descends, ...sub_sector_descends],
       country,
       uk_postcode,
       uk_region,


### PR DESCRIPTION
## Description of change

Refactor the building of sector_descends list. Instead of checking if either the `sector_descends` or `sub_sector_descends` lists exists, they are set to empty arrays by default and combined using the spread operator.

There is no functional change.

This work and PR are linked with **https://github.com/uktrade/data-hub-api/pull/5168**.

## Test instructions

No changes, all tests should pass.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?