### PR TITLE
Cls2 698 add adviser parameter to investement project call

### DIFF
--- a/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormFields.jsx
@@ -183,6 +183,7 @@ const TaskFormFields = ({
                               payload: {
                                 limit: 250,
                                 companyId: companyId,
+                                adviser: [currentAdviserId],
                               },
                               onSuccessDispatch: INVESTMENTS__PROJECTS_LOADED,
                             })

--- a/test/component/cypress/specs/Tasks/TaskForm/TaskFormFields.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskForm/TaskFormFields.cy.jsx
@@ -29,6 +29,7 @@ import advisersListFaker, {
 import { OPTION_NO, OPTION_YES } from '../../../../../../src/common/constants'
 import { convertDateToFieldDateObject } from '../../../../../../src/client/utils/date'
 import { companyFaker } from '../../../../../functional/cypress/fakers/companies'
+import { investmentProjectFaker } from '../../../../../functional/cypress/fakers/investment-projects'
 
 describe('Task form', () => {
   const Component = (props) => (


### PR DESCRIPTION
## Description of change

When creating a new task and a company has been selected. The call to `/api-proxy/v3/search/investment_project` now includes an adviser parameter containing the id of the current adviser. This is to ensure that only those Investment projects that they are associated with are included in the Investment Project drop down list.

## Test instructions

Run the backend on branch `feature/CLS2-680-include-global-account-manager-in-investment-project-index` as well as the frontend with Docker. On the frontend, navigate to the Tasks tab on the homepage and add a new task. Scroll down to the company dropdown within the form and select a company. The investment project dropdown should be visible. Your id should be associated with an investment project for it to show. Click into the dropdown and select a investment project. Inspect the page and check within the payload, the adviser parameter should be visible. 


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
