### PR TITLE
Fix a number of issues in ExportWins/Review

### DIFF
--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -132,7 +132,7 @@ const Step2Agree = () => (
 )
 
 const Step2Disagree = () => (
-  <Step name="2-disagree">
+  <Step name="2-disagree" submitButtonLabel="Confirm and send">
     <FieldTextarea
       name="comments"
       label="Comments"
@@ -189,6 +189,7 @@ const Step4 = () => (
     <FieldCheckboxes
       name="checkboxes1"
       legend="Please tick all that apply to this win:"
+      required="Select at least 1 of the 3 options below."
       options={[
         {
           label:
@@ -208,9 +209,10 @@ const Step4 = () => (
     <FieldCheckboxes
       name="checkboxes2"
       legend="Tick any that apply to this win:"
+      required="Select at least 1 of the 5 options below."
       options={[
         {
-          label: 'It enabled vou to expand into a new market',
+          label: 'It enabled you to expand into a new market',
           value: 'has_enabled_expansion_into_new_market',
         },
         {
@@ -249,7 +251,7 @@ const Step5 = () => (
 )
 
 const Step6 = () => (
-  <Step name="6">
+  <Step name="6" submitButtonLabel="Confirm and send">
     <H2>Marketing</H2>
     <FieldRadios
       name="case_study_willing"
@@ -272,8 +274,9 @@ const Step6 = () => (
                 <FieldInput
                   name="other_marketing_source"
                   type="text"
-                  label="Label comes later"
-                  required="Please specify"
+                  label="Other way you heard about DBT"
+                  required="Enter a description of the other way you heard about DBT"
+                  hint="Please describe the other way you heard about DBT"
                 />
               ),
             }
@@ -299,7 +302,6 @@ const Review = ({ token }) => (
           id={FORM_ID}
           analyticsFormName={FORM_ID}
           submissionTaskName="TASK_PATCH_EXPORT_WIN_REVIEW"
-          // showStepInUrl={true}
           redirectMode="soft"
           redirectTo={() => '/exportwins/review-win/thankyou'}
           transformPayload={transformPayload(token)}

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -6,6 +6,7 @@ import {
   assertFieldRadiosStrict,
   assertFieldCheckboxes,
   assertFieldTextarea,
+  assertErrorSummary,
 } from '../../../../functional/cypress/support/assertions'
 import Review from '../../../../../src/client/modules/ExportWins/Review'
 import { createTestProvider } from '../provider'
@@ -148,7 +149,10 @@ describe('ExportWins/Review', () => {
 
       const MARKETING_SOURCE = [
         { id: 'marketing-source-a', name: 'marketing-source-A' },
-        { id: 'marketing-source-b', name: 'marketing-source-B' },
+        {
+          id: 'marketing-source-b',
+          name: 'marketing-source-B (please specify)',
+        },
         { id: 'marketing-source-c', name: 'marketing-source-C' },
       ]
 
@@ -286,15 +290,11 @@ describe('ExportWins/Review', () => {
         ],
       })
 
-      cy.contains(
-        'Our support was a prerequisite to generate this value'
-      ).click()
-
       assertFieldCheckboxes({
         element: '#field-checkboxes2',
         legend: 'Tick any that apply to this win:',
         options: [
-          { label: 'It enabled vou to expand into a new market' },
+          { label: 'It enabled you to expand into a new market' },
           {
             label: 'It enabled you to maintain or expand in an existing market',
           },
@@ -313,12 +313,22 @@ describe('ExportWins/Review', () => {
         ],
       })
 
+      cy.get('@continue').click()
+
+      // Assert errors
+      assertErrorSummary([
+        'Select at least 1 of the 3 options below.',
+        'Select at least 1 of the 5 options below.',
+      ])
+
+      cy.get('@continue').click()
+
       cy.contains(
-        'It enabled you to maintain or expand in an existing market'
+        'Our support was a prerequisite to generate this value'
       ).click()
 
       cy.contains(
-        "If you hadn't achieved this win, your company might have stopped exporting"
+        'It enabled you to maintain or expand in an existing market'
       ).click()
 
       cy.get('@continue').click()
@@ -354,7 +364,23 @@ describe('ExportWins/Review', () => {
         selectIndex: 1,
       })
 
-      cy.contains('button', 'Submit').click()
+      // There should appear an input field
+      cy.get('input#other_marketing_source')
+      cy.get('label[for="other_marketing_source"]').should(
+        'have.text',
+        'Other way you heard about DBT'
+      )
+
+      // The field should be required
+      cy.contains('button', 'Confirm and send').click()
+      assertErrorSummary([
+        'Enter a description of the other way you heard about DBT',
+      ])
+
+      // Fill out the field
+      cy.get('input#other_marketing_source').type('Blah blah blah')
+
+      cy.contains('button', 'Confirm and send').click()
 
       assertReviewed()
 
@@ -430,7 +456,7 @@ describe('ExportWins/Review', () => {
 
       cy.get('#comments').type('Lorem ipsum dolor sit amet')
 
-      cy.contains('button', 'Submit').click()
+      cy.contains('button', 'Confirm and send').click()
 
       assertReviewed()
 


### PR DESCRIPTION
## Description of change

This PR fixes a number of issues on the Export Wins Review page:

* Submit button labels on last form steps
* Form field _required_ messages
* Label, hint and _required_ message on the `other_marketing_source` input field
* Fixed typos

