### PR TITLE
Add customer confidentiality radio buttons for Export Wins

### DIFF
--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -208,9 +208,11 @@ const WinDetailsTable = ({ values, goToStep }) => {
       <SummaryTable.Row heading="Summary of support given">
         {values.description}
       </SummaryTable.Row>
-      <SummaryTable.Row heading="Overseas customer">
-        {values.name_of_customer}
-      </SummaryTable.Row>
+      {values.name_of_customer && (
+        <SummaryTable.Row heading="Overseas customer">
+          {values.name_of_customer}
+        </SummaryTable.Row>
+      )}
       <SummaryTable.Row heading="Confidential">
         {transformCustomerConfidential(values.name_of_customer_confidential)}
       </SummaryTable.Row>

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -10,7 +10,6 @@ import CountriesResource from '../../../components/Resource/Countries'
 import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
 import { SectorResource } from '../../../components/Resource'
-import { OPTION_YES } from '../../../../common/constants'
 import { validateWinDate } from './validators'
 import { WinTypeValues } from './WinTypeValues'
 import { StyledHintParagraph } from './styled'
@@ -18,6 +17,7 @@ import {
   Step,
   FieldDate,
   FieldInput,
+  FieldRadios,
   FieldTextarea,
   FieldTypeahead,
   FieldCheckboxes,
@@ -79,21 +79,29 @@ const WinDetailsStep = () => {
         maxWords={MAX_WORDS}
       />
 
-      <FieldInput
-        type="text"
-        name="name_of_customer"
-        label="Overseas customer"
-        required="Enter the name of the overseas customer"
-        placeholder="Add name"
-      />
-
-      <FieldCheckboxes
+      <FieldRadios
         name="name_of_customer_confidential"
-        hint="Check this box if your customer has asked for this not to be public (optional)."
+        label="Overseas customer"
+        hint="Is the customer's name confidential?"
+        required="Select Yes or No"
         options={[
           {
-            value: OPTION_YES,
-            label: 'Confidential',
+            label: 'Yes',
+            value: 'yes',
+          },
+          {
+            label: 'No',
+            value: 'no',
+            children: (
+              <FieldInput
+                type="text"
+                name="name_of_customer"
+                label="Customer's name"
+                hint="Enter the customer’s name, this will be displayed on Data Hub."
+                required="Enter the name of the overseas customer"
+                placeholder="Add name"
+              />
+            ),
           },
         ]}
       />

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -16,6 +16,8 @@ import {
   goodsServicesIdToLabelMap,
 } from './constants'
 
+const CONFIDENTIAL = 'confidential'
+
 const transformContributingOfficersToAdvisers = (values) =>
   Object.keys(values)
     .filter((key) => key.startsWith('contributing_officer'))
@@ -147,8 +149,9 @@ export const transformExportWinForForm = (exportWin) => ({
   date: convertDateToFieldDateObject(exportWin.date),
   description: exportWin.description,
   name_of_customer: exportWin.name_of_customer,
-  name_of_customer_confidential:
-    exportWin.name_of_customer_confidential === true ? OPTION_YES : OPTION_NO,
+  name_of_customer_confidential: exportWin.name_of_customer_confidential
+    ? OPTION_YES
+    : OPTION_NO,
   business_type: exportWin.business_type,
   ...transformBreakdownsToYearlyValues(exportWin.breakdowns),
   win_type: getWinTypesFromBreakdowns(exportWin.breakdowns),
@@ -189,9 +192,12 @@ export const transformFormValuesForAPI = (values) => ({
   country: values.country.value,
   date: `${values.date.year}-${values.date.month}-01`,
   description: values.description,
-  name_of_customer: values.name_of_customer,
+  name_of_customer:
+    values.name_of_customer_confidential === OPTION_YES
+      ? CONFIDENTIAL
+      : values.name_of_customer,
   name_of_customer_confidential:
-    values.name_of_customer_confidential[0] === OPTION_YES,
+    values.name_of_customer_confidential === OPTION_YES,
   business_type: values.business_type,
   breakdowns: [
     ...transformYearlyValuesToBreakdowns(

--- a/test/functional/cypress/specs/export-win/add-export-win-from-export-project.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-from-export-project.js
@@ -271,8 +271,8 @@ describe('Adding an export win from an export project', () => {
             dateMonth: null, // pre-populated but must be within the last 12 months
             dateYear: null, // pre-populated but must be within the last 12 months
             description: 'Foo bar baz',
+            nameOfCustomerConfidential: false,
             nameOfCustomer: 'David French',
-            isConfidential: true,
             businessType: 'Contract',
             exportValues: ['1000000'],
             goodsVsServices: 'goods',
@@ -332,10 +332,11 @@ describe('Adding an export win from an export project', () => {
               'country',
               'date',
               'sector',
+              'name_of_customer_confidential',
+              'name_of_customer',
             ])
           ).to.deep.equal({
-            // We only need to assert the fields that have
-            // been pre-populated from an export project
+            // Assert the fields that have been pre-populated from an export project
             lead_officer: exportProject.owner.id,
             team_members: exportProject.team_members.map(({ id }) => id),
             company_contacts: exportProject.contacts.map(({ id }) => id),
@@ -343,6 +344,9 @@ describe('Adding an export win from an export project', () => {
             country: exportProject.destination_country.id,
             date: `${year}-${month}-01`,
             sector: exportProject.sector.id,
+            // Assert the customer name and that it's not confidential
+            name_of_customer_confidential: false,
+            name_of_customer: 'David French',
           })
         })
 

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -119,7 +119,6 @@ describe('Adding an export win', () => {
     })
   })
 
-  // Disable testIsolation due to multi step form with lots of data.
   context(
     'When the export win is created from scratch',
     { testIsolation: false },
@@ -157,8 +156,7 @@ describe('Adding an export win', () => {
           dateMonth: month,
           dateYear: year,
           description: 'Foo bar baz',
-          nameOfCustomer: 'David French',
-          isConfidential: true,
+          nameOfCustomerConfidential: true,
           businessType: 'Contract',
           exportValues: ['1000000', '1000000', '1000000', '1000000', '1000000'],
           businessSuccessValues: [
@@ -244,7 +242,6 @@ describe('Adding an export win', () => {
             Destination: 'United States',
             'Date won': `${month}/${year}`,
             'Summary of support given': 'Foo bar baz',
-            'Overseas customer': 'David French',
             Confidential: 'Yes',
             'Type of win': 'Contract',
             'Export value': '£5,000,000 over 5 years',
@@ -306,7 +303,7 @@ describe('Adding an export win', () => {
             country: '81756b9a-5d95-e211-a939-e4115bead28a',
             date: `${year}-${month}-01`,
             description: 'Foo bar baz',
-            name_of_customer: 'David French',
+            name_of_customer: 'confidential',
             name_of_customer_confidential: true,
             business_type: 'Contract',
             breakdowns: [

--- a/test/functional/cypress/specs/export-win/constants.js
+++ b/test/functional/cypress/specs/export-win/constants.js
@@ -55,7 +55,12 @@ export const formFields = {
     dateYear: '[data-test="date-year"]',
     description: '[data-test="field-description"]',
     nameOfCustomer: '[data-test="field-name_of_customer"]',
-    confidential: '[data-test="field-name_of_customer_confidential"]',
+    nameOfCustomerConfidential:
+      '[data-test="field-name_of_customer_confidential"]',
+    nameOfCustomerConfidentialYes:
+      '[data-test="name-of-customer-confidential-yes"]',
+    nameOfCustomerConfidentialNo:
+      '[data-test="name-of-customer-confidential-no"]',
     businessType: '[data-test="field-business_type"]',
     winType: '[data-test="field-win_type"]',
     goodsVsServices: '[data-test="field-goods_vs_services"]',

--- a/test/functional/cypress/specs/export-win/credit-for-this-win-spec.js
+++ b/test/functional/cypress/specs/export-win/credit-for-this-win-spec.js
@@ -42,14 +42,8 @@ describe('Credit for this win', () => {
       legend: 'Did any other teams help with this win?',
       options: ['Yes', 'No'],
     })
-    cy.get(creditForThisWin.radiosBtnYes)
-      .should('not.be.checked')
-      .parent()
-      .should('have.text', 'Yes')
-    cy.get(creditForThisWin.radiosBtnNo)
-      .should('not.be.checked')
-      .parent()
-      .should('have.text', 'No')
+    cy.get(creditForThisWin.radiosBtnYes).should('not.be.checked')
+    cy.get(creditForThisWin.radiosBtnNo).should('not.be.checked')
   })
 
   it('should go to the next step when selecting "No" and then "Continue"', () => {

--- a/test/functional/cypress/specs/export-win/utils.js
+++ b/test/functional/cypress/specs/export-win/utils.js
@@ -56,8 +56,8 @@ export const fillWinDetails = ({
   dateMonth,
   dateYear,
   description,
+  nameOfCustomerConfidential,
   nameOfCustomer,
-  isConfidential,
   businessType,
   exportValues,
   businessSuccessValues,
@@ -76,10 +76,13 @@ export const fillWinDetails = ({
   description &&
     cy.get(winDetails.description).find('textarea').type(description)
 
-  nameOfCustomer &&
-    cy.get(winDetails.nameOfCustomer).find('input').type(nameOfCustomer)
+  nameOfCustomerConfidential
+    ? cy.get(winDetails.nameOfCustomerConfidentialYes).click()
+    : cy.get(winDetails.nameOfCustomerConfidentialNo).click()
 
-  isConfidential && cy.get(winDetails.confidential).find('input').check()
+  !nameOfCustomerConfidential &&
+    nameOfCustomer &&
+    cy.get(winDetails.nameOfCustomer).find('input').type(nameOfCustomer)
 
   businessType &&
     cy.get(winDetails.businessType).find('input').type(businessType)

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -272,13 +272,22 @@ const assertFieldRadios = ({ element, label, value, optionsCount }) =>
 /**
  * @param {{inputName: string, options: string[], legend?: string, selectIndex?: number}} options
  */
-const assertFieldRadiosStrict = ({ inputName, options, legend, selectIndex }) =>
+const assertFieldRadiosStrict = ({
+  inputName,
+  options,
+  legend,
+  hint,
+  selectIndex,
+}) =>
   cy
     .get(`[data-test="field-${inputName}"]`)
     .should('exist')
     .within(() => {
       if (legend) {
         cy.get('legend').should('have.text', legend)
+      }
+      if (hint) {
+        cy.get('[data-test="hint-text"]').should('have.text', hint)
       }
 
       cy.get('input[type="radio"]')


### PR DESCRIPTION
## Description of change
**Export wins**
Adds two radio buttons that asks the user if the customer name is confidential. If the name is confidential we assign `'confidential'` to `name_of_customer`, if not, the user enters the customer's name which is assigned to `name_of_customer` and displayed on Data Hub. 

Question: **Is the customer's name confidential?**

User answers **Yes**:
```js
// Payload
name_of_customer: 'confidential'
name_of_customer_confidential: true
```

User answers **No** :
```js
// Payload
name_of_customer: 'Joseph Lee'
name_of_customer_confidential: false
```

## Test instructions
Go to: `/companies/<company-uuid>/exportwins/create?step=win_details`


## Screenshots
<img width="1003" alt="Screenshot 2024-03-18 at 11 47 16" src="https://github.com/uktrade/data-hub-frontend/assets/964268/94d9381a-08cd-425c-b43f-1371d99253a9">
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
