### PR TITLE
Only show the 'resend export win' button when the win status is sent. 

### DIFF
--- a/src/client/components/Typeahead/Typeahead.jsx
+++ b/src/client/components/Typeahead/Typeahead.jsx
@@ -270,9 +270,7 @@ const Typeahead = ({
         <AutocompleteInput
           {...inputProps}
           id={name}
-          // Tell autocomplete that this is a password to stop Chrome autofilling.
-          // Setting 'off' is ignored by Chrome and a custom string fails accessibility.
-          autoComplete="new-password"
+          autoComplete="off"
           autoCorrect="off"
           autoCapitalize="off"
           spellCheck="false"

--- a/src/client/modules/ExportWins/Details/ResendExportWin.jsx
+++ b/src/client/modules/ExportWins/Details/ResendExportWin.jsx
@@ -14,6 +14,7 @@ const _ResendExportWin = ({ id }) => {
         return (
           <Button
             disabled={task.progress}
+            data-test="resend-export-win"
             onClick={() => {
               task.start({
                 payload: id,

--- a/src/client/modules/ExportWins/Details/index.jsx
+++ b/src/client/modules/ExportWins/Details/index.jsx
@@ -13,6 +13,7 @@ import { formatMediumDate } from '../../../utils/date'
 import { ResendExportWin } from './ResendExportWin'
 import urls from '../../../../lib/urls'
 import { state2props } from './state'
+import { WIN_STATUS } from '../Status/constants'
 
 const VerticalSpacer = styled.div`
   display: flex;
@@ -147,7 +148,10 @@ const Detail = (props) => {
                     (exportWin.isPersonallyConfirmed ? 'Yes' : 'No')}
                 </SummaryTable.Row>
               </Summary>
-              {exportWin && <ResendExportWin id={exportWin.id} />}
+              {exportWin &&
+                exportWin.customerResponse.agreeWithWin === WIN_STATUS.SENT && (
+                  <ResendExportWin id={exportWin.id} />
+                )}
               <VerticalSpacer>
                 {exportWin?.isPersonallyConfirmed && (
                   <Link

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -4,13 +4,13 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
-import { WIN_FILTERS } from './constants'
+import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-rejected"
-    payload={{ confirmed: WIN_FILTERS.REJECTED }}
+    payload={{ confirmed: WIN_STATUS.REJECTED }}
   >
     {(page) => (
       <ul>

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -4,13 +4,13 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
-import { WIN_FILTERS } from './constants'
+import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-sent"
-    payload={{ confirmed: WIN_FILTERS.SENT }}
+    payload={{ confirmed: WIN_STATUS.SENT }}
   >
     {(page) => (
       <ul>

--- a/src/client/modules/ExportWins/Status/WinsWonTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsWonTable.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
-import { WIN_FILTERS } from './constants'
+import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 const NoWrapCell = styled(Table.Cell)`
@@ -67,7 +67,7 @@ export const WinsWonTable = ({ exportWins }) => (
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-won"
-    payload={{ confirmed: WIN_FILTERS.WON }}
+    payload={{ confirmed: WIN_STATUS.WON }}
   >
     {(page) => <WinsWonTable exportWins={page} />}
   </ExportWinsResource.Paginated>

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -1,5 +1,5 @@
-export const WIN_FILTERS = {
-  SENT: 'null',
+export const WIN_STATUS = {
   REJECTED: false,
+  SENT: null,
   WON: true,
 }

--- a/test/component/cypress/specs/ExportWins/Details.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Details.cy.jsx
@@ -5,6 +5,7 @@ import {
   assertLocalHeader,
   assertLink,
 } from '../../../../functional/cypress/support/assertions'
+import { WIN_STATUS } from '../../../../../src/client/modules/ExportWins/Status/constants'
 import Details from '../../../../../src/client/modules/ExportWins/Details'
 import urls from '../../../../../src/lib/urls'
 import DataHubProvider from '../provider'
@@ -45,6 +46,9 @@ const EXPORT_WIN = {
       year: 3,
     },
   ],
+  customer_response: {
+    agree_with_win: WIN_STATUS.SENT, // the default
+  },
 }
 
 const EXPECTED_ROWS = {
@@ -334,6 +338,51 @@ describe('ExportWins/Details', () => {
         } else {
           cy.contains('View customer feedback').should('not.exist')
         }
+      })
+    }
+  )
+
+  context(
+    'When the "Resend export win" button is hidden/shown on the details page',
+    () => {
+      it('should not be visible when the status of the export win is "rejected"', () => {
+        cy.mount(
+          <Component
+            exportWinAPIResponse={{
+              ...EXPORT_WIN,
+              customer_response: {
+                agree_with_win: WIN_STATUS.REJECTED,
+              },
+            }}
+          />
+        )
+        cy.get('[data-test="resend-export-win"]').should('not.exist')
+      })
+      it('should be visible when the status of the export win is "sent"', () => {
+        cy.mount(
+          <Component
+            exportWinAPIResponse={{
+              ...EXPORT_WIN,
+              customer_response: {
+                agree_with_win: WIN_STATUS.SENT,
+              },
+            }}
+          />
+        )
+        cy.get('[data-test="resend-export-win"]').should('exist')
+      })
+      it('should not be visible when the status of the export win is "won"', () => {
+        cy.mount(
+          <Component
+            exportWinAPIResponse={{
+              ...EXPORT_WIN,
+              customer_response: {
+                agree_with_win: WIN_STATUS.WON,
+              },
+            }}
+          />
+        )
+        cy.get('[data-test="resend-export-win"]').should('not.exist')
       })
     }
   )


### PR DESCRIPTION
## Description of change
Only show the **Resend export win** button on the export win details page when the status of the win is `sent`. Hide the same button when the win has been `rejected` or `won`.

## Test instructions
1. Go to the details page by going to `/exportwins/sent` and select an export win by clicking on the title.
2. You **should see the 'resend export win' button**.
3. Go to the details page by going to `/exportwins/rejected` and select an export win by clicking on the title.
4. You **shouldn't see any button**.
5. Go to the details page by going to `/exportwins/won` and select an export win by clicking on the title.
6. You **shouldn't see any button**.

## Screenshots
<img width="598" alt="Screenshot 2024-03-04 at 12 53 52" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d1fd2d85-35b4-43af-9a99-1e82dbeef4f1">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
