### PR TITLE
Fix/export wins review css

### DIFF
--- a/src/client/components/Footer/index.jsx
+++ b/src/client/components/Footer/index.jsx
@@ -40,6 +40,7 @@ const StyleList = styled.ul`
   display: flex;
   flex: 1;
   flex-direction: row;
+  list-style: none;
   li + li {
     margin-left: ${SPACING.SCALE_3};
   }

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -70,6 +70,7 @@ const StyledFieldsetNoStyling = styled('fieldset')`
 const StyledLegend = styled('legend')`
   font-weight: 700;
   font-size: 19px;
+  line-height: 1.25;
   padding: 0;
   margin: 0;
   padding-bottom: ${SPACING.SCALE_1};

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -68,16 +68,11 @@ const StyledFieldsetNoStyling = styled('fieldset')`
 `
 
 const StyledLegend = styled('legend')`
-  box-sizing: border-box;
-  display: table;
-  white-space: normal;
+  font-weight: 700;
   font-size: 19px;
   padding: 0;
   margin: 0;
   padding-bottom: ${SPACING.SCALE_1};
-  * {
-    margin-bottom: ${SPACING.SCALE_1} !important;
-  }
   ${(props) =>
     props.error &&
     `
@@ -137,7 +132,6 @@ const FieldInner = ({
     // FIXME: This shouldn't be a fieldset
     <StyledFieldset showBorder={showBorder}>
       <StyledLegend
-        className="govuk-heading-m"
         error={error}
         showBorder={showBorder}
         bigLegend={bigLegend}

--- a/src/client/modules/ExportWins/Review/Layout.jsx
+++ b/src/client/modules/ExportWins/Review/Layout.jsx
@@ -10,7 +10,7 @@ const Grid = styled.div({
   minHeight: '100vh',
   display: 'grid',
   gridTemplateRows: 'auto auto 1fr minmax(min-content, 30px)',
-  gridTemplateColumns: `1fr min(100vw, calc(960px + ${SPACING.SCALE_3} * 2)) 1fr`,
+  gridTemplateColumns: `1fr min(100vw, calc(960px + ${SPACING.SCALE_5} * 2)) 1fr`,
   gridTemplateAreas: `
     ". main-bar ."
     ". header ."
@@ -31,7 +31,7 @@ const MainBar = styled.div({
   fontWeight: FONT_WEIGHTS.bold,
   fontSize: FONT_SIZE.SIZE_27,
   color: WHITE,
-  padding: SPACING.SCALE_3,
+  padding: SPACING.SCALE_5,
 })
 
 const HeaderBackground = styled.div({
@@ -43,7 +43,7 @@ const HeaderBackground = styled.div({
 const Header = styled.header({
   gridArea: 'header',
   alignSelf: 'center',
-  padding: SPACING.SCALE_3,
+  padding: SPACING.SCALE_5,
   paddingBottom: SPACING.SCALE_5,
 })
 
@@ -54,6 +54,9 @@ const Main = styled.main({
 
 const GridCellFooter = styled(Footer)({
   gridArea: 'footer',
+  ul: {
+    padding: 0,
+  },
 })
 
 const Title = styled(H1)({


### PR DESCRIPTION
## Description of change

This PR fixes a number of styling issues in `/exportwins/review/:token`, whose Nunjucks template doesn't extend from `govuk/template.njk` and which is using some components that still rely on global CSS provided by the govuk template.
