### PR TITLE
Updated page title of the /exportwins/review page

### DIFF
--- a/src/apps/__export-wins-review/view.njk
+++ b/src/apps/__export-wins-review/view.njk
@@ -1,18 +1,28 @@
-{% extends "_layouts/template.njk" %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>DBT Export Wins</title>
+    <style>
+      html, body {
+        font-family: Arial,"Helvetica Neue",sans-serif;
+        font-size: 19px;
+        font-weight: 400;
+        -webkit-font-smoothing: antialiased;
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="react-app">
+      <noscript>Please enable JavaScript in your browser to see the content.</noscript>
+    </div>
 
-{% block header %}{% endblock %}
-{% block local_header %}{% endblock %}
-{% block bodyStart %}{% endblock %}
-{% block main %}{% endblock %}
-{% block footer %}{% endblock %}
-
-{% block bodyEnd %}
-  <div id="react-app">
-    <noscript>Please enable JavaScript in your browser to see the content.</noscript>
-  </div>
-
-  <!--[if gt IE 8]><!-->
-  <script src="{{ getAssetPath('app.js') }}"></script>
-  <script src="{{ getAssetPath('export-win-review.js') }}"></script>
-  <!--<![endif]-->
-{% endblock %}
+    <!--[if gt IE 8]><!-->
+    <script src="{{ getAssetPath('app.js') }}"></script>
+    <script src="{{ getAssetPath('export-win-review.js') }}"></script>
+    <!--<![endif]-->
+  </body>
+</html>

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -1,7 +1,11 @@
 import _ from 'lodash'
 import React from 'react'
 import { H2, H4 } from 'govuk-react'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
 import { Route, Switch } from 'react-router-dom'
+
+import { GREY_2 } from '../../../utils/colours'
 
 import Layout from './Layout'
 import {
@@ -25,6 +29,11 @@ import Err from '../../../components/Task/Error'
 import ThankYou from './ThankYou'
 
 const FORM_ID = 'export-wins-customer-feedback'
+
+const HR = styled.hr({
+  borderTop: `1px solid ${GREY_2}`,
+  margin: `${SPACING.SCALE_5} 0`,
+})
 
 const NotFound = (props) =>
   props.error?.httpStatusCode === 404 ? (
@@ -96,7 +105,7 @@ const Step1 = ({ win, name }) => (
       Thank you for taking the time to review our record of your recent export
       success.
     </p>
-    <hr />
+    <HR />
     <H2>Details of your recent success</H2>
     <Summary exportWin={win}>
       <SummaryTable.Row heading="Summary of support received">

--- a/src/server.js
+++ b/src/server.js
@@ -113,11 +113,12 @@ app.use(
 )
 
 app.use(locals)
+
+app.use(require('./apps/__export-wins-review'))
+
 app.use(title())
 app.use(breadcrumbs.init())
 app.use(breadcrumbs.setHome())
-
-app.use(require('./apps/__export-wins-review'))
 
 app.use(redisCheck)
 app.use(sessionStore)


### PR DESCRIPTION
## Description of change

This PR changes the page title of the `/exportwins/review/:token` page from _DBT Data Hub_ to _DBT Export Wins_.

## Test instructions

1. Go to `/exportwins/review/:token`
2. Verify that the page title is _DBT Export Wins_

## Screenshots

### Before

<img width="890" alt="Screenshot 2024-03-14 at 15 21 42" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/62a6f9ff-c53d-4c2a-a00f-4311761962c1">


### After

<img width="887" alt="Screenshot 2024-03-14 at 15 14 22" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/c15fda39-6af3-42cb-86a8-f589453bac2a">
