### PR TITLE
Add the export win success page

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -33,6 +33,7 @@ const reactRoutes = [
   '/exportwins/sent',
   '/exportwins/rejected',
   '/exportwins/:winId/details',
+  '/exportwins/:winId/success',
   '/exportwins/:winId/customer-feedback',
   '/companies/:companyId/dnb-hierarchy',
   '/companies/:companyId/company-tree',

--- a/src/client/components/LocalHeader/FlashMessages.jsx
+++ b/src/client/components/LocalHeader/FlashMessages.jsx
@@ -66,7 +66,7 @@ const FlashMessages = ({
     getFlashMessages()
     return () => clearFlashMessages()
   }, [])
-  return !isEmpty(flashMessages) ? (
+  return isEmpty(flashMessages) ? null : (
     <UnorderedList listStyleType="none" data-test="flash">
       {Object.entries(flashMessages).map(([type, messages]) => {
         /*
@@ -82,20 +82,30 @@ const FlashMessages = ({
                 <li key={body}>
                   <StyledStatusMessage colour={messageColours[parts[0]]}>
                     <StyledHeading>{heading}</StyledHeading>
-                    <StyledBody dangerouslySetInnerHTML={{ __html: body }} />
+                    {typeof body === 'string' ? (
+                      <StyledBody dangerouslySetInnerHTML={{ __html: body }} />
+                    ) : (
+                      <StyledBody>{body}</StyledBody>
+                    )}
                   </StyledStatusMessage>
                 </li>
               ))
             : messages.map((body, i) => (
                 <li key={i}>
                   <StyledStatusMessage colour={messageColours[type]}>
-                    <StyledMessage dangerouslySetInnerHTML={{ __html: body }} />
+                    {typeof body === 'string' ? (
+                      <StyledMessage
+                        dangerouslySetInnerHTML={{ __html: body }}
+                      />
+                    ) : (
+                      <StyledMessage>{body}</StyledMessage>
+                    )}
                   </StyledStatusMessage>
                 </li>
               ))
       })}
     </UnorderedList>
-  ) : null
+  )
 }
 
 const flashMessagePropTypes = {

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -62,7 +62,9 @@ const ExportWinForm = ({
           id="export-win-form"
           showStepInUrl={true}
           cancelRedirectTo={() => urls.companies.exportWins.sent()}
-          redirectTo={() => urls.companies.exportWins.sent()}
+          redirectTo={(result) =>
+            urls.companies.exportWins.success(result.data.id)
+          }
           analyticsFormName="exportWinForm"
           submissionTaskName={TASK_GET_EXPORT_WINS_SAVE_FORM}
           initialValuesTaskName={initialValuesTaskName}

--- a/src/client/modules/ExportWins/Form/Success.jsx
+++ b/src/client/modules/ExportWins/Form/Success.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { H4 } from '@govuk-react/heading'
+
+import ExportWin from '../../../components/Resource/ExportWin'
+import { ExportWinsLink, VerticalSpacer } from '../Details'
+import { DefaultLayout } from '../../../components'
+import urls from '../../../../lib/urls'
+
+const ExportWinSuccess = ({ winId }) => (
+  <ExportWin.Inline id={winId}>
+    {(exportWin) =>
+      exportWin &&
+      `The export win ${exportWin.nameOfExport} to ${exportWin.country.name} has been` +
+        ` sent to ${exportWin.companyContacts[0].email} for review and confirmation.`
+    }
+  </ExportWin.Inline>
+)
+
+const Success = ({ match }) => (
+  <DefaultLayout
+    pageTitle="Success"
+    breadcrumbs={[
+      {
+        link: urls.dashboard.index(),
+        text: 'Home',
+      },
+      {
+        link: urls.companies.exportWins.index(),
+        text: 'Export wins',
+      },
+      {
+        text: 'Success',
+      },
+    ]}
+    flashMessages={{
+      success: [<ExportWinSuccess winId={match.params.winId} />],
+    }}
+  >
+    <H4 data-test="heading" as="h2">
+      What happens next?
+    </H4>
+    <p data-test="review">
+      The customer will review the export win and have the option to provide
+      feedback.
+    </p>
+    <p data-test="email">
+      You will be sent an email once the customer has responded.
+    </p>
+    <VerticalSpacer>
+      <ExportWinsLink />
+    </VerticalSpacer>
+  </DefaultLayout>
+)
+
+export default Success

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -200,7 +200,7 @@ const WinDetailsStep = () => {
       <FieldCheckboxes
         name="goods_vs_services"
         legend="What does the value relate to?"
-        hint="Select goods or services"
+        hint="Select all that apply."
         required="Select at least one option"
         options={goodsServicesOptions}
       />

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -20,6 +20,7 @@ import ExportWinsTabNav from './modules/ExportWins/Status/ExportWinsTabNav'
 import { CreateExportWin, EditExportWin } from './modules/ExportWins/Form'
 import ExportWinsRedirect from './modules/ExportWins/Status/Redirect'
 import ExportWinDetails from './modules/ExportWins/Details'
+import Success from './modules/ExportWins/Form/Success'
 import CompanyHierarchy from './modules/Companies/CompanyHierarchy'
 import CompanyTree from './modules/Companies/CompanyHierarchy/CompanyTree'
 import Community from './modules/Community'
@@ -506,6 +507,11 @@ const routes = {
       path: '/companies/:companyId/export/:exportId/exportwins/create',
       module: 'datahub:companies',
       component: CreateExportWin,
+    },
+    {
+      path: '/exportwins/:winId/success',
+      module: 'datahub:companies',
+      component: Success,
     },
     {
       path: '/exportwins/:winId/edit',

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -230,6 +230,7 @@ module.exports = {
         '/companies',
         '/:companyId/export/:exportId/exportwins/create'
       ),
+      success: url('/exportwins', '/:winId/success'),
       customerFeedback: url('/exportwins', '/:winId/customer-feedback'),
     },
     overview: {

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -150,7 +150,7 @@ export const urlTestExclusions = [
   { url: '/exportwins/sent/' },
   { url: '/exportwins/rejected/' },
   { url: '/exportwins/:winId/edit' },
-  { url: '/exportwins/:winId/thankyou' },
+  { url: '/exportwins/:winId/success' },
   { url: '/exportwins/:winId/customer-feedback' },
   { url: '/companies/:companyId/export/:exportId/exportwins/create' },
 

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -150,6 +150,7 @@ export const urlTestExclusions = [
   { url: '/exportwins/sent/' },
   { url: '/exportwins/rejected/' },
   { url: '/exportwins/:winId/edit' },
+  { url: '/exportwins/:winId/thankyou' },
   { url: '/exportwins/:winId/customer-feedback' },
   { url: '/companies/:companyId/export/:exportId/exportwins/create' },
 

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 /**
  * Generate fake data for a single export win.
  */
-export const exportWinsFaker = (overrides = {}) => ({
+export const exportWinsFaker = () => ({
   id: faker.string.uuid(),
   adviser: {
     id: faker.string.uuid(),
@@ -28,5 +28,4 @@ export const exportWinsFaker = (overrides = {}) => ({
   customer_response: {
     responded_on: faker.date.anytime().toISOString(),
   },
-  ...overrides,
 })

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -3,7 +3,7 @@ import { faker } from '@faker-js/faker'
 /**
  * Generate fake data for a single export win.
  */
-export const exportWinsFaker = () => ({
+export const exportWinsFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
   adviser: {
     id: faker.string.uuid(),
@@ -28,4 +28,5 @@ export const exportWinsFaker = () => ({
   customer_response: {
     responded_on: faker.date.anytime().toISOString(),
   },
+  ...overrides,
 })

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -32,11 +32,12 @@ const company = companyFaker({
   name: 'Advanced Mini Devices',
 })
 
-const exportWin = exportWinsFaker({
+const exportWin = {
+  ...exportWinsFaker(),
   country: { name: 'Dubai' },
   name_of_export: 'Rolls Reece Cars',
   company_contacts: [{ email: 'jeff.marks@test.com' }],
-})
+}
 
 const twelveMonthsAgo = getTwelveMonthsAgo()
 const month = twelveMonthsAgo.getMonth() + 1

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -9,6 +9,7 @@ import { clickContinueButton } from '../../support/actions'
 import { companyFaker } from '../../fakers/companies'
 import { contactFaker } from '../../fakers/contacts'
 import { exportFaker } from '../../fakers/export'
+import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
 import {
   assertUrl,
@@ -29,6 +30,12 @@ import {
 
 const company = companyFaker({
   name: 'Advanced Mini Devices',
+})
+
+const exportWin = exportWinsFaker({
+  country: { name: 'Dubai' },
+  name_of_export: 'Rolls Reece Cars',
+  company_contacts: [{ email: 'jeff.marks@test.com' }],
 })
 
 const twelveMonthsAgo = getTwelveMonthsAgo()
@@ -105,6 +112,13 @@ const formFields = {
     personallyConfirmed: '[data-test="field-is_personally_confirmed"]',
     lineManagerConfirmed: '[data-test="field-is_line_manager_confirmed"]',
   },
+  successPage: {
+    flash: '[data-test="flash"]',
+    heading: '[data-test="heading"]',
+    review: '[data-test="review"]',
+    email: '[data-test="email"]',
+    exportWinsLink: '[data-test="export-wins-link"]',
+  },
 }
 
 const clickContinueAndAssertUrl = (url) => {
@@ -163,6 +177,12 @@ describe('Adding an export win', () => {
     cy.intercept('GET', '/api-proxy/v4/metadata/associated-programme', [
       { id: '600', name: 'Afterburner' },
     ])
+    cy.intercept('POST', '/api-proxy/v4/export-win', {
+      statusCode: 201,
+    }).as('apiPostExportWin')
+    cy.intercept('GET', '/api-proxy/v4/export-win/*', exportWin).as(
+      'apiGetExportWin'
+    )
   })
 
   context('Breadcrumbs', () => {
@@ -1055,16 +1075,15 @@ describe('Adding an export win', () => {
       )
     })
 
-    it('should POST to the API and have the correct payload', () => {
+    it('should POST to the API and redirect to the success page', () => {
+      const successPageRegex = /\/exportwins\/[^/]+\/success/
+
       cy.get('[data-test="confirm-and-send-to-customer"]').should(
         'have.text',
         'Confirm and send to customer'
       )
-      cy.intercept('POST', '/api-proxy/v4/export-win', {
-        statusCode: 201,
-      }).as('apiRequest')
       cy.get('[data-test="confirm-and-send-to-customer"]').click()
-      cy.wait('@apiRequest').then(({ request }) => {
+      cy.wait('@apiPostExportWin').then(({ request }) => {
         expect(omit(request.body, '_csrf')).to.deep.equal({
           lead_officer: '100',
           team_type: '42bdaf2e-ae19-4589-9840-5dbb67b50add',
@@ -1116,6 +1135,34 @@ describe('Adding an export win', () => {
           adviser: '7d19d407-9aec-4d06-b190-d3f404627f21',
         })
       })
+      cy.location().should(({ pathname }) => {
+        expect(pathname).to.match(successPageRegex)
+      })
+    })
+
+    it('should render a success page', () => {
+      const { successPage } = formFields
+
+      cy.get(successPage.flash).should(
+        'have.text',
+        'The export win Rolls Reece Cars to Dubai has been sent to jeff.marks@test.com for review and confirmation.'
+      )
+
+      cy.get(successPage.heading).should('have.text', 'What happens next?')
+
+      cy.get(successPage.review).should(
+        'have.text',
+        'The customer will review the export win and have the option to provide feedback.'
+      )
+
+      cy.get(successPage.email).should(
+        'have.text',
+        'You will be sent an email once the customer has responded.'
+      )
+
+      cy.get(successPage.exportWinsLink)
+        .should('have.text', 'Export wins')
+        .should('have.attr', 'href', '/exportwins')
     })
   })
 

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -672,7 +672,7 @@ describe('Adding an export win', () => {
       assertFieldCheckboxes({
         element: winDetails.goodsVsServices,
         legend: 'What does the value relate to?',
-        hint: 'Select goods or services',
+        hint: 'Select all that apply.',
         options: [
           {
             label: 'Goods',


### PR DESCRIPTION
## Description of change
After a user has added an export win they will be redirected to a success page. This page guides them on what will happen next.

## Screenshots
<img width="1082" alt="Screenshot 2024-03-12 at 14 49 00" src="https://github.com/uktrade/data-hub-frontend/assets/964268/46b60cad-222a-4ee7-8d05-bd5ec1158488">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
