### PR TITLE
Add export potential mapping along with the last updated field

### DIFF
--- a/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsEdit.jsx
@@ -16,6 +16,10 @@ import {
   ExportExperienceCategoriesResource,
 } from '../../../components/Resource'
 import { transformArrayIdNameToValueLabel } from '../../../transformers'
+import {
+  buildExportPotential,
+  buildExportPotentialLastModified,
+} from './transformers'
 import { exportDetailsLabels } from './labels'
 import { buildCompanyBreadcrumbs } from '../utils'
 
@@ -77,9 +81,14 @@ const ExportsEdit = () => {
                       }}
                     />
                   </StyledDd>
-
                   <StyledDt>{exportDetailsLabels.exportPotential}</StyledDt>
-                  <StyledDd>Unavailable</StyledDd>
+                  <StyledDd>{buildExportPotential(company)}</StyledDd>
+                  <StyledDt>
+                    {exportDetailsLabels.lastModifiedPotential}
+                  </StyledDt>
+                  <StyledDd>
+                    {buildExportPotentialLastModified(company)}
+                  </StyledDd>
                 </dl>
                 <FieldInput
                   type="hidden"

--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -14,7 +14,11 @@ import GreatProfile from './GreatProfile'
 import { CompanyResource } from '../../../components/Resource'
 import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import { exportDetailsLabels, exportPotentialLabels } from './labels'
-import { transformExportCountries } from './transformers'
+import {
+  buildExportPotential,
+  buildExportPotentialLastModified,
+  transformExportCountries,
+} from './transformers'
 import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
 
 const StyledSummaryTable = styled(SummaryTable)`
@@ -68,7 +72,13 @@ const ExportsIndex = () => {
                 heading={exportDetailsLabels.exportPotential}
                 key={exportDetailsLabels.exportPotential}
               >
-                Unavailable
+                {buildExportPotential(company)}
+              </SummaryTable.Row>
+              <SummaryTable.Row
+                heading={exportDetailsLabels.lastModifiedPotential}
+                key={exportDetailsLabels.lastModifiedPotential}
+              >
+                {buildExportPotentialLastModified(company)}
               </SummaryTable.Row>
             </SummaryTable>
 

--- a/src/client/modules/Companies/CompanyExports/labels.js
+++ b/src/client/modules/Companies/CompanyExports/labels.js
@@ -5,6 +5,7 @@ export const exportDetailsLabels = {
   noInterestCountries: 'Countries of no interest',
   greatProfile: 'great.gov.uk business profile',
   exportPotential: 'Export potential',
+  lastModifiedPotential: 'Export potential last updated',
 }
 
 export const exportPotentialLabels = {

--- a/src/client/modules/Companies/CompanyExports/transformers.js
+++ b/src/client/modules/Companies/CompanyExports/transformers.js
@@ -10,6 +10,12 @@ export const buildExportPotential = (company) => {
     : 'No score given'
 }
 
+export const buildExportPotentialLastModified = (company) => {
+  return company.lastModifiedPotential
+    ? new Date(company.lastModifiedPotential).toISOString().split('T')[0]
+    : 'No score given'
+}
+
 export const transformCountriesForTypeahead = (exportCountries) => {
   const groupedExportCountries = groupExportCountries(exportCountries)
   return [

--- a/test/end-to-end/cypress/specs/DIT/companies-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/companies-spec.js
@@ -94,7 +94,8 @@ describe('Export', () => {
           assertTable([
             'Export growth',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'None',
             'None',
             'None',
@@ -112,7 +113,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'None',
             'None',
             'None',
@@ -152,7 +154,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'None',
             'None',
             'None',
@@ -175,7 +178,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'France, Germany',
             'None',
             'None',
@@ -191,7 +195,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'France, Germany',
             'None',
             'None',
@@ -218,7 +223,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'Brazil, France, Germany',
             'Honduras',
             'Chile',
@@ -245,7 +251,8 @@ describe('Export', () => {
           assertTable([
             'None',
             'No profile',
-            'Unavailable',
+            'No score given',
+            'No score given',
             'None',
             'None',
             'None',

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -62,7 +62,8 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: 'No profile',
           },
-          { label: 'Export potential', value: 'Unavailable' },
+          { label: 'Export potential', value: 'No score given' },
+          { label: 'Export potential last updated', value: 'No score given' },
         ])
       })
 
@@ -111,7 +112,8 @@ describe('Company Export tab - Edit exports', () => {
             label: 'great.gov.uk business profile',
             value: '"Find a supplier" profile (opens in new tab)',
           },
-          { label: 'Export potential', value: 'Unavailable' },
+          { label: 'Export potential', value: 'Medium' },
+          { label: 'Export potential last updated', value: '2024-03-07' },
         ])
 
         cy.contains('"Find a supplier" profile').should(

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -79,7 +79,8 @@ describe('Company Export tab', () => {
         assertExportsTable(fixtures.company.dnbCorp.id, [
           { label: 'Export win category', value: 'None' },
           { label: 'great.gov.uk business profile', value: 'No profile' },
-          { label: 'Export potential', value: 'Unavailable' },
+          { label: 'Export potential', value: 'No score given' },
+          { label: 'Export potential last updated', value: 'No score given' },
         ])
       })
 
@@ -261,7 +262,8 @@ describe('Company Export tab', () => {
             value: '"Find a supplier" profile (opens in new tab)',
           },
 
-          { label: 'Export potential', value: 'Unavailable' },
+          { label: 'Export potential', value: 'Medium' },
+          { label: 'Export potential last updated', value: '2024-03-07' },
         ])
 
         cy.contains('"Find a supplier" profile').should(

--- a/test/sandbox/fixtures/v4/company/company-dnb-ltd.json
+++ b/test/sandbox/fixtures/v4/company/company-dnb-ltd.json
@@ -35,6 +35,7 @@
   "is_number_of_employees_estimated": true,
   "great_profile_status": "published",
   "export_potential": "medium",
+  "last_modified_potential": "2024-03-07",
   "export_countries": [
     {
       "country": {


### PR DESCRIPTION
## Description of change

Link to the story: https://uktrade.atlassian.net/browse/TET-642

- Re-introducing the hardcoded "Export potential" field from "Unavailable" to reading it from the database
- Added mapping to a new field "Export potential last update"

Both fields mapping were included in the export and edit pages for companies

## Test instructions

Added functional tests to cover the mapping, these should be successful.

## Screenshots

<img width="688" alt="Screenshot 2024-03-07 at 09 29 20" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/ad5afc0e-0496-4181-8e1d-0a305b01944b">
<img width="443" alt="Screenshot 2024-03-07 at 09 31 29" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/6c1ebe0e-4d23-4e0a-8cc2-8e6b153f448d">
<img width="709" alt="Screenshot 2024-03-07 at 09 31 21" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/40c2dc39-bb6f-40bc-837b-f83dc659e28b">
<img width="618" alt="Screenshot 2024-03-07 at 09 29 32" src="https://github.com/uktrade/data-hub-frontend/assets/105509190/56206107-af56-42a2-8d26-815648825c97">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
