### PR TITLE
Add convert to export win functional tests

### DIFF
--- a/src/client/modules/ExportWins/Form/utils.js
+++ b/src/client/modules/ExportWins/Form/utils.js
@@ -120,6 +120,9 @@ export const getTwelveMonthsAgo = () => {
   return new Date(today.getFullYear() - 1, today.getMonth(), 1)
 }
 
+export const getRandomDate = ({ start, end }) =>
+  new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()))
+
 export const isDateWithinLastTwelveMonths = (date) => {
   // Business date logic
   const today = new Date()


### PR DESCRIPTION
## Description of change
Add functional tests around the conversion of an export project to an export win. The export win form will have certain fields pre-populated from the export project.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
