### PR TITLE
Added the missing our_support row

### DIFF
--- a/src/client/modules/ExportWins/Details/index.jsx
+++ b/src/client/modules/ExportWins/Details/index.jsx
@@ -159,6 +159,11 @@ const Detail = (props) => {
                   {exportWin &&
                     (exportWin.customerResponse.agreeWithWin ? 'Yes' : 'No')}
                 </SummaryTable.Row>
+                {exportWin?.customerResponse?.agreeWithWin && (
+                  <SummaryTable.Row heading="What value do you estimate you would have achieved without our support">
+                    {exportWin?.customerResponse.ourSupport?.name}
+                  </SummaryTable.Row>
+                )}
               </Summary>
               {exportWin &&
                 exportWin.customerResponse.agreeWithWin === WIN_STATUS.SENT && (

--- a/test/component/cypress/specs/ExportWins/Details.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Details.cy.jsx
@@ -50,6 +50,7 @@ const EXPORT_WIN = {
   ],
   customer_response: {
     agree_with_win: WIN_STATUS.SENT, // the default
+    our_support: null,
   },
 }
 
@@ -78,7 +79,6 @@ describe('ExportWins/Details', () => {
   )
 
   ;[
-    // FIXME: There's no test case for rejected win
     {
       testTitle: 'Confirmed',
       exportWinAPIResponse: {
@@ -86,12 +86,17 @@ describe('ExportWins/Details', () => {
         customer_response: {
           agree_with_win: true,
           comments: 'I agree',
+          our_support: {
+            name: 'Not very much',
+          },
         },
       },
       tableRows: insertAfter(
         {
           ...EXPECTED_ROWS,
           'Export win confirmed': 'Yes',
+          'What value do you estimate you would have achieved without our support':
+            'Not very much',
         },
         'Lead officer name',
         {
@@ -412,6 +417,9 @@ describe('ExportWins/Details', () => {
               ...EXPORT_WIN,
               customer_response: {
                 agree_with_win: WIN_STATUS.WON,
+                our_support: {
+                  name: 'A fortune',
+                },
               },
             }}
           />


### PR DESCRIPTION
## Description of change

_Document what the PR does and why the change is needed_

## Test instructions

1. Go to `/exportwins/won`
2. Click on one of the _View details_ link
3. There should be a row with the heading _What value do you estimate you would have achieved without our support_ in the very bottom of the table.

## Screenshots

### Before

![before](https://github.com/uktrade/data-hub-frontend/assets/2333157/98a91cd5-aa95-4606-a632-8ef39a1d2beb)

### After

![after](https://github.com/uktrade/data-hub-frontend/assets/2333157/4e39a9e1-f72d-43f0-8ac4-dc881c21fbca)

