### PR TITLE
Added a not about a Segmentation fault error

### DIFF
--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -4,6 +4,14 @@ _Helpful Docker commands that allow you to bring up containers, run a bunch of t
 
 **Note for Mac Users:** By default, docker on Mac will restrict itself to using just 2GB of memory. This [should be increased](https://docs.docker.com/docker-for-mac/#resources) to at least 6GB to avoid running in to unexpected problems.
 
+**Note for Mac Users 2:** Should you ever come across this error:
+```
+qemu: uncaught target signal 11 (Segmentation fault) - core dumped
+```
+Go to _Docker Desktop -> Settings -> General_ and check the
+_Use Rosetta for x86/amd64 emulation on Apple Silicon_ checkbox.
+That should fix the issue.
+
 **Note for all users:** The docker volumes for the frontend, api and sandbox api are all mounted. This means that you should not need to rebuild the containers when you make changes and you should see your changes reflected immediately. However, there are certain changes that will require you to rebuild. In that case, bring down the containers and run the script again. The scripts will always rebuild you containers if it detects code changes, otherwise they will be quick to come up and will just use the images it has in the docker cache.
 
 Prerequisite:


### PR DESCRIPTION
## Description of change

Adds a note for Mac users with Apple silicon for what to do if they come across this error:
```
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
```

## Test instructions

No changes to the code