### PR TITLE
 Add validation to both the win date and win type yearly values for export wins

### DIFF
--- a/src/client/modules/ExportWins/Form/AddExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/AddExportWinForm.jsx
@@ -21,7 +21,7 @@ import CreditForThisWinStep from './CreditForThisWinStep'
 import CustomerDetailsStep from './CustomerDetailsStep'
 import WinDetailsStep from './WinDetailsStep'
 import SupportProvidedStep from './SupportProvidedStep'
-import CheckBeforeSendingStep from './CheckBeforeSending'
+import CheckBeforeSendingStep from './CheckBeforeSendingStep'
 
 const StyledLoadingBox = styled(LoadingBox)({
   height: 16,

--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import pluralize from 'pluralize'
 
 import { Step, ButtonLink, FieldInput, SummaryTable } from '../../../components'
-import { useFormContext } from '../../../../client/components/Form/hooks'
+import { useFormContext } from '../../../components/Form/hooks'
 import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
 import { steps } from './constants'
 import {

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -3,13 +3,11 @@ import { useLocation } from 'react-router-dom'
 import { H3 } from '@govuk-react/heading'
 
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
-import { TASK_REDIRECT_TO_CONTACT_FORM } from '../../../components/ContactForm/state'
-import { Step, FieldTypeahead, ContactInformation } from '../../../components'
 import { getQueryParamsFromLocation } from '../../../../client/utils/url'
-import { useFormContext } from '../../../../client/components/Form/hooks'
 import { idNameToValueLabel } from '../../../../client/utils'
-import Task from '../../../components/Task'
-import { ID } from './state'
+import { Step, FieldTypeahead } from '../../../components'
+import { StyledHintParagraph } from './styled'
+
 import { steps } from './constants'
 import {
   UKRegionsResource,
@@ -19,7 +17,6 @@ import {
 } from '../../../components/Resource'
 
 const CustomerDetailsStep = () => {
-  const { values } = useFormContext()
   const location = useLocation()
   const queryParams = getQueryParamsFromLocation(location)
   const companyId = queryParams.company
@@ -39,25 +36,10 @@ const CustomerDetailsStep = () => {
         autoScroll={true}
         resultToOptions={({ results }) => results.map(idNameToValueLabel)}
       />
-      <Task>
-        {(getTask) => {
-          const openContactFormTask = getTask(TASK_REDIRECT_TO_CONTACT_FORM, ID)
-          return (
-            <ContactInformation
-              companyId={companyId}
-              onOpenContactForm={({ redirectUrl }) => {
-                openContactFormTask.start({
-                  payload: {
-                    values,
-                    url: redirectUrl,
-                    storeId: ID,
-                  },
-                })
-              }}
-            />
-          )
-        }}
-      </Task>
+      <StyledHintParagraph data-test="contact-hint">
+        To select a customer contact name, it must have already been added to
+        Data Hub. If not listed, go to the company page to add them.
+      </StyledHintParagraph>
       <ResourceOptionsField
         name="customer_location"
         id="customer-location"

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -9,6 +9,7 @@ import CountriesResource from '../../../components/Resource/Countries'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
 import { SectorResource } from '../../../components/Resource'
 import { OPTION_YES } from '../../../../common/constants'
+import { validateWinDate } from './validators'
 import { WinTypeValues } from './WinTypeValues'
 import { StyledHintParagraph } from './styled'
 import {
@@ -70,6 +71,7 @@ const WinDetailsStep = () => {
         hint={`For example ${month} ${year}, date of win must be in the last 12 months.`}
         required="Enter the win date"
         invalid="Enter a valid date"
+        validate={validateWinDate}
       />
       <FieldTextarea
         name="description"

--- a/src/client/modules/ExportWins/Form/WinTypeValues.jsx
+++ b/src/client/modules/ExportWins/Form/WinTypeValues.jsx
@@ -2,10 +2,12 @@ import React from 'react'
 import Label from '@govuk-react/label'
 import pluralize from 'pluralize'
 import styled from 'styled-components'
+import { isEmpty } from 'lodash'
 
 import { LIGHT_GREY } from '../../../../client/utils/colours'
 import { FieldCurrency } from '../../../components'
 import { StyledHintParagraph } from './styled'
+import { isPositiveInteger } from './validators'
 import {
   formatValue,
   getYearFromWinType,
@@ -31,6 +33,15 @@ const StyledParagraph = styled('p')({
   backgroundColor: LIGHT_GREY,
 })
 
+const allWinTypeYearlyValuesAreEmpty = (field, values) => {
+  const fieldName = field.slice(0, field.length - 2)
+  const allFields = Object.keys(values).filter((key) =>
+    key.startsWith(fieldName)
+  )
+  const allEmptyFields = allFields.filter((key) => values[key] === '')
+  return allEmptyFields.length === allFields.length
+}
+
 export const WinTypeValues = ({ label, name, years = 5, values }) => {
   const year = getYearFromWinType(name, values)
   return (
@@ -47,6 +58,19 @@ export const WinTypeValues = ({ label, name, years = 5, values }) => {
             key={`${name}_${index}`}
             label={`Year ${index + 1}`}
             boldLabel={true}
+            validate={(value, field, { values }) => {
+              if (allWinTypeYearlyValuesAreEmpty(field.name, values)) {
+                return 'Enter a value for at least one of the years'
+              } else if (isEmpty(value)) {
+                // An empty field is valid providing the other fields of
+                // the same win type have at least 1 yearly value defined.
+                return null
+              } else if (isPositiveInteger(value)) {
+                return null
+              } else {
+                return 'The value must not contain letters, be negative or over 19 digits'
+              }
+            }}
           />
         ))}
       </FieldCurrencyContainer>

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -2,7 +2,7 @@ import { isEmpty } from 'lodash'
 
 import { convertDateToFieldDateObject } from '../../../../client/utils/date'
 import { OPTION_YES, OPTION_NO } from '../../../../common/constants'
-import { getTwelveMonthsAgo, sumWinTypeYearlyValues } from './utils'
+import { sumWinTypeYearlyValues, isDateWithinLastTwelveMonths } from './utils'
 import { idNameToValueLabel } from '../../../../client/utils'
 import {
   winTypeId,
@@ -31,13 +31,6 @@ const transformYearlyValuesToBreakdowns = (key, id, values) =>
       year: parseInt(k[k.length - 1], 10) + 1,
       value: values[k],
     }))
-
-const isEstimatedWinDateValid = (estimatedWinDate) => {
-  // Business date logic
-  const today = new Date()
-  const from = getTwelveMonthsAgo()
-  return estimatedWinDate >= from && estimatedWinDate <= today
-}
 
 const transformAdvisersToContributingOfficers = (advisers = []) =>
   advisers.reduce(
@@ -118,7 +111,7 @@ export const transformExportProjectForForm = (exportProject) => {
         ? idNameToValueLabel(exportProject.contacts[0])
         : null, // Get the user to choose the contact
     // Win Details
-    date: isEstimatedWinDateValid(date) && {
+    date: isDateWithinLastTwelveMonths(date) && {
       year: String(date.getFullYear()),
       month: String(date.getMonth() + 1),
     },

--- a/src/client/modules/ExportWins/Form/utils.js
+++ b/src/client/modules/ExportWins/Form/utils.js
@@ -119,3 +119,10 @@ export const getTwelveMonthsAgo = () => {
   const today = new Date()
   return new Date(today.getFullYear() - 1, today.getMonth(), 1)
 }
+
+export const isDateWithinLastTwelveMonths = (date) => {
+  // Business date logic
+  const today = new Date()
+  const from = getTwelveMonthsAgo()
+  return date >= from && date <= today
+}

--- a/src/client/modules/ExportWins/Form/validators.js
+++ b/src/client/modules/ExportWins/Form/validators.js
@@ -1,4 +1,12 @@
+import { isDateWithinLastTwelveMonths } from './utils'
+
+export const POSITIVE_INT_REGEX = /^[0-9]{1,19}$/
+export const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
+
 export const validateTeamMembers = (team_members) =>
   Array.isArray(team_members) && team_members.length > 5
     ? 'You can only add 5 team members'
     : null
+
+export const validateWinDate = ({ month, year }) =>
+  !isDateWithinLastTwelveMonths(new Date(year, month - 1))

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -56,8 +56,7 @@ const formFields = {
   customerDetails: {
     heading: '[data-test="step-heading"]',
     contacts: '[data-test="field-company_contacts"]',
-    addContactLink: '[data-test="add-a-new-contact-link"]',
-    details: '[data-test="contact-information-details"]',
+    contactHint: '[data-test="contact-hint"]',
     location: '[data-test="field-customer_location"]',
     potential: '[data-test="field-business_potential"]',
     experience: '[data-test="field-export_experience"]',
@@ -373,9 +372,11 @@ describe('Adding an export win', () => {
       cy.get(customerDetails.heading).should('have.text', 'Customer details')
     })
 
-    it('should show a contact link and details', () => {
-      cy.get(customerDetails.addContactLink).should('be.visible')
-      cy.get(customerDetails.details).should('be.visible')
+    it('should render a contact hint', () => {
+      cy.get(customerDetails.contactHint).should(
+        'have.text',
+        'To select a customer contact name, it must have already been added to Data Hub. If not listed, go to the company page to add them.'
+      )
     })
 
     it('should render Company contacts label and a Typeahead', () => {


### PR DESCRIPTION
## Description of change
Added form validation to the following fields:
*  Win date
* Win type yearly values

In addition:
* The functionality of adding a contact on the fly when adding an export win to Data Hub has been removed and a contact hint text is now in its place.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
