### PR TITLE
Refactored thank you page to avoid using flash message

### DIFF
--- a/src/client/modules/ExportWins/Review/ThankYou.jsx
+++ b/src/client/modules/ExportWins/Review/ThankYou.jsx
@@ -1,10 +1,53 @@
 import React from 'react'
+import { Route } from 'react-router-dom'
+import styled from 'styled-components'
+
+import { GREEN, WHITE } from '../../../utils/colours'
+import { StatusMessage } from '../../../components'
 
 import Layout from './Layout'
-import FlashMessages from '../../../components/LocalHeader/FlashMessages'
+
+const StyledStatusMessage = styled(StatusMessage)({
+  background: WHITE,
+  '& > *:first-child': {
+    marginTop: 0,
+  },
+  '& > *:last-child': {
+    marginBottom: 0,
+  },
+})
 
 export default () => (
-  <Layout title="Export win reviewed" headingContent={<FlashMessages />}>
-    Your feedback will help us to improve our support services.
-  </Layout>
+  <Route>
+    {({ location: { search } }) => {
+      const agree = search.includes('agree=yes')
+      return (
+        <Layout
+          title={
+            agree
+              ? 'Export win reviewed'
+              : 'Export win reviewed and changes are needed'
+          }
+          headingContent={
+            agree ? (
+              <StyledStatusMessage colour={GREEN}>
+                Thank you for taking time to review this export win.
+              </StyledStatusMessage>
+            ) : (
+              <StyledStatusMessage>
+                <p>Thank you for reviewing this export win.</p>
+                <p>
+                  As you have asked for some changes to be made, we will review
+                  your comments and may need to contact you if we need more
+                  information.
+                </p>
+              </StyledStatusMessage>
+            )
+          }
+        >
+          Your feedback will help us to improve our support services.
+        </Layout>
+      )
+    }}
+  </Route>
 )

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -312,29 +312,10 @@ const Review = ({ token }) => (
           analyticsFormName={FORM_ID}
           submissionTaskName="TASK_PATCH_EXPORT_WIN_REVIEW"
           redirectMode="soft"
-          redirectTo={() => '/exportwins/review-win/thankyou'}
-          transformPayload={transformPayload(token)}
-          flashMessage={(_, { agree_with_win }) =>
-            agree_with_win === 'yes'
-              ? // TODO: Move to constants
-                [
-                  'Success',
-                  'Thank you for taking time to review this export win',
-                  'success',
-                ]
-              : [
-                  'Important',
-                  `
-                  <p>Thank you for reviewing this export win</p>
-                  <p>
-                    As you have asked for some changes to be made,
-                    we will review your comments and may need to contact you
-                    if we need more information.
-                  </p>
-                  `,
-                  'info',
-                ]
+          redirectTo={(_, { agree_with_win }) =>
+            `/exportwins/review-win/thankyou?agree=${agree_with_win}`
           }
+          transformPayload={transformPayload(token)}
         >
           {(formData) => (
             <>

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -22,9 +22,9 @@ const assertHeader = () => {
   cy.get('header h1').should('have.text', HEADING)
 }
 
-const assertReviewed = () => {
+const assertReviewed = ({ heading }) => {
   cy.contains(DBT_HEADING)
-  cy.get('header h1').should('have.text', 'Export win reviewed')
+  cy.get('header h1').should('have.text', heading)
   cy.get('main').should(
     'have.text',
     'Your feedback will help us to improve our support services.'
@@ -382,15 +382,12 @@ describe('ExportWins/Review', () => {
 
       cy.contains('button', 'Confirm and send').click()
 
-      assertReviewed()
+      assertReviewed({ heading: 'Export win reviewed' })
 
-      cy.get('[role="alert"').within(() => {
-        cy.contains('h2', /^Success$/)
-        cy.contains(
-          'p',
-          /^Thank you for taking time to review this export win$/
-        )
-      })
+      cy.get('[role="alert"').should(
+        'have.text',
+        'Thank you for taking time to review this export win.'
+      )
     })
 
     it('User disagrees with win', () => {
@@ -458,14 +455,13 @@ describe('ExportWins/Review', () => {
 
       cy.contains('button', 'Confirm and send').click()
 
-      assertReviewed()
+      assertReviewed({ heading: 'Export win reviewed and changes are needed' })
 
       cy.get('[role="alert"').within(() => {
-        cy.contains('h2', /^Important$/)
-        cy.contains('p', /^\s*Thank you for reviewing this export win\s*$/)
+        cy.contains('p', /^\s*Thank you for reviewing this export win.\s*$/)
         cy.contains(
           'p',
-          /^\s*As you have asked for some changes to be made, we will review your comments and may need to contact you if we need more information.\s*$/
+          /^\s*As you have asked for some changes to be made, we will review your comments and may need to contact you if we need more information.*$/
         )
       })
     })


### PR DESCRIPTION
## Description of change

This PR fixes some discrepancies of the _export wins thank you_ page with the designs.

## Test instructions

1. Go to `/companies/:company-id/exportwins/create` to create a new export win
    * In the third step of the form set _Company contacts_ field to a contact with your email address so you get access to the _export win review token_.
    * Once you receive the email, click the _Review win_ link which should take you to `/exportwins/review/:token`
2. Once on `/exportwins/review/:token`
3. Select the _I confirm this information is correct_ radio
4. Fill out the rest of the form and finally hit the _Confirm and send_ button
5. It should redirect you to `/exportwins/review-win/thankyou?agree=yes` where you should see
    * Header with big "Export win reviewed" heading
    * A green box saying "Thank you for taking time to review this export win."
6. Repeat steps 1 and 2
7. Select the _Some of this information needs revising_ radio
8. Fill out the rest of the form and finally hit the _Confirm and send_ button
9. It should redirect you to `/exportwins/review-win/thankyou?agree=no` where you should see
    * Header with big "Export win reviewed and changes are needed"" heading
    * A green box with two paragraphs with these texts:
       1. "Thank you for reviewing this export win."
       2. "As you have asked for some changes to be made, we will review your comments and may need to contact you if we need more information."

## Screenshots

### Before

![before-agree](https://github.com/uktrade/data-hub-frontend/assets/2333157/7c0f17d1-bae2-4817-9528-e24409bbb171)

![before-disagree](https://github.com/uktrade/data-hub-frontend/assets/2333157/d7a477dd-a8bc-4df0-a539-fe5aa7c3159b)

### After

![after-agree](https://github.com/uktrade/data-hub-frontend/assets/2333157/8b4c9899-1e2b-43dc-a359-c74634e193d3)

![after-disagree](https://github.com/uktrade/data-hub-frontend/assets/2333157/4fbafa92-57e0-4733-970d-b32d0692eb93)


