### PR TITLE
Show both 'Add export win' button and 'Export wins' link

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -124,6 +124,7 @@ const CompanyLocalHeader = ({
   flashMessages,
   company,
   csrfToken,
+  hasExportWinFeatureGroup,
 }) =>
   company && (
     <>
@@ -188,6 +189,18 @@ const CompanyLocalHeader = ({
               >
                 Add export project
               </Button>
+              {hasExportWinFeatureGroup && (
+                <Button
+                  as={StyledButtonLink}
+                  data-test="header-add-export-win"
+                  href={`${urls.companies.exportWins.create()}?step=officer_details&company=${company.id}`}
+                  aria-label={`Add export win`}
+                  buttonColour={GREY_3}
+                  buttonTextColour={TEXT_COLOUR}
+                >
+                  Add export win
+                </Button>
+              )}
             </StyledButtonContainer>
           </GridCol>
         </GridRow>

--- a/src/client/components/CompanyLocalHeader/state.js
+++ b/src/client/components/CompanyLocalHeader/state.js
@@ -4,4 +4,5 @@ export const state2props = (state) => state[ID]
 
 export const companyState2Props = (state) => ({
   csrfToken: state.csrfToken,
+  hasExportWinFeatureGroup: state.activeFeatureGroups?.includes('export-wins'),
 })

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useHistory } from 'react-router-dom'
 import { HEADING_SIZES, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
-import { UnorderedList, ListItem, H2 } from 'govuk-react'
+import { UnorderedList, ListItem, H2, Link } from 'govuk-react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
@@ -13,6 +13,7 @@ import { MID_GREY } from '../../../utils/colours'
 import ListItemRenderer from './ItemRenderer'
 import Task from '../../../components/Task'
 import ExportSelect from './ExportSelect'
+import urls from '../../../../lib/urls'
 import ExportDate from './ExportDate'
 import List from './List'
 
@@ -68,8 +69,18 @@ const HeaderContainer = styled('div')({
   marginTop: 30,
 })
 
+const LinkContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
+  padding: 5,
+  alignItems: 'end',
+  gap: 10,
+})
+
 const StyledButtonLink = styled(ButtonLink)({
   marginBottom: 0,
+  border: 0,
+  padding: 0,
 })
 
 const ListContainer = styled('div')({
@@ -83,6 +94,7 @@ const ExportList = ({
   maxItemsToPaginate,
   payload,
   filters,
+  hasExportWinFeatureGroup,
 }) => {
   const history = useHistory()
   const maxItems = Math.min(count, maxItemsToPaginate)
@@ -168,11 +180,24 @@ const ExportList = ({
               </StyledResultCount>{' '}
               Exports
             </StyledHeader>
-            {filters.areActive && (
-              <StyledButtonLink onClick={onClearAll} data-test="clear-filters">
-                Remove all filters
-              </StyledButtonLink>
-            )}
+            <LinkContainer>
+              {filters.areActive && (
+                <StyledButtonLink
+                  onClick={onClearAll}
+                  data-test="clear-filters"
+                >
+                  Remove all filters
+                </StyledButtonLink>
+              )}
+              {hasExportWinFeatureGroup && (
+                <Link
+                  href={urls.companies.exportWins.index()}
+                  data-test="export-wins"
+                >
+                  Export wins
+                </Link>
+              )}
+            </LinkContainer>
           </HeaderContainer>
         </>
       )}
@@ -239,6 +264,7 @@ ExportList.propTypes = {
   results: PropTypes.array,
   itemsPerPage: PropTypes.number,
   maxItemsToPaginate: PropTypes.number,
+  hasExportWinFeatureGroup: PropTypes.bool,
 }
 
 export default connect(state2props)(ExportList)

--- a/src/client/modules/ExportPipeline/ExportList/state.js
+++ b/src/client/modules/ExportPipeline/ExportList/state.js
@@ -28,6 +28,8 @@ const areFiltersActive = (queryParams) => {
 export const state2props = ({ router, ...state }) => {
   const queryParams = getQueryParamsFromLocation(router.location)
   const { sectorOptions, countryOptions, ownerOptions } = state[ID]
+  const hasExportWinFeatureGroup =
+    state.activeFeatureGroups?.includes('export-wins')
   return {
     ...state[ID],
     payload: {
@@ -55,5 +57,6 @@ export const state2props = ({ router, ...state }) => {
         options: SORT_OPTIONS,
       },
     },
+    hasExportWinFeatureGroup,
   }
 }

--- a/src/client/modules/ExportWins/Status/WinsWonTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsWonTable.jsx
@@ -48,7 +48,7 @@ export const WinsWonTable = ({ exportWins }) => (
           <Table.Cell>{currencyGBP(total_expected_export_value)}</Table.Cell>
           <NoWrapCell>{formatMediumDate(date)}</NoWrapCell>
           <NoWrapCell>
-            {formatMediumDate(customer_response?.created_on)}
+            {formatMediumDate(customer_response.responded_on)}
           </NoWrapCell>
           <NoWrapCell>
             <Link

--- a/test/component/cypress/specs/ExportWins/Table.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Table.cy.jsx
@@ -13,7 +13,7 @@ const exportWinToRow = (exportWin) => [
   exportWin.country.name,
   currencyGBP(exportWin.total_expected_export_value),
   formatMediumDate(exportWin.date),
-  formatMediumDate(exportWin.customer_response.created_on),
+  formatMediumDate(exportWin.customer_response.responded_on),
   'View details',
 ]
 
@@ -31,7 +31,7 @@ describe('Export wins table', () => {
         total_expected_export_value: 1111111,
         date: '1111-11-11',
         customer_response: {
-          created_on: '1212-12-12',
+          responded_on: '1212-12-12',
         },
       },
       {
@@ -45,7 +45,7 @@ describe('Export wins table', () => {
         total_expected_export_value: 222222,
         date: '0101-01-01',
         customer_response: {
-          created_on: '0202-02-02',
+          responded_on: '0202-02-02',
         },
       },
       exportWinsFaker(),

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -26,6 +26,6 @@ export const exportWinsFaker = () => ({
   }),
   date: faker.date.anytime().toISOString(),
   customer_response: {
-    created_on: faker.date.anytime().toISOString(),
+    responded_on: faker.date.anytime().toISOString(),
   },
 })

--- a/test/functional/cypress/specs/export-win/user-feature-group-spec.js
+++ b/test/functional/cypress/specs/export-win/user-feature-group-spec.js
@@ -1,0 +1,55 @@
+import qs from 'qs'
+
+import { exportListFaker } from '../../fakers/export'
+import urls from '../../../../../src/lib/urls'
+
+describe('Export win user feature groups', () => {
+  const company = '/companies/00009ae3-1912-e411-8a2b-e4115bead28a/overview'
+
+  context('Company page"', () => {
+    it('should show the "Add export win" button when the feature is active', () => {
+      cy.setUserFeatureGroups(['export-wins'])
+      cy.visit(company)
+      cy.get('[data-test="header-add-export-win"]').should('exist')
+    })
+    it('should hide the "Add export win" button when the feature is inactive', () => {
+      cy.setUserFeatureGroups([])
+      cy.visit(company)
+      cy.get('[data-test="header-add-export-win"]').should('not.exist')
+    })
+  })
+
+  context('Dashboard"', () => {
+    const exports = exportListFaker(3)
+    const endpoint = '/api-proxy/v4/export'
+    const queryParams = qs.stringify({
+      limit: 10,
+      page: 1,
+      offset: 0,
+      archived: false,
+      sortby: 'created_on:desc',
+    })
+
+    beforeEach(() => {
+      cy.intercept('GET', `${endpoint}?${queryParams}`, {
+        body: {
+          count: exports.length,
+          results: exports,
+        },
+      }).as('apiReqList')
+      cy.intercept('GET', '/api-proxy/v4/export/owner', [])
+    })
+
+    it('should show the "Export wins" link when the feature is active', () => {
+      cy.setUserFeatureGroups(['export-wins'])
+      cy.visit(urls.exportPipeline.index())
+      cy.get('[data-test="export-wins"]').should('exist')
+    })
+
+    it('should hide the "Export wins" link when the feature is inactive', () => {
+      cy.setUserFeatureGroups([])
+      cy.visit(urls.exportPipeline.index())
+      cy.get('[data-test="export-wins"]').should('not.exist')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Added an **Add export win** button and an **Export wins** link to the company overview page and export projects tab respectively. Both are hidden behind the same `export-wins` user feature group. 

Both of these elements reveal the export wins functionality for the first time. However, to view both elements you need to enable the feature on a per-user basis.

## Test instructions

### To enable the feature
1. Go to Django Admin (dev or staging)
2. Advisers
3. Search for a name and go into the record
4. Scroll down to feature groups
5. Select `export-wins` and slide it to the right
6. Save

### To view the feature
Go to either:
- `/companies/<company-uuid>/overview` to view the button.
- `/export` to view the link.

## Screenshots
<img width="970" alt="Screenshot 2024-02-29 at 18 00 17" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b819a128-7054-4b00-a568-4b813aa9ed6c">

<img width="1080" alt="Screenshot 2024-03-01 at 07 29 08" src="https://github.com/uktrade/data-hub-frontend/assets/964268/a7ca4b39-fee9-4638-b246-9f3cedf40943">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
