### PR TITLE
Add company contact email address to the  export win form

### DIFF
--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -50,8 +50,8 @@ const CheckBeforeSendingStep = ({ isEditing }) => {
       <WinDetailsTable {...props} />
       <SupportGivenTable {...props} />
       <WarningText data-test="warning-text">
-        This information will be sent to {values.contact?.label} so they can
-        confirm the export win.
+        This information will be sent to {values.company_contacts?.email} so
+        they can confirm the export win.
       </WarningText>
       {/*
           TODO: We have to include this hidden field 

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -4,10 +4,8 @@ import { H3 } from '@govuk-react/heading'
 
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
 import { getQueryParamsFromLocation } from '../../../../client/utils/url'
-import { idNameToValueLabel } from '../../../../client/utils'
 import { Step, FieldTypeahead } from '../../../components'
 import { StyledHintParagraph } from './styled'
-
 import { steps } from './constants'
 import {
   UKRegionsResource,
@@ -34,7 +32,13 @@ const CustomerDetailsStep = () => {
         resource={CompanyContactsResource}
         field={FieldTypeahead}
         autoScroll={true}
-        resultToOptions={({ results }) => results.map(idNameToValueLabel)}
+        resultToOptions={({ results }) =>
+          results.map(({ id, name, email }) => ({
+            value: id,
+            label: name,
+            email,
+          }))
+        }
       />
       <StyledHintParagraph data-test="contact-hint">
         To select a customer contact name, it must have already been added to

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -69,6 +69,12 @@ const getWinTypesFromBreakdowns = (breakdowns) => {
   return Array.from(winTypeSet)
 }
 
+const transformCompanyContact = ({ id, name, email }) => ({
+  value: id,
+  label: name,
+  email,
+})
+
 export const transformTeamsAndAdvisers = (values) =>
   Object.keys(values)
     .filter((key) => key.startsWith('contributing_officer_'))
@@ -101,14 +107,15 @@ export const transformExportProjectForForm = (exportProject) => {
     lead_officer: idNameToValueLabel(exportProject.owner),
     team_members: exportProject.team_members.map(idNameToValueLabel),
     // Customer details
-    export_experience:
-      // We need the check here as exporter_experience is
-      // optional within the Export project form
-      exportProject.exporter_experience &&
-      idNameToValueLabel(exportProject.exporter_experience).value,
-    contact:
+    // The exporter experience field is optional when adding an Export Project
+    ...(exportProject.exporter_experience && {
+      export_experience: [
+        idNameToValueLabel(exportProject.exporter_experience),
+      ],
+    }),
+    company_contacts:
       exportProject.contacts.length === 1
-        ? idNameToValueLabel(exportProject.contacts[0])
+        ? transformCompanyContact(exportProject.contacts[0])
         : null, // Get the user to choose the contact
     // Win Details
     date: isDateWithinLastTwelveMonths(date) && {
@@ -130,7 +137,7 @@ export const transformExportWinForForm = (exportWin) => ({
   credit_for_win: exportWin.advisers.length ? OPTION_YES : OPTION_NO,
   ...transformAdvisersToContributingOfficers(exportWin.advisers),
   // Customer details
-  company_contacts: idNameToValueLabel(exportWin.company_contacts[0]),
+  company_contacts: transformCompanyContact(exportWin.company_contacts[0]),
   customer_location: idNameToValueLabel(exportWin.customer_location),
   business_potential: idNameToValueLabel(exportWin.business_potential),
   export_experience: idNameToValueLabel(exportWin.export_experience),

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -4,6 +4,7 @@ import { getTwelveMonthsAgo } from '../../../../../src/client/modules/ExportWins
 import { winTypeId } from '../../../../../src/client/modules/ExportWins/Form/constants'
 import { clickContinueButton } from '../../support/actions'
 import { companyFaker } from '../../fakers/companies'
+import { contactFaker } from '../../fakers/contacts'
 import urls from '../../../../../src/lib/urls'
 import {
   assertUrl,
@@ -118,6 +119,16 @@ const createBreakdown = ({ type, values }) =>
 describe('Adding an export win', () => {
   beforeEach(() => {
     cy.intercept('GET', `/api-proxy/v4/company/${company.id}`, company)
+    cy.intercept('GET', `/api-proxy/v4/contact?company_id=${company.id}`, {
+      results: [
+        contactFaker({
+          name: 'Joseph Barker',
+          email: 'joseph.barker@test.com',
+          id: '000',
+        }),
+      ],
+    })
+
     cy.intercept('/api-proxy/adviser/?*', {
       results: [
         { id: '100', name: 'David Meyer' },
@@ -862,7 +873,7 @@ describe('Adding an export win', () => {
       clickContinueAndAssertUrl(customerDetailsStep)
 
       // Customer details
-      cy.get(customerDetails.contacts).selectTypeaheadOption('Joseph Woof')
+      cy.get(customerDetails.contacts).selectTypeaheadOption('Joseph Barker')
       cy.get(customerDetails.location).selectTypeaheadOption('Scotland')
       cy.get(customerDetails.potential).selectTypeaheadOption(
         'The company is a Medium Sized Business'
@@ -965,7 +976,7 @@ describe('Adding an export win', () => {
         heading: 'Customer details',
         showEditLink: false,
         content: {
-          'Contact name': 'Joseph Woof',
+          'Contact name': 'Joseph Barker',
           'HQ location': 'Scotland',
           'Export potential': 'The company is a Medium Sized Business',
           'Export experience': 'Never exported',
@@ -1014,7 +1025,7 @@ describe('Adding an export win', () => {
     it('should render warning text', () => {
       cy.get('[data-test="warning-text"]').should(
         'contain',
-        'This information will be sent to  so they can confirm the export win.'
+        'This information will be sent to joseph.barker@test.com so they can confirm the export win.'
       )
     })
 
@@ -1040,7 +1051,7 @@ describe('Adding an export win', () => {
               team_type: '201',
             },
           ],
-          company_contacts: ['5e75d636-1d24-416a-aaf0-3fb220d594ce'],
+          company_contacts: ['000'],
           customer_location: '8c4cd12a-6095-e211-a939-e4115bead28a',
           business_potential: 'e4d74957-60a4-4eab-a17b-d4c7b792ad25',
           export_experience: '051a0362-d1a9-41c0-8a58-3171e5f59a8e',


### PR DESCRIPTION
## Description of change
Adds the company contact email address to the final page of the add Export Win user journey.

## Before
<img width="942" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/4deffa28-58ad-482c-a7c1-50d70b27a05d">

## After
<img width="942" alt="Screenshot 2024-02-20 at 07 09 59" src="https://github.com/uktrade/data-hub-frontend/assets/964268/63256a32-e7a9-4a68-bd9e-da09e80285ae">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
