### PR TITLE
Fix an issue when case_study_willing was not treated as boolean

### DIFF
--- a/src/client/modules/ExportWins/CustomerFeedback.jsx
+++ b/src/client/modules/ExportWins/CustomerFeedback.jsx
@@ -99,7 +99,7 @@ const CustomerFeedback = ({
             </SummaryTable>
             <SummaryTable caption="4. Marketing">
               <SummaryTable.Row heading="Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?">
-                {response.case_study_willing?.name}
+                {toYesNo(response.case_study_willing)}
               </SummaryTable.Row>
               <SummaryTable.Row heading="How did you first hear about DBT(or it predecessor, DIT)?">
                 {response.marketing_source?.name}

--- a/test/component/cypress/specs/ExportWins/CustomerFeedback.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/CustomerFeedback.cy.jsx
@@ -36,7 +36,7 @@ const dummyExportWin = (prefix, booleans) => ({
     has_explicit_export_plans: booleans,
 
     last_export: { name: `${prefix}-last_export` },
-    case_study_willing: { name: `${prefix}-case_study_willing` },
+    case_study_willing: booleans,
     marketing_source: { name: `${prefix}-marketing_source` },
   },
 })
@@ -103,7 +103,7 @@ describe('ExportWins/CustomerFeedback', () => {
       assertSummaryTableStrict({
         caption: '4. Marketing',
         rows: [
-          ['Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?', win.customer_response.case_study_willing.name],
+          ['Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?', toYesNo(win.customer_response.case_study_willing)],
           ['How did you first hear about DBT(or it predecessor, DIT)?', win.customer_response.marketing_source.name],
         ],
       })


### PR DESCRIPTION
## Description of change

Fixes an bug when the value for the _Would you be willing for..._ (`export_win.customer_response.case_study_willing`) was always empty even if present in API response.

## Test instructions

1. Go to `/exportwins/<export-win-id>/customer-feedback
2. The _Would you be willing for..._ should always show either "Yes" or "No" (once loading is over)

## Screenshots

![localhost_3000_exportwins_45334006-cbcb-403a-b0f9-90da66b894ea_details](https://github.com/uktrade/data-hub-frontend/assets/2333157/99431b4e-6b57-42fa-95cb-dbd8bbd7d7bf)

