### PR TITLE
Metadata resource form fields

### DIFF
--- a/src/client/components/Resource/Resource.jsx
+++ b/src/client/components/Resource/Resource.jsx
@@ -10,6 +10,11 @@ import { deepKeysToCamelCase } from '../../utils'
 import ProgressIndicator from '../ProgressIndicator'
 import Err from '../Task/Error'
 import PaginatedResource from './Paginated'
+import ResourceOptionsField from '../Form/elements/ResourceOptionsField'
+import FieldRadios from '../Form/elements/FieldRadios'
+import FieldCheckboxes from '../Form/elements/FieldCheckboxes'
+import FieldTypeahead from '../Form/elements/FieldTypeahead'
+import FieldSelect from '../Form/elements/FieldSelect'
 
 /**
  * @function Resource
@@ -240,6 +245,13 @@ export const createCollectionResource = (name, endpoint) => {
  * API task to the specified {endpoint}. The total collection count is passed
  * as the second argument to the component's {children} function and the raw
  * response data as third.
+ * The resulting component also comes with these form field subcomponents,
+ * which you can use with the `<Form/>` component:
+ * - `FieldOptions`
+ * - `FieldRadios`
+ * - `FieldSelect`
+ * - `FieldCheckboxes`
+ * - `FieldTypeahead`
  * @example
  * // Create a Resource component pre-bound to name="Company"
  * const CountriesResource = createMetadataResource('Countries', 'country')
@@ -255,6 +267,16 @@ export const createCollectionResource = (name, endpoint) => {
  *     <pre>{JSON.stringify({total, countries, rawData}, null, 2)}</pre>
  *   }
  * </CountriesResource>
+ *
+ * // Form field sub-components
+ * <Form
+ *   // ...
+ * >
+ *   <CountriesResource.FieldRadios name="countryRadios"/>
+ *   <CountriesResource.FieldSelect name="countrySelect"/>
+ *   <CountriesResource.FieldCheckboxes name="countryCheckboxes"/>
+ *   <CountriesResource.FieldTypeahead name="countryTypeahead"/>
+ * </Form>
  */
 export const createMetadataResource = (name, endpoint) => {
   const EntityResource = createEntityResource(
@@ -274,5 +296,26 @@ export const createMetadataResource = (name, endpoint) => {
   Component.tasks = EntityResource.tasks
   Component.transformer = transformer
   Component.taskName = name
+
+  Component.FieldOptions = (props) => (
+    <ResourceOptionsField id="__METADATA__" {...props} resource={Component} />
+  )
+
+  Component.FieldRadios = (props) => (
+    <Component.FieldOptions {...props} field={FieldRadios} />
+  )
+
+  Component.FieldSelect = (props) => (
+    <Component.FieldOptions {...props} field={FieldSelect} />
+  )
+
+  Component.FieldCheckboxes = (props) => (
+    <Component.FieldOptions {...props} field={FieldCheckboxes} />
+  )
+
+  Component.FieldTypeahead = (props) => (
+    <Component.FieldOptions {...props} field={FieldTypeahead} />
+  )
+
   return Component
 }

--- a/src/client/components/Resource/__stories__/Resource.stories.jsx
+++ b/src/client/components/Resource/__stories__/Resource.stories.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 
+import Form from '../../Form'
 import TabNav from '../../TabNav'
 import Contact from '../Contact'
 import Company from '../Company'
 import Resource from '../Resource'
 import { InlineTemplate } from '../../Task/__stories__/utils'
+import Countries from '../Countries'
+import BusinessPotential from '../BusinessPotential'
 
 const Json = ({ children }) => <pre>{JSON.stringify(children, null, 2)}</pre>
 
@@ -87,4 +90,24 @@ export const Inline = () => (
     dismissable={<ContactName id="foo" />}
     noRetry={<ContactName id="foo" dismissable={false} noRetry={true} />}
   />
+)
+
+export const MetadataFormFields = () => (
+  <Form id="my-form">
+    {({ values }) => (
+      <>
+        <Countries.FieldSelect name="countrySelect" label="Country" />
+        <Countries.FieldTypeahead name="countryTypeahead" label="Country" />
+        <BusinessPotential.FieldRadios
+          name="businessPotentialRadios"
+          label="Business potential"
+        />
+        <BusinessPotential.FieldCheckboxes
+          name="businessPotentialCheckboxes"
+          label="Business potential"
+        />
+        <Json>{values}</Json>
+      </>
+    )}
+  </Form>
 )

--- a/src/client/components/Resource/__stories__/tasks.js
+++ b/src/client/components/Resource/__stories__/tasks.js
@@ -1,3 +1,6 @@
+import countries from '../../../../../test/sandbox/fixtures/v4/metadata/country.json'
+import businessPotential from '../../../../../test/sandbox/fixtures/v4/metadata/business-potential.json'
+
 const CONTACT = {
   id: 'some-random-contact-id',
   companyId: '008ba003-b528-4e79-b209-49fcfcceb371',
@@ -32,6 +35,8 @@ export default {
           })
     ),
   TASK_GET_REMINDER_SUMMARY: () => Promise.resolve('???'),
+  Countries: () => countries,
+  BusinessPotential: () => businessPotential,
   Contact: () => {
     return new Promise((resolve, reject) => {
       Math.random() > 0.5


### PR DESCRIPTION
## Description of change

Adds the `.FieldOptions`, `.FieldRadios`, `.FieldSelect`, `.FieldCheckboxes` and `.FieldTypeahead` sub-components to each `Resource` component created with the `createMetadataResource` factory function.

## Test instructions

Not used anywhere in the code yet, but there is a storybook example. You can verify the functionality by following these steps:

1. Copy this form snippet and paste it somewhere:
    ```js
    // The imports assume that this module is in ./src/
    import Form from './components/Form'
    import Countries from './components/Resource/Countries'
    
    <Form id="example">
      {({values}) =>
        <>
          <Countries.FieldCheckboxes name="checkboxes"/>
          <Countries.FieldRadios name="radios"/>
          <Countries.FieldSelect name="select"/>
          <Countries.FieldTypeahead name="typeahead"/>
          <pre>{JSON.stringify(values, null, 2)}</pre>
        </>
      }
    </Form>
    ```
2. All the inputs should be populated with items from the resource
3. Selecting items in the form fields should be reflected in the injected `values` object
4. The fields should behave as any other `Field*` component, e.g. it should accept props like `label`, `validate`, `required`, etc
5. This should work with any resource component defined with `createMetadataResource`, e.g. `AssetClasses`, `BreakdownType`, `ExperienceCategories`, etc


## Screenshots

https://github.com/uktrade/data-hub-frontend/assets/2333157/1ca7a137-b634-46eb-95d4-0a3e2738d17f


