### PR TITLE
Fixes a bug that prevents the export win from being saved

### DIFF
--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -109,9 +109,7 @@ export const transformExportProjectForForm = (exportProject) => {
     // Customer details
     // The exporter experience field is optional when adding an Export Project
     ...(exportProject.exporter_experience && {
-      export_experience: [
-        idNameToValueLabel(exportProject.exporter_experience),
-      ],
+      export_experience: idNameToValueLabel(exportProject.exporter_experience),
     }),
     company_contacts:
       exportProject.contacts.length === 1


### PR DESCRIPTION
## Description of change
When converting an Export Project to an Export Win the transformer was incorrectly transforming the `exporter_experience` into an array when it should have been an object. This is problematic when the user gets to the end of the form and attempts to save. At this point the API endpoint validation rejects the HTTP POST with a 400.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
