### PR TITLE
Bugfix/tet 616 sub sector filter download

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -5,6 +5,7 @@ const QUERY_FIELDS_MAP = {
   archived: 'archived',
   name: 'name',
   sectorDescends: 'sector_descends',
+  subSectorDescends: 'sub_sector_descends',
   country: 'country',
   ukRegion: 'uk_region',
   headquarterType: 'headquarter_type',

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -33,10 +33,9 @@ const mergeSectorAndSubSectorParams = (requestBody) => {
     ...(sub_sector_descends ? sub_sector_descends : []),
   ]
 
-  return {
-    ...reqBody,
-    sector_descends: mergedSectors,
-  }
+  return mergedSectors.length
+    ? { ...reqBody, sector_descends: mergedSectors }
+    : reqBody
 }
 
 function search({

--- a/src/modules/search/services.js
+++ b/src/modules/search/services.js
@@ -26,6 +26,19 @@ const buildOptions = (isAggregation, searchUrl, body, entity) => {
   }
 }
 
+const mergeSectorAndSubSectorParams = (requestBody) => {
+  const { sub_sector_descends, sector_descends, ...reqBody } = requestBody
+  const mergedSectors = [
+    ...(sector_descends ? sector_descends : []),
+    ...(sub_sector_descends ? sub_sector_descends : []),
+  ]
+
+  return {
+    ...reqBody,
+    sector_descends: mergedSectors,
+  }
+}
+
 function search({
   req,
   searchTerm: term = '',
@@ -68,7 +81,7 @@ function exportSearch({ req, searchTerm = '', searchEntity, requestBody }) {
   if (searchEntity == 'investment_project') {
     transformedRequestBody = transformLandDateFilters(requestBody)
   } else {
-    transformedRequestBody = requestBody
+    transformedRequestBody = mergeSectorAndSubSectorParams(requestBody)
   }
   const searchUrl = `${config.apiRoot}/${apiVersion}/search`
   // If the requested CSV export should contain policy feedback, we need to call
@@ -125,4 +138,5 @@ module.exports = {
   exportSearch,
   searchAutocomplete,
   searchDnbCompanies,
+  mergeSectorAndSubSectorParams,
 }

--- a/src/modules/search/transformers/__test__/services.test.js
+++ b/src/modules/search/transformers/__test__/services.test.js
@@ -1,0 +1,70 @@
+const { mergeSectorAndSubSectorParams } = require('../../services')
+
+describe('mergeSectorAndSubSectorParams', () => {
+  const basicRequestBody = {
+    sortby: 'desc',
+    archived: 'false',
+    area: [],
+    uk_postcode: undefined,
+  }
+  it('should merge the sector and sub sector params when both are present', () => {
+    const reqBody = {
+      ...basicRequestBody,
+      sector_descends: ['sector_uuid1'],
+      sub_sector_descends: ['sub_sector_uuid1'],
+    }
+
+    expect(mergeSectorAndSubSectorParams(reqBody)).to.deep.equal({
+      ...basicRequestBody,
+      sector_descends: ['sector_uuid1', 'sub_sector_uuid1'],
+    })
+  })
+
+  it('should merge all sector and sub sector params when multiple of both are present', () => {
+    const reqBody = {
+      ...basicRequestBody,
+      sector_descends: ['sector_uuid1', 'sector_uuid2'],
+      sub_sector_descends: ['sub_sector_uuid1', 'sub_sector_uuid2'],
+    }
+
+    expect(mergeSectorAndSubSectorParams(reqBody)).to.deep.equal({
+      ...basicRequestBody,
+      sector_descends: [
+        'sector_uuid1',
+        'sector_uuid2',
+        'sub_sector_uuid1',
+        'sub_sector_uuid2',
+      ],
+    })
+  })
+
+  it('should include just the sector params if there are not any sub sector params', () => {
+    const reqBody = {
+      ...basicRequestBody,
+      sector_descends: ['sector_uuid1', 'sector_uuid2'],
+    }
+
+    expect(mergeSectorAndSubSectorParams(reqBody)).to.deep.equal({
+      ...basicRequestBody,
+      sector_descends: ['sector_uuid1', 'sector_uuid2'],
+    })
+  })
+
+  it('should include just the sub sector params if there are not any sector params', () => {
+    const reqBody = {
+      ...basicRequestBody,
+      sub_sector_descends: ['sub_sector_uuid1', 'sub_sector_uuid2'],
+    }
+
+    expect(mergeSectorAndSubSectorParams(reqBody)).to.deep.equal({
+      ...basicRequestBody,
+      sector_descends: ['sub_sector_uuid1', 'sub_sector_uuid2'],
+    })
+  })
+
+  it('should not include any sector or sub sector params if neither are present', () => {
+    expect(mergeSectorAndSubSectorParams(basicRequestBody)).to.deep.equal(
+      basicRequestBody
+    )
+  })
+})


### PR DESCRIPTION
## Description of change

Add sub sector filtering to the company downloads

## Test instructions

Go onto the companies list and choose a sector and sub-sector filter. Download the file to see that the only results should be companies that fall into both the sector and sub-sector categories. Previously when downloading you would see all companies that fell into the sector, because the sub-sector filter was being missed off the download call

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
