### PR TITLE
Fixes an export win pagination bug

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -12,7 +12,9 @@ export default () => (
     id="export-wins-sent"
     heading="Export win"
     noResults="You don't have any sent export wins."
-    payload={{ confirmed: WIN_STATUS.SENT }}
+    // We have to send null as a string otherwise
+    // it's stripped out of the payload by Axois
+    payload={{ confirmed: String(WIN_STATUS.SENT) }}
   >
     {(page) => (
       <ul>


### PR DESCRIPTION
## Description of change

When posting to an endpoint using Axios any value that is `null` in the payload is stripped out. This is problematic for export wins paginated pages.

When we want to fetch export wins the following payloads apply:

1. Rejected  `{ confirmed: false}`
2. Won `{ confirmed: true}`
3. Sent `{ confirmed: null}`

The last API call ultimately fails in the sense no filter is applied.

The temporary fix is to cast `null` to a string `"null"`. The proper fix is to create an Axios interceptor which we don't have time for - tech-debt!

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
