### PR TITLE
Remove resend export win button and link to export win details page

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -45,12 +45,13 @@ const StyledLinkHeader = styled(StyledHeader)`
 `
 
 const StyledSubheading = styled('h4')`
-  font-size: 14px;
+  font-size: ${({ fontSize }) => (fontSize ? `${fontSize}px` : '14px')};
   line-height: 20px;
   color: ${DARK_GREY};
   font-weight: normal;
   margin: -${SPACING.SCALE_3} 0 ${SPACING.SCALE_2} 0;
 `
+
 const StyledButtonWrapper = styled('div')`
   margin-bottom: -30px;
   margin-right: 10px;
@@ -66,6 +67,7 @@ const StyledFooterWrapper = styled('div')`
 const CollectionItem = ({
   headingText,
   subheading,
+  subheadingUrl,
   headingUrl,
   badges,
   tags,
@@ -75,7 +77,6 @@ const CollectionItem = ({
   titleRenderer = null,
   useReactRouter = false,
   buttons,
-  buttonRenderer,
   footerRenderer,
   footerdata,
 }) => (
@@ -123,25 +124,22 @@ const CollectionItem = ({
     ) : (
       <StyledHeader>{headingText}</StyledHeader>
     )}
-    {subheading && <StyledSubheading>{subheading}</StyledSubheading>}
+    {subheading ? (
+      subheadingUrl ? (
+        <StyledSubheading fontSize={16}>
+          <Link href={subheadingUrl}>{subheading}</Link>
+        </StyledSubheading>
+      ) : (
+        <StyledSubheading>{subheading}</StyledSubheading>
+      )
+    ) : null}
 
     {metadataRenderer ? (
       metadataRenderer(metadata)
     ) : (
       <Metadata rows={metadata} />
     )}
-    {/* 
-      TODO: Tech-debt, this needs to be refactored so we have a consistent
-      way of rendering buttons, ideally we should use the buttonRenderer
-      prop as a function that returns a JSX element and do away with the
-      buttons prop altogether as it's completely inflexible.
-    */}
-    {buttons ? (
-      <StyledButtonWrapper>{buttons}</StyledButtonWrapper>
-    ) : buttonRenderer ? (
-      buttonRenderer()
-    ) : null}
-
+    {buttons && <StyledButtonWrapper>{buttons}</StyledButtonWrapper>}
     {footerRenderer && (
       <StyledFooterWrapper>{footerRenderer(footerdata)} </StyledFooterWrapper>
     )}
@@ -152,6 +150,7 @@ CollectionItem.propTypes = {
   headingUrl: PropTypes.string,
   headingText: PropTypes.string.isRequired,
   subheading: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+  subheadingUrl: PropTypes.string,
   badges: PropTypes.arrayOf(
     PropTypes.shape({
       text: PropTypes.string,

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -1,7 +1,4 @@
 import React from 'react'
-import { Link as ReactRouterLink } from 'react-router-dom'
-import { Button } from 'govuk-react'
-import styled from 'styled-components'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -9,10 +6,6 @@ import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { WIN_FILTERS } from './constants'
 import urls from '../../../../lib/urls'
-
-const ButtonContainer = styled('div')({
-  marginTop: 10,
-})
 
 export default () => (
   <ExportWinsResource.Paginated
@@ -24,8 +17,10 @@ export default () => (
         {page.map((item) => (
           <li key={item.id}>
             <CollectionItem
-              headingText={item.company.name}
-              headingUrl={urls.companies.overview.index(item.company.id)}
+              headingText={`${item.name_of_export} to ${item?.country?.name}`}
+              headingUrl={urls.companies.exportWins.details(item.id)}
+              subheading={item.company.name}
+              subheadingUrl={urls.companies.overview.index(item.company.id)}
               metadata={[
                 { label: 'Destination:', value: item.country.name },
                 {
@@ -44,16 +39,6 @@ export default () => (
                   value: formatMediumDate(item.modified_on),
                 },
               ]}
-              buttonRenderer={() => (
-                <ButtonContainer>
-                  <Button
-                    as={ReactRouterLink}
-                    to={urls.companies.exportWins.details(item.id)}
-                  >
-                    Review export win
-                  </Button>
-                </ButtonContainer>
-              )}
             />
           </li>
         ))}

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { WIN_FILTERS } from './constants'
 import urls from '../../../../lib/urls'
@@ -34,8 +34,14 @@ export default () => (
                   value: currencyGBP(item.total_expected_export_value),
                 },
                 { label: 'Date won: ', value: formatMediumDate(item.date) },
-                { label: 'First sent: ', value: '???' },
-                { label: 'Last sent: ', value: '???' },
+                {
+                  label: 'First sent: ',
+                  value: formatMediumDateTime(item.first_sent),
+                },
+                {
+                  label: 'Last sent: ',
+                  value: formatMediumDateTime(item.last_sent),
+                },
               ]}
             />
           </li>

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -1,7 +1,4 @@
 import React from 'react'
-import { Link as ReactRouterLink } from 'react-router-dom'
-import { Button } from 'govuk-react'
-import styled from 'styled-components'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -9,10 +6,6 @@ import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { WIN_FILTERS } from './constants'
 import urls from '../../../../lib/urls'
-
-const ButtonContainer = styled('div')({
-  marginTop: 10,
-})
 
 export default () => (
   <ExportWinsResource.Paginated
@@ -24,8 +17,10 @@ export default () => (
         {page.map((item) => (
           <li key={item.id}>
             <CollectionItem
-              headingText={item.company.name}
-              headingUrl={urls.companies.overview.index(item.company.id)}
+              headingText={`${item.name_of_export} to ${item?.country?.name}`}
+              headingUrl={urls.companies.exportWins.details(item.id)}
+              subheading={item.company.name}
+              subheadingUrl={urls.companies.overview.index(item.company.id)}
               metadata={[
                 { label: 'Destination: ', value: item.country.name },
                 {
@@ -42,13 +37,6 @@ export default () => (
                 { label: 'First sent: ', value: '???' },
                 { label: 'Last sent: ', value: '???' },
               ]}
-              buttonRenderer={() => (
-                <ButtonContainer>
-                  <Button as={ReactRouterLink} onClick={() => alert('TODO')}>
-                    Resend export win
-                  </Button>
-                </ButtonContainer>
-              )}
             />
           </li>
         ))}


### PR DESCRIPTION
## Description of change
There's been a design change brought about by technical issues we've encountered when redirecting to a success page (which has now been dropped) after clicking the _resend export win_ button from a list item. 

The main problem is that you can't redirect to a success page unless you know the API call will always succeed, which will never be the case due to network failures. That means you have to wait for the response before routing to either a success/error page. A success page is something we're lacking in Data Hub, and for good reason, typically we perform an action on the page and the user is notified by a success or error message in the form of a banner at the top of the page or the top of the page you're routing to (which is not a success page).

In a separate [implementation](https://github.com/uktrade/data-hub-frontend/pull/6558), we tried to keep the user on the page but it was deemed inaccessible :cry:.

The _resend export win_ button will be moved from the list to the export win details page where the user can resend the win from there - we got there eventually :smile:.

**This minor refactor keeps things simple and consistent with the rest of Data Hub, something we didn't foresee at the beginning - live and learn.**

The other small fixes include:
1. Linking to the export win details page.
2. Rendering both the _First sent_ and _Last sent_ fields. 

## Test instructions

Go to:
 * `/exportwins/rejected`
 * `/exportwins/sent`

###  Before
<img width="333" alt="Screenshot 2024-02-28 at 15 24 52" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d9b9b3a1-0721-4a9c-96fc-4e21d234524a">

###  After
<img width="304" alt="Screenshot 2024-02-28 at 15 27 03" src="https://github.com/uktrade/data-hub-frontend/assets/964268/c3ced0e8-f909-4ac0-b056-d3f4a996060d">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
