### PR TITLE
Add 'convert to export win' button to the export project details page

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -193,7 +193,7 @@ const CompanyLocalHeader = ({
                 <Button
                   as={StyledButtonLink}
                   data-test="header-add-export-win"
-                  href={`${urls.companies.exportWins.create()}?step=officer_details&company=${company.id}`}
+                  href={urls.companies.exportWins.create(company.id)}
                   aria-label={`Add export win`}
                   buttonColour={GREY_3}
                   buttonTextColour={TEXT_COLOUR}

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -192,7 +192,10 @@ const ExportDetailsForm = ({ exportItem, hasExportWinFeatureGroup }) => {
                   {hasExportWinFeatureGroup && (
                     <Button
                       as={Link}
-                      href={`${urls.companies.exportWins.create()}?step=officer_details&company=${exportItem.company.id}&export=${exportId}`}
+                      href={urls.companies.exportWins.createFromExport(
+                        exportItem.company.id,
+                        exportId
+                      )}
                       data-test="convert-to-export-win"
                     >
                       Convert to export win

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -70,7 +70,7 @@ const getBreadcrumbs = (exportItem) => {
   return defaultBreadcrumbs
 }
 
-const ExportDetailsForm = ({ exportItem }) => {
+const ExportDetailsForm = ({ exportItem, hasExportWinFeatureGroup }) => {
   const { exportId } = useParams()
 
   return (
@@ -189,6 +189,15 @@ const ExportDetailsForm = ({ exportItem }) => {
                   >
                     Edit
                   </Button>
+                  {hasExportWinFeatureGroup && (
+                    <Button
+                      as={Link}
+                      href={`${urls.companies.exportWins.create()}?step=officer_details&company=${exportItem.company.id}&export=${exportId}`}
+                      data-test="convert-to-export-win"
+                    >
+                      Convert to export win
+                    </Button>
+                  )}
                   <Link
                     href={urls.exportPipeline.delete(exportId)}
                     data-test="delete-export-details-button"

--- a/src/client/modules/ExportPipeline/ExportDetails/state.js
+++ b/src/client/modules/ExportPipeline/ExportDetails/state.js
@@ -4,4 +4,5 @@ export const ID = 'exportDetails'
 
 export const state2props = ({ ...state }) => ({
   exportItem: state[ID].exportItem,
+  hasExportWinFeatureGroup: state.activeFeatureGroups?.includes('export-wins'),
 })

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -220,12 +220,14 @@ module.exports = {
     },
     exportWins: {
       index: url('/exportwins'),
-      create: url('/exportwins/create'),
-      details: url('/exportwins', '/:winId/details'),
-      rejected: url('/exportwins/rejected'),
-      sent: url('/exportwins/sent'),
       won: url('/exportwins/won'),
+      sent: url('/exportwins/sent'),
+      rejected: url('/exportwins/rejected'),
       edit: url('/exportwins', '/:winId/edit'),
+      details: url('/exportwins', '/:winId/details'),
+      create: url('/exportwins/create?company=', ':companyId'),
+      createFromExport: (companyId, exportId) =>
+        `/exportwins/create?company=${companyId}&export=${exportId}`,
       customerFeedback: url('/exportwins', '/:winId/customer-feedback'),
     },
     overview: {

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -29,12 +29,14 @@ const twelveMonthsAgo = getTwelveMonthsAgo()
 const month = twelveMonthsAgo.getMonth() + 1
 const year = twelveMonthsAgo.getFullYear()
 
-const officerDetailsStep = `?step=officer_details&company=${company.id}`
-const creditForThisWinStep = `?step=credit_for_this_win&company=${company.id}`
-const customerDetailsStep = `?step=customer_details&company=${company.id}`
-const winDetailsStep = `?step=win_details&company=${company.id}`
-const supportProvidedStep = `?step=support_provided&company=${company.id}`
-const checkBeforeSendingStep = `?step=check_before_sending&company=${company.id}`
+const create = urls.companies.exportWins.create(company.id)
+
+const officerDetailsStep = create + '&step=officer_details'
+const creditForThisWinStep = create + '&step=credit_for_this_win'
+const customerDetailsStep = create + '&step=customer_details'
+const winDetailsStep = create + '&step=win_details'
+const supportProvidedStep = create + '&step=support_provided'
+const checkBeforeSendingStep = create + '&step=check_before_sending'
 
 const formFields = {
   officerDetails: {
@@ -159,7 +161,7 @@ describe('Adding an export win', () => {
 
   context('Breadcrumbs', () => {
     it('should render the breadcrumbs', () => {
-      cy.visit(`${urls.companies.exportWins.create()}${officerDetailsStep}`)
+      cy.visit(officerDetailsStep)
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
         Companies: urls.companies.index(),
@@ -171,7 +173,7 @@ describe('Adding an export win', () => {
 
   context('Page headers', () => {
     it('should render both the header and subheader', () => {
-      cy.visit(`${urls.companies.exportWins.create()}${officerDetailsStep}`)
+      cy.visit(officerDetailsStep)
       assertLocalHeader('Add export win')
       cy.get('[data-test="subheading"]').should(
         'have.text',
@@ -183,9 +185,7 @@ describe('Adding an export win', () => {
   context('Officer details', () => {
     const { officerDetails } = formFields
 
-    beforeEach(() =>
-      cy.visit(`${urls.companies.exportWins.create()}${officerDetailsStep}`)
-    )
+    beforeEach(() => cy.visit(officerDetailsStep))
 
     it('should render an officer details heading', () => {
       cy.get(officerDetails.heading).should('have.text', 'Officer details')
@@ -268,9 +268,7 @@ describe('Adding an export win', () => {
   context('Credit for this win', () => {
     const { creditForThisWin } = formFields
 
-    beforeEach(() =>
-      cy.visit(`${urls.companies.exportWins.create()}${creditForThisWinStep}`)
-    )
+    beforeEach(() => cy.visit(creditForThisWinStep))
 
     it('should render a step heading', () => {
       cy.get(creditForThisWin.heading).should(
@@ -390,9 +388,7 @@ describe('Adding an export win', () => {
   context('Customer details', () => {
     const { customerDetails } = formFields
 
-    beforeEach(() =>
-      cy.visit(`${urls.companies.exportWins.create()}${customerDetailsStep}`)
-    )
+    beforeEach(() => cy.visit(customerDetailsStep))
 
     it('should render a step heading', () => {
       cy.get(customerDetails.heading).should('have.text', 'Customer details')
@@ -477,9 +473,7 @@ describe('Adding an export win', () => {
   context('Win details', () => {
     const { winDetails } = formFields
 
-    beforeEach(() =>
-      cy.visit(`${urls.companies.exportWins.create()}${winDetailsStep}`)
-    )
+    beforeEach(() => cy.visit(winDetailsStep))
 
     it('should render a step heading', () => {
       cy.get(winDetails.heading).should('have.text', 'Win details')
@@ -738,9 +732,7 @@ describe('Adding an export win', () => {
   context('Support provided', () => {
     const { supportProvided } = formFields
 
-    beforeEach(() => {
-      cy.visit(`${urls.companies.exportWins.create()}${supportProvidedStep}`)
-    })
+    beforeEach(() => cy.visit(supportProvidedStep))
 
     it('should render a step heading', () => {
       cy.get(supportProvided.heading).should('have.text', 'Support given')
@@ -848,9 +840,7 @@ describe('Adding an export win', () => {
       supportProvided,
     } = formFields
 
-    before(() => {
-      cy.visit(`${urls.companies.exportWins.create()}${officerDetailsStep}`)
-    })
+    before(() => cy.visit(officerDetailsStep))
 
     it('should complete the entire export win user journey', () => {
       // Officer details

--- a/test/functional/cypress/specs/export-win/user-feature-group-spec.js
+++ b/test/functional/cypress/specs/export-win/user-feature-group-spec.js
@@ -1,6 +1,6 @@
 import qs from 'qs'
 
-import { exportListFaker } from '../../fakers/export'
+import { exportListFaker, exportFaker } from '../../fakers/export'
 import urls from '../../../../../src/lib/urls'
 
 describe('Export win user feature groups', () => {
@@ -50,6 +50,26 @@ describe('Export win user feature groups', () => {
       cy.setUserFeatureGroups([])
       cy.visit(urls.exportPipeline.index())
       cy.get('[data-test="export-wins"]').should('not.exist')
+    })
+  })
+
+  context('Export project details page"', () => {
+    beforeEach(() => {
+      cy.intercept('GET', '/api-proxy/v4/export/1', exportFaker()).as(
+        'apiRequest'
+      )
+    })
+
+    it('should show the "Convert to export win" button when the feature is active', () => {
+      cy.setUserFeatureGroups(['export-wins'])
+      cy.visit(urls.exportPipeline.details('1'))
+      cy.get('[data-test="convert-to-export-win"]').should('exist')
+    })
+
+    it('should hide the "Convert to export win" button when the feature is inactive', () => {
+      cy.setUserFeatureGroups([])
+      cy.visit(urls.exportPipeline.details('1'))
+      cy.get('[data-test="convert-to-export-win"]').should('not.exist')
     })
   })
 })


### PR DESCRIPTION
## Description of change
Adds a **convert to export win** button to the export project details page. The button is hidden behind an `export-wins` user feature group. 

Once a user clicks the button some of the export project details are pre-populated into the add export win user journey - this saves users time by not having to input the same details - a bugbear of the previous system.

## Test instructions
### To enable the feature
1. Go to Django Admin (dev or staging)
2. Advisers
3. Search for a name and go into the record
4. Scroll down to feature groups
5. Select `export-wins` and slide it to the right
6. Save
7. Go to `/export/<export-uuid>/details` to view the button.

## Screenshots
<img width="692" alt="Screenshot 2024-03-04 at 15 13 56" src="https://github.com/uktrade/data-hub-frontend/assets/964268/5f929a11-8dff-4eda-ab0c-134a016e7a89">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
