### PR TITLE
Revert "Temporarily skip tests reliant on ActivityStream"

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -114,7 +114,7 @@ describe('Event', () => {
       createEvent()
     })
 
-    it.skip('should create an attendee on a event', () => {
+    it('should create an attendee on a event', () => {
       createEvent()
       // This is here to allow the activity stream to poll the event api and detect the new event.
       //TODO once the activity stream poll is made customisable remove this wait
@@ -142,7 +142,7 @@ describe('Event', () => {
     })
   })
 
-  describe.skip('edit', () => {
+  describe('edit', () => {
     beforeEach(() => {
       cy.visit(urls.events.index())
     })


### PR DESCRIPTION
Reverts uktrade/data-hub-frontend#6303

A few months ago an issue with `ActivityStream` required us to skip a few e2e tests. These tests are now running without issue so we can unskip them.

The test currently failing is the broken investments one. There are no actual code changes here so I feel that this is fine to be reviewed while the CI pipeline is broken