### PR TITLE
Added the CustomerFeedback page

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -32,6 +32,7 @@ const reactRoutes = [
   '/exportwins/sent',
   '/exportwins/rejected',
   '/exportwins/:winId/details',
+  '/exportwins/:winId/customer-feedback',
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',
   '/companies/:companyId/account-management/strategy/create',

--- a/src/client/components/ProtectedLink/index.jsx
+++ b/src/client/components/ProtectedLink/index.jsx
@@ -2,7 +2,7 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
 const ProtectedLink = ({ module, modulePermissions, children = null }) =>
-  modulePermissions.includes(module) ? children : null
+  modulePermissions?.includes(module) ? children : null
 
 ProtectedLink.propTypes = {
   module: PropTypes.string.isRequired,

--- a/src/client/modules/ExportWins/CustomerFeedback.jsx
+++ b/src/client/modules/ExportWins/CustomerFeedback.jsx
@@ -1,0 +1,121 @@
+import React from 'react'
+import { Link } from 'govuk-react'
+import { Link as ReactRouterLink } from 'react-router-dom/cjs/react-router-dom'
+
+import { DefaultLayout } from '../../components'
+import urls from '../../../lib/urls'
+import SummaryTable from '../../components/SummaryTable'
+import ExportWin from '../../components/Resource/ExportWin'
+
+import { ExportWinTitle, ExportWinsLink, VerticalSpacer } from './Details'
+
+const toYesNo = (val) => {
+  if (val === undefined || val === null) return
+  return val ? 'Yes' : 'No'
+}
+
+const CustomerFeedback = ({
+  match: {
+    params: { winId },
+  },
+}) => (
+  <DefaultLayout
+    heading="Customer feedback"
+    pageTitle={<ExportWinTitle id={winId} />}
+    breadcrumbs={[
+      {
+        link: urls.dashboard.index(),
+        text: 'Home',
+      },
+      {
+        link: urls.companies.exportWins.index(),
+        text: 'Export wins',
+      },
+      {
+        text: <ExportWinTitle id={winId} />,
+        link: urls.companies.exportWins.details(winId),
+      },
+      { text: 'Customer feedback' },
+    ]}
+  >
+    <ExportWin id={winId} progressBox={true}>
+      {(_, win) => {
+        const response = win?.customer_response || {}
+        return (
+          <>
+            <SummaryTable caption="1. To what extent did our support help in?">
+              <SummaryTable.Row heading="Securing the win overall?">
+                {response.our_support?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Gaining access to contacts?">
+                {response.access_to_contacts?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Getting information or improved understanding of this country?">
+                {response.access_to_information?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Improving your profile or credibility in the country?">
+                {response.improved_profile?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Having confidence to explore or expand in the country?">
+                {response.gained_confidence?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Developing or nurturing critical relationships?">
+                {response.developed_relationships?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Overcoming a problem in the country (eg legal, regulatory, commercial)">
+                {response.overcame_problem?.name}
+              </SummaryTable.Row>
+            </SummaryTable>
+            <SummaryTable caption="2. About this win">
+              <SummaryTable.Row heading="The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)">
+                {toYesNo(response.involved_state_enterprise)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Our support was a prerequisite to generate this value">
+                {toYesNo(response.interventions_were_prerequisite)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Our support helped you achieve this win more quickly">
+                {toYesNo(response.support_improved_speed)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="It enabled you to expand into a new market">
+                {toYesNo(response.has_enabled_expansion_into_new_market)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="It enabled you to maintain or expand in an existing market">
+                {toYesNo(response.has_enabled_expansion_into_existing_market)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="It enabled you to increase exports as a proportion of your turnover">
+                {toYesNo(response.has_increased_exports_as_percent_of_turnover)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="If you hadn't achieved this win, your company might have stopped exporting">
+                {toYesNo(response.company_was_at_risk_of_not_exporting)}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="Apart from this win, you already have plans to export in the next 12 months">
+                {toYesNo(response.has_explicit_export_plans)}
+              </SummaryTable.Row>
+            </SummaryTable>
+            <SummaryTable caption="3. Your export experience">
+              <SummaryTable.Row heading="Apart from this win, when did your company last export goods or services?">
+                {response.last_export?.name}
+              </SummaryTable.Row>
+            </SummaryTable>
+            <SummaryTable caption="4. Marketing">
+              <SummaryTable.Row heading="Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?">
+                {response.case_study_willing?.name}
+              </SummaryTable.Row>
+              <SummaryTable.Row heading="How did you first hear about DBT(or it predecessor, DIT)?">
+                {response.marketing_source?.name}
+              </SummaryTable.Row>
+            </SummaryTable>
+          </>
+        )
+      }}
+    </ExportWin>
+    <VerticalSpacer>
+      <ExportWinsLink />
+      <Link as={ReactRouterLink} to={urls.companies.exportWins.details(winId)}>
+        Back
+      </Link>
+    </VerticalSpacer>
+  </DefaultLayout>
+)
+
+export default CustomerFeedback

--- a/src/client/modules/ExportWins/Details/index.jsx
+++ b/src/client/modules/ExportWins/Details/index.jsx
@@ -14,7 +14,7 @@ import { ResendExportWin } from './ResendExportWin'
 import urls from '../../../../lib/urls'
 import { state2props } from './state'
 
-const VerticalSpacer = styled.div`
+export const VerticalSpacer = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${SPACING.SCALE_1};
@@ -27,7 +27,7 @@ const NormalFontWeightRow = styled(SummaryTable.Row)`
   }
 `
 
-const ExportWinTitle = (props) => (
+export const ExportWinTitle = (props) => (
   <ExportWin.Inline {...props}>
     {(exportWin) => (
       <>
@@ -35,6 +35,16 @@ const ExportWinTitle = (props) => (
       </>
     )}
   </ExportWin.Inline>
+)
+
+export const ExportWinsLink = () => (
+  <Link
+    data-test="export-wins-link"
+    as={ReactRouterLink}
+    to={urls.companies.exportWins.index()}
+  >
+    Export wins
+  </Link>
 )
 
 const groupBreakdowns = (breakdowns) => {
@@ -144,12 +154,12 @@ const Detail = (props) => {
                 </SummaryTable.Row>
                 <SummaryTable.Row heading="Export win confirmed">
                   {exportWin &&
-                    (exportWin.isPersonallyConfirmed ? 'Yes' : 'No')}
+                    (exportWin.customerResponse.agreeWithWin ? 'Yes' : 'No')}
                 </SummaryTable.Row>
               </Summary>
               {exportWin && <ResendExportWin id={exportWin.id} />}
               <VerticalSpacer>
-                {exportWin?.isPersonallyConfirmed && (
+                {exportWin?.customerResponse.agreeWithWin && (
                   <Link
                     as={ReactRouterLink}
                     to={urls.companies.exportWins.customerFeedback(winId)}
@@ -157,13 +167,7 @@ const Detail = (props) => {
                     View customer feedback
                   </Link>
                 )}
-                <Link
-                  data-test="export-wins-link"
-                  as={ReactRouterLink}
-                  to={urls.companies.exportWins.index()}
-                >
-                  Export wins
-                </Link>
+                <ExportWinsLink />
               </VerticalSpacer>
             </>
           )

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -99,6 +99,7 @@ import OrderQuote from './modules/Omis/OrderQuote'
 import OrdersReconciliationCollection from './modules/Omis/CollectionList/OrdersReconciliationCollection'
 import CompanyEditHistory from './modules/Companies/CompanyBusinessDetails/CompanyEditHistory/CompanyEditHistory'
 import AddProjectDocument from './modules/Investments/Projects/Evidence/AddProjectDocument'
+import CustomerFeedback from './modules/ExportWins/CustomerFeedback'
 
 const routes = {
   companies: [
@@ -505,6 +506,11 @@ const routes = {
       path: '/exportwins/:winId/edit',
       module: 'datahub:companies',
       component: EditExportWin,
+    },
+    {
+      path: '/exportwins/:winId/customer-feedback',
+      module: 'datahub:companies',
+      component: CustomerFeedback,
     },
   ],
   investments: [

--- a/test/component/cypress/specs/ExportWins/Details.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Details.cy.jsx
@@ -36,6 +36,9 @@ const EXPORT_WIN = {
     name: 'Services',
   },
   is_personally_confirmed: false,
+  customer_response: {
+    agree_with_win: false,
+  },
   breakdowns: [
     {
       type: {
@@ -74,7 +77,9 @@ describe('ExportWins/Details', () => {
       testTitle: 'Confirmed',
       exportWinAPIResponse: {
         ...EXPORT_WIN,
-        is_personally_confirmed: true,
+        customer_response: {
+          agree_with_win: true,
+        },
       },
       tableRows: {
         ...EXPECTED_ROWS,
@@ -86,7 +91,6 @@ describe('ExportWins/Details', () => {
       testTitle: 'Unconfirmed',
       exportWinAPIResponse: {
         ...EXPORT_WIN,
-        is_personally_confirmed: false,
       },
       tableRows: {
         ...EXPECTED_ROWS,

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -76,21 +76,30 @@ const assertSummaryTable = ({
 }
 
 /**
- * @param {{rows: [string, string | number][]}} options
+ * @param {{rows: [string, string | number][], caption?: string}} options
  */
-const assertSummaryTableStrict = ({ rows }) => {
-  cy.get('[data-component="SummaryTable"] tr')
-    .as('rows')
-    .should('have.length', rows.length)
+const assertSummaryTableStrict = ({ caption, rows }) => {
+  const assertRows = (el) => {
+    cy.wrap(el).find('tr').as('rows').should('have.length', rows.length)
 
-  rows.forEach(([key, val], i) => {
-    cy.get('@rows')
-      .eq(i)
-      .within(() => {
-        cy.get('th').should('have.length', 1).should('have.text', key)
-        cy.get('td').should('have.length', 1).should('have.text', val)
-      })
-  })
+    rows.forEach(([key, val], i) => {
+      cy.get('@rows')
+        .eq(i)
+        .within(() => {
+          cy.get('th').should('have.length', 1).should('have.text', key)
+          cy.get('td').should('have.length', 1).should('have.text', val)
+        })
+    })
+  }
+
+  if (caption) {
+    cy.contains('caption', caption)
+      .closest('[data-component="SummaryTable"]')
+      .then(assertRows)
+    return
+  }
+
+  cy.get('[data-component="SummaryTable"]').then(assertRows)
 }
 
 const assertGovReactTable = ({ element, headings, rows }) => {

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -54,15 +54,68 @@ const fakeExportWin = () => ({
     max: 10_000_000,
   }),
   date: faker.date.anytime(),
-  customer_response: {
-    created_on: faker.date.anytime(),
-  },
   goods_vs_services: {
     id: faker.string.uuid(),
     name: faker.helpers.arrayElement(['Goods', 'Services']),
   },
   breakdowns: faker.helpers.multiple(fakeBreakdown),
   description: faker.lorem.lines(),
+  customer_response: {
+    id: faker.string.uuid(),
+    our_support: {
+      name: 'Very little',
+      id: faker.string.uuid(),
+    },
+    access_to_contacts: {
+      name: 'Great extent',
+      id: faker.string.uuid(),
+    },
+    access_to_information: {
+      name: 'Great extent',
+      id: faker.string.uuid(),
+    },
+    improved_profile: {
+      name: 'Completely',
+      id: faker.string.uuid(),
+    },
+    gained_confidence: {
+      name: "Didn't help",
+      id: faker.string.uuid(),
+    },
+    developed_relationships: {
+      name: 'Completely',
+      id: faker.string.uuid(),
+    },
+    overcame_problem: {
+      name: 'N/A',
+      id: faker.string.uuid(),
+    },
+    involved_state_enterprise: true,
+    support_improved_speed: true,
+    expected_portion_without_help: {
+      name: 'Up to 40%',
+      id: faker.string.uuid(),
+    },
+    last_export: {
+      name: 'Apart from this win, we have exported in the last 12 months',
+      id: faker.string.uuid(),
+    },
+    has_enabled_expansion_into_new_market: false,
+    has_enabled_expansion_into_existing_market: true,
+    has_increased_exports_as_percent_of_turnover: false,
+    company_was_at_risk_of_not_exporting: true,
+    has_explicit_export_plans: false,
+    agree_with_win: true,
+    case_study_willing: false,
+    comments: 'Test only',
+    name: '',
+    marketing_source: {
+      name: 'Advertisements I saw or read about the Exporting is GREAT campaign',
+      id: faker.string.uuid(),
+    },
+    other_marketing_source: '',
+    responded_on: null,
+  },
 })
 
 const WON_EXPORT_WINS = Array(123).fill().map(fakeExportWin)


### PR DESCRIPTION
## Description of change

Adds the `/exportwins/<win-id>/customer-feedback` page.

## Test instructions

1. Go to `/exportwins/won`
2. Click on one of the _View details_ links, which will get you to the _export win details_ page
3. There should be a _View customer feedback_ link on the bottom of the page
4. Click on the link
5. It should get you to the `/exportwins/<win-id>/customer-feedback` page
6. The page should look according to design
7. Then go to `/exportwins/rejected`
8. Click on the title of one of the items, which should get you again to the _export win details_ page
9. This time though there should be no _View customer feedback_ link

## Screenshots `/exportwins/won`

![localhost_3000_exportwins_c0adb4f9-0abc-4f56-9a1d-a994f459fe0e_customer-feedback](https://github.com/uktrade/data-hub-frontend/assets/2333157/b34d2577-df52-4aea-874c-423d8234b790)

