### PR TITLE
Add no results message to paginated data

### DIFF
--- a/src/client/components/Resource/Paginated.js
+++ b/src/client/components/Resource/Paginated.js
@@ -88,12 +88,14 @@ const PaginatedResource = multiInstance({
     onPageClick,
     currentPage,
     result,
+    noResults = "You don't have any results",
   }) => (
     <Route>
       {({ location }) => {
         const qsParams = qs.parse(location.search.slice(1))
         const routePage = parseInt(qsParams.page, 10) || 1
         const totalPages = result ? Math.ceil(result.count / pageSize) : 0
+        const hasZeroResults = result?.count === 0
 
         return (
           <Task>
@@ -122,6 +124,7 @@ const PaginatedResource = multiInstance({
                       }}
                     />
                   )}
+
                   {result ? (
                     <LoadingBox name={name} id={id}>
                       <CollectionHeader
@@ -152,6 +155,7 @@ const PaginatedResource = multiInstance({
                   ) : (
                     <Task.Status name={name} id={id} />
                   )}
+                  {hasZeroResults && <p data-test="no-results">{noResults}</p>}
                 </>
               )
             }}

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -10,6 +10,7 @@ import urls from '../../../../lib/urls'
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-rejected"
+    noResults="You don't have any rejected export wins."
     payload={{ confirmed: WIN_STATUS.REJECTED }}
   >
     {(page) => (

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -10,6 +10,7 @@ import urls from '../../../../lib/urls'
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-sent"
+    noResults="You don't have any sent export wins."
     payload={{ confirmed: WIN_STATUS.SENT }}
   >
     {(page) => (

--- a/src/client/modules/ExportWins/Status/WinsWonTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsWonTable.jsx
@@ -13,60 +13,63 @@ const NoWrapCell = styled(Table.Cell)`
   white-space: nowrap;
 `
 
-export const WinsWonTable = ({ exportWins }) => (
-  <Table
-    head={
-      <Table.Row>
-        <Table.CellHeader>UK Company</Table.CellHeader>
-        <Table.CellHeader>Destination</Table.CellHeader>
-        <Table.CellHeader>Export amount</Table.CellHeader>
-        <Table.CellHeader>Date won</Table.CellHeader>
-        <Table.CellHeader>Date responded</Table.CellHeader>
-        <Table.CellHeader>Details</Table.CellHeader>
-      </Table.Row>
-    }
-  >
-    {exportWins.map(
-      ({
-        id,
-        company,
-        country,
-        date,
-        total_expected_export_value,
-        customer_response,
-      }) => (
-        <Table.Row key={id}>
-          <Table.Cell>
-            <Link
-              as={ReactRouterLink}
-              to={urls.companies.overview.index(company.id)}
-            >
-              {company.name}
-            </Link>
-          </Table.Cell>
-          <Table.Cell>{country.name}</Table.Cell>
-          <Table.Cell>{currencyGBP(total_expected_export_value)}</Table.Cell>
-          <NoWrapCell>{formatMediumDate(date)}</NoWrapCell>
-          <NoWrapCell>
-            {formatMediumDate(customer_response.responded_on)}
-          </NoWrapCell>
-          <NoWrapCell>
-            <Link
-              as={ReactRouterLink}
-              to={urls.companies.exportWins.details(id)}
-            >
-              View details
-            </Link>
-          </NoWrapCell>
+export const WinsWonTable = ({ exportWins }) => {
+  return exportWins.length === 0 ? null : (
+    <Table
+      head={
+        <Table.Row>
+          <Table.CellHeader>UK Company</Table.CellHeader>
+          <Table.CellHeader>Destination</Table.CellHeader>
+          <Table.CellHeader>Export amount</Table.CellHeader>
+          <Table.CellHeader>Date won</Table.CellHeader>
+          <Table.CellHeader>Date responded</Table.CellHeader>
+          <Table.CellHeader>Details</Table.CellHeader>
         </Table.Row>
-      )
-    )}
-  </Table>
-)
+      }
+    >
+      {exportWins.map(
+        ({
+          id,
+          company,
+          country,
+          date,
+          total_expected_export_value,
+          customer_response,
+        }) => (
+          <Table.Row key={id}>
+            <Table.Cell>
+              <Link
+                as={ReactRouterLink}
+                to={urls.companies.overview.index(company.id)}
+              >
+                {company.name}
+              </Link>
+            </Table.Cell>
+            <Table.Cell>{country.name}</Table.Cell>
+            <Table.Cell>{currencyGBP(total_expected_export_value)}</Table.Cell>
+            <NoWrapCell>{formatMediumDate(date)}</NoWrapCell>
+            <NoWrapCell>
+              {formatMediumDate(customer_response.responded_on)}
+            </NoWrapCell>
+            <NoWrapCell>
+              <Link
+                as={ReactRouterLink}
+                to={urls.companies.exportWins.details(id)}
+              >
+                View details
+              </Link>
+            </NoWrapCell>
+          </Table.Row>
+        )
+      )}
+    </Table>
+  )
+}
 
 export default () => (
   <ExportWinsResource.Paginated
     id="export-wins-won"
+    noResults="You don't have any won export wins."
     payload={{ confirmed: WIN_STATUS.WON }}
   >
     {(page) => <WinsWonTable exportWins={page} />}

--- a/test/component/cypress/specs/Resource/Paginated.cy.jsx
+++ b/test/component/cypress/specs/Resource/Paginated.cy.jsx
@@ -28,6 +28,8 @@ describe('Resource/Paginated', () => {
       </DataHubProvider>
     )
 
+    cy.get('[data-test="no-results"]').should('not.exist')
+
     cy.get('pre').as('page').should('have.text', JSON.stringify(PAGES[0]))
 
     cy.get('[data-test="pagination-summary"]')
@@ -107,5 +109,56 @@ describe('Resource/Paginated', () => {
     // The resource should reload
     cy.contains('Loading')
     cy.get('pre').as('page').should('have.text', JSON.stringify(PAGES[0]))
+  })
+
+  it('Should render the default no results message', () => {
+    cy.mount(
+      <DataHubProvider
+        resetTasks={true}
+        tasks={{
+          foo: () => ({
+            count: 0,
+            results: [],
+          }),
+        }}
+      >
+        <PaginatedResource name="foo" id="whatever" pageSize={PAGE_SIZE}>
+          {(page) => <pre>{JSON.stringify(page)}</pre>}
+        </PaginatedResource>
+      </DataHubProvider>
+    )
+    cy.get('[data-test="pagination-summary"]').should('not.exist')
+    cy.get('[data-test="pagination"]').should('not.exist')
+    cy.get('[data-test="no-results"]').should(
+      'have.text',
+      "You don't have any results"
+    )
+  })
+
+  it('Should override the default results message"', () => {
+    cy.mount(
+      <DataHubProvider
+        resetTasks={true}
+        tasks={{
+          foo: () => ({
+            count: 0,
+            results: [],
+          }),
+        }}
+      >
+        <PaginatedResource
+          name="foo"
+          id="whatever"
+          pageSize={PAGE_SIZE}
+          noResults="You don't have any sent export wins."
+        >
+          {(page) => <pre>{JSON.stringify(page)}</pre>}
+        </PaginatedResource>
+      </DataHubProvider>
+    )
+    cy.get('[data-test="no-results"]').should(
+      'have.text',
+      "You don't have any sent export wins."
+    )
   })
 })


### PR DESCRIPTION
## Description of change
Adds a no results message when there are no results from a paginated endpoint.

## Test instructions
In the staging environment go to `/exportwins/rejected` and view the message.

## Screenshots
<img width="683" alt="Screenshot 2024-03-04 at 17 17 45" src="https://github.com/uktrade/data-hub-frontend/assets/964268/980edefd-a36f-488a-9c0e-cd798e0569ea">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
