### PR TITLE
Feat/export wins customer journey

### DIFF
--- a/src/apps/__export-wins-review/index.js
+++ b/src/apps/__export-wins-review/index.js
@@ -1,0 +1,14 @@
+/* eslint-disable prettier/prettier */
+const express = require('express')
+
+const router = express.Router()
+
+router.get(
+  [
+    '/exportwins/review/:id',
+    '/exportwins/review-win/thankyou',
+  ],
+  (req, res) => res.render('__export-wins-review/view')
+)
+
+module.exports = router

--- a/src/apps/__export-wins-review/view.njk
+++ b/src/apps/__export-wins-review/view.njk
@@ -1,0 +1,18 @@
+{% extends "_layouts/template.njk" %}
+
+{% block header %}{% endblock %}
+{% block local_header %}{% endblock %}
+{% block bodyStart %}{% endblock %}
+{% block main %}{% endblock %}
+{% block footer %}{% endblock %}
+
+{% block bodyEnd %}
+  <div id="react-app">
+    <noscript>Please enable JavaScript in your browser to see the content.</noscript>
+  </div>
+
+  <!--[if gt IE 8]><!-->
+  <script src="{{ getAssetPath('app.js') }}"></script>
+  <script src="{{ getAssetPath('export-win-review.js') }}"></script>
+  <!--<![endif]-->
+{% endblock %}

--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -50,6 +50,7 @@ const FieldRadios = ({
   return (
     <FieldWrapper
       {...{ ...props, name, label, legend, hint, error, bigLegend }}
+      data-component="FieldRadios"
     >
       <MultiChoice meta={{ error, touched }}>
         {options.map(

--- a/src/client/components/Resource/ExportWinReview.js
+++ b/src/client/components/Resource/ExportWinReview.js
@@ -1,0 +1,6 @@
+import { createEntityResource } from './Resource'
+
+export default createEntityResource(
+  'Export Win Review',
+  (id) => `v4/export-win/review/${id}`
+)

--- a/src/client/components/Resource/tasks.js
+++ b/src/client/components/Resource/tasks.js
@@ -23,6 +23,7 @@ import CompanyOneListTeam from './CompanyOneListTeam'
 import ExportYears from './ExportYears'
 import ExportWin from './ExportWin'
 import ExportWins from './ExportWins'
+import ExportWinReview from './ExportWinReview'
 import Sector from './Sector'
 import Export from './Export'
 import ExpectedValueRelation from './ExpectedValueRelation'
@@ -125,6 +126,7 @@ export default {
   ...ExportYears.tasks,
   ...ExportWin.tasks,
   ...ExportWins.tasks,
+  ...ExportWinReview.tasks,
   ...Sector.tasks,
   ...Export.tasks,
   ...LargeInvestorProfile.tasks,

--- a/src/client/components/SummaryTable/index.jsx
+++ b/src/client/components/SummaryTable/index.jsx
@@ -44,7 +44,11 @@ const StyledTag = styled(Tag)`
 `
 
 const SummaryTable = ({ caption, actions, children, ...rest }) => (
-  <StyledTable caption={caption && [caption, actions]} {...rest}>
+  <StyledTable
+    caption={caption && [caption, actions]}
+    {...rest}
+    data-component="SummaryTable"
+  >
     {children}
   </StyledTable>
 )

--- a/src/client/export-win-review.jsx
+++ b/src/client/export-win-review.jsx
@@ -1,0 +1,31 @@
+/* eslint-disable prettier/prettier */
+import React from 'react'
+import ReactDOM from 'react-dom'
+
+import DataHubProvider from './provider'
+import WithoutOurSupport from './components/Resource/WithoutOurSupport'
+import ExportWinReview from './components/Resource/ExportWinReview'
+import Rating from './components/Resource/Rating'
+import Experience from './components/Resource/Experience'
+import MarketingSource from './components/Resource/MarketingSource'
+
+import Review from './modules/ExportWins/Review'
+import { patchExportWinReview } from './modules/ExportWins/tasks'
+
+window.addEventListener('DOMContentLoaded', () =>
+  ReactDOM.render(
+    <DataHubProvider
+      tasks={{
+        ...ExportWinReview.tasks,
+        ...WithoutOurSupport.tasks,
+        ...Rating.tasks,
+        ...Experience.tasks,
+        ...MarketingSource.tasks,
+        TASK_PATCH_EXPORT_WIN_REVIEW: patchExportWinReview,
+      }}
+    >
+      <Review/>
+    </DataHubProvider>,
+    document.getElementById('react-app'),
+  )
+)

--- a/src/client/modules/ExportWins/Details/index.jsx
+++ b/src/client/modules/ExportWins/Details/index.jsx
@@ -74,6 +74,44 @@ const groupBreakdowns = (breakdowns) => {
   }
 }
 
+export const Summary = ({ exportWin, children }) => {
+  const { groups, totalAmount, totalYears } = exportWin
+    ? groupBreakdowns(exportWin.breakdowns)
+    : {}
+
+  return (
+    <SummaryTable data-test="export-wins-details-table">
+      <SummaryTable.Row heading="Goods or services">
+        {exportWin?.goodsVsServices.name}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Destination country">
+        {exportWin?.country.name}
+      </SummaryTable.Row>
+      {exportWin &&
+        Object.keys(groups).length > 1 &&
+        Object.entries(groups).map(([k, { total, yearRange }]) => {
+          const years = yearRange.max - yearRange.min + 1
+          return (
+            <NormalFontWeightRow key={k} heading={k}>
+              {`${currencyGBP(total)} over ${years} ${pluralize('year', years)}`}
+            </NormalFontWeightRow>
+          )
+        })}
+      <SummaryTable.Row heading="Total value">
+        {exportWin &&
+          `${currencyGBP(totalAmount)} over ${totalYears} ${pluralize('year', totalYears)}`}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Date won">
+        {exportWin && formatMediumDate(exportWin.date)}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Lead officer name">
+        {exportWin?.leadOfficer.name}
+      </SummaryTable.Row>
+      {children}
+    </SummaryTable>
+  )
+}
+
 const Detail = (props) => {
   const { winId } = props.match.params
   const success = props[winId]?.success
@@ -98,39 +136,9 @@ const Detail = (props) => {
     >
       <ExportWin id={winId} progressBox={true}>
         {(exportWin) => {
-          const { groups, totalAmount, totalYears } = exportWin
-            ? groupBreakdowns(exportWin.breakdowns)
-            : {}
-
           return (
             <>
-              <SummaryTable data-test="export-wins-details-table">
-                <SummaryTable.Row heading="Goods or services">
-                  {exportWin?.goodsVsServices.name}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Destination country">
-                  {exportWin?.country.name}
-                </SummaryTable.Row>
-                {exportWin &&
-                  Object.keys(groups).length > 1 &&
-                  Object.entries(groups).map(([k, { total, yearRange }]) => {
-                    const years = yearRange.max - yearRange.min + 1
-                    return (
-                      <NormalFontWeightRow key={k} heading={k}>
-                        {`${currencyGBP(total)} over ${years} ${pluralize('year', years)}`}
-                      </NormalFontWeightRow>
-                    )
-                  })}
-                <SummaryTable.Row heading="Total value">
-                  {exportWin &&
-                    `${currencyGBP(totalAmount)} over ${totalYears} ${pluralize('year', totalYears)}`}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Date won">
-                  {exportWin && formatMediumDate(exportWin.date)}
-                </SummaryTable.Row>
-                <SummaryTable.Row heading="Lead officer name">
-                  {exportWin?.leadOfficer.name}
-                </SummaryTable.Row>
+              <Summary exportWin={exportWin}>
                 <SummaryTable.Row heading="Comments">
                   {exportWin?.comments}
                 </SummaryTable.Row>
@@ -138,7 +146,7 @@ const Detail = (props) => {
                   {exportWin &&
                     (exportWin.isPersonallyConfirmed ? 'Yes' : 'No')}
                 </SummaryTable.Row>
-              </SummaryTable>
+              </Summary>
               {exportWin && <ResendExportWin id={exportWin.id} />}
               <VerticalSpacer>
                 {exportWin?.isPersonallyConfirmed && (

--- a/src/client/modules/ExportWins/Review/Layout.jsx
+++ b/src/client/modules/ExportWins/Review/Layout.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable prettier/prettier */
+import React from 'react'
+import styled from 'styled-components'
+import {H1} from 'govuk-react'
+import {
+  FONT_SIZE,
+  FONT_WEIGHTS,
+  SPACING,
+} from '@govuk-react/constants'
+
+import Footer from '../../../components/Footer'
+import { BLACK, WHITE, LIGHT_GREY } from '../../../utils/colours'
+
+const Grid = styled.div({
+  minHeight: '100vh',
+  display: 'grid',
+  gridTemplateRows: 'auto auto 1fr minmax(min-content, 30px)',
+  gridTemplateColumns: `1fr min(100vw, calc(960px + ${SPACING.SCALE_3} * 2)) 1fr`,
+  gridTemplateAreas: `
+    ". main-bar ."
+    ". header ."
+    ". main ."
+    "footer footer footer"
+  `,
+})
+
+const MainBarBackground = styled.div({
+  gridRow: 'main-bar',
+  gridColumn: '1 / -1',
+  background: BLACK,
+})
+
+const MainBar = styled.div({
+  gridArea: 'main-bar',
+  alignSelf: 'center',
+  fontWeight: FONT_WEIGHTS.bold,
+  fontSize: FONT_SIZE.SIZE_27,
+  color: WHITE,
+  padding: SPACING.SCALE_3,
+})
+
+const HeaderBackground = styled.div({
+  gridRow: 'header',
+  gridColumn: '1 / -1',
+  background: LIGHT_GREY,
+})
+
+const Header = styled.header({
+  gridArea: 'header',
+  alignSelf: 'center',
+  padding: SPACING.SCALE_3,
+  paddingBottom: SPACING.SCALE_5,
+})
+
+const Main = styled.main({
+  gridArea: 'main',
+  padding: SPACING.SCALE_5,
+})
+
+const GridCellFooter = styled(Footer)({
+  gridArea: 'footer',
+})
+
+const Title = styled(H1)({
+  margin: 0,
+  marginBottom: SPACING.SCALE_5,
+})
+
+const Layout = ({children, title, supertitle, headingContent}) =>
+  <Grid>
+    <MainBarBackground/>
+    <MainBar>
+      Department for Business & Trade
+    </MainBar>
+    <HeaderBackground/>
+    <Header>
+      <p>{supertitle}</p>
+      <Title>{title}</Title>
+      {headingContent}
+    </Header>
+    <Main>
+      {children}
+    </Main>
+    <GridCellFooter links={{
+      'Privacy Policy': 'http://example.com/not-implemented-yet',
+      'Accessibility Statement': 'http://example.com/not-implemented-yet',
+    }} />
+  </Grid>
+
+export default Layout

--- a/src/client/modules/ExportWins/Review/Layout.jsx
+++ b/src/client/modules/ExportWins/Review/Layout.jsx
@@ -1,12 +1,7 @@
-/* eslint-disable prettier/prettier */
 import React from 'react'
 import styled from 'styled-components'
-import {H1} from 'govuk-react'
-import {
-  FONT_SIZE,
-  FONT_WEIGHTS,
-  SPACING,
-} from '@govuk-react/constants'
+import { H1 } from 'govuk-react'
+import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
 import Footer from '../../../components/Footer'
 import { BLACK, WHITE, LIGHT_GREY } from '../../../utils/colours'
@@ -66,25 +61,24 @@ const Title = styled(H1)({
   marginBottom: SPACING.SCALE_5,
 })
 
-const Layout = ({children, title, supertitle, headingContent}) =>
+const Layout = ({ children, title, supertitle, headingContent }) => (
   <Grid>
-    <MainBarBackground/>
-    <MainBar>
-      Department for Business & Trade
-    </MainBar>
-    <HeaderBackground/>
+    <MainBarBackground />
+    <MainBar>Department for Business & Trade</MainBar>
+    <HeaderBackground />
     <Header>
       <p>{supertitle}</p>
       <Title>{title}</Title>
       {headingContent}
     </Header>
-    <Main>
-      {children}
-    </Main>
-    <GridCellFooter links={{
-      'Privacy Policy': 'http://example.com/not-implemented-yet',
-      'Accessibility Statement': 'http://example.com/not-implemented-yet',
-    }} />
+    <Main>{children}</Main>
+    <GridCellFooter
+      links={{
+        'Privacy Policy': 'http://example.com/not-implemented-yet',
+        'Accessibility Statement': 'http://example.com/not-implemented-yet',
+      }}
+    />
   </Grid>
+)
 
 export default Layout

--- a/src/client/modules/ExportWins/Review/ThankYou.jsx
+++ b/src/client/modules/ExportWins/Review/ThankYou.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import Layout from './Layout'
+import FlashMessages from '../../../components/LocalHeader/FlashMessages'
+
+export default () => (
+  <Layout title="Export win reviewed" headingContent={<FlashMessages />}>
+    Your feedback will help us to improve our support services.
+  </Layout>
+)

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -1,0 +1,330 @@
+/* eslint-disable prettier/prettier */
+import _ from 'lodash'
+import React from "react"
+import {H2, H4} from 'govuk-react'
+import {Route, Switch} from 'react-router-dom'
+
+import Layout from "./Layout"
+import {Form, FieldInput, FieldRadios, Step, SummaryTable, FieldTextarea, FieldCheckboxes} from '../../../components'
+import State from '../../../components/State'
+import ExportWinReview from '../../../components/Resource/ExportWinReview'
+import { Summary } from "../Details"
+import Rating from "../../../components/Resource/Rating"
+import Experience from "../../../components/Resource/Experience"
+import { WithoutOurSupport } from "../../../components/Resource"
+import MarketingSource from "../../../components/Resource/MarketingSource"
+import Err from '../../../components/Task/Error'
+
+import ThankYou from './ThankYou'
+
+const FORM_ID = 'export-wins-customer-feedback'
+
+const NotFound = (props) =>
+  props.errorMessage?.httpStatusCode === 404
+  ?
+  <>
+    <H4 as="h2">The link you used has expired</H4>
+    <p>
+      Please get in touch with the Department of Business and Trade
+      contact mentioned in your email, who will be able to send you a new link.
+    </p>
+  </>
+  : Err(props)
+
+const transformPayload = token => ({checkboxes1 = [], checkboxes2 = [], ...values}) => ({
+  token,
+  review: {
+    ...values,
+    ...Object.fromEntries([
+      ...checkboxes1,
+      ...checkboxes2,
+    ].map(x => [x, true])),
+    ..._(values)
+      .pick(['agree_with_win', 'case_study_willing'])
+      .mapValues(value => value === 'yes' ? true : false)
+      .value(),
+    ..._(values)
+      .pick([
+        'access_to_contacts',
+        'access_to_information',
+        'developed_relationships',
+        'expected_portion_without_help',
+        'gained_confidence',
+        'improved_profile',
+        'last_export',
+        'marketing_source',
+        'our_support',
+        'overcame_problem',
+      ])
+      .mapValues(id => ({id}))
+      .value(),
+  },
+})
+
+const FieldComments = () =>
+  <FieldTextarea
+    name="comments"
+    label="Comments (optional)"
+    hint="Please provide feedback on the help we have provided. If any of the information is incorrect please provide details."
+  />
+
+const CurrentFormStepInfo = () =>
+  <State>
+    {({Form}) => {
+      if (!Form?.[FORM_ID]) return null
+      const {currentStep, steps} = Form[FORM_ID]
+      const isFirstStep = currentStep === 0
+      const informationNeedsRevising = steps.length === 2
+      // We only want to show the form step info when the user
+      // confirms that the presented information is correct
+      if (isFirstStep || informationNeedsRevising) return null
+      return <>Step {currentStep} of {steps.length - 1}</>
+    }}
+  </State>
+
+const Step1 = ({win, name}) =>
+  <Step name="1">
+    <p>Hi {name},</p>
+    <p>
+      Thank you for taking the time to review our record
+      of your recent export success.
+    </p>
+    <hr/>
+    <H2>Details of your recent success</H2>
+    <Summary exportWin={win}>
+      <SummaryTable.Row heading="Summary of support received">
+        {win?.description}
+      </SummaryTable.Row>
+    </Summary>
+
+    {/* TODO: Create a FieldBoolean component */}
+    <FieldRadios
+      name="agree_with_win"
+      required="Choose one of the options"
+      options={[
+        {label: 'I confirm this information is correct', value: 'yes'},
+        {label: 'Some of this information needs revising', value: 'no'},
+      ]}
+    />
+  </Step>
+
+const Step2Agree = () =>
+  <Step name="2-agree">
+    <WithoutOurSupport.FieldRadios
+      name="expected_portion_without_help"
+      legend="What value do you estimate you would have achieved without our support?"
+      required="Choose one of the options"
+    />
+    <FieldComments/>
+  </Step>
+
+const Step2Disagree = () =>
+  <Step name="2-disagree">
+    <FieldComments/>
+  </Step>
+
+const Step3 = () =>
+  <Step name="3">
+    <H2>The extent our support helped</H2>
+    <Rating.FieldRadios
+      name="our_support"
+      legend="Securing the win overall?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="access_to_contacts"
+      legend="Gaining access to contacts?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="access_to_information"
+      legend="Getting information or improved understanding of the country?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="improved_profile"
+      legend="Improving your profile or credibility in the country?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="gained_confidence"
+      legend="Having confidence to explore or expand in the country?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="developed_relationships"
+      legend="Developing or nurturing critical relationships?"
+      required="Choose one of the options"
+    />
+    <Rating.FieldRadios
+      name="overcame_problem"
+      legend="Overcoming a problem in the country (eg legal, regulatory, commercial)"
+      required="Choose one of the options"
+    />
+  </Step>
+
+const Step4 = () =>
+  <Step name="4">
+    <H2>About this win</H2>
+    <FieldCheckboxes
+      name="checkboxes1"
+      legend="Please tick all that apply to this win:"
+      options={[
+        {
+          label: 'The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)',
+          value: 'involved_state_enterprise',
+        },
+        {
+          label: 'Our support was a prerequisite to generate this value',
+          value: 'interventions_were_prerequisite',
+        },
+        {
+          label: 'Our support helped you achieve this win more quickly',
+          value: 'support_improved_speed',
+        },
+      ]}
+    />
+    <FieldCheckboxes
+      name="checkboxes2"
+      legend="Tick any that apply to this win:"
+      options={[
+        {
+          label: 'It enabled vou to expand into a new market',
+          value: 'has_enabled_expansion_into_new_market',
+        },
+        {
+          label: 'It enabled you to maintain or expand in an existing market',
+          value: 'has_enabled_expansion_into_existing_market',
+        },
+        {
+          label: 'It enabled you to increase exports as a proportion of your turnover',
+          value: 'has_increased_exports_as_percent_of_turnover',
+        },
+        {
+          label: "If you hadn't achieved this win, your company might have stopped exporting",
+          value: 'company_was_at_risk_of_not_exporting',
+        },
+        {
+          label: 'Apart from this win, you already have plans to export in the next 12 months',
+          value: 'has_explicit_export_plans',
+        },
+      ]}
+    />
+  </Step>
+
+const Step5 = () =>
+  <Step name="5">
+    <H2>Your export experience</H2>
+    <Experience.FieldRadios
+      name="last_export"
+      legend="Apart from this win, when did your company last export goods or services?"
+      required="Choose one of the options"
+    />
+  </Step>
+
+const Step6 = () =>
+  <Step name="6">
+    <H2>Marketing</H2>
+    <FieldRadios
+      name="case_study_willing"
+      legend="Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?"
+      required="Choose one of the options"
+      options={[
+        {label: 'Yes', value: 'yes'},
+        {label: 'No', value: 'no'},
+      ]}
+    />
+    <MarketingSource.FieldRadios
+      name="marketing_source"
+      legend="How did you first hear about DBT (or it predecessor, DIT)?"
+      required="Choose one of the options"
+      interceptOption={option =>
+        option.label.endsWith('(please specify)')
+          ? {
+            ...option,
+            children:
+              <FieldInput
+                name="other_marketing_source"
+                type="text"
+                label="Label comes later"
+                required="Please specify"
+              />,
+          }
+          : option
+      }
+    />
+  </Step>
+
+const Review = ({token}) =>
+  <Layout
+    title="Tell us what made a difference"
+    supertitle={<CurrentFormStepInfo/>}
+  >
+    <ExportWinReview id={token}
+      taskStatusProps={{
+        renderError: NotFound,
+      }}
+    >
+      {(review) =>
+        <Form
+          id={FORM_ID}
+          analyticsFormName={FORM_ID}
+          submissionTaskName="TASK_PATCH_EXPORT_WIN_REVIEW"
+          // showStepInUrl={true}
+          redirectMode="soft"
+          redirectTo={() => '/exportwins/review-win/thankyou'}
+          transformPayload={transformPayload(token)}
+          flashMessage={(_, {agree_with_win}) =>
+            agree_with_win === 'yes'
+              // TODO: Move to constants
+              ? [
+                  'Success',
+                  'Thank you for taking time to review this export win',
+                  'success',
+                ]
+              : [
+                  'Important',
+                  `
+                  <p>Thank you for reviewing this export win</p>
+                  <p>
+                    As you have asked for some changes to be made,
+                    we will review your comments and may need to contact you
+                    if we need more information.
+                  </p>
+                  `,
+                  'info',
+                ]
+          }
+        >
+          {formData =>
+            <>
+              <Step1
+                win={review.win}
+                name={review?.companyContact?.name}
+              />
+              {formData.values.agree_with_win === 'yes' ?
+                <>
+                  <Step2Agree/>
+                  <Step3/>
+                  <Step4/>
+                  <Step5/>
+                  <Step6/>
+                </>
+                : <Step2Disagree/>
+              }
+            </>
+          }
+        </Form>
+      }
+    </ExportWinReview>
+  </Layout>
+
+export default () =>
+  <Switch>
+    <Route exact={true} path="/exportwins/review/:token">
+      {({match}) =>
+        <Review token={match.params.token}/>
+      }
+    </Route>
+    <Route exact={true} path="/exportwins/review-win/thankyou" component={ThankYou}/>
+  </Switch>

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -1,18 +1,25 @@
-/* eslint-disable prettier/prettier */
 import _ from 'lodash'
-import React from "react"
-import {H2, H4} from 'govuk-react'
-import {Route, Switch} from 'react-router-dom'
+import React from 'react'
+import { H2, H4 } from 'govuk-react'
+import { Route, Switch } from 'react-router-dom'
 
-import Layout from "./Layout"
-import {Form, FieldInput, FieldRadios, Step, SummaryTable, FieldTextarea, FieldCheckboxes} from '../../../components'
+import Layout from './Layout'
+import {
+  Form,
+  FieldInput,
+  FieldRadios,
+  Step,
+  SummaryTable,
+  FieldTextarea,
+  FieldCheckboxes,
+} from '../../../components'
 import State from '../../../components/State'
 import ExportWinReview from '../../../components/Resource/ExportWinReview'
-import { Summary } from "../Details"
-import Rating from "../../../components/Resource/Rating"
-import Experience from "../../../components/Resource/Experience"
-import { WithoutOurSupport } from "../../../components/Resource"
-import MarketingSource from "../../../components/Resource/MarketingSource"
+import { Summary } from '../Details'
+import Rating from '../../../components/Resource/Rating'
+import Experience from '../../../components/Resource/Experience'
+import { WithoutOurSupport } from '../../../components/Resource'
+import MarketingSource from '../../../components/Resource/MarketingSource'
 import Err from '../../../components/Task/Error'
 
 import ThankYou from './ThankYou'
@@ -20,76 +27,84 @@ import ThankYou from './ThankYou'
 const FORM_ID = 'export-wins-customer-feedback'
 
 const NotFound = (props) =>
-  props.errorMessage?.httpStatusCode === 404
-  ?
-  <>
-    <H4 as="h2">The link you used has expired</H4>
-    <p>
-      Please get in touch with the Department of Business and Trade
-      contact mentioned in your email, who will be able to send you a new link.
-    </p>
-  </>
-  : Err(props)
+  props.errorMessage?.httpStatusCode === 404 ? (
+    <>
+      <H4 as="h2">The link you used has expired</H4>
+      <p>
+        Please get in touch with the Department of Business and Trade contact
+        mentioned in your email, who will be able to send you a new link.
+      </p>
+    </>
+  ) : (
+    Err(props)
+  )
 
-const transformPayload = token => ({checkboxes1 = [], checkboxes2 = [], ...values}) => ({
-  token,
-  review: {
-    ...values,
-    ...Object.fromEntries([
-      ...checkboxes1,
-      ...checkboxes2,
-    ].map(x => [x, true])),
-    ..._(values)
-      .pick(['agree_with_win', 'case_study_willing'])
-      .mapValues(value => value === 'yes' ? true : false)
-      .value(),
-    ..._(values)
-      .pick([
-        'access_to_contacts',
-        'access_to_information',
-        'developed_relationships',
-        'expected_portion_without_help',
-        'gained_confidence',
-        'improved_profile',
-        'last_export',
-        'marketing_source',
-        'our_support',
-        'overcame_problem',
-      ])
-      .mapValues(id => ({id}))
-      .value(),
-  },
-})
+const transformPayload =
+  (token) =>
+  ({ checkboxes1 = [], checkboxes2 = [], ...values }) => ({
+    token,
+    review: {
+      ...values,
+      ...Object.fromEntries(
+        [...checkboxes1, ...checkboxes2].map((x) => [x, true])
+      ),
+      ..._(values)
+        .pick(['agree_with_win', 'case_study_willing'])
+        .mapValues((value) => (value === 'yes' ? true : false))
+        .value(),
+      ..._(values)
+        .pick([
+          'access_to_contacts',
+          'access_to_information',
+          'developed_relationships',
+          'expected_portion_without_help',
+          'gained_confidence',
+          'improved_profile',
+          'last_export',
+          'marketing_source',
+          'our_support',
+          'overcame_problem',
+        ])
+        .mapValues((id) => ({ id }))
+        .value(),
+    },
+  })
 
-const FieldComments = () =>
+const FieldComments = () => (
   <FieldTextarea
     name="comments"
     label="Comments (optional)"
     hint="Please provide feedback on the help we have provided. If any of the information is incorrect please provide details."
   />
+)
 
-const CurrentFormStepInfo = () =>
+const CurrentFormStepInfo = () => (
   <State>
-    {({Form}) => {
+    {({ Form }) => {
       if (!Form?.[FORM_ID]) return null
-      const {currentStep, steps} = Form[FORM_ID]
+      const { currentStep, steps } = Form[FORM_ID]
       const isFirstStep = currentStep === 0
       const informationNeedsRevising = steps.length === 2
       // We only want to show the form step info when the user
       // confirms that the presented information is correct
       if (isFirstStep || informationNeedsRevising) return null
-      return <>Step {currentStep} of {steps.length - 1}</>
+      return (
+        <>
+          Step {currentStep} of {steps.length - 1}
+        </>
+      )
     }}
   </State>
+)
 
-const Step1 = ({win, name}) =>
+const Step1 = ({ win, name }) => (
   <Step name="1">
     <p>Hi {name},</p>
     <p>
-      Thank you for taking the time to review our record
-      of your recent export success.
+      Thank you for taking the time to review our record of your recent export
+      success.
     </p>
-    <hr/>
+    <hr />
     <H2>Details of your recent success</H2>
     <Summary exportWin={win}>
       <SummaryTable.Row heading="Summary of support received">
@@ -102,28 +117,31 @@ const Step1 = ({win, name}) =>
       name="agree_with_win"
       required="Choose one of the options"
       options={[
-        {label: 'I confirm this information is correct', value: 'yes'},
-        {label: 'Some of this information needs revising', value: 'no'},
+        { label: 'I confirm this information is correct', value: 'yes' },
+        { label: 'Some of this information needs revising', value: 'no' },
       ]}
     />
   </Step>
+)
 
-const Step2Agree = () =>
+const Step2Agree = () => (
   <Step name="2-agree">
     <WithoutOurSupport.FieldRadios
       name="expected_portion_without_help"
       legend="What value do you estimate you would have achieved without our support?"
       required="Choose one of the options"
     />
-    <FieldComments/>
+    <FieldComments />
   </Step>
+)
 
-const Step2Disagree = () =>
+const Step2Disagree = () => (
   <Step name="2-disagree">
-    <FieldComments/>
+    <FieldComments />
   </Step>
+)
 
-const Step3 = () =>
+const Step3 = () => (
   <Step name="3">
     <H2>The extent our support helped</H2>
     <Rating.FieldRadios
@@ -162,8 +180,9 @@ const Step3 = () =>
       required="Choose one of the options"
     />
   </Step>
+)
 
-const Step4 = () =>
+const Step4 = () => (
   <Step name="4">
     <H2>About this win</H2>
     <FieldCheckboxes
@@ -171,7 +190,8 @@ const Step4 = () =>
       legend="Please tick all that apply to this win:"
       options={[
         {
-          label: 'The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)',
+          label:
+            'The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)',
           value: 'involved_state_enterprise',
         },
         {
@@ -197,22 +217,26 @@ const Step4 = () =>
           value: 'has_enabled_expansion_into_existing_market',
         },
         {
-          label: 'It enabled you to increase exports as a proportion of your turnover',
+          label:
+            'It enabled you to increase exports as a proportion of your turnover',
           value: 'has_increased_exports_as_percent_of_turnover',
         },
         {
-          label: "If you hadn't achieved this win, your company might have stopped exporting",
+          label:
+            "If you hadn't achieved this win, your company might have stopped exporting",
           value: 'company_was_at_risk_of_not_exporting',
         },
         {
-          label: 'Apart from this win, you already have plans to export in the next 12 months',
+          label:
+            'Apart from this win, you already have plans to export in the next 12 months',
           value: 'has_explicit_export_plans',
         },
       ]}
     />
   </Step>
+)
 
-const Step5 = () =>
+const Step5 = () => (
   <Step name="5">
     <H2>Your export experience</H2>
     <Experience.FieldRadios
@@ -221,8 +245,9 @@ const Step5 = () =>
       required="Choose one of the options"
     />
   </Step>
+)
 
-const Step6 = () =>
+const Step6 = () => (
   <Step name="6">
     <H2>Marketing</H2>
     <FieldRadios
@@ -230,42 +255,45 @@ const Step6 = () =>
       legend="Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?"
       required="Choose one of the options"
       options={[
-        {label: 'Yes', value: 'yes'},
-        {label: 'No', value: 'no'},
+        { label: 'Yes', value: 'yes' },
+        { label: 'No', value: 'no' },
       ]}
     />
     <MarketingSource.FieldRadios
       name="marketing_source"
       legend="How did you first hear about DBT (or it predecessor, DIT)?"
       required="Choose one of the options"
-      interceptOption={option =>
+      interceptOption={(option) =>
         option.label.endsWith('(please specify)')
           ? {
-            ...option,
-            children:
-              <FieldInput
-                name="other_marketing_source"
-                type="text"
-                label="Label comes later"
-                required="Please specify"
-              />,
-          }
+              ...option,
+              children: (
+                <FieldInput
+                  name="other_marketing_source"
+                  type="text"
+                  label="Label comes later"
+                  required="Please specify"
+                />
+              ),
+            }
           : option
       }
     />
   </Step>
+)
 
-const Review = ({token}) =>
+const Review = ({ token }) => (
   <Layout
     title="Tell us what made a difference"
-    supertitle={<CurrentFormStepInfo/>}
+    supertitle={<CurrentFormStepInfo />}
   >
-    <ExportWinReview id={token}
+    <ExportWinReview
+      id={token}
       taskStatusProps={{
         renderError: NotFound,
       }}
     >
-      {(review) =>
+      {(review) => (
         <Form
           id={FORM_ID}
           analyticsFormName={FORM_ID}
@@ -274,10 +302,10 @@ const Review = ({token}) =>
           redirectMode="soft"
           redirectTo={() => '/exportwins/review-win/thankyou'}
           transformPayload={transformPayload(token)}
-          flashMessage={(_, {agree_with_win}) =>
+          flashMessage={(_, { agree_with_win }) =>
             agree_with_win === 'yes'
-              // TODO: Move to constants
-              ? [
+              ? // TODO: Move to constants
+                [
                   'Success',
                   'Thank you for taking time to review this export win',
                   'success',
@@ -296,35 +324,37 @@ const Review = ({token}) =>
                 ]
           }
         >
-          {formData =>
+          {(formData) => (
             <>
-              <Step1
-                win={review.win}
-                name={review?.companyContact?.name}
-              />
-              {formData.values.agree_with_win === 'yes' ?
+              <Step1 win={review.win} name={review?.companyContact?.name} />
+              {formData.values.agree_with_win === 'yes' ? (
                 <>
-                  <Step2Agree/>
-                  <Step3/>
-                  <Step4/>
-                  <Step5/>
-                  <Step6/>
+                  <Step2Agree />
+                  <Step3 />
+                  <Step4 />
+                  <Step5 />
+                  <Step6 />
                 </>
-                : <Step2Disagree/>
-              }
+              ) : (
+                <Step2Disagree />
+              )}
             </>
-          }
+          )}
         </Form>
-      }
+      )}
     </ExportWinReview>
   </Layout>
+)
 
-export default () =>
+export default () => (
   <Switch>
     <Route exact={true} path="/exportwins/review/:token">
-      {({match}) =>
-        <Review token={match.params.token}/>
-      }
+      {({ match }) => <Review token={match.params.token} />}
     </Route>
-    <Route exact={true} path="/exportwins/review-win/thankyou" component={ThankYou}/>
+    <Route
+      exact={true}
+      path="/exportwins/review-win/thankyou"
+      component={ThankYou}
+    />
   </Switch>
+)

--- a/src/client/modules/ExportWins/tasks.js
+++ b/src/client/modules/ExportWins/tasks.js
@@ -1,0 +1,4 @@
+import { apiProxyAxios } from '../../components/Task/utils'
+
+export const patchExportWinReview = ({ review, token }) =>
+  apiProxyAxios.patch(`/v4/export-win/review/${token}`, review)

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -19,10 +19,12 @@ const preloadedState = {
   referrerUrl: window.document.referrer,
 }
 
+// TODO: Remove once DataHubProvider is implemented with createProvider
 const sagaMiddleware = createSagaMiddleware()
 
 const history = createBrowserHistory()
 
+// TODO: Remove once DataHubProvider is implemented with createProvider
 const store = configureStore({
   devTools: process.env.NODE_ENV === 'development',
   middleware: () => [sagaMiddleware, routerMiddleware(history)],
@@ -40,10 +42,40 @@ const store = configureStore({
   },
 })
 
+// TODO: Remove once DataHubProvider is implemented with createProvider
 const runMiddlewareOnce = _.once((tasks, sagaMiddleware) =>
   sagaMiddleware.run(rootSaga(tasks))
 )
 
+export const createProvider = ({ tasks, history, preloadedState }) => {
+  const sagaMiddleware = createSagaMiddleware()
+  const store = configureStore({
+    devTools: process.env.NODE_ENV === 'development',
+    middleware: () => [sagaMiddleware, routerMiddleware(history)],
+    preloadedState,
+    reducer: {
+      // This is to prevent the silly "Unexpected key ..." error thrown by combineReducers
+      ..._.mapValues(
+        preloadedState,
+        () =>
+          (state = null) =>
+            state
+      ),
+      ...reducers,
+      router: connectRouter(history),
+    },
+  })
+
+  sagaMiddleware.run(rootSaga(tasks))
+
+  return ({ children }) => (
+    <Provider store={store}>
+      <ConnectedRouter history={history}>{children}</ConnectedRouter>
+    </Provider>
+  )
+}
+
+// TODO: Re-implement this in with createProvider
 /**
  * Provides state management and routing infrastructure required by the
  * stateful/routed components.

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -57,6 +57,7 @@ const ALLOWLIST = [
   '/v3/event/',
   '/v4/event/',
   '/v4/export-win/',
+  '/v4/export-win/review/:token',
   '/v4/export-win/:exportWinId',
   '/v4/event/:id',
   '/v3/omis/order/:id/assignee',

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,8 +1,22 @@
+const PUBLICLY_ACCESSIBLE_API_ENDPOINTS = [
+  '/api-proxy/v4/export-win/review',
+  '/api-proxy/v4/metadata/without-our-support',
+  '/api-proxy/v4/metadata/rating',
+  '/api-proxy/v4/metadata/experience',
+  '/api-proxy/v4/metadata/marketing-source',
+]
+
+const REGEX = new RegExp(PUBLICLY_ACCESSIBLE_API_ENDPOINTS.join('|'))
+
 module.exports = function auth(req, res, next) {
   const passThrough =
     req.session.token || /^\/(healthcheck|oauth)\b/.test(req.url)
 
   if (passThrough) {
+    return next()
+  }
+
+  if (REGEX.test(req.url)) {
     return next()
   }
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,5 @@
 require('dotenv').config()
 
-// require('elastic-apm-node').start()
-
 const path = require('path')
 const bodyParser = require('body-parser')
 const compression = require('compression')
@@ -114,12 +112,14 @@ app.use(
   )
 )
 
+app.use(locals)
 app.use(title())
 app.use(breadcrumbs.init())
 app.use(breadcrumbs.setHome())
-app.use(locals)
-app.use(redisCheck)
 
+app.use(require('./apps/__export-wins-review'))
+
+app.use(redisCheck)
 app.use(sessionStore)
 
 app.use(bodyParser.urlencoded({ extended: true, limit: '1mb' }))

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -1,0 +1,445 @@
+import React from 'react'
+import { Redirect } from 'react-router-dom'
+
+import {
+  assertSummaryTableStrict,
+  assertFieldRadiosStrict,
+  assertFieldCheckboxes,
+  assertFieldTextarea,
+} from '../../../../functional/cypress/support/assertions'
+import Review from '../../../../../src/client/modules/ExportWins/Review'
+import { createTestProvider } from '../provider'
+
+const assertNoErrorDialog = () =>
+  cy.get('[data-test="error-dialog"').should('not.exist')
+
+const DBT_HEADING = 'Department for Business & Trade'
+const HEADING = 'Tell us what made a difference'
+
+const assertHeader = () => {
+  cy.contains(DBT_HEADING)
+  cy.get('header h1').should('have.text', HEADING)
+}
+
+const assertReviewed = () => {
+  cy.contains(DBT_HEADING)
+  cy.get('header h1').should('have.text', 'Export win reviewed')
+  cy.get('main').should(
+    'have.text',
+    'Your feedback will help us to improve our support services.'
+  )
+}
+
+const EXPORT_WIN = {
+  id: 'export-win-id',
+  name_of_export: 'Rubber chicken',
+  lead_officer: {
+    name: 'Leo Jacobs',
+  },
+  country: {
+    name: 'Australia',
+  },
+  comments: 'Lorem ipsum dolor sit amet',
+  total_expected_export_value: 2528571,
+  date: '2024-03-26T14:29:01.521Z',
+  goods_vs_services: {
+    name: 'Services',
+  },
+  is_personally_confirmed: false,
+  description: 'Lorem ipsum dolor sit amet',
+  breakdowns: [
+    {
+      type: {
+        name: 'Export',
+      },
+      value: 123456,
+      year: 3,
+    },
+  ],
+}
+
+const REVIEW = {
+  win: EXPORT_WIN,
+  company_contact: {
+    name: 'Andy Pipkin',
+  },
+}
+
+describe('ExportWins/Review', () => {
+  // We need to clear local storage after each test so that flash messages won't leak between tests
+  // TODO: This should actually be applied globally
+  afterEach(() => sessionStorage.clear())
+
+  context('If there is a problem loading the review', () => {
+    it("should render not found view if token is expired or doesn't exist", () => {
+      const Provider = createTestProvider({
+        'Export Win Review': () =>
+          Promise.reject({
+            httpStatusCode: 404,
+          }),
+      })
+      cy.mount(
+        <Provider>
+          <Redirect to="/exportwins/review/123" />
+          <Review />
+        </Provider>
+      )
+
+      assertHeader()
+
+      // TODO: Assert footer links
+      assertNoErrorDialog()
+
+      cy.contains('h2', 'The link you used has expired')
+      cy.contains(
+        'p',
+        'Please get in touch with the Department of Business and Trade contact mentioned in your email, who will be able to send you a new link.'
+      )
+    })
+
+    it("should render default error view if the review couldn't be loaded for", () => {
+      const Provider = createTestProvider({
+        'Export Win Review': () => Promise.reject(),
+      })
+      cy.mount(
+        <Provider>
+          <Redirect to="/exportwins/review/123" />
+          <Review />
+        </Provider>
+      )
+
+      assertHeader()
+
+      cy.contains('h2', 'The link you used has expired').should('not.exist')
+      cy.contains(
+        'p',
+        'Please get in touch with the Department of Business and Trade contact mentioned in your email, who will be able to send you a new link.'
+      ).should('not.exist')
+
+      cy.get('[data-test="error-dialog"')
+        .should('exist')
+        .within(() => {
+          cy.contains('h2', 'Could not load Export Win Review')
+          cy.contains('button', 'Retry')
+          cy.contains('button', 'Dismiss')
+        })
+    })
+  })
+
+  context('If the review loads', () => {
+    it('User agrees with win', () => {
+      const RATING = [
+        { id: 'rating-a', name: 'rating-A' },
+        { id: 'rating-b', name: 'rating-B' },
+        { id: 'rating-c', name: 'rating-C' },
+      ]
+
+      const WITHOUT_OUR_SUPPORT = [
+        { id: 'without-our-support-a', name: 'without-our-support-A' },
+        { id: 'without-our-support-b', name: 'without-our-support-B' },
+        { id: 'without-our-support-c', name: 'without-our-support-C' },
+      ]
+
+      const EXPERIENCE = [
+        { id: 'experience-a', name: 'experience-A' },
+        { id: 'experience-b', name: 'experience-B' },
+        { id: 'experience-c', name: 'experience-C' },
+      ]
+
+      const MARKETING_SOURCE = [
+        { id: 'marketing-source-a', name: 'marketing-source-A' },
+        { id: 'marketing-source-b', name: 'marketing-source-B' },
+        { id: 'marketing-source-c', name: 'marketing-source-C' },
+      ]
+
+      const Provider = createTestProvider({
+        'Export Win Review': () => Promise.resolve(REVIEW),
+        WithoutOurSupport: () => Promise.resolve(WITHOUT_OUR_SUPPORT),
+        Rating: () => Promise.resolve(RATING),
+        Experience: () => Promise.resolve(EXPERIENCE),
+        MarketingSource: () => Promise.resolve(MARKETING_SOURCE),
+        TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+      })
+
+      cy.mount(
+        <Provider>
+          <Redirect to="/exportwins/review/123" />
+          <Review />
+        </Provider>
+      )
+
+      assertHeader()
+      assertNoErrorDialog()
+
+      cy.contains('p', 'Hi Andy Pipkin,')
+        .next()
+        .should('match', 'p')
+        .should(
+          'have.text',
+          'Thank you for taking the time to review our record of your recent export success.'
+        )
+        .next()
+        .should('match', 'hr')
+        .next()
+        .should('match', 'h2')
+        .should('have.text', 'Details of your recent success')
+
+      assertSummaryTableStrict({
+        rows: [
+          ['Goods or services', EXPORT_WIN.goods_vs_services.name],
+          ['Destination country', EXPORT_WIN.country.name],
+          ['Total value', '£123,456 over 1 year'],
+          ['Date won', '26 Mar 2024'],
+          ['Lead officer name', EXPORT_WIN.lead_officer.name],
+          ['Summary of support received', EXPORT_WIN.description],
+        ],
+      })
+
+      assertFieldRadiosStrict({
+        inputName: 'agree_with_win',
+        options: [
+          'I confirm this information is correct',
+          'Some of this information needs revising',
+        ],
+        selectIndex: 0,
+      })
+
+      cy.contains('button', 'Continue').as('continue').click()
+
+      // Assert that the step info is between the headings
+      cy.contains(DBT_HEADING + 'Step 1 of 5' + HEADING)
+
+      assertFieldRadiosStrict({
+        inputName: 'expected_portion_without_help',
+        legend:
+          'What value do you estimate you would have achieved without our support?',
+        options: WITHOUT_OUR_SUPPORT.map((x) => x.name),
+        selectIndex: 1,
+      })
+
+      cy.get('#field-comments').then((element) => {
+        assertFieldTextarea({
+          element,
+          label: 'Comments (optional)',
+          hint: 'Please provide feedback on the help we have provided. If any of the information is incorrect please provide details.',
+        })
+      })
+
+      cy.contains('button', 'Back')
+
+      cy.get('@continue').click()
+
+      cy.contains(DBT_HEADING + 'Step 2 of 5' + HEADING)
+      cy.contains('h2', 'The extent our support helped')
+      ;[
+        { inputName: 'our_support', legend: 'Securing the win overall?' },
+        {
+          inputName: 'access_to_contacts',
+          legend: 'Gaining access to contacts?',
+        },
+        {
+          inputName: 'access_to_information',
+          legend:
+            'Getting information or improved understanding of the country?',
+        },
+        {
+          inputName: 'improved_profile',
+          legend: 'Improving your profile or credibility in the country?',
+        },
+        {
+          inputName: 'gained_confidence',
+          legend: 'Having confidence to explore or expand in the country?',
+        },
+        {
+          inputName: 'developed_relationships',
+          legend: 'Developing or nurturing critical relationships?',
+        },
+        {
+          inputName: 'overcame_problem',
+          legend:
+            'Overcoming a problem in the country (eg legal, regulatory, commercial)',
+        },
+      ].forEach(({ inputName, legend }) => {
+        assertFieldRadiosStrict({
+          inputName,
+          legend,
+          options: RATING.map((x) => x.name),
+          selectIndex: 1,
+        })
+      })
+
+      cy.get('@continue').click()
+
+      cy.contains(DBT_HEADING + 'Step 3 of 5' + HEADING)
+      cy.contains('h2', 'About this win')
+
+      assertFieldCheckboxes({
+        element: '#field-checkboxes1',
+        legend: 'Please tick all that apply to this win:',
+        options: [
+          {
+            label:
+              'The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)',
+          },
+          { label: 'Our support was a prerequisite to generate this value' },
+          { label: 'Our support helped you achieve this win more quickly' },
+        ],
+      })
+
+      cy.contains(
+        'Our support was a prerequisite to generate this value'
+      ).click()
+
+      assertFieldCheckboxes({
+        element: '#field-checkboxes2',
+        legend: 'Tick any that apply to this win:',
+        options: [
+          { label: 'It enabled vou to expand into a new market' },
+          {
+            label: 'It enabled you to maintain or expand in an existing market',
+          },
+          {
+            label:
+              'It enabled you to increase exports as a proportion of your turnover',
+          },
+          {
+            label:
+              "If you hadn't achieved this win, your company might have stopped exporting",
+          },
+          {
+            label:
+              'Apart from this win, you already have plans to export in the next 12 months',
+          },
+        ],
+      })
+
+      cy.contains(
+        'It enabled you to maintain or expand in an existing market'
+      ).click()
+
+      cy.contains(
+        "If you hadn't achieved this win, your company might have stopped exporting"
+      ).click()
+
+      cy.get('@continue').click()
+
+      cy.contains(DBT_HEADING + 'Step 4 of 5' + HEADING)
+      cy.contains('h2', 'Your export experience')
+
+      assertFieldRadiosStrict({
+        inputName: 'last_export',
+        legend:
+          'Apart from this win, when did your company last export goods or services?',
+        options: EXPERIENCE.map((x) => x.name),
+        selectIndex: 1,
+      })
+
+      cy.get('@continue').click()
+
+      cy.contains(DBT_HEADING + 'Step 5 of 5' + HEADING)
+      cy.contains('h2', 'Marketing')
+
+      assertFieldRadiosStrict({
+        inputName: 'case_study_willing',
+        legend:
+          'Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?',
+        options: ['Yes', 'No'],
+        selectIndex: 1,
+      })
+
+      assertFieldRadiosStrict({
+        inputName: 'marketing_source',
+        legend: 'How did you first hear about DBT (or it predecessor, DIT)?',
+        options: MARKETING_SOURCE.map((x) => x.name),
+        selectIndex: 1,
+      })
+
+      cy.contains('button', 'Submit').click()
+
+      assertReviewed()
+
+      cy.get('[role="alert"').within(() => {
+        cy.contains('h2', /^Success$/)
+        cy.contains(
+          'p',
+          /^Thank you for taking time to review this export win$/
+        )
+      })
+    })
+
+    it('User disagrees with win', () => {
+      const Provider = createTestProvider({
+        'Export Win Review': () => Promise.resolve(REVIEW),
+        TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+      })
+      cy.mount(
+        <Provider>
+          <Redirect to="/exportwins/review/123" />
+          <Review token="whatever" />
+        </Provider>
+      )
+
+      assertHeader()
+      assertNoErrorDialog()
+
+      cy.contains('p', 'Hi Andy Pipkin,')
+        .next()
+        .should('match', 'p')
+        .should(
+          'have.text',
+          'Thank you for taking the time to review our record of your recent export success.'
+        )
+        .next()
+        .should('match', 'hr')
+        .next()
+        .should('match', 'h2')
+        .should('have.text', 'Details of your recent success')
+
+      assertSummaryTableStrict({
+        rows: [
+          ['Goods or services', EXPORT_WIN.goods_vs_services.name],
+          ['Destination country', EXPORT_WIN.country.name],
+          ['Total value', '£123,456 over 1 year'],
+          ['Date won', '26 Mar 2024'],
+          ['Lead officer name', EXPORT_WIN.lead_officer.name],
+          ['Summary of support received', EXPORT_WIN.description],
+        ],
+      })
+
+      assertFieldRadiosStrict({
+        inputName: 'agree_with_win',
+        options: [
+          'I confirm this information is correct',
+          'Some of this information needs revising',
+        ],
+        selectIndex: 1,
+      })
+
+      cy.contains('button', 'Continue').click()
+
+      // There should be no form step info between the two headings
+      cy.contains(DBT_HEADING + HEADING)
+
+      cy.get('#field-comments').then((el) =>
+        assertFieldTextarea({
+          element: el,
+          label: 'Comments (optional)',
+          hint: 'Please provide feedback on the help we have provided. If any of the information is incorrect please provide details.',
+        })
+      )
+
+      cy.contains('button', 'Submit').click()
+
+      assertReviewed()
+
+      cy.get('[role="alert"').within(() => {
+        cy.contains('h2', /^Important$/)
+        cy.contains('p', /^\s*Thank you for reviewing this export win\s*$/)
+        cy.contains(
+          'p',
+          /^\s*As you have asked for some changes to be made, we will review your comments and may need to contact you if we need more information.\s*$/
+        )
+      })
+    })
+  })
+})

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -4,19 +4,22 @@ import { Provider } from 'react-redux'
 import { combineReducers, applyMiddleware, legacy_createStore } from 'redux'
 import createSagaMiddleware from 'redux-saga'
 import { connectRouter } from 'connected-react-router'
-import { createBrowserHistory } from 'history'
-
-import queryString from 'qs'
+import { createMemoryHistory } from 'history'
 
 import rootSaga from '../../../../src/client/root-saga'
 import { reducers } from '../../../../src/client/reducers'
 import { tasks as appTasks } from '../../../../src/client/tasks'
+import { createProvider } from '../../../../src/client/provider'
 
 const sagaMiddleware = createSagaMiddleware()
 
-const history = createBrowserHistory({
-  basename: queryString.stringify(new URL(document.baseURI).pathname),
-})
+const history = createMemoryHistory()
+
+export const createTestProvider = (tasks) =>
+  createProvider({
+    tasks,
+    history,
+  })
 
 const reducer = (state, action) =>
   combineReducers({
@@ -36,13 +39,14 @@ export const dispatchResetAction = () => store.dispatch({ type: 'RESET' })
 
 const runMiddlewareOnce = _.once((tasks) => sagaMiddleware.run(rootSaga(tasks)))
 
+// TODO: Get rid of this and use createTestProvider in each test
 export default ({ children, tasks = appTasks, resetTasks = false }) => {
   // We only ever want to start the sagas once
   resetTasks ? sagaMiddleware.run(rootSaga(tasks)) : runMiddlewareOnce(tasks)
 
   return (
     <Provider store={store}>
-      <BrowserRouter>{children}</BrowserRouter>
+      <BrowserRouter history={history}>{children}</BrowserRouter>
     </Provider>
   )
 }

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -75,6 +75,24 @@ const assertSummaryTable = ({
   }
 }
 
+/**
+ * @param {{rows: [string, string | number][]}} options
+ */
+const assertSummaryTableStrict = ({ rows }) => {
+  cy.get('[data-component="SummaryTable"] tr')
+    .as('rows')
+    .should('have.length', rows.length)
+
+  rows.forEach(([key, val], i) => {
+    cy.get('@rows')
+      .eq(i)
+      .within(() => {
+        cy.get('th').should('have.length', 1).should('have.text', key)
+        cy.get('td').should('have.length', 1).should('have.text', val)
+      })
+  })
+}
+
 const assertGovReactTable = ({ element, headings, rows }) => {
   cy.get(element).as('table')
 
@@ -918,6 +936,7 @@ module.exports = {
   assertKeyValueTable,
   assertValueTable,
   assertSummaryTable,
+  assertSummaryTableStrict,
   assertGovReactTable,
   assertBreadcrumbs,
   testBreadcrumbs,

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -242,6 +242,35 @@ const assertFieldRadios = ({ element, label, value, optionsCount }) =>
           .should('have.text', value)
     )
 
+/**
+ * @param {{inputName: string, options: string[], legend?: string, selectIndex?: number}} options
+ */
+const assertFieldRadiosStrict = ({ inputName, options, legend, selectIndex }) =>
+  cy
+    .get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      if (legend) {
+        cy.get('legend').should('have.text', legend)
+      }
+
+      cy.get('input[type="radio"]')
+        .should('have.length', options.length)
+        .each(($el, i) => {
+          const label = options[i]
+          const wrapped = cy
+            .wrap($el)
+            .should('have.attr', 'aria-label', label)
+            .parent()
+            .should('match', 'label')
+            .should('have.text', label)
+
+          if (i === selectIndex) {
+            wrapped.click()
+          }
+        })
+    })
+
 // As part of the accessibility work, a sample of pages have been refactored to use legends instead of labels.
 // Use this assertion for radios which have legends applied.
 const assertFieldRadiosWithLegend = ({
@@ -407,6 +436,7 @@ const assertFieldInputNoLabel = ({ element, value = undefined }) =>
 const assertFieldHidden = ({ element, name, value }) =>
   cy.wrap(element).should('have.attr', 'name', name).should('have.value', value)
 
+// FIXME: Make element optional, because it's a real pain to use
 const assertFieldTextarea = ({ element, label, hint, value, wordCount }) => {
   cy.wrap(element)
     .find('label')
@@ -901,6 +931,7 @@ module.exports = {
   assertFieldSelect,
   assertSelectOptions,
   assertFieldRadios,
+  assertFieldRadiosStrict,
   assertFieldRadiosWithLegend,
   assertFieldRadiosWithoutLabel,
   assertFieldCheckboxes,

--- a/test/sandbox/fixtures/v4/export/without-our-support.json
+++ b/test/sandbox/fixtures/v4/export/without-our-support.json
@@ -1,0 +1,37 @@
+[
+  {
+    "id": "9a23de5e-6961-4cb0-a8a1-03c31b7ee4b3",
+    "name": "No value without our help",
+    "disabled_on": null
+  },
+  {
+    "id": "4a4fd78b-c6fe-434d-a81c-3cc47226e09c",
+    "name": "Up to 20% of the total expected value without our help",
+    "disabled_on": null
+  },
+  {
+    "id": "be65c0c4-c35e-4876-a035-21ea40134e9f",
+    "name": "Up to 40%",
+    "disabled_on": null
+  },
+  {
+    "id": "4f463265-5172-4b76-b7ce-42e8011ff856",
+    "name": "Up to 60%",
+    "disabled_on": null
+  },
+  {
+    "id": "a44251c1-ab7e-4357-af87-de161c6b373c",
+    "name": "Up to 80%",
+    "disabled_on": null
+  },
+  {
+    "id": "e25d8d73-6d06-42d4-9b36-99123084ad50",
+    "name": "More than 80%",
+    "disabled_on": null
+  },
+  {
+    "id": "6ff5db71-ad1c-4e45-8dd5-4e5a9ce39e7c",
+    "name": "You could have won the entire value or similar without our help",
+    "disabled_on": null
+  }
+]

--- a/test/sandbox/fixtures/v4/metadata/experience.json
+++ b/test/sandbox/fixtures/v4/metadata/experience.json
@@ -1,0 +1,32 @@
+[
+  {
+      "id": "28e72562-b9cf-492a-9687-c343517087e4",
+      "name": "We had not started exporting before this win",
+      "disabled_on": null
+  },
+  {
+      "id": "f87ff818-4829-4695-a015-4cca8c10537c",
+      "name": "Apart from this win, we have exported in the last 12 months",
+      "disabled_on": null
+  },
+  {
+      "id": "a30c77d7-62bc-475e-add8-68d49d9f6975",
+      "name": "We last exported 1 to 2 years ago",
+      "disabled_on": null
+  },
+  {
+      "id": "6d5c13f2-443e-4a64-b327-bd6ba2e9a995",
+      "name": "2 to 5 years ago",
+      "disabled_on": null
+  },
+  {
+      "id": "d9028c12-549f-462e-a004-e5f230127f3e",
+      "name": "5 to 10 years ago",
+      "disabled_on": null
+  },
+  {
+      "id": "c50614a8-79d5-49a4-a7c1-fca21bd39c57",
+      "name": "More than 10 years ago",
+      "disabled_on": null
+  }
+]

--- a/test/sandbox/fixtures/v4/metadata/marketing-source.json
+++ b/test/sandbox/fixtures/v4/metadata/marketing-source.json
@@ -1,0 +1,62 @@
+[
+  {
+      "id": "a1fad32d-e972-40f1-a1d9-c8b4cd7a780d",
+      "name": "Business / professional contacts in the private sector",
+      "disabled_on": null
+  },
+  {
+      "id": "ad558b2f-e628-48c4-9240-2557de0fddff",
+      "name": "Business / professional contacts in the public sector",
+      "disabled_on": null
+  },
+  {
+      "id": "5001e2e8-2d3b-433e-9c1a-bbb2e7b3bfd5",
+      "name": "Articles/information I saw or read",
+      "disabled_on": null
+  },
+  {
+      "id": "5133b7b1-32df-488c-95a5-378ded3b4bab",
+      "name": "Advertisements I saw or read about the Exporting is GREAT campaign",
+      "disabled_on": null
+  },
+  {
+      "id": "4a74caa8-c3c7-44ee-a65e-b902b57bf0d5",
+      "name": "Great.gov.uk website",
+      "disabled_on": null
+  },
+  {
+      "id": "c7e34211-e537-48e0-a3e5-f9079bdfa0e1",
+      "name": "Searched online",
+      "disabled_on": null
+  },
+  {
+      "id": "d69437d5-e241-4160-99f3-b67d887606a8",
+      "name": "Direct call from an international trade advisor",
+      "disabled_on": null
+  },
+  {
+      "id": "065cb966-6789-46e2-ade0-3c173c090eec",
+      "name": "The Exporting is GREAT truck",
+      "disabled_on": null
+  },
+  {
+      "id": "0fe5bc9e-b405-41cb-a68d-c1150033932b",
+      "name": "UK trade fair",
+      "disabled_on": null
+  },
+  {
+      "id": "f0f4511b-3f0d-45f3-bb73-871ca7badcf9",
+      "name": "Overseas trade fair",
+      "disabled_on": null
+  },
+  {
+      "id": "5ac7e9a8-2347-4d4f-9b52-0047d32abb05",
+      "name": "Don’t know",
+      "disabled_on": null
+  },
+  {
+      "id": "391ad3b8-e028-48f1-9cf6-ac7149fb3756",
+      "name": "Other (please specify)",
+      "disabled_on": null
+  }
+]

--- a/test/sandbox/fixtures/v4/metadata/rating.json
+++ b/test/sandbox/fixtures/v4/metadata/rating.json
@@ -1,0 +1,32 @@
+[
+  {
+    "id": "471ce323-266f-4af5-bdd6-e38b30f78ce2",
+    "name": "Didn't help",
+    "disabled_on": null
+  },
+  {
+    "id": "740f9e5e-0d26-4dff-900a-1db7e2205267",
+    "name": "Very little",
+    "disabled_on": null
+  },
+  {
+    "id": "aeb0298b-8ac8-44ff-a371-41d5bd8328d5",
+    "name": "Some extent",
+    "disabled_on": null
+  },
+  {
+    "id": "8d878413-ffc2-4562-92c9-98414d08d714",
+    "name": "Great extent",
+    "disabled_on": null
+  },
+  {
+    "id": "7efd335d-f963-4c34-8a4f-2ae57419d632",
+    "name": "Completely",
+    "disabled_on": null
+  },
+  {
+    "id": "dbfc571c-ffbe-4ef8-8840-16364ed46824",
+    "name": "N/A",
+    "disabled_on": null
+  }
+]

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -62,6 +62,7 @@ const fakeExportWin = () => ({
     name: faker.helpers.arrayElement(['Goods', 'Services']),
   },
   breakdowns: faker.helpers.multiple(fakeBreakdown),
+  description: faker.lorem.lines(),
 })
 
 const WON_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
@@ -83,3 +84,72 @@ export const getExportWinCollection = (req, res) => {
 export const getExportWin = (req, res) => {
   res.json(fakeExportWin())
 }
+
+export const getExportWinReview = (req, res) => {
+  if (req.params.token === 'non-existent') {
+    return res.status(404).json({ error: 'Not found' })
+  }
+  res.json({
+    win: fakeExportWin(),
+    company_contact: {
+      name: faker.person.fullName(),
+    },
+    agree_with_win: false,
+    name: 'John Doe',
+    comments: 'Comments',
+    our_support: {
+      id: faker.string.uuid(),
+      name: 'Our support',
+    },
+    access_to_contacts: {
+      id: faker.string.uuid(),
+      name: 'Access to contacts',
+    },
+    access_to_information: {
+      id: faker.string.uuid(),
+      name: 'Access to informaiton',
+    },
+    improved_profile: {
+      id: faker.string.uuid(),
+      name: 'Improved profile',
+    },
+    gained_confidence: {
+      id: faker.string.uuid(),
+      name: 'Gained confidence',
+    },
+    developed_relationships: {
+      id: faker.string.uuid(),
+      name: 'Developer relationship',
+    },
+    overcame_problem: {
+      id: faker.string.uuid(),
+      name: 'Overcame problem',
+    },
+    involved_state_enterprise: 'Involved state enterprise',
+    interventions_were_prerequisite: 'Interventions were prerequisite',
+    support_improved_speed: 'Support improved speed',
+    expected_portion_without_help: {
+      id: faker.string.uuid(),
+      name: 'Expected portion without help',
+    },
+    last_export: {
+      id: faker.string.uuid(),
+      name: 'Last export',
+    },
+    company_was_at_risk_of_not_exporting: false,
+    has_explicit_export_plans: false,
+    has_enabled_expansion_into_new_market: false,
+    has_increased_exports_as_percent_of_turnover: false,
+    has_enabled_expansion_into_existing_market: false,
+    case_study_willing: false,
+    marketing_source: {
+      id: faker.string.uuid(),
+      name: 'Marketing source',
+    },
+    other_marketing_source: 'Other marketing source',
+  })
+}
+
+export const patchExportWinReview = (req, res) =>
+  // TODO: Update this to correct response
+  res.json({ foo: 'bar' })

--- a/test/sandbox/routes/v4/metadata/index.js
+++ b/test/sandbox/routes/v4/metadata/index.js
@@ -52,10 +52,14 @@ import capitalInvestmentDesiredDealRoles from '../../../fixtures/v4/metadata/cap
 import capitalInvestmentAssetClassInterest from '../../../fixtures/v4/metadata/capital-investment-asset-class-interest.json' assert { type: 'json' }
 import capitalInvestmentValueTypes from '../../../fixtures/metadata/capital-investment-opportunity-value-types.json' assert { type: 'json' }
 import capitalInvestmentStatusTypes from '../../../fixtures/metadata/capital-investment-opportunity-status-types.json' assert { type: 'json' }
+import experience from '../../../fixtures/v4/metadata/experience.json' assert { type: 'json' }
+import rating from '../../../fixtures/v4/metadata/rating.json' assert { type: 'json' }
+import marketingSource from '../../../fixtures/v4/metadata/marketing-source.json' assert { type: 'json' }
 import oneListTier from '../../../fixtures/v4/metadata/one-list-tier.json' assert { type: 'json' }
 import tradeAgreement from '../../../fixtures/v4/metadata/trade-agreement.json' assert { type: 'json' }
 import estimatedYears from '../../../fixtures/v4/export/estimated-years.json' assert { type: 'json' }
 import exportExperience from '../../../fixtures/v4/export/export-experience.json' assert { type: 'json' }
+import withoutOurSupport from '../../../fixtures/v4/export/without-our-support.json' assert { type: 'json' }
 
 export const getLikelihoodToLand = function (req, res) {
   res.json(likelihoodToLand)
@@ -292,4 +296,20 @@ export const getExportYears = function (req, res) {
 
 export const getExportExperience = function (req, res) {
   res.json(exportExperience)
+}
+
+export const getExperience = function (req, res) {
+  res.json(experience)
+}
+
+export const getRating = function (req, res) {
+  res.json(rating)
+}
+
+export const getMarketingSource = function (req, res) {
+  res.json(marketingSource)
+}
+
+export const getWithoutOurSupport = function (req, res) {
+  res.json(withoutOurSupport)
 }

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -247,6 +247,10 @@ import {
   getTradeAgreement,
   getExportYears,
   getExportExperience,
+  getExperience,
+  getRating,
+  getMarketingSource,
+  getWithoutOurSupport,
 } from './routes/v4/metadata/index.js'
 import { searchCompanies as __companies } from './routes/v4/search/company.js'
 import { companiesAutocomplete } from './routes/v4/search/company/autocomplete.js'
@@ -291,6 +295,8 @@ import { tasks } from './routes/v4/search/tasks.js'
 import {
   getExportWin,
   getExportWinCollection,
+  getExportWinReview,
+  patchExportWinReview,
 } from './routes/v4/export-win/export-win.js'
 
 // Data store service (github.com/uktrade/data-store-service)
@@ -512,6 +518,11 @@ app.get('/v4/metadata/trade-agreement', getTradeAgreement)
 app.get('/v4/metadata/export-years', getExportYears)
 app.get('/v4/metadata/export-experience', getExportExperience)
 
+app.get('/v4/metadata/experience', getExperience)
+app.get('/v4/metadata/rating', getRating)
+app.get('/v4/metadata/marketing-source', getMarketingSource)
+app.get('/v4/metadata/without-our-support', getWithoutOurSupport)
+
 // Ping
 app.get('/ping.xml', ping)
 
@@ -532,8 +543,10 @@ app.patch('/v4/event/:eventId', patchEvent)
 app.post('/v4/event', createEvent)
 
 // V4 Export Win
-app.get('/v4/export_win', getExportWinCollection)
+app.get('/v4/export-win', getExportWinCollection)
 app.get('/v4/export-win/:exportWinId', getExportWin)
+app.get('/v4/export-win/review/:token', getExportWinReview)
+app.patch('/v4/export-win/review/:token', patchExportWinReview)
 
 // V3 Feature Flag
 app.get('/v3/feature-flag', featureFlag)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,6 +43,7 @@ module.exports = (env) => ({
       'details-element-polyfill',
       './src/client/index.jsx',
     ],
+    'export-win-review': ['./src/client/export-win-review.jsx'],
   },
   output: {
     path: config.buildDir,


### PR DESCRIPTION
## Description of change

Adds the `/exportwins/review/:token` page which is exposed to unauthenticated users.

## Test instructions

1. Obtain a _token_ for reviewing an export win. You can get one when you
   2. Go to `/exportwins/create?company=<company-id>`
   3. Start filling out the form
   4. In step 3 add yourself as a _Company contact_ so you can receive the email with the token
   5. Ensure your email is allow-listed in GovUK Notify sandbox
   6. Fill out the rest of the form and hit submit
   7. Go to your inbox and look for an email with the subject "Export win feedback requested"
   8. In the email there should be a "Review win" link of the format `/exportwins/review/<token>`
2. With the token, go to `/exportwins/review/<token>` (or just click the link in the email if you followed the above instruction)
3. You should see the Export Win Review page with a big "Tell us what made a difference" headline.
4. You should be able to load the page even if you are not logged in to DataHub, e.g. in an incognito browser window
5. Verify that the whole feature works as specified (have look at the test)

