### PR TITLE
Feature/cls2 704 use status for active and complete

### DIFF
--- a/src/client/modules/Tasks/TaskDetails/state.js
+++ b/src/client/modules/Tasks/TaskDetails/state.js
@@ -6,6 +6,8 @@ import { getTaskBreadcrumbs } from '../TaskForm/state'
 export const ID = 'taskDetails'
 
 export const TASK_GET_TASK_DETAILS = 'TASK_GET_TASK_DETAILS'
+export const TASK_SAVE_STATUS_COMPLETE = 'TASK_SAVE_STATUS_COMPLETE'
+export const TASK_SAVE_STATUS_ACTIVE = 'TASK_SAVE_STATUS_ACTIVE'
 export const TASK_ARCHIVE_TASK = 'TASK_ARCHIVE_TASK'
 
 export const state2props = (state) => {

--- a/src/client/modules/Tasks/TaskDetails/tasks.js
+++ b/src/client/modules/Tasks/TaskDetails/tasks.js
@@ -4,4 +4,7 @@ export const getTaskDetail = (id) =>
   apiProxyAxios.get(`v4/task/${id}`).then(({ data }) => data)
 
 export const saveTaskStatusComplete = ({ taskId }) =>
-  apiProxyAxios.post(`/v4/task/${taskId}/status_complete`)
+  apiProxyAxios.post(`/v4/task/${taskId}/status-complete`)
+
+export const saveTaskStatusActive = ({ taskId }) =>
+  apiProxyAxios.post(`/v4/task/${taskId}/status-active`)

--- a/src/client/tasks.js
+++ b/src/client/tasks.js
@@ -419,10 +419,12 @@ import { TASK_CREATE_ORDER } from './modules/Omis/CreateOrder/state'
 import { createOrder } from './modules/Omis/CreateOrder/tasks'
 
 import {
+  saveTaskStatusActive,
   saveTaskStatusComplete,
   getTaskDetail,
 } from './modules/Tasks/TaskDetails/tasks'
 import {
+  TASK_SAVE_STATUS_ACTIVE,
   TASK_SAVE_STATUS_COMPLETE,
   TASK_GET_TASK_DETAILS,
 } from './modules/Tasks/TaskDetails/state'
@@ -651,6 +653,7 @@ export const tasks = {
   [TASK_GET_TASK_DETAILS]: getTaskDetail,
   [TASK_GET_INVESTMENT_PROJECT]: investmentProjectTasks.getInvestmentProject,
   [TASK_SAVE_STATUS_COMPLETE]: saveTaskStatusComplete,
+  [TASK_SAVE_STATUS_ACTIVE]: saveTaskStatusActive,
   [TASK_RECONCILE_OMIS_PAYMENT]: savePayment,
   [TASK_SAVE_TASK_DETAILS]: saveTaskDetail,
   [TASK_EDIT_INVOICE_DETAILS]: updateOrder,

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -729,5 +729,7 @@ module.exports = {
     createInteraction: url('/tasks/create?interactionId=', ':interactionId'),
     createCopyTask: url('/tasks/create?copyTaskId=', ':copyTaskId'),
     edit: url('/tasks', '/:taskId/edit'),
+    statusComplete: url('/tasks', '/:taskId/status-complete'),
+    statusActive: url('/tasks', '/:taskId/status-active'),
   },
 }

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -132,6 +132,11 @@ export const urlTestExclusions = [
   { url: '/investments/projects/:investmentId/propositions/:propositionId' },
   { url: '/companies/:companyId/hierarchies/ghq/:globalHqId/add' },
   { url: '/companies/:companyId/hierarchies/ghq/remove' },
+  // API calls with redirect
+  { url: '/tasks/:taskId/status-complete' },
+  { url: '/tasks/:taskId/status-active' },
+  { url: '/tasks/:taskId/archive' },
+  { url: '/tasks/:taskId/unarchive' },
   // 501 errors
   { url: '/api-proxy/v4/company/:companyId/export-win' },
   { url: '/investments/projects/:projectId/edit-ukcompany/:companyId' },

--- a/test/functional/cypress/specs/tasks/details-spec.js
+++ b/test/functional/cypress/specs/tasks/details-spec.js
@@ -7,15 +7,15 @@ import {
 import {
   assertSummaryTable,
   assertBreadcrumbs,
-  assertPayload,
   assertUrl,
 } from '../../support/assertions'
 import { clickButton } from '../../support/actions'
 import interactionsListFaker from '../../fakers/interactions'
+import { STATUS } from '../../../../../src/client/modules/Tasks/TaskForm/constants'
 
 describe('View details for a generic task', () => {
-  const genericTaskCompleted = taskFaker({ archived: true })
-  const genericTaskNotCompleteTask = taskFaker({ archived: false })
+  const genericTaskCompleted = taskFaker({ status: STATUS.COMPLETED })
+  const genericTaskNotCompleteTask = taskFaker({ status: STATUS.ACTIVE })
 
   context('When visiting a completed task details', () => {
     beforeEach(() => {
@@ -71,17 +71,6 @@ describe('View details for a generic task', () => {
 
       cy.get('[data-test="activity-kind-label"]').should('not.exist')
     })
-
-    it('should redirect to the dashboard and show the Flash message after marking as complete', () => {
-      cy.intercept(
-        'POST',
-        `/api-proxy/v4/task/${genericTaskNotCompleteTask.id}/archive`,
-        {}
-      ).as('postTaskArchiveApiRequest')
-      clickButton('Mark as complete')
-      assertPayload('@postTaskArchiveApiRequest', { reason: 'completed' })
-      assertUrl(dashboard.myTasks())
-    })
   })
 })
 
@@ -91,7 +80,7 @@ describe('View details for task that is assigned to an investment project', () =
   })
 
   context('When visiting a not complete task details', () => {
-    before(() => {
+    beforeEach(() => {
       cy.intercept(
         'GET',
         `/api-proxy/v4/task/${investmentProjectTask.id}`,
@@ -104,11 +93,11 @@ describe('View details for task that is assigned to an investment project', () =
     it('should redirect to the investment project and show the Flash message after marking as complete', () => {
       cy.intercept(
         'POST',
-        `/api-proxy/v4/task/${investmentProjectTask.id}/archive`,
+        `/api-proxy/v4/task/${investmentProjectTask.id}/status-complete`,
         {}
-      ).as('postTaskArchiveApiRequest')
+      ).as('postTaskStatusCompleteApiRequest')
       clickButton('Mark as complete')
-      assertPayload('@postTaskArchiveApiRequest', { reason: 'completed' })
+      cy.wait('@postTaskStatusCompleteApiRequest')
       assertUrl(dashboard.myTasks())
     })
   })
@@ -118,7 +107,7 @@ describe('View details for task that is assigned to a company', () => {
   const companyTask = taskWithCompanyFaker({ archived: false })
 
   context('When visiting a not complete task details', () => {
-    before(() => {
+    beforeEach(() => {
       cy.intercept(
         'GET',
         `/api-proxy/v4/task/${companyTask.id}`,
@@ -131,11 +120,11 @@ describe('View details for task that is assigned to a company', () => {
     it('should redirect to the investment project and show the Flash message after marking as complete', () => {
       cy.intercept(
         'POST',
-        `/api-proxy/v4/task/${companyTask.id}/archive`,
+        `/api-proxy/v4/task/${companyTask.id}/status-complete`,
         {}
-      ).as('postTaskArchiveApiRequest')
+      ).as('postTaskStatusCompleteApiRequest')
       clickButton('Mark as complete')
-      assertPayload('@postTaskArchiveApiRequest', { reason: 'completed' })
+      cy.wait('@postTaskStatusCompleteApiRequest')
       assertUrl(dashboard.myTasks())
     })
   })


### PR DESCRIPTION
## Description of change

Works with PR CLS2-704 on API. Allows for marking task status as active / complete.

## Test instructions

Create a Task and view it. Mark it as completed using the button. View the task and it should have the Complete tag and no Mark as complete button. 

## Screenshots

No visual changes


![image](https://github.com/uktrade/data-hub-frontend/assets/699259/43292dcf-d6e6-453c-b1eb-b61fff2de906)

![image](https://github.com/uktrade/data-hub-frontend/assets/699259/8abe9b54-75c9-43e0-8b69-94d00582ad1c)

![image](https://github.com/uktrade/data-hub-frontend/assets/699259/3a59e959-8d9e-4b77-9674-682939d0ad64)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
