### PR TITLE
Export win content fixes

### DIFF
--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -172,7 +172,7 @@ const CustomerDetailsTable = ({ values, goToStep, isEditing }) => (
       <SummaryTable.Row heading="HQ location">
         {values.customer_location?.label}
       </SummaryTable.Row>
-      <SummaryTable.Row heading="Export potential">
+      <SummaryTable.Row heading="Medium-sized and high potential companies">
         {values.business_potential?.label}
       </SummaryTable.Row>
       <SummaryTable.Row heading="Export experience">

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -52,8 +52,8 @@ const CustomerDetailsStep = ({ companyId, isEditing }) => {
       <ResourceOptionsField
         name="business_potential"
         id="business-potential"
-        label="Export potential"
-        required="Select export potential"
+        label="Medium-sized and high potential companies"
+        required="Select medium-sized and high potential companies"
         field={FieldTypeahead}
         resource={BusinessPotentialResource}
       />

--- a/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
@@ -69,7 +69,8 @@ const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
       <FieldAdvisersTypeahead
         name="team_members"
         label="Team members (optional)"
-        hint="You can add up to 5 team members. They will not be credited for the win but will be notified when this win is updated."
+        hint="These are your secondary contacts, such as your manager or direct team,
+               they will not be credited for this win. You can add up to 5 team members."
         validate={validators.validateTeamMembers}
         isMulti={true}
       />

--- a/src/client/modules/ExportWins/Form/WinTypeValues.jsx
+++ b/src/client/modules/ExportWins/Form/WinTypeValues.jsx
@@ -68,7 +68,7 @@ export const WinTypeValues = ({ label, name, years = 5, values }) => {
               } else if (isPositiveInteger(value)) {
                 return null
               } else {
-                return 'The value must not contain letters, be negative or over 19 digits'
+                return 'The value must not contain letters, symbols, be negative or have over 19 digits'
               }
             }}
           />

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -215,7 +215,8 @@ describe('Adding an export win', () => {
           content: {
             'Contact name': 'Joseph Barker',
             'HQ location': 'Scotland',
-            'Export potential': 'The company is a Medium Sized Business',
+            'Medium-sized and high potential companies':
+              'The company is a Medium Sized Business',
             'Export experience': 'Never exported',
           },
         })

--- a/test/functional/cypress/specs/export-win/customer-details-spec.js
+++ b/test/functional/cypress/specs/export-win/customer-details-spec.js
@@ -45,16 +45,16 @@ describe('Customer details', () => {
     })
   })
 
-  it('should render Export potential label and a Typeahead', () => {
+  it('should render "Medium-sized and high potential companies" label and a Typeahead', () => {
     cy.get(customerDetails.potential).then((element) => {
       assertFieldTypeahead({
         element,
-        label: 'Export potential',
+        label: 'Medium-sized and high potential companies',
       })
     })
   })
 
-  it('should render Export potential label and a Typeahead', () => {
+  it('should render Export experience label and a Typeahead', () => {
     cy.get(customerDetails.experience).then((element) => {
       assertFieldTypeahead({
         element,
@@ -69,7 +69,7 @@ describe('Customer details', () => {
     assertErrorSummary([
       'Select a company contact',
       'Select HQ location',
-      'Select export potential',
+      'Select medium-sized and high potential companies',
       'Select export experience',
     ])
     assertFieldError(
@@ -84,7 +84,7 @@ describe('Customer details', () => {
     )
     assertFieldError(
       cy.get(customerDetails.potential),
-      'Select export potential',
+      'Select medium-sized and high potential companies',
       false
     )
     assertFieldError(

--- a/test/functional/cypress/specs/export-win/officer-details-spec.js
+++ b/test/functional/cypress/specs/export-win/officer-details-spec.js
@@ -56,7 +56,8 @@ describe('Officer details', () => {
     })
     cy.get(officerDetails.teamMembersHintText).should(
       'have.text',
-      'You can add up to 5 team members. They will not be credited for the win but will be notified when this win is updated.'
+      'These are your secondary contacts, such as your manager or direct team, ' +
+        'they will not be credited for this win. You can add up to 5 team members.'
     )
   })
 


### PR DESCRIPTION
## Description of change
Export win content changes.

## Screenshots

### Before
**Officer details** 
<img width="979" alt="Screenshot 2024-03-26 at 09 28 17" src="https://github.com/uktrade/data-hub-frontend/assets/964268/ee75066a-db8f-4897-af11-24c527d32468">

**Customer details** 
<img width="981" alt="Screenshot 2024-03-26 at 09 27 46" src="https://github.com/uktrade/data-hub-frontend/assets/964268/4371ec1c-6f96-4e48-8b93-2d22f76d9cff">

### After
**Officer details** 
<img width="984" alt="Screenshot 2024-03-26 at 09 26 01" src="https://github.com/uktrade/data-hub-frontend/assets/964268/22c549ce-a5bf-41a0-a5e4-dfdfa68ad4cc">

**Customer details** 
<img width="981" alt="Screenshot 2024-03-26 at 09 26 51" src="https://github.com/uktrade/data-hub-frontend/assets/964268/89a110b4-ba84-419a-ac7a-2325d98527f2">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
