### PR TITLE
Increase the size of the first column of SummaryTable

### DIFF
--- a/src/client/modules/ExportWins/CustomerFeedback.jsx
+++ b/src/client/modules/ExportWins/CustomerFeedback.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import styled from 'styled-components'
 import { Link } from 'govuk-react'
 import { Link as ReactRouterLink } from 'react-router-dom/cjs/react-router-dom'
 
@@ -13,6 +14,12 @@ const toYesNo = (val) => {
   if (val === undefined || val === null) return
   return val ? 'Yes' : 'No'
 }
+
+const SummaryTable60PerCentHeader = styled(SummaryTable)({
+  '&& th': {
+    width: '60%',
+  },
+})
 
 const CustomerFeedback = ({
   match: {
@@ -43,7 +50,7 @@ const CustomerFeedback = ({
         const response = win?.customer_response || {}
         return (
           <>
-            <SummaryTable caption="1. To what extent did our support help in?">
+            <SummaryTable60PerCentHeader caption="1. To what extent did our support help in?">
               <SummaryTable.Row heading="Securing the win overall?">
                 {response.our_support?.name}
               </SummaryTable.Row>
@@ -65,8 +72,8 @@ const CustomerFeedback = ({
               <SummaryTable.Row heading="Overcoming a problem in the country (eg legal, regulatory, commercial)">
                 {response.overcame_problem?.name}
               </SummaryTable.Row>
-            </SummaryTable>
-            <SummaryTable caption="2. About this win">
+            </SummaryTable60PerCentHeader>
+            <SummaryTable60PerCentHeader caption="2. About this win">
               <SummaryTable.Row heading="The win involved a foreign government or state-owned enterprise (eg as an intermediary or facilitator)">
                 {toYesNo(response.involved_state_enterprise)}
               </SummaryTable.Row>
@@ -91,20 +98,20 @@ const CustomerFeedback = ({
               <SummaryTable.Row heading="Apart from this win, you already have plans to export in the next 12 months">
                 {toYesNo(response.has_explicit_export_plans)}
               </SummaryTable.Row>
-            </SummaryTable>
-            <SummaryTable caption="3. Your export experience">
+            </SummaryTable60PerCentHeader>
+            <SummaryTable60PerCentHeader caption="3. Your export experience">
               <SummaryTable.Row heading="Apart from this win, when did your company last export goods or services?">
                 {response.last_export?.name}
               </SummaryTable.Row>
-            </SummaryTable>
-            <SummaryTable caption="4. Marketing">
+            </SummaryTable60PerCentHeader>
+            <SummaryTable60PerCentHeader caption="4. Marketing">
               <SummaryTable.Row heading="Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?">
                 {toYesNo(response.case_study_willing)}
               </SummaryTable.Row>
               <SummaryTable.Row heading="How did you first hear about DBT(or it predecessor, DIT)?">
                 {response.marketing_source?.name}
               </SummaryTable.Row>
-            </SummaryTable>
+            </SummaryTable60PerCentHeader>
           </>
         )
       }}


### PR DESCRIPTION
## Description of change

This PR increases the width of the heading column of `SummaryTable` in `ExportWins/CustomerFeedback`.

## Test instructions

1. Go to `/exportwins/won`
2. Click on one of the _View details_ link
3. Click the _View customer feedback_ link to the bottom of the page
4. The headings column of summary tables should be wider than the values column

## Screenshots

### Before

![www datahub dev uktrade io_exportwins_c0adb4f9-0abc-4f56-9a1d-a994f459fe0e_customer-feedback](https://github.com/uktrade/data-hub-frontend/assets/2333157/a5e89e83-ce87-4709-b4c4-d2481b4a3bed)

### After

![localhost_3000_exportwins_c0adb4f9-0abc-4f56-9a1d-a994f459fe0e_customer-feedback (1)](https://github.com/uktrade/data-hub-frontend/assets/2333157/7d534646-7d1c-4620-8bf6-b4bc4a755352)
