### PR TITLE
Add date unit tests and fix a flaky test.

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -5,7 +5,9 @@ import styled from 'styled-components'
 
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
 import { useFormContext } from '../../../../client/components/Form/hooks'
+import { getStartDateOfTwelveMonthsAgo } from '../../../utils/date'
 import CountriesResource from '../../../components/Resource/Countries'
+import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
 import { SectorResource } from '../../../components/Resource'
 import { OPTION_YES } from '../../../../common/constants'
@@ -26,11 +28,6 @@ import {
   winTypeOptions,
   goodsServicesOptions,
 } from './constants'
-import {
-  formatValue,
-  sumAllWinTypeYearlyValues,
-  getDateTwelveMonthsAgoWithFirstDay,
-} from './utils'
 
 const MAX_WORDS = 100
 
@@ -46,7 +43,7 @@ const StyledExportTotal = styled('p')({
 
 const WinDetailsStep = () => {
   const { values } = useFormContext()
-  const twelveMonthsAgo = getDateTwelveMonthsAgoWithFirstDay()
+  const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
   const month = twelveMonthsAgo.getMonth() + 1
   const year = twelveMonthsAgo.getFullYear()
 

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -1,9 +1,12 @@
 import { isEmpty } from 'lodash'
 
-import { convertDateToFieldDateObject } from '../../../../client/utils/date'
 import { OPTION_YES, OPTION_NO } from '../../../../common/constants'
-import { sumWinTypeYearlyValues, isWithinLastTwelveMonths } from './utils'
 import { idNameToValueLabel } from '../../../../client/utils'
+import { sumWinTypeYearlyValues } from './utils'
+import {
+  convertDateToFieldDateObject,
+  isWithinLastTwelveMonths,
+} from '../../../utils/date'
 import {
   winTypeId,
   GOODS_ID,

--- a/src/client/modules/ExportWins/Form/utils.js
+++ b/src/client/modules/ExportWins/Form/utils.js
@@ -1,9 +1,5 @@
 import { currencyGBP } from '../../../../client/utils/number-utils'
-import {
-  subtractMonths,
-  isDateAfter,
-  getStartOfMonth,
-} from '../../../utils/date'
+
 /**
  * @param {String} winType the name of the win type
  * @param {Object} values the form values object containing the keys
@@ -118,21 +114,9 @@ export const getMaxYearFromWinTypes = (winTypes, values) =>
   Math.max(...winTypes.map((winType) => getYearFromWinType(winType, values)))
 
 /**
- * Returns a date that is 12 months ago from the current date that includes the 1st of the month
- * @returns {Date} A date that is 12 months ago from the current date that includes the 1st of the month
- */
-export const getDateTwelveMonthsAgoWithFirstDay = () =>
-  subtractMonths(getStartOfMonth(new Date()), 12)
-
-/**
  * Tests whether a given date is within the last twelve months and not in the future.
  * @param {Date} date - The date to test.
  * @returns {boolean} True if the date is within the last twelve months and not in the future, false otherwise.
  */
-export const isWithinLastTwelveMonths = (date) =>
-  // Business date logic
-  isDateAfter(date, new Date())
-    ? false // Date is in the future
-    : isDateAfter(date, getDateTwelveMonthsAgoWithFirstDay())
 
 export const formatValue = (sum) => currencyGBP(sum)

--- a/src/client/modules/ExportWins/Form/validators.js
+++ b/src/client/modules/ExportWins/Form/validators.js
@@ -1,4 +1,4 @@
-import { isWithinLastTwelveMonths } from './utils'
+import { isWithinLastTwelveMonths } from '../../../utils/date'
 
 export const POSITIVE_INT_REGEX = /^[0-9]{1,19}$/
 export const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -1,6 +1,14 @@
 import {
+  addDays,
+  areDatesEqual,
+  subtractYears,
+  subtractMonths,
+  getStartOfMonth,
+  getRandomDateInRange,
+  isWithinLastTwelveMonths,
   convertDateToFieldDateObject,
   convertDateToFieldShortDateObject,
+  getStartDateOfTwelveMonthsAgo,
 } from '../date'
 
 describe('convertDateToFieldShortDateObject', () => {
@@ -46,5 +54,79 @@ describe('convertDateToFieldDateObject', () => {
         }
       )
     })
+  })
+})
+
+describe('getStartDateOfTwelveMonthsAgo', () => {
+  it(
+    'should return a date that is 12 months ago from the current ' +
+      'date and includes the 1st of the month',
+    () => {
+      const today = new Date()
+      const expectedDate = subtractMonths(getStartOfMonth(today), 12)
+      const actualDate = getStartDateOfTwelveMonthsAgo()
+      expect(actualDate).to.be.instanceOf(Date)
+      expect(areDatesEqual(actualDate, expectedDate)).to.equal(true)
+    }
+  )
+})
+
+describe('isWithinLastTwelveMonths', () => {
+  const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
+  const twelveMonthsAgoAddOneDay = addDays(twelveMonthsAgo, 1)
+  const twelveMonthsAgoSubOneDay = subtractYears(twelveMonthsAgo, 1)
+  const today = new Date()
+  const tomorrow = addDays(today, 1)
+  const yesterday = subtractYears(today, 1)
+
+  it('should be valid for the 1st of the month twelve months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgo)).to.equal(true)
+  })
+
+  it('should be valid for the 2nd of the month twelve months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgoAddOneDay)).to.equal(true)
+  })
+
+  it('should be invalid one day before the 1st of the month, thirteen months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgoSubOneDay)).to.equal(false)
+  })
+
+  it('should be valid for today', () => {
+    expect(isWithinLastTwelveMonths(today)).to.equal(true)
+  })
+
+  it('should be invalid for tomorrow', () => {
+    expect(isWithinLastTwelveMonths(tomorrow)).to.equal(false)
+  })
+
+  it('should be valid for yesterday', () => {
+    expect(isWithinLastTwelveMonths(yesterday)).to.equal(true)
+  })
+})
+
+describe('getRandomDateInRange', () => {
+  it('should return a random date within the specified range', () => {
+    const startDate = new Date(2024, 0, 1) // January 1, 2024
+    const endDate = new Date(2024, 0, 10) // January 10, 2024
+    const randomDate = getRandomDateInRange(startDate, endDate)
+    expect(randomDate).to.be.instanceOf(Date)
+    expect(randomDate.getTime()).to.be.at.least(startDate.getTime())
+    expect(randomDate.getTime()).to.be.at.most(endDate.getTime())
+  })
+
+  it('should throw an error if the start date and the end date are the same', () => {
+    const startDate = new Date(2024, 0, 1)
+    const endDate = new Date(2024, 0, 1)
+    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
+      'Start date and end date cannot be the same.'
+    )
+  })
+
+  it('should throw error if the start date is greater than the end date', () => {
+    const startDate = new Date(2024, 0, 10)
+    const endDate = new Date(2024, 0, 1)
+    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
+      'Start date cannot be greater than end date.'
+    )
   })
 })

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -15,6 +15,7 @@ const {
   isSameDay,
   endOfToday,
   startOfMonth: getStartOfMonth,
+  isWithinInterval,
   endOfYesterday,
   format: formatFns,
   formatDistanceToNowStrict,
@@ -28,6 +29,7 @@ const {
   subWeeks,
   differenceInCalendarMonths,
   isFuture,
+  isEqual: areDatesEqual,
 } = require('date-fns')
 
 const {
@@ -300,11 +302,33 @@ function getRandomDateInRange(startDate, endDate) {
     throw new Error('Start date and end date cannot be the same.')
   }
   if (startDate > endDate) {
-    throw new Error('Start date must be less than or equal to end date.')
+    throw new Error('Start date cannot be greater than end date.')
   }
   const daysDifference = differenceInDays(endDate, startDate)
   const randomNumberOfDays = Math.floor(Math.random() * (daysDifference + 1))
   return addDays(startDate, randomNumberOfDays)
+}
+
+/**
+ * Returns the start date (1st day) of the month twelve months ago from the current date.
+ * @returns {Date} The start date (1st day) of the month twelve months ago from the current date.
+ */
+function getStartDateOfTwelveMonthsAgo() {
+  return subMonths(getStartOfMonth(new Date()), 12)
+}
+
+/**
+ * Checks if a given date falls within the last twelve months from the current date.
+ * The last twelve months include the 1st of the month.
+ * @param {Date} date - The date to be checked.
+ * @returns {boolean} Returns true if the date falls within the last twelve months
+ * from the current date, otherwise false.
+ */
+function isWithinLastTwelveMonths(date) {
+  return isWithinInterval(date, {
+    start: getStartDateOfTwelveMonthsAgo(),
+    end: new Date(),
+  })
 }
 
 module.exports = {
@@ -345,5 +369,9 @@ module.exports = {
   parseDateISO,
   convertDateToFieldDateObject,
   getRandomDateInRange,
+  isWithinLastTwelveMonths,
+  getStartDateOfTwelveMonthsAgo,
   getStartOfMonth,
+  subtractMonths,
+  areDatesEqual,
 }

--- a/test/functional/cypress/specs/export-win/utils.js
+++ b/test/functional/cypress/specs/export-win/utils.js
@@ -1,8 +1,8 @@
-import { getDateTwelveMonthsAgoWithFirstDay } from '../../../../../src/client/modules/ExportWins/Form/utils'
 import {
   subtractMonths,
   addMonths,
   getRandomDateInRange,
+  getStartDateOfTwelveMonthsAgo,
 } from '../../../../../src/client/utils/date'
 import { clickContinueButton } from '../../support/actions'
 import { assertUrl } from '../../support/assertions'
@@ -166,7 +166,7 @@ const getMonthAndYearFromDate = (date) => ({
 
 export const getDateWithinLastTwelveMonths = () =>
   getMonthAndYearFromDate(
-    getRandomDateInRange(getDateTwelveMonthsAgoWithFirstDay(), new Date())
+    getRandomDateInRange(getStartDateOfTwelveMonthsAgo(), new Date())
   )
 
 export const getDateThirteenMonthsAgo = () =>


### PR DESCRIPTION
## Description of change
Adds some unit tests around our date utility functions and fixes a flaky test.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
