### PR TITLE
Use @businessandtrade.gov.uk for emails

### DIFF
--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditRequirementsForm.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/EditRequirementsForm.jsx
@@ -78,8 +78,8 @@ const EditRequirementsForm = ({ profile }) => {
         <p>
           If the asset class you wish to select is not shown above, then request
           it from&nbsp;
-          <a href={`mailto:capitalinvestment@trade.gov.uk`}>
-            capitalinvestment@trade.gov.uk
+          <a href={`mailto:capitalinvestment@businessandtrade.gov.uk`}>
+            capitalinvestment@businessandtrade.gov.uk
           </a>
           .
         </p>

--- a/src/client/modules/Investments/Opportunities/CollectionList/OpportunitiesCollection.jsx
+++ b/src/client/modules/Investments/Opportunities/CollectionList/OpportunitiesCollection.jsx
@@ -34,8 +34,8 @@ const LargeCapitalOpportunityCollection = ({
 
       <p>
         For further information email 
-        <Link href="mailto:capitalinvestment@trade.gov.uk">
-          capitalinvestment@trade.gov.uk
+        <Link href="mailto:capitalinvestment@businessandtrade.gov.uk">
+          capitalinvestment@businessandtrade.gov.uk
         </Link>
       </p>
     </div>

--- a/src/client/modules/Investments/Opportunities/OpportunityDetails.jsx
+++ b/src/client/modules/Investments/Opportunities/OpportunityDetails.jsx
@@ -117,7 +117,7 @@ const OpportunityDetails = ({
       </OpportunitySection>
       <StyledDetails summary="Need to delete this opportunity?">
         To delete this opportunity, email{' '}
-        <Link>capitalinvestment@trade.gov.uk</Link>
+        <Link>capitalinvestment@businessandtrade.gov.uk</Link>
       </StyledDetails>
     </>
   )

--- a/src/client/modules/Investments/Opportunities/OpportunityDetailsForm.jsx
+++ b/src/client/modules/Investments/Opportunities/OpportunityDetailsForm.jsx
@@ -191,8 +191,8 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
               <p>
                 If the asset class you wish to select is not shown above, then
                 request it from&nbsp;
-                <a href={`mailto:capitalinvestment@trade.gov.uk`}>
-                  capitalinvestment@trade.gov.uk
+                <a href={`mailto:capitalinvestment@businessandtrade.gov.uk`}>
+                  capitalinvestment@businessandtrade.gov.uk
                 </a>
                 .
               </p>

--- a/src/client/modules/Investments/Opportunities/OpportunityRequirementsForm.jsx
+++ b/src/client/modules/Investments/Opportunities/OpportunityRequirementsForm.jsx
@@ -125,7 +125,7 @@ const OpportunityRequirementsForm = (state) => {
                 />
                 <StyledP>
                   If you can’t see the type of investment you need, request it
-                  from <Link>capitalinvestment@trade.gov.uk</Link>.
+                  from <Link>capitalinvestment@businessandtrade.gov.uk</Link>.
                 </StyledP>
                 <FieldRadios
                   legend="Estimated return rate"


### PR DESCRIPTION
## Description of change

We have a few email addresses listed in Data Hub that are still using the deprecated `@trade.gov.uk` domain. These have been updated to use the `@businessandtrade.gov.uk` domain.

## Test instructions

The changes pages should display the correct email domain.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
