### PR TITLE
Allow flash message type to be specified in Form

### DIFF
--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -468,12 +468,25 @@ const dispatchToProps = (dispatch) => ({
       type: 'FORM__STEP_DEREGISTER',
       stepName,
     }),
-  writeFlashMessage: (message) =>
+  writeFlashMessage: (message) => {
+    if (!message) return
+
+    if (typeof message === 'string') {
+      dispatch({
+        type: 'FLASH_MESSAGE__WRITE_TO_SESSION',
+        messageType: 'success',
+        message,
+      })
+      return
+    }
+
+    const [heading, body, messageType] = message
     dispatch({
       type: 'FLASH_MESSAGE__WRITE_TO_SESSION',
-      messageType: 'success',
-      message,
-    }),
+      messageType,
+      message: [heading, body],
+    })
+  },
 })
 
 /**
@@ -520,7 +533,7 @@ const dispatchToProps = (dispatch) => ({
  * `window.location.href`, the _soft_ mode uses React-Router.
  * @param {Props['flashMessage']} [props.flashMessage] - A function which should
  * convert the result of the submission task and the submitted form values into
- * a flash message text or a tuple of `[heading, body]`, which will be used as
+ * a flash message text or a tuple of `[heading, body, type]`, which will be used as
  * a flash message when the submission task resolves.
  * @param {Props['initialValues']} [props.initialValues] - An object mapping
  * field names to their initial values.

--- a/src/client/components/Form/types.d.ts
+++ b/src/client/components/Form/types.d.ts
@@ -6,7 +6,8 @@ type Values = Record<string, string>
 type Errors = Record<string, string>
 type FlashMessageHeading = string
 type FlashMessageBody = string
-type FlashMessage = FlashMessageBody | [FlashMessageHeading, FlashMessageBody]
+type FlashMessageType = 'info' | 'success' | 'warning' | 'error' | 'muted'
+type FlashMessage = FlashMessageBody | [FlashMessageHeading, FlashMessageBody, FlashMessageType?]
 
 type ChildFn = ({
   errors: Errors,


### PR DESCRIPTION
## Description of change

Adds an option to `Form` component to specify the type of the flash message it sets when the form is submitted successfully.

## Test instructions

1. Paste this code snipped somewhere (or tweak an existing form):
   ```js
    <Form
       // ...
      flashMessage={() => [
        'Heading',
        'Body',
        // The third, optional item in the array denotes the message type
        'info', // info | warning | success | error | muted
      ]}
    >
       {/* ... */}
    </Form>
   ```
 2. Submit the form
 3. Verify that the flash message displayed wherever the form might redirect has the [color matching the type](https://github.com/uktrade/data-hub-frontend/blob/d454b21bb508c026de744b508340f36055d2644e/src/client/components/LocalHeader/FlashMessages.jsx#L47-L51) specified above

Other than that, there should be no noticable change and a ll tests should still be passing.
