### PR TITLE
Tidy up external URLs

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
@@ -39,7 +39,7 @@ const StepReferralDetails = ({
         <br />
         <NewWindowLink
           data-test="referral-guidance"
-          href={urls.external.referrals}
+          href={urls.external.helpCentre.referrals}
         >
           Read more guidance here
         </NewWindowLink>

--- a/src/apps/global-nav-items.js
+++ b/src/apps/global-nav-items.js
@@ -26,7 +26,7 @@ const SORTED_APP_GLOBAL_NAV_ITEMS = sortBy(
   (globalNavItem) => globalNavItem.order
 )
 const GLOBAL_NAV_ITEMS = concat(SORTED_APP_GLOBAL_NAV_ITEMS, {
-  path: urls.external.findExporters(),
+  path: urls.external.dataWorkspace.findExporters,
   label: 'Find exporters',
   key: 'find-exporters',
 })

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -218,7 +218,7 @@ const StepInteractionDetails = ({
       : null
 
   const helpUrl = (position) =>
-    urls.external.helpCentre.policyFeedback() +
+    urls.external.helpCentre.policyFeedback +
     '?' +
     qs.stringify({
       ..._.pick(values, ['theme', 'kind']),

--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -44,7 +44,7 @@ const StepInteractionType = () => {
         <br />
         <br />
         For more information see{' '}
-        <NewWindowLink href={urls.external.helpCentre.tradeagreementGuidance()}>
+        <NewWindowLink href={urls.external.helpCentre.tradeAgreementGuidance}>
           recording trade agreement activity
         </NewWindowLink>
         .{' '}

--- a/src/client/components/DataHubFeed/index.jsx
+++ b/src/client/components/DataHubFeed/index.jsx
@@ -41,7 +41,7 @@ const DataHubFeed = ({ items, feedLimit = 5 }) => (
           ))}
         </UnorderedList>
         <NewWindowLink
-          href={urls.external.helpCentre.allUpdates()}
+          href={urls.external.helpCentre.allUpdates}
           data-test={`data-hub-feed-view-all`}
         >
           View all Data Hub updates

--- a/src/client/components/Footer/index.jsx
+++ b/src/client/components/Footer/index.jsx
@@ -110,10 +110,10 @@ const Container = styled(InnerContainer)`
 
 export const LINKS = {
   'Request Support': urls.support(),
-  'Help Centre': urls.external.helpCentre.dhHomepage(),
-  'Privacy Notice': urls.external.helpCentre.privacyNotice(),
-  Cookies: urls.external.helpCentre.cookies(),
-  'Accessibility Statement': urls.external.helpCentre.accessibilityStatement(),
+  'Help Centre': urls.external.helpCentre.dhHomepage,
+  'Privacy Notice': urls.external.helpCentre.privacyNotice,
+  Cookies: urls.external.helpCentre.cookies,
+  'Accessibility Statement': urls.external.helpCentre.accessibilityStatement,
 }
 
 /**
@@ -141,7 +141,7 @@ export default function Footer({ links = LINKS, ...props }) {
           ))}
         </StyleList>
         <CopyrightLink
-          href={urls.external.copyright}
+          href={urls.external.nationalArchives.copyright}
           target="_blank"
           rel="noopener noreferrer"
           aria-label="Crown copyright (opens in new tab)"

--- a/src/client/modules/Community/index.jsx
+++ b/src/client/modules/Community/index.jsx
@@ -72,9 +72,7 @@ const Community = () => {
             </StyledHeading>
             <StyledParagraph data-test="community-roadmap-paragraph">
               Our{' '}
-              <NewWindowLink
-                href={urls.external.helpCentre.community.roadmap()}
-              >
+              <NewWindowLink href={urls.external.helpCentre.community.roadmap}>
                 CRM roadmap
               </NewWindowLink>{' '}
               shows what we&apos;re currently working on and the work that is
@@ -90,7 +88,7 @@ const Community = () => {
             </StyledHeading>
             <StyledParagraph>
               Do you have a great idea? We would love to hear it. Tell us your{' '}
-              <Link href={urls.external.helpCentre.community.feedback()}>
+              <Link href={urls.external.helpCentre.community.feedback}>
                 feedback or experience
               </Link>{' '}
               using our CRM tools.
@@ -110,7 +108,7 @@ const Community = () => {
               relationship management and help us to plan and prioritise
               upcoming development.{' '}
               <NewWindowLink
-                href={urls.external.helpCentre.community.principles()}
+                href={urls.external.helpCentre.community.principles}
               >
                 Find out more about our CRM principles
               </NewWindowLink>
@@ -129,9 +127,7 @@ const Community = () => {
               We offer introductions to Data Hub and Data Workspace as well as
               bootcamps to help use our analysis and visualisation tools
               effectively.{' '}
-              <NewWindowLink
-                href={urls.external.helpCentre.community.training()}
-              >
+              <NewWindowLink href={urls.external.helpCentre.community.training}>
                 View available training
               </NewWindowLink>{' '}
               and sign up today!

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -82,7 +82,9 @@ const DataWorkspaceAccountPlan = ({ company }) => (
         </GridRow>
       </GridCol>
       <br />
-      <NewWindowLink href={urls.external.dataWorkspace(company.id)}>
+      <NewWindowLink
+        href={urls.external.dataWorkspace.accountPlans(company.id)}
+      >
         View {company.name}'s account plan
       </NewWindowLink>
     </GridCol>

--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -85,7 +85,7 @@ const ExportsIndex = () => {
               The export potential score is a prediction of a company's
               likelihood of exporting, and was originally created for the{' '}
               <Link
-                href={urls.external.findExporters()}
+                href={urls.external.dataWorkspace.findExporters}
                 target="_blank"
                 aria-label="opens in a new tab"
               >
@@ -157,7 +157,7 @@ const ExportsIndex = () => {
             <p>
               <Link
                 data-test-id="exportWinsLink"
-                href={urls.external.exportWins()}
+                href={urls.external.exportWins}
                 target="_blank"
                 aria-label="opens in a new tab"
               >

--- a/src/client/modules/Companies/CompanyExports/GreatProfile.jsx
+++ b/src/client/modules/Companies/CompanyExports/GreatProfile.jsx
@@ -5,7 +5,7 @@ import { NewWindowLink } from '../../../components'
 
 export default ({ profileStatus, companyNumber }) =>
   profileStatus === 'published' ? (
-    <NewWindowLink href={urls.external.greatProfile(companyNumber)}>
+    <NewWindowLink href={urls.external.great.companyProfile(companyNumber)}>
       "Find a supplier" profile
     </NewWindowLink>
   ) : profileStatus === 'unpublished' ? (

--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -26,7 +26,7 @@ export const EventFormFields = ({ values }) => (
       <p>
         Find{' '}
         <Link
-          href={urls.external.helpCentre.tradeagreementGuidance()}
+          href={urls.external.helpCentre.tradeAgreementGuidance}
           target="_blank"
           aria-label="This will open in a new window"
         >

--- a/src/client/modules/Reminders/Reminders.jsx
+++ b/src/client/modules/Reminders/Reminders.jsx
@@ -133,7 +133,7 @@ export const Reminders = ({ defaultUrl }) => {
         </Container>
         <FooterLink
           headingText="Need Help?"
-          linkUrl={urls.external.reminderAndSettings}
+          linkUrl={urls.external.helpCentre.reminderAndSettings}
           linkText="guidance on reminders and email notifications"
         />
       </>

--- a/src/client/modules/Reminders/Settings/RemindersForms.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersForms.jsx
@@ -81,7 +81,7 @@ const RemindersForms = () => {
       </>
       <FooterLink
         headingText="Need Help?"
-        linkUrl={urls.external.reminderAndSettings}
+        linkUrl={urls.external.helpCentre.reminderAndSettings}
         linkText="guidance on reminders and email notifications"
       />
     </DefaultLayout>

--- a/src/client/modules/Reminders/Settings/RemindersSettings.jsx
+++ b/src/client/modules/Reminders/Settings/RemindersSettings.jsx
@@ -323,7 +323,7 @@ export const RemindersSettings = ({
 
             <FooterLink
               headingText="Need Help?"
-              linkUrl={urls.external.reminderAndSettings}
+              linkUrl={urls.external.helpCentre.reminderAndSettings}
               linkText="guidance on reminders and email notifications"
             />
           </>

--- a/src/lib/__test__/urls.test.js
+++ b/src/lib/__test__/urls.test.js
@@ -6,7 +6,7 @@ describe('urls', () => {
   describe('external', () => {
     it('should have the correct urls', () => {
       const companyNumber = faker.string.alphanumeric(8)
-      expect(urls.external.greatProfile(companyNumber)).to.equal(
+      expect(urls.external.great.companyProfile(companyNumber)).to.equal(
         `https://www.great.gov.uk/international/trade/suppliers/${companyNumber}`
       )
 
@@ -14,11 +14,11 @@ describe('urls', () => {
         `https://beta.companieshouse.gov.uk/company/${companyNumber}`
       )
 
-      expect(urls.external.findExporters()).to.equal(
+      expect(urls.external.dataWorkspace.findExporters).to.equal(
         'https://data.trade.gov.uk/datasets/4a0da123-a933-4250-90b5-df5cde34930b'
       )
 
-      expect(urls.external.exportWins()).to.equal(
+      expect(urls.external.exportWins).to.equal(
         'https://www.exportwins.service.trade.gov.uk/'
       )
     })

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -78,21 +78,25 @@ module.exports = {
     index: url('/testing'),
   },
   external: {
-    greatProfile: (id) =>
-      `https://www.great.gov.uk/international/trade/suppliers/${id}`,
     companiesHouse: (companyNumber) =>
       `https://beta.companieshouse.gov.uk/company/${companyNumber}`,
-    findExporters: () =>
-      'https://data.trade.gov.uk/datasets/4a0da123-a933-4250-90b5-df5cde34930b',
-    exportWins: () => 'https://www.exportwins.service.trade.gov.uk/',
-    dataWorkspace: (id) =>
-      `https://data.trade.gov.uk/visualisations/link/e69bbfde-0e68-49d3-ad81-ddffbad6bac6#p.CompanyID=${id}`,
+    exportWins: 'https://www.exportwins.service.trade.gov.uk/',
     omis: 'https://omis.trade.gov.uk/',
+    dataWorkspace: {
+      findExporters:
+        'https://data.trade.gov.uk/datasets/4a0da123-a933-4250-90b5-df5cde34930b',
+      accountPlans: (id) =>
+        `https://data.trade.gov.uk/visualisations/link/e69bbfde-0e68-49d3-ad81-ddffbad6bac6#p.CompanyID=${id}`,
+    },
     nationalArchives: {
+      copyright:
+        'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/',
       openGovLicence:
-        'http://www.nationalarchives.gov.uk/doc/open-government-licence',
+        'https://www.nationalarchives.gov.uk/doc/open-government-licence',
     },
     great: {
+      companyProfile: (id) =>
+        `https://www.great.gov.uk/international/trade/suppliers/${id}`,
       privacyPolicy: 'https://www.great.gov.uk/uk/privacy-policy/',
     },
     govUkHomepage: 'https://www.gov.uk/',
@@ -101,41 +105,37 @@ module.exports = {
         'https://people.trade.gov.uk/teams/department-for-international-trade',
       accountManagement:
         'https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/strategic-relationship-account-management/',
-      accountManagementStrategyTeam:
-        'https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/the-account-management-strategy-team',
     },
     helpCentre: {
       community: {
-        roadmap: () =>
+        roadmap:
           'https://data-services-help.trade.gov.uk/data-hub/updates/roadmap/data-hub-roadmap/ ',
-        feedback: () =>
+        feedback:
           'https://data-services-help.trade.gov.uk/data-hub/crm-community/feedback-or-propose-changes',
-        principles: () =>
+        principles:
           'https://data-services-help.trade.gov.uk/data-hub/crm-community/crm-principles',
-        training: () =>
+        training:
           'https://data-services-help.trade.gov.uk/data-hub/crm-community/training',
       },
-      accessibilityStatement: () =>
+      accessibilityStatement:
         'https://data-services-help.trade.gov.uk/data-hub/how-articles/data-hub-accessibility-statement/data-hub-accessibility-statement/',
-      dhHomepage: () => 'https://data-services-help.trade.gov.uk/data-hub/',
-      policyFeedback: () =>
+      dhHomepage: 'https://data-services-help.trade.gov.uk/data-hub/',
+      policyFeedback:
         'https://data-services-help.trade.gov.uk/data-hub/how-articles/interactions-and-service-delivery/record-business-intelligence-interaction/',
-      tradeagreementGuidance: () =>
+      tradeAgreementGuidance:
         'https://data-services-help.trade.gov.uk/data-hub/how-articles/trade-agreement-activity/recording-trade-agreement-activity/',
-      cookies: () =>
+      cookies:
         'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/data-hub-cookie-policy/',
-      privacyNotice: () =>
+      privacyNotice:
         'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/data-hub-privacy-notice/',
-      allUpdates: () =>
+      allUpdates:
         'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/',
+      referrals:
+        'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/improving-collaboration-internal-referrals/',
+      reminderAndSettings:
+        'https://data-services-help.trade.gov.uk/data-hub/how-articles/reminders-and-email-notifications/',
     },
-    copyright:
-      'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/',
-    referrals:
-      'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/improving-collaboration-internal-referrals/',
-    reminderAndSettings:
-      'https://data-services-help.trade.gov.uk/data-hub/how-articles/reminders-and-email-notifications/',
-    euVIES: 'http://ec.europa.eu/taxation_customs/vies/',
+    euVIES: 'https://ec.europa.eu/taxation_customs/vies/',
   },
 
   dashboard: {

--- a/test/component/cypress/specs/Referrals/StepReferralDetails.cy.jsx
+++ b/test/component/cypress/specs/Referrals/StepReferralDetails.cy.jsx
@@ -62,7 +62,7 @@ describe('StepReferralDetails component', () => {
             'Referrals are for when you want to ask another DBT advisor to help out an account you are working on.Read more guidance here (opens in new tab)'
           )
 
-        assertLink('referral-guidance', urls.external.referrals)
+        assertLink('referral-guidance', urls.external.helpCentre.referrals)
       })
 
       it('should display the headings and four fields', () => {

--- a/test/functional/cypress/specs/community/community-spec.js
+++ b/test/functional/cypress/specs/community/community-spec.js
@@ -1,6 +1,8 @@
 import urls from '../../../../../src/lib/urls'
 import { assertBreadcrumbs } from '../../support/assertions'
 
+const helpCentreLinks = urls.external.helpCentre.community
+
 describe('Community', () => {
   context('When visiting the Community page', () => {
     beforeEach(() => {
@@ -34,11 +36,7 @@ describe('Community', () => {
         .should('exist')
         .should('contain.text', "Take a look at what we're working on")
         .children()
-        .should(
-          'have.attr',
-          'href',
-          urls.external.helpCentre.community.roadmap()
-        )
+        .should('have.attr', 'href', helpCentreLinks.roadmap)
     })
 
     it('should display the feedback block', () => {
@@ -47,11 +45,7 @@ describe('Community', () => {
         .should('exist')
         .should('contain.text', 'Discuss and give feedback')
         .children()
-        .should(
-          'have.attr',
-          'href',
-          urls.external.helpCentre.community.feedback()
-        )
+        .should('have.attr', 'href', helpCentreLinks.feedback)
     })
 
     it('should display the principles block', () => {
@@ -60,11 +54,7 @@ describe('Community', () => {
         .should('exist')
         .should('contain.text', 'Our CRM principles')
         .children()
-        .should(
-          'have.attr',
-          'href',
-          urls.external.helpCentre.community.principles()
-        )
+        .should('have.attr', 'href', helpCentreLinks.principles)
     })
 
     it('should display the training block', () => {
@@ -73,11 +63,7 @@ describe('Community', () => {
         .should('exist')
         .should('contain.text', 'Sign up for training')
         .children()
-        .should(
-          'have.attr',
-          'href',
-          urls.external.helpCentre.community.training()
-        )
+        .should('have.attr', 'href', helpCentreLinks.training)
     })
 
     it('should display the user research block', () => {

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -246,7 +246,11 @@ describe('Company account management', () => {
     it('should navigate to the account plan page when the link is clicked', () => {
       cy.get('[data-test="newWindowLink"]')
         .should('exist')
-        .should('have.attr', 'href', urls.external.dataWorkspace(companyId))
+        .should(
+          'have.attr',
+          'href',
+          urls.external.dataWorkspace.accountPlans(companyId)
+        )
     })
   })
 })

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -119,7 +119,7 @@ describe('Company Export tab - Edit exports', () => {
         cy.contains('"Find a supplier" profile').should(
           'have.attr',
           'href',
-          urls.external.greatProfile(dnbLimited.company_number)
+          urls.external.great.companyProfile(dnbLimited.company_number)
         )
       })
 

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -1,4 +1,4 @@
-const fixtures = require('../../../fixtures')
+const { company } = require('../../../fixtures')
 const { assertBreadcrumbs } = require('../../../support/assertions')
 const urls = require('../../../../../../src/lib/urls')
 
@@ -57,7 +57,7 @@ describe('Company Export tab', () => {
     'when viewing the export tab for an active company with no export information and 8 Export Wins',
     () => {
       beforeEach(() => {
-        visitExportIndex(fixtures.company.dnbCorp.id)
+        visitExportIndex(company.dnbCorp.id)
       })
 
       it('should render a meta title', () => {
@@ -68,15 +68,13 @@ describe('Company Export tab', () => {
         assertBreadcrumbs({
           Home: '/',
           Companies: urls.companies.index(),
-          [fixtures.company.dnbCorp.name]: urls.companies.detail(
-            fixtures.company.dnbCorp.id
-          ),
+          [company.dnbCorp.name]: urls.companies.detail(company.dnbCorp.id),
           Exports: null,
         })
       })
 
       it('should render the "Exports" table', () => {
-        assertExportsTable(fixtures.company.dnbCorp.id, [
+        assertExportsTable(company.dnbCorp.id, [
           { label: 'Export win category', value: 'None' },
           { label: 'great.gov.uk business profile', value: 'No profile' },
           { label: 'Export potential', value: 'No score given' },
@@ -90,12 +88,16 @@ describe('Company Export tab', () => {
           "The export potential score is a prediction of a company's likelihood of exporting, and was originally created for the Find Exporters tool. DBT's data science team compared all HMRC export information with the features of all UK companies to find patterns; they then repeatedly tested their model against a subset of known-good data to improve it. The scores are as follows:Very High - Most companies like this one are exportersHigh - This business shares some features with successful exportersMedium - Some businesses that look like this one export, others don'tLow - This business shares many features with companies that do not exportVery Low - Most of the businesses like this aren't exportersWe are continuing to improve the algorithm so please do share your feedback or let us know of any anomalies through the support channel."
         )
         cy.contains('Find Exporters tool')
-          .should('have.attr', 'href', urls.external.findExporters())
+          .should(
+            'have.attr',
+            'href',
+            urls.external.dataWorkspace.findExporters
+          )
           .should('have.attr', 'aria-label', 'opens in a new tab')
       })
 
       it('should render the "Export countries information table', () => {
-        assertExportCountriesTable(fixtures.company.dnbCorp.id, [
+        assertExportCountriesTable(company.dnbCorp.id, [
           { label: 'Currently exporting to', value: 'None' },
           { label: 'Future countries of interest', value: 'None' },
           { label: 'Countries of no interest', value: 'None' },
@@ -106,7 +108,7 @@ describe('Company Export tab', () => {
         cy.contains('View full export countries history').should(
           'have.attr',
           'href',
-          urls.companies.exports.history.index(fixtures.company.dnbCorp.id)
+          urls.companies.exports.history.index(company.dnbCorp.id)
         )
       })
 
@@ -125,7 +127,7 @@ describe('Company Export tab', () => {
         cy.contains('Record your win').should(
           'have.attr',
           'href',
-          urls.external.exportWins()
+          urls.external.exportWins
         )
         cy.contains('Record your win')
           .should('have.attr', 'target', '_blank')
@@ -251,11 +253,11 @@ describe('Company Export tab', () => {
     'when viewing the export tab for an active company with export information in each field',
     () => {
       beforeEach(() => {
-        cy.visit(urls.companies.exports.index(fixtures.company.dnbLtd.id))
+        cy.visit(urls.companies.exports.index(company.dnbLtd.id))
       })
 
       it('should render the "Exports" table', () => {
-        assertExportsTable(fixtures.company.dnbLtd.id, [
+        assertExportsTable(company.dnbLtd.id, [
           { label: 'Export win category', value: 'Increasing export turnover' },
           {
             label: 'great.gov.uk business profile',
@@ -269,7 +271,7 @@ describe('Company Export tab', () => {
         cy.contains('"Find a supplier" profile').should(
           'have.attr',
           'href',
-          urls.external.greatProfile(fixtures.company.dnbLtd.company_number)
+          urls.external.great.companyProfile(company.dnbLtd.company_number)
         )
       })
 
@@ -277,12 +279,12 @@ describe('Company Export tab', () => {
         cy.contains('View full export countries history').should(
           'have.attr',
           'href',
-          urls.companies.exports.history.index(fixtures.company.dnbLtd.id)
+          urls.companies.exports.history.index(company.dnbLtd.id)
         )
       })
 
       it('should render the "Exports countries information" table', () => {
-        assertExportCountriesTable(fixtures.company.dnbLtd.id, [
+        assertExportCountriesTable(company.dnbLtd.id, [
           { label: 'Currently exporting to', value: 'France, Spain' },
           { label: 'Future countries of interest', value: 'Germany' },
           { label: 'Countries of no interest', value: 'Sweden' },
@@ -293,7 +295,7 @@ describe('Company Export tab', () => {
 
   context('when viewing exports for an archived company', () => {
     beforeEach(() => {
-      cy.visit(urls.companies.exports.index(fixtures.company.archivedLtd.id))
+      cy.visit(urls.companies.exports.index(company.archivedLtd.id))
     })
 
     it('the edit exports link should not exist', () => {
@@ -330,7 +332,7 @@ describe('Company Export tab', () => {
 
     context('when the API for Export Wins returns a 501', () => {
       before(() => {
-        visitExports(fixtures.company.lambdaPlc.id)
+        visitExports(company.lambdaPlc.id)
       })
 
       it('shold not have an Export Wins list', () => {
@@ -342,37 +344,37 @@ describe('Company Export tab', () => {
 
     context('when the API for Export Wins returns a 500', () => {
       before(() => {
-        visitExports(fixtures.company.minimallyMinimalLtd.id)
+        visitExports(company.minimallyMinimalLtd.id)
       })
 
       it('should show an error message', () => {
-        assertErrorMessage(fixtures.company.minimallyMinimalLtd.name)
+        assertErrorMessage(company.minimallyMinimalLtd.name)
       })
     })
 
     context('when the API for Export Wins returns a 502', () => {
       before(() => {
-        visitExports(fixtures.company.investigationLimited.id)
+        visitExports(company.investigationLimited.id)
       })
 
       it('should show an error message', () => {
-        assertErrorMessage(fixtures.company.investigationLimited.name)
+        assertErrorMessage(company.investigationLimited.name)
       })
     })
 
     context('when the API for Export Wins returns a 404', () => {
       before(() => {
-        visitExports(fixtures.company.oneListCorp.id)
+        visitExports(company.oneListCorp.id)
       })
 
       it('should show an error message', () => {
-        assertErrorMessage(fixtures.company.oneListCorp.name)
+        assertErrorMessage(company.oneListCorp.name)
       })
     })
 
     context('When there is more than one page of results', () => {
       beforeEach(() => {
-        visitExports(fixtures.company.marsExportsLtd.id)
+        visitExports(company.marsExportsLtd.id)
       })
 
       it('should not display a download data header', () => {

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -51,7 +51,7 @@ describe('Dashboard', () => {
       cy.get('@infoFeedTopLink')
         .should('exist')
         .should('have.text', 'View all Data Hub updates (opens in new tab)')
-        .should('have.attr', 'href', urls.external.helpCentre.allUpdates())
+        .should('have.attr', 'href', urls.external.helpCentre.allUpdates)
     })
   })
 


### PR DESCRIPTION
## Description of change

The collection of external links within the URLs module had become a bit muddled so I've tidied it up.

The following changes have been made:
- There were several static URLs that were setup to take dynamic parameters. These URLs have been updated to not accept parameters.
- The stray help centre and national archives URLs have been moved to their proper place.
- Some URLs have been renamed to be more descriptive and better reflect their new position within a group.
- The `accountManagementStrategyTeam` link wasn't being used anywhere so it has been removed (the link leads to an error page anyway).

## Test instructions

All external links should still work

## Screenshots

No visual changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
