### PR TITLE
Renamed task.error to task.isError

### DIFF
--- a/src/apps/companies/apps/add-company/client/tasks.js
+++ b/src/apps/companies/apps/add-company/client/tasks.js
@@ -14,7 +14,7 @@ export const createCompany = ({ csrfToken, ...values }) => {
   return axios
     .post(postUrl, values)
     .catch((err) => {
-      return Promise.reject(err.response.data.error.message)
+      return Promise.reject(err.response.data.error.message[0])
     })
     .then((response) => response.data)
 }

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -354,7 +354,9 @@ export function saveInteraction({ values, companyIds, referralId }) {
     .catch((e) => {
       // Accounts for non-standard API error on contacts field
       const contactsError = e.response?.data?.contacts[0]
-      return contactsError ? Promise.reject(contactsError) : catchApiError(e)
+      return contactsError
+        ? Promise.reject(contactsError)
+        : catchApiError(e).message
     })
 }
 

--- a/src/client/components/AccessDenied/index.jsx
+++ b/src/client/components/AccessDenied/index.jsx
@@ -3,8 +3,8 @@ import React from 'react'
 import DefaultLayout from '../Layout/DefaultLayout'
 
 const AccessDenied = ({ breadcrumbs }) => (
-  // FIXME: This shouldn't DefaultLayout as it can appear anywhere in a page in which case
-  // it completely breaks the layout.
+  // FIXME: This shouldn't use DefaultLayout as it can appear anywhere in a page
+  // and it completely breaks the layout.
   <DefaultLayout
     heading="You don't have permission to view this page"
     pageTitle="Access denied"

--- a/src/client/components/AccessDenied/index.jsx
+++ b/src/client/components/AccessDenied/index.jsx
@@ -3,6 +3,8 @@ import React from 'react'
 import DefaultLayout from '../Layout/DefaultLayout'
 
 const AccessDenied = ({ breadcrumbs }) => (
+  // FIXME: This shouldn't DefaultLayout as it can appear anywhere in a page in which case
+  // it completely breaks the layout.
   <DefaultLayout
     heading="You don't have permission to view this page"
     pageTitle="Access denied"

--- a/src/client/components/ContactForm/tasks.js
+++ b/src/client/components/ContactForm/tasks.js
@@ -8,13 +8,7 @@ export const saveContact = ({ contactId, values }) => {
   values.company = { id: values.company.id }
 
   return request(contactId ? `${endpoint}/${contactId}` : endpoint, values)
-    .catch((e) => {
-      if (e?.errors) {
-        return { data: e }
-      } else {
-        return Promise.reject(e.message)
-      }
-    })
+    .catch((e) => Promise.reject(e?.data?.email?.[0] || e.message))
     .then((response) => {
       return response.data
     })

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -324,9 +324,9 @@ const _Form = ({
                               }
                             />
                             <Effect
-                              dependencyList={[submissionTask.error]}
+                              dependencyList={[submissionTask.isError]}
                               effect={() => {
-                                submissionTask.error &&
+                                submissionTask.isError &&
                                   analytics('Submission request error', {
                                     error: submissionTask.errorMessage,
                                   })

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -324,9 +324,9 @@ const _Form = ({
                               }
                             />
                             <Effect
-                              dependencyList={[submissionTask.isError]}
+                              dependencyList={[submissionTask.hasError]}
                               effect={() => {
-                                submissionTask.isError &&
+                                submissionTask.hasError &&
                                   analytics('Submission request error', {
                                     error: submissionTask.errorMessage,
                                   })

--- a/src/client/components/Task/LoadingBox.jsx
+++ b/src/client/components/Task/LoadingBox.jsx
@@ -50,7 +50,7 @@ export default ({ name, id, when, children, startOnRender, ...props }) => (
             effect={() => startOnRender && task.start(startOnRender)}
           />
           <StyledContentWrapper>
-            {task.isError ? (
+            {task.hasError ? (
               <>
                 {children}
                 <StyledErrorOverlay>

--- a/src/client/components/Task/LoadingBox.jsx
+++ b/src/client/components/Task/LoadingBox.jsx
@@ -50,7 +50,7 @@ export default ({ name, id, when, children, startOnRender, ...props }) => (
             effect={() => startOnRender && task.start(startOnRender)}
           />
           <StyledContentWrapper>
-            {task.error ? (
+            {task.isError ? (
               <>
                 {children}
                 <StyledErrorOverlay>

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -143,7 +143,7 @@ const Task = connect(
     return {
       ...taskState,
       progress: taskState.status === 'progress',
-      error: taskState.status === 'error',
+      isError: taskState.status === 'error',
       start: (options) => start(name, id, options),
       cancel: () => cancel(name, id),
       retry: () => start(name, id, taskState),
@@ -240,7 +240,7 @@ Task.Status = ({
         start,
         status,
         progress,
-        error,
+        isError,
         payload,
         errorMessage,
         onSuccessDispatch,
@@ -262,7 +262,7 @@ Task.Status = ({
           {!progressOverlay &&
             progress &&
             renderProgress({ message: progressMessage, noun })}
-          {error &&
+          {isError &&
             (errorMessage ===
             'You do not have permission to perform this action.' ? (
               <AccessDenied />

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -52,7 +52,7 @@ const startOnRenderPropTypes = {
  * @typedef Task
  * @property {'progress' | 'error'} status - The current status of the task
  * @property {Boolean} progress - Whether the task is in progress
- * @property {Boolean} isError - Whether the task is in error state
+ * @property {Boolean} hasError - Whether the task is in error state
  * @property {(name, id, StartOptions) => void} start - Starts a task.
  * @property {any} [payload=undefined] - The value of the payload with which the task was started.
  * @property {any} [error=undefined] - The value with wich the task rejected
@@ -149,7 +149,7 @@ const Task = connect(
     return {
       ...taskState,
       progress: taskState.status === 'progress',
-      isError: taskState.status === 'error',
+      hasError: taskState.status === 'error',
       start: (options) => start(name, id, options),
       cancel: () => cancel(name, id),
       retry: () => start(name, id, taskState),
@@ -246,7 +246,7 @@ Task.Status = ({
         start,
         status,
         progress,
-        isError,
+        hasError,
         payload,
         errorMessage,
         onSuccessDispatch,
@@ -269,7 +269,7 @@ Task.Status = ({
           {!progressOverlay &&
             progress &&
             renderProgress({ message: progressMessage, noun })}
-          {isError &&
+          {hasError &&
             // FIXME: This is shouldn't be done here and it shouldn't be done this way
             (errorMessage ===
             'You do not have permission to perform this action.' ? (

--- a/src/client/components/Task/index.jsx
+++ b/src/client/components/Task/index.jsx
@@ -52,8 +52,14 @@ const startOnRenderPropTypes = {
  * @typedef Task
  * @property {'progress' | 'error'} status - The current status of the task
  * @property {Boolean} progress - Whether the task is in progress
- * @property {Boolean} error - Whether the task is in error state
+ * @property {Boolean} isError - Whether the task is in error state
  * @property {(name, id, StartOptions) => void} start - Starts a task.
+ * @property {any} [payload=undefined] - The value of the payload with which the task was started.
+ * @property {any} [error=undefined] - The value with wich the task rejected
+ * @property {string} [errorMessage=undefined] - Error message extracted from {error.message}.
+ * @property {string} [onSuccessDispatch=undefined] - Action that will be dispatched when the task resolves
+ * @property {() => void} [dismissError=undefined] - When when the task is in `state === 'error'`
+ * will reset the tasks state.
  */
 
 /**
@@ -245,6 +251,7 @@ Task.Status = ({
         errorMessage,
         onSuccessDispatch,
         dismissError,
+        error,
       } = getTask(name, id)
 
       const retry = () =>
@@ -263,12 +270,14 @@ Task.Status = ({
             progress &&
             renderProgress({ message: progressMessage, noun })}
           {isError &&
+            // FIXME: This is shouldn't be done here and it shouldn't be done this way
             (errorMessage ===
             'You do not have permission to perform this action.' ? (
               <AccessDenied />
             ) : (
               renderError({
                 noun,
+                error,
                 errorMessage,
                 retry: !noRetry && retry,
                 dismiss: !noDismiss && dismissError,

--- a/src/client/components/Task/saga.js
+++ b/src/client/components/Task/saga.js
@@ -47,7 +47,9 @@ function* startTask(task, action) {
         type: TASK__ERROR,
         id,
         name,
-        errorMessage: error,
+        error,
+        // FIXME: This should be handled on the renderError level
+        errorMessage: typeof error === 'string' ? error : error.message,
       })
     }
   }

--- a/src/client/components/Task/utils.js
+++ b/src/client/components/Task/utils.js
@@ -20,17 +20,17 @@ export const delay = curry((duration, task, payload) =>
 )
 
 export const catchApiError = ({ response, message }) =>
-  Promise.reject(
-    response?.data?.detail ||
+  Promise.reject({
+    message:
+      response?.data?.detail ||
       response?.text ||
       response?.data?.non_field_errors ||
-      (response?.data && {
-        errors: response.data,
-        httpStatusCode: response.status,
-      }) ||
       response?.statusText ||
-      message
-  )
+      response.data ||
+      message,
+    data: response.data,
+    httpStatusCode: response.status,
+  })
 
 /**
  * A custom Axios instance for easy access to the `/api-proxy` endpoint.

--- a/src/client/modules/Companies/CompanyExports/ExportCountriesEdit/index.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportCountriesEdit/index.jsx
@@ -29,27 +29,25 @@ const StyledP = styled.p`
   margin: 0;
 `
 
-function ErrorHandler({ errorMessage }) {
+function ErrorHandler({ error }) {
   return (
     <>
-      {errorMessage[API_ERROR] && (
+      {error[API_ERROR] && (
         <StatusMessage
           colour={ERROR_COLOUR}
           aria-labelledby="api-error-summary-title"
           role="alert"
         >
-          <StyledH2 id="api-error-summary-title">
-            {errorMessage[API_ERROR]}
-          </StyledH2>
+          <StyledH2 id="api-error-summary-title">{error[API_ERROR]}</StyledH2>
         </StatusMessage>
       )}
 
-      {errorMessage[API_WARN] && (
+      {error[API_WARN] && (
         <StatusMessage aria-labelledby="error-summary-title" role="alert">
           <StyledH2 id="error-summary-title">
             Export countries could not be saved, try again later.
           </StyledH2>
-          <StyledP>{errorMessage[API_WARN]}</StyledP>
+          <StyledP>{error[API_WARN]}</StyledP>
         </StatusMessage>
       )}
     </>

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -27,7 +27,7 @@ import ThankYou from './ThankYou'
 const FORM_ID = 'export-wins-customer-feedback'
 
 const NotFound = (props) =>
-  props.errorMessage?.httpStatusCode === 404 ? (
+  props.error?.httpStatusCode === 404 ? (
     <>
       <H4 as="h2">The link you used has expired</H4>
       <p>

--- a/src/client/modules/Interactions/ESSInteractionDetails/index.jsx
+++ b/src/client/modules/Interactions/ESSInteractionDetails/index.jsx
@@ -45,6 +45,7 @@ const ESSInteractionDetails = ({
       breadcrumbs={breadcrumbs}
       useReactRouter={true}
     >
+      {/* TODO: Use Resource */}
       <Task.Status
         name={TASK_GET_ESS_INTERACTION_DETAILS}
         id={ID}

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -99,7 +99,7 @@ describe('ExportWins/Review', () => {
 
     it("should render default error view if the review couldn't be loaded for", () => {
       const Provider = createTestProvider({
-        'Export Win Review': () => Promise.reject(),
+        'Export Win Review': () => Promise.reject({}),
       })
       cy.mount(
         <Provider>

--- a/test/end-to-end/cypress/specs/DIT/contacts-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/contacts-spec.js
@@ -78,12 +78,16 @@ describe('Contacts', () => {
       `A contact with this email already exists at ${COMPANY_NAME}.`
     ).should('exist')
 
+    cy.contains('button', 'Dismiss').click()
+
     // Clicking again should not be successful
     cy.clickSubmitButton('Add contact')
     cy.contains('You have successfully added a new contact').should('not.exist')
     cy.contains(
       `A contact with this email already exists at ${COMPANY_NAME}.`
     ).should('exist')
+
+    cy.contains('button', 'Dismiss').click()
 
     cy.get('[name="email"]').focus().clear().type(EMAIL_2)
     // Chaging the email should succeed

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -142,6 +142,9 @@ export const getExportWinReview = (req, res) => {
   if (req.params.token === 'non-existent') {
     return res.status(404).json({ detail: 'Not found' })
   }
+  if (req.params.token === 'server-error') {
+    return res.status(500).json({ detail: 'Server error' })
+  }
   res.json({
     win: fakeExportWin(),
     company_contact: {


### PR DESCRIPTION
## Description of change

This PR changes how `Task` handles rejected values.

* `task.error` has been renamed to `task.isError`
* `task.error` now contains the value with which the task rejected

## Test instructions

There should be no visible change.