### PR TITLE
When editing an export win show banners and remove fields

### DIFF
--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -136,8 +136,8 @@ export default (
         : 0
       return {
         ...state,
-        currentStep: nextCurrentStep,
-
+        currentStep: nextCurrentStep, // TODO: rename this to currentStepIndex
+        currentStepName: action.stepName,
         previousValues: state.values,
       }
     case FORM__STEP_REGISTER:

--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 import WarningText from '@govuk-react/warning-text'
+import InsetText from '@govuk-react/inset-text'
+import { FONT_SIZE } from '@govuk-react/constants'
 import { H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
@@ -7,6 +9,7 @@ import pluralize from 'pluralize'
 import { Step, ButtonLink, FieldInput, SummaryTable } from '../../../components'
 import { useFormContext } from '../../../components/Form/hooks'
 import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
+import { ContactLink } from './ExportWinForm'
 import { steps } from './constants'
 import {
   transformTeamsAndAdvisers,
@@ -32,6 +35,17 @@ const StyledContributingTeamsAndAdvisers = styled('div')({
 
 const StyledOrderedList = styled('ol')({
   marginTop: 10,
+})
+
+const StyledSummaryTable = styled(SummaryTable)(({ isEditing }) => ({
+  marginBottom: isEditing ? 15 : 30,
+}))
+
+const StyledInsetText = styled(InsetText)({
+  marginTop: 0,
+  marginBottom: 30,
+  padding: '0 0 0 5px',
+  fontSize: FONT_SIZE.SIZE_14,
 })
 
 const CheckBeforeSendingStep = ({ isEditing }) => {
@@ -136,33 +150,41 @@ const CreditForThisWinTable = ({ values, goToStep }) => {
   )
 }
 
-const CustomerDetailsTable = ({ values, goToStep }) => (
-  <SummaryTable
-    caption="Customer details"
-    data-test="customer-details"
-    actions={
-      <StyledButtonLink
-        onClick={() => {
-          goToStep(steps.CUSTOMER_DETAILS)
-        }}
-      >
-        Edit
-      </StyledButtonLink>
-    }
-  >
-    <SummaryTable.Row heading="Contact name">
-      {values.company_contacts?.label}
-    </SummaryTable.Row>
-    <SummaryTable.Row heading="HQ location">
-      {values.customer_location?.label}
-    </SummaryTable.Row>
-    <SummaryTable.Row heading="Export potential">
-      {values.business_potential?.label}
-    </SummaryTable.Row>
-    <SummaryTable.Row heading="Export experience">
-      {values.export_experience?.label}
-    </SummaryTable.Row>
-  </SummaryTable>
+const CustomerDetailsTable = ({ values, goToStep, isEditing }) => (
+  <>
+    <StyledSummaryTable
+      isEditing={isEditing}
+      caption="Customer details"
+      data-test="customer-details"
+      actions={
+        <StyledButtonLink
+          onClick={() => {
+            goToStep(steps.CUSTOMER_DETAILS)
+          }}
+        >
+          Edit
+        </StyledButtonLink>
+      }
+    >
+      <SummaryTable.Row heading="Contact name">
+        {values.company_contacts?.label}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="HQ location">
+        {values.customer_location?.label}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Export potential">
+        {values.business_potential?.label}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Export experience">
+        {values.export_experience?.label}
+      </SummaryTable.Row>
+    </StyledSummaryTable>
+    {isEditing && (
+      <StyledInsetText>
+        <ContactLink sections={['Export experience']} />
+      </StyledInsetText>
+    )}
+  </>
 )
 
 const getWinTypeValue = (winType, values) => {
@@ -177,7 +199,7 @@ const getTotalWinTypeValue = (winTypes = [], values) => {
   return `${sum} over ${maxYear} ${pluralize('year', maxYear)}`
 }
 
-const WinDetailsTable = ({ values, goToStep }) => {
+const WinDetailsTable = ({ values, goToStep, isEditing }) => {
   const exportSum = sumWinTypeYearlyValues('export_win', values)
   const odiWinSum = sumWinTypeYearlyValues('odi_win', values)
   const busSuccSum = sumWinTypeYearlyValues('business_success_win', values)
@@ -188,67 +210,82 @@ const WinDetailsTable = ({ values, goToStep }) => {
   const showOdiWin = odiWinSum > 0 && hasMoreThanOneWinType
 
   return (
-    <SummaryTable
-      caption="Win details"
-      data-test="win-details"
-      actions={
-        <StyledButtonLink
-          onClick={() => {
-            goToStep(steps.WIN_DETAILS)
-          }}
-        >
-          Edit
-        </StyledButtonLink>
-      }
-    >
-      <SummaryTable.Row heading="Destination">
-        {values.country?.label}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Date won">
-        {`${values.date?.month}/${values.date?.year}`}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Summary of support given">
-        {values.description}
-      </SummaryTable.Row>
-      {values.name_of_customer && (
-        <SummaryTable.Row heading="Overseas customer">
-          {values.name_of_customer}
+    <>
+      <StyledSummaryTable
+        isEditing={isEditing}
+        caption="Win details"
+        data-test="win-details"
+        actions={
+          <StyledButtonLink
+            onClick={() => {
+              goToStep(steps.WIN_DETAILS)
+            }}
+          >
+            Edit
+          </StyledButtonLink>
+        }
+      >
+        <SummaryTable.Row heading="Destination">
+          {values.country?.label}
         </SummaryTable.Row>
-      )}
-      <SummaryTable.Row heading="Confidential">
-        {transformCustomerConfidential(values.name_of_customer_confidential)}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Type of win">
-        {values.business_type}
-      </SummaryTable.Row>
-      {showExportWin && (
-        <SummaryTable.Row heading="Export value">
-          {getWinTypeValue('export_win', values)}
+        <SummaryTable.Row heading="Date won">
+          {`${values.date?.month}/${values.date?.year}`}
         </SummaryTable.Row>
-      )}
-      {showBusinessSuccessWin && (
-        <SummaryTable.Row heading="Business success value">
-          {getWinTypeValue('business_success_win', values)}
+        <SummaryTable.Row heading="Summary of support given">
+          {values.description}
         </SummaryTable.Row>
-      )}
-      {showOdiWin && (
-        <SummaryTable.Row heading="Outward Direct Investment (ODI) value">
-          {getWinTypeValue('odi_win', values)}
+        {values.name_of_customer && (
+          <SummaryTable.Row heading="Overseas customer">
+            {values.name_of_customer}
+          </SummaryTable.Row>
+        )}
+        <SummaryTable.Row heading="Confidential">
+          {transformCustomerConfidential(values.name_of_customer_confidential)}
         </SummaryTable.Row>
+        <SummaryTable.Row heading="Type of win">
+          {values.business_type}
+        </SummaryTable.Row>
+        {showExportWin && (
+          <SummaryTable.Row heading="Export value">
+            {getWinTypeValue('export_win', values)}
+          </SummaryTable.Row>
+        )}
+        {showBusinessSuccessWin && (
+          <SummaryTable.Row heading="Business success value">
+            {getWinTypeValue('business_success_win', values)}
+          </SummaryTable.Row>
+        )}
+        {showOdiWin && (
+          <SummaryTable.Row heading="Outward Direct Investment (ODI) value">
+            {getWinTypeValue('odi_win', values)}
+          </SummaryTable.Row>
+        )}
+        <SummaryTable.Row heading="Total value">
+          {getTotalWinTypeValue(values.win_type, values)}
+        </SummaryTable.Row>
+        <SummaryTable.Row heading="What does the value relate to?">
+          {transformGoodsAndServices(values.goods_vs_services)}
+        </SummaryTable.Row>
+        <SummaryTable.Row heading="Type of goods or services">
+          {values.name_of_export}
+        </SummaryTable.Row>
+        <SummaryTable.Row heading="Sector">
+          {values.sector?.label}
+        </SummaryTable.Row>
+      </StyledSummaryTable>
+      {isEditing && (
+        <StyledInsetText>
+          <ContactLink
+            sections={[
+              'Summary of the support you provided',
+              'Destination',
+              'Date won',
+              'Type of export win and Value',
+            ]}
+          />
+        </StyledInsetText>
       )}
-      <SummaryTable.Row heading="Total value">
-        {getTotalWinTypeValue(values.win_type, values)}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="What does the value relate to?">
-        {transformGoodsAndServices(values.goods_vs_services)}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Type of goods or services">
-        {values.name_of_export}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Sector">
-        {values.sector?.label}
-      </SummaryTable.Row>
-    </SummaryTable>
+    </>
   )
 }
 

--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -180,7 +180,7 @@ const CustomerDetailsTable = ({ values, goToStep, isEditing }) => (
       </SummaryTable.Row>
     </StyledSummaryTable>
     {isEditing && (
-      <StyledInsetText>
+      <StyledInsetText data-test="customer-details-contact">
         <ContactLink sections={['Export experience']} />
       </StyledInsetText>
     )}
@@ -274,7 +274,7 @@ const WinDetailsTable = ({ values, goToStep, isEditing }) => {
         </SummaryTable.Row>
       </StyledSummaryTable>
       {isEditing && (
-        <StyledInsetText>
+        <StyledInsetText data-test="win-details-contact">
           <ContactLink
             sections={[
               'Summary of the support you provided',

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -13,7 +13,7 @@ import {
   WinUKRegions,
 } from '../../../components/Resource'
 
-const CustomerDetailsStep = ({ companyId }) => {
+const CustomerDetailsStep = ({ companyId, isEditing }) => {
   return (
     <Step name={steps.CUSTOMER_DETAILS}>
       <H3 data-test="step-heading">Customer details</H3>
@@ -57,15 +57,17 @@ const CustomerDetailsStep = ({ companyId }) => {
         field={FieldTypeahead}
         resource={BusinessPotentialResource}
       />
-      <ResourceOptionsField
-        name="export_experience"
-        id="export-experience"
-        label="Export experience"
-        required="Select export experience"
-        hint="Your customer will be asked to confirm this information."
-        field={FieldTypeahead}
-        resource={ExportExperienceResource}
-      />
+      {!isEditing && (
+        <ResourceOptionsField
+          name="export_experience"
+          id="export-experience"
+          label="Export experience"
+          required="Select export experience"
+          hint="Your customer will be asked to confirm this information."
+          field={FieldTypeahead}
+          resource={ExportExperienceResource}
+        />
+      )}
     </Step>
   )
 }

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -1,17 +1,37 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { Link } from 'govuk-react'
+import styled from 'styled-components'
+import { FONT_SIZE } from '@govuk-react/constants'
+import pluralize from 'pluralize'
 
 import { state2props, TASK_GET_EXPORT_WINS_SAVE_FORM } from './state'
-import { DefaultLayout, Form, FormLayout } from '../../../components'
-import { transformFormValuesForAPI } from './transformers'
-import urls from '../../../../lib/urls'
-
+import { steps, EMAIL } from './constants'
 import CheckBeforeSendingStep from './CheckBeforeSendingStep'
+import { transformFormValuesForAPI } from './transformers'
 import CreditForThisWinStep from './CreditForThisWinStep'
 import CustomerDetailsStep from './CustomerDetailsStep'
 import SupportProvidedStep from './SupportProvidedStep'
 import OfficerDetailsStep from './OfficerDetailsStep'
 import WinDetailsStep from './WinDetailsStep'
+import urls from '../../../../lib/urls'
+import {
+  Form,
+  FormLayout,
+  DefaultLayout,
+  StatusMessage,
+} from '../../../components'
+
+const Spacer = styled('div')({
+  marginTop: 10,
+})
+
+const StyledStatusMessage = styled(StatusMessage)({
+  fontSize: FONT_SIZE.SIZE_20,
+  fontWeight: 700,
+  marginTop: 25,
+  marginBottom: 5,
+})
 
 const ExportWinForm = ({
   heading,
@@ -21,6 +41,8 @@ const ExportWinForm = ({
   companyId,
   exportWinId,
   breadcrumbs,
+  currentStepName,
+  excludedStepFields,
   initialValuesTaskName,
   initialValuesPayload,
   csrfToken,
@@ -32,12 +54,32 @@ const ExportWinForm = ({
     companyId,
     exportWinId,
   }
+
   return (
     <DefaultLayout
       pageTitle={heading}
       heading={heading}
       subheading={subheading}
       breadcrumbs={breadcrumbs}
+      localHeaderChildren={
+        isEditing ? (
+          currentStepName === steps.CHECK_BEFORE_SENDING ? (
+            <StyledStatusMessage>
+              To edit an export win
+              <Spacer>
+                Edit each section that needs changing then return to the summary
+                page. When you are happy with all the changes save the page.
+              </Spacer>
+            </StyledStatusMessage>
+          ) : excludedStepFields ? (
+            <StyledStatusMessage>
+              Contact <Link href={`mailto:${EMAIL}`}>{EMAIL}</Link> if you need
+              to update the {pluralize('section', excludedStepFields.length)}:{' '}
+              {excludedStepFields.join(', ')}
+            </StyledStatusMessage>
+          ) : null
+        ) : null
+      }
     >
       <FormLayout>
         <Form

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -22,15 +22,15 @@ import {
   StatusMessage,
 } from '../../../components'
 
-const Spacer = styled('div')({
-  marginTop: 10,
-})
-
 const StyledStatusMessage = styled(StatusMessage)({
   fontSize: FONT_SIZE.SIZE_20,
   fontWeight: 700,
   marginTop: 25,
   marginBottom: 5,
+})
+
+const StyledParagraph = styled('p')({
+  fontWeight: 'bold',
 })
 
 export const ContactLink = ({ sections }) => (
@@ -72,11 +72,11 @@ const ExportWinForm = ({
         isEditing ? (
           currentStepName === steps.CHECK_BEFORE_SENDING ? (
             <StyledStatusMessage>
-              To edit an export win
-              <Spacer>
+              <StyledParagraph>To edit an export win</StyledParagraph>
+              <StyledParagraph>
                 Edit each section that needs changing then return to the summary
                 page. When you are happy with all the changes save the page.
-              </Spacer>
+              </StyledParagraph>
             </StyledStatusMessage>
           ) : excludedStepFields ? (
             <StyledStatusMessage>

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -33,6 +33,13 @@ const StyledStatusMessage = styled(StatusMessage)({
   marginBottom: 5,
 })
 
+export const ContactLink = ({ sections }) => (
+  <>
+    Contact <Link href={`mailto:${EMAIL}`}>{EMAIL}</Link> if you need to update
+    the {pluralize('section', sections.length)}: {sections.join(', ')}
+  </>
+)
+
 const ExportWinForm = ({
   heading,
   subheading,
@@ -73,9 +80,7 @@ const ExportWinForm = ({
             </StyledStatusMessage>
           ) : excludedStepFields ? (
             <StyledStatusMessage>
-              Contact <Link href={`mailto:${EMAIL}`}>{EMAIL}</Link> if you need
-              to update the {pluralize('section', excludedStepFields.length)}:{' '}
-              {excludedStepFields.join(', ')}
+              <ContactLink sections={excludedStepFields} />
             </StyledStatusMessage>
           ) : null
         ) : null

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -41,7 +41,7 @@ const StyledExportTotal = styled('p')({
   backgroundColor: BLACK,
 })
 
-const WinDetailsStep = () => {
+const WinDetailsStep = ({ isEditing }) => {
   const { values } = useFormContext()
   const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
   const month = twelveMonthsAgo.getMonth() + 1
@@ -53,31 +53,40 @@ const WinDetailsStep = () => {
       <StyledHintParagraph data-test="hint">
         The customer will be asked to confirm this information.
       </StyledHintParagraph>
-      <ResourceOptionsField
-        name="country"
-        id="country"
-        label="Destination country"
-        required="Choose a destination country"
-        resource={CountriesResource}
-        field={FieldTypeahead}
-      />
-      <FieldDate
-        name="date"
-        format="short"
-        label="Date won"
-        hint={`For example ${month} ${year}, date of win must be in the last 12 months.`}
-        required="Enter the win date"
-        invalid="Enter a valid date"
-        validate={validateWinDate}
-      />
-      <FieldTextarea
-        name="description"
-        label="Summary of the support given"
-        hint="Outline what had the most impact or would be memorable to the customer in less than 100 words."
-        required="Enter a summary"
-        invalid={`Summary must be ${MAX_WORDS} words or less`}
-        maxWords={MAX_WORDS}
-      />
+
+      {!isEditing && (
+        <ResourceOptionsField
+          name="country"
+          id="country"
+          label="Destination country"
+          required="Choose a destination country"
+          resource={CountriesResource}
+          field={FieldTypeahead}
+        />
+      )}
+
+      {!isEditing && (
+        <FieldDate
+          name="date"
+          format="short"
+          label="Date won"
+          hint={`For example ${month} ${year}, date of win must be in the last 12 months.`}
+          required="Enter the win date"
+          invalid="Enter a valid date"
+          validate={validateWinDate}
+        />
+      )}
+
+      {!isEditing && (
+        <FieldTextarea
+          name="description"
+          label="Summary of the support given"
+          hint="Outline what had the most impact or would be memorable to the customer in less than 100 words."
+          required="Enter a summary"
+          invalid={`Summary must be ${MAX_WORDS} words or less`}
+          maxWords={MAX_WORDS}
+        />
+      )}
 
       <FieldRadios
         name="name_of_customer_confidential"
@@ -115,87 +124,92 @@ const WinDetailsStep = () => {
         placeholder="Enter a type of business deal"
       />
 
-      <FieldCheckboxes
-        name="win_type"
-        legend="Type of win"
-        required="Choose at least one type of win"
-        options={winTypeOptions.map((option) => ({
-          ...option,
-          ...(option.value === winTypes.EXPORT && {
-            children: (
-              <WinTypeValues
-                label="Export value over the next 5 years"
-                name="export_win"
-                values={values}
-              />
-            ),
-          }),
-          ...(option.value === winTypes.BUSINESS_SUCCESS && {
-            link: (
-              <StyledDetails
-                summary="What is business success?"
-                data-test="business-success-details"
-              >
-                <p>Business success is defined as:</p>
-                <UnorderedList listStyleType="bullet">
-                  <ListItem>
-                    the exchange of ownership of goods/services from a
-                    subsidiary of an eligible UK company to a non-UK resident.
-                  </ListItem>
-                  <ListItem>
-                    in financial services, the value of assets under management
-                    or the value of a listing.
-                  </ListItem>
-                  <ListItem>
-                    the collection of cash from an overdue invoice.
-                  </ListItem>
-                  <ListItem>
-                    reduced tax burden on a customer achieved by lobbying.
-                  </ListItem>
-                  <ListItem>repatriation of profits to the UK.</ListItem>
-                </UnorderedList>
-              </StyledDetails>
-            ),
-            children: (
-              <WinTypeValues
-                label="Business success over the next 5 years"
-                name="business_success_win"
-                values={values}
-              />
-            ),
-          }),
-          ...(option.value === winTypes.ODI && {
-            link: (
-              <StyledDetails summary="What is an ODI?" data-test="odi-details">
-                <p>
-                  An ODI is a cross-border investment from the UK into another
-                  country, where the source of the money is the UK.
-                </p>
-                <p>
-                  The aim of the investment is to set up a lasting interest in a
-                  company, where the investor has a genuine influence in the
-                  management. This may involve providing capital for vehicles,
-                  machinery, buildings, and running costs to:
-                </p>
-                <UnorderedList listStyleType="bullet">
-                  <ListItem>set up an overseas subsidiary.</ListItem>
-                  <ListItem>enter into a joint venture.</ListItem>
-                  <ListItem>expand current overseas operations.</ListItem>
-                </UnorderedList>
-              </StyledDetails>
-            ),
-            children: (
-              <WinTypeValues
-                label="Outward Direct Investment over the next 5 years"
-                name="odi_win"
-                values={values}
-              />
-            ),
-          }),
-        }))}
-      />
+      {!isEditing && (
+        <FieldCheckboxes
+          name="win_type"
+          legend="Type of win"
+          required="Choose at least one type of win"
+          options={winTypeOptions.map((option) => ({
+            ...option,
+            ...(option.value === winTypes.EXPORT && {
+              children: (
+                <WinTypeValues
+                  label="Export value over the next 5 years"
+                  name="export_win"
+                  values={values}
+                />
+              ),
+            }),
+            ...(option.value === winTypes.BUSINESS_SUCCESS && {
+              link: (
+                <StyledDetails
+                  summary="What is business success?"
+                  data-test="business-success-details"
+                >
+                  <p>Business success is defined as:</p>
+                  <UnorderedList listStyleType="bullet">
+                    <ListItem>
+                      the exchange of ownership of goods/services from a
+                      subsidiary of an eligible UK company to a non-UK resident.
+                    </ListItem>
+                    <ListItem>
+                      in financial services, the value of assets under
+                      management or the value of a listing.
+                    </ListItem>
+                    <ListItem>
+                      the collection of cash from an overdue invoice.
+                    </ListItem>
+                    <ListItem>
+                      reduced tax burden on a customer achieved by lobbying.
+                    </ListItem>
+                    <ListItem>repatriation of profits to the UK.</ListItem>
+                  </UnorderedList>
+                </StyledDetails>
+              ),
+              children: (
+                <WinTypeValues
+                  label="Business success over the next 5 years"
+                  name="business_success_win"
+                  values={values}
+                />
+              ),
+            }),
+            ...(option.value === winTypes.ODI && {
+              link: (
+                <StyledDetails
+                  summary="What is an ODI?"
+                  data-test="odi-details"
+                >
+                  <p>
+                    An ODI is a cross-border investment from the UK into another
+                    country, where the source of the money is the UK.
+                  </p>
+                  <p>
+                    The aim of the investment is to set up a lasting interest in
+                    a company, where the investor has a genuine influence in the
+                    management. This may involve providing capital for vehicles,
+                    machinery, buildings, and running costs to:
+                  </p>
+                  <UnorderedList listStyleType="bullet">
+                    <ListItem>set up an overseas subsidiary.</ListItem>
+                    <ListItem>enter into a joint venture.</ListItem>
+                    <ListItem>expand current overseas operations.</ListItem>
+                  </UnorderedList>
+                </StyledDetails>
+              ),
+              children: (
+                <WinTypeValues
+                  label="Outward Direct Investment over the next 5 years"
+                  name="odi_win"
+                  values={values}
+                />
+              ),
+            }),
+          }))}
+        />
+      )}
 
-      {values?.win_type?.length > 1 && (
+      {!isEditing && values?.win_type?.length > 1 && (
         <StyledExportTotal data-test="total-export-value">
           Total export value:{' '}
           {formatValue(sumAllWinTypeYearlyValues(values?.win_type, values))}

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -51,3 +51,15 @@ export const bothGoodsAndServices = {
   label: 'Both goods and services',
   value: GOODS_AND_SERVICES_ID,
 }
+
+export const STEP_TO_EXCLUDED_FIELDS_MAP = {
+  [steps.CUSTOMER_DETAILS]: ['Export experience'],
+  [steps.WIN_DETAILS]: [
+    'Summary of the support you provided',
+    'Destination',
+    'Date won',
+    'Type of export win and Value',
+  ],
+}
+
+export const EMAIL = 'exportwins@businessandtrade.gov.uk'

--- a/src/client/modules/ExportWins/Form/state.js
+++ b/src/client/modules/ExportWins/Form/state.js
@@ -1,3 +1,5 @@
+import { STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
+
 export const TASK_GET_EXPORT_WINS_SAVE_FORM = 'TASK_GET_EXPORT_WINS_SAVE_FORM'
 export const ID = 'exportWinForm'
 
@@ -5,9 +7,20 @@ export const TASK_GET_EXPORT_PROJECT = 'TASK_GET_EXPORT_PROJECT'
 export const EXPORT_PROJECT_ID = 'exportProject'
 
 export const TASK_GET_EXPORT_WIN = 'TASK_GET_EXPORT_WIN'
-export const EXPORT_WIN_ID = 'exportWin'
 
-export const state2props = ({ router, ...state }) => ({
-  csrfToken: state.csrfToken,
-  currentAdviserId: state.currentAdviserId,
-})
+export const state2props = ({ router, ...state }) => {
+  // We need to know the name of the current step so we can show the
+  // appropriate banner for that step. All of the steps use the step
+  // name, so for consistency we shouldn't use the step index, it's one
+  // or the other. We cannot use form context as that is limited to the
+  // scope of the form and the banner is displayed as a child of
+  // LocalHeader which is a child of DefaultLayout.
+  const currentStepName = state.Form['export-win-form']?.currentStepName
+
+  return {
+    csrfToken: state.csrfToken,
+    currentAdviserId: state.currentAdviserId,
+    currentStepName,
+    excludedStepFields: STEP_TO_EXCLUDED_FIELDS_MAP[currentStepName],
+  }
+}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -225,6 +225,33 @@ module.exports = {
       rejected: url('/exportwins/rejected'),
       details: url('/exportwins', '/:winId/details'),
       create: url('/companies', '/:companyId/exportwins/create'),
+      createFromExport: url(
+        '/companies',
+        '/:companyId/export/:exportId/exportwins/create'
+      ),
+      createSuccess: url('/exportwins', '/:winId/success'),
+      customerFeedback: url('/exportwins', '/:winId/customer-feedback'),
+      editOfficerDetails: url(
+        '/companies',
+        '/:companyId/exportwins/:winId/edit?step=officer_details'
+      ),
+      editCreditForThisWin: url(
+        '/companies',
+        '/:companyId/exportwins/:winId/edit?step=credit_for_this_win'
+      ),
+      editCustomerDetails: url(
+        '/companies',
+        '/:companyId/exportwins/:winId/edit?step=customer_details'
+      ),
+      editWinDetails: url(
+        '/companies',
+        '/:companyId/exportwins/:winId/edit?step=win_details'
+      ),
+      editSupportProvided: url(
+        '/companies',
+        '/:companyId/exportwins/:winId/edit?step=support_provided'
+      ),
+      // TODO: rename this to editSummary and rename check_before_sending to summary
       edit: url(
         '/companies',
         '/:companyId/exportwins/:winId/edit?step=check_before_sending'
@@ -233,12 +260,6 @@ module.exports = {
         '/companies',
         '/:companyId/exportwins/:winId/edit-success'
       ),
-      createFromExport: url(
-        '/companies',
-        '/:companyId/export/:exportId/exportwins/create'
-      ),
-      createSuccess: url('/exportwins', '/:winId/success'),
-      customerFeedback: url('/exportwins', '/:winId/customer-feedback'),
     },
     overview: {
       index: url('/companies', '/:companyId/overview'),

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -1,16 +1,47 @@
 import { faker } from '@faker-js/faker'
 
 import { contactFaker } from './contacts'
+import { sectorFaker } from './sectors'
 
 /**
  * Generate fake data for a single export win.
  */
 export const exportWinsFaker = () => ({
   id: faker.string.uuid(),
+  lead_officer: faker.person.fullName(),
+  lead_officer: {
+    id: faker.string.uuid(),
+    name: faker.person.fullName(),
+    first_name: faker.person.firstName(),
+    last_name: faker.person.lastName(),
+  },
+  team_type: {
+    name: 'Trade (TD or ST)',
+    id: faker.string.uuid(),
+  },
+  hq_team: {
+    id: faker.string.uuid(),
+    name: 'TD - Events - Education',
+  },
+  team_members: [
+    {
+      id: faker.string.uuid(),
+      name: 'David Luker',
+      first_name: 'David',
+      last_name: 'Luke',
+    },
+    {
+      id: faker.string.uuid(),
+      name: 'Kelly Shields',
+      first_name: 'Kelly',
+      last_name: 'Shields',
+    },
+  ],
   adviser: {
     id: faker.string.uuid(),
     name: faker.person.fullName(),
   },
+  advisers: [],
   company: {
     id: faker.string.uuid(),
     name: faker.company.name(),
@@ -20,6 +51,61 @@ export const exportWinsFaker = () => ({
     name: faker.location.country(),
   },
   customer_name: faker.person.fullName(),
+  customer_location: {
+    id: faker.string.uuid(),
+    name: 'North West',
+  },
+  name_of_export: 'Rolls Royce',
+  business_potential: {
+    id: faker.string.uuid(),
+    name: 'The company is an exporter with High Export Potential',
+  },
+  export_experience: {
+    id: faker.string.uuid(),
+    name: 'Exported before, but no exports in the last 12 months',
+  },
+  goods_vs_services: {
+    id: faker.string.uuid(),
+    name: 'Goods',
+  },
+  sector: sectorFaker(),
+  type_of_support: [
+    {
+      id: faker.string.uuid(),
+      name: 'Missions, tradeshows and events (DIT/FCO)',
+    },
+    {
+      id: faker.string.uuid(),
+      name: 'Lobbying to overcome a problem – DIT/FCO',
+    },
+  ],
+  breakdowns: [
+    {
+      id: faker.string.uuid(),
+      type: {
+        name: 'Export',
+        id: faker.string.uuid(),
+      },
+      year: 1,
+      value: 10000000,
+    },
+  ],
+  associated_programme: [
+    {
+      id: faker.string.uuid(),
+      name: 'Afterburner',
+    },
+    {
+      id: faker.string.uuid(),
+      name: 'British Business Network',
+    },
+  ],
+  hvc: {
+    id: faker.string.uuid(),
+    name: 'Australia & NZ Automotive: E001',
+  },
+  is_personally_confirmed: true,
+  is_line_manager_confirmed: true,
   customer_job_title: faker.person.jobTitle(),
   customer_email_address: faker.internet.email(),
   company_contacts: [contactFaker()],
@@ -29,6 +115,7 @@ export const exportWinsFaker = () => ({
   }),
   date: faker.date.anytime().toISOString(),
   customer_response: {
+    agree_with_win: null, // Sent
     responded_on: faker.date.anytime().toISOString(),
   },
 })

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -172,7 +172,12 @@ describe('Adding an export win', () => {
       })
 
       it('should not render an edit status message', () => {
-        cy.get('[data-test="status-message"]').should('not.exist')
+        cy.get('[data-test="localHeader"]').should(
+          'not.contain',
+          'To edit an export win' +
+            'Edit each section that needs changing then return to the summary page. ' +
+            'When you are happy with all the changes save the page.'
+        )
       })
 
       it('should render an officer details table', () => {

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -171,6 +171,10 @@ describe('Adding an export win', () => {
         )
       })
 
+      it('should not render an edit status message', () => {
+        cy.get('[data-test="status-message"]').should('not.exist')
+      })
+
       it('should render an officer details table', () => {
         assertSummaryTable({
           dataTest: 'officer-details',

--- a/test/functional/cypress/specs/export-win/constants.js
+++ b/test/functional/cypress/specs/export-win/constants.js
@@ -40,6 +40,7 @@ export const formFields = {
   },
   customerDetails: {
     heading: '[data-test="step-heading"]',
+    editStatusMessage: '[data-test="status-message"]',
     contacts: '[data-test="field-company_contacts"]',
     contactHint: '[data-test="contact-hint"]',
     location: '[data-test="field-customer_location"]',
@@ -48,6 +49,7 @@ export const formFields = {
   },
   winDetails: {
     heading: '[data-test="step-heading"]',
+    editStatusMessage: '[data-test="status-message"]',
     hint: '[data-test="hint"]',
     country: '[data-test="field-country"]',
     date: '[data-test="field-date"]',

--- a/test/functional/cypress/specs/export-win/customer-details-spec.js
+++ b/test/functional/cypress/specs/export-win/customer-details-spec.js
@@ -15,6 +15,10 @@ describe('Customer details', () => {
     cy.get(customerDetails.heading).should('have.text', 'Customer details')
   })
 
+  it('should not render an edit status message', () => {
+    cy.get('[data-test="status-message"]').should('not.exist')
+  })
+
   it('should render a contact hint', () => {
     cy.get(customerDetails.contactHint).should(
       'have.text',

--- a/test/functional/cypress/specs/export-win/edit-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-spec.js
@@ -137,7 +137,26 @@ describe('Editing an export win', () => {
       cy.get('[data-test="status-message"]').should(
         'contain',
         'To edit an export win' +
-          'Edit each section that needs changing then return to the summary page. When you are happy with all the changes save the page.'
+          'Edit each section that needs changing then return to the summary page. ' +
+          'When you are happy with all the changes save the page.'
+      )
+    })
+    it('should render a customer details contact link', () => {
+      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.wait(['@apiGetExportWin'])
+      cy.get('[data-test="customer-details-contact"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: ' +
+          'Export experience'
+      )
+    })
+    it('should render a win details contact link', () => {
+      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.wait(['@apiGetExportWin'])
+      cy.get('[data-test="win-details-contact"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
+          'Summary of the support you provided, Destination, Date won, Type of export win and Value'
       )
     })
   })

--- a/test/functional/cypress/specs/export-win/edit-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-spec.js
@@ -1,0 +1,144 @@
+import { exportWinsFaker } from '../../fakers/export-wins'
+import urls from '../../../../../src/lib/urls'
+import { company, formFields } from './constants'
+
+const exportWin = exportWinsFaker()
+
+describe('Editing an export win', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api-proxy/v4/export-win/*', exportWin).as(
+      'apiGetExportWin'
+    )
+    cy.intercept('GET', '/api-proxy/v4/metadata/team-type', [
+      {
+        id: '1',
+        name: 'Trade (TD or ST)',
+      },
+    ]).as('apiTeamType')
+    cy.intercept('GET', '/api-proxy/v4/metadata/hq-team-region-or-post?*', [
+      {
+        id: '1',
+        name: 'TD - Events - Financial & Professional Business Services',
+        team_type: {
+          name: 'Trade (TD or ST)',
+          id: '1',
+        },
+      },
+      {
+        id: '2',
+        name: 'TD - Events - Education',
+        team_type: {
+          name: 'Trade (TD or ST)',
+          id: '1',
+        },
+      },
+    ]).as('apiHqTeam')
+  })
+
+  context('Officer details', () => {
+    it('should not render an edit status message', () => {
+      cy.visit(
+        urls.companies.exportWins.editOfficerDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+      cy.get('[data-test="status-message"]').should('not.exist')
+    })
+  })
+
+  context('Credit for this win', () => {
+    it('should not render an edit status message', () => {
+      cy.visit(
+        urls.companies.exportWins.editCreditForThisWin(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+      cy.get('[data-test="status-message"]').should('not.exist')
+    })
+  })
+
+  context('Customer details', () => {
+    beforeEach(() => {
+      cy.visit(
+        urls.companies.exportWins.editCustomerDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+    })
+
+    it('should render an edit status message', () => {
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the section: Export experience'
+        )
+    })
+
+    it('should not render Export experience', () => {
+      cy.get(formFields.customerDetails.experience).should('not.exist')
+    })
+  })
+
+  context('Win details', () => {
+    const { winDetails } = formFields
+
+    beforeEach(() => {
+      cy.visit(
+        urls.companies.exportWins.editWinDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+    })
+
+    it('should render an edit status message', () => {
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
+            'Summary of the support you provided, Destination, Date won, Type of export win and Value'
+        )
+    })
+
+    it('should not render summary of the support given', () => {
+      cy.get(winDetails.description).should('not.exist')
+    })
+
+    it('should not render destination country', () => {
+      cy.get(winDetails.country).should('not.exist')
+    })
+
+    it('should not render the Win date', () => {
+      cy.get(winDetails.date).should('not.exist')
+    })
+
+    it('should not render the win type', () => {
+      cy.get(winDetails.winType).should('not.exist')
+    })
+
+    it('should not render any win type values', () => {
+      cy.get(winDetails.winTypeValuesExport).should('not.exist')
+      cy.get(winDetails.winTypeValuesBusSupp).should('not.exist')
+      cy.get(winDetails.winTypeValuesODI).should('not.exist')
+    })
+  })
+
+  context('Support provided', () => {
+    it('should not render an edit status message', () => {
+      cy.visit(
+        urls.companies.exportWins.editSupportProvided(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin'])
+      cy.get('[data-test="status-message"]').should('not.exist')
+    })
+  })
+
+  context('Check before sending', () => {
+    it('should render an edit status message', () => {
+      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.wait(['@apiGetExportWin'])
+      cy.get('[data-test="status-message"]').should(
+        'contain',
+        'To edit an export win' +
+          'Edit each section that needs changing then return to the summary page. When you are happy with all the changes save the page.'
+      )
+    })
+  })
+})

--- a/test/functional/cypress/specs/export-win/win-details-spec.js
+++ b/test/functional/cypress/specs/export-win/win-details-spec.js
@@ -33,6 +33,10 @@ describe('Win details', () => {
     cy.get(winDetails.heading).should('have.text', 'Win details')
   })
 
+  it('should not render an edit status message', () => {
+    cy.get('[data-test="status-message"]').should('not.exist')
+  })
+
   it('should render a hint', () => {
     cy.get(winDetails.hint).should(
       'have.text',


### PR DESCRIPTION
## Description of change
Adds three banners to the edit export win user journey and removes some of the fields so they can't be edited.

**Customer details field removed:**
- Export experience

**Win details fields removed:**
- Summary of the support you provided
- Destination
- Date won
- Type of export win and Value

## Screenshots
### Summary page
<img width="990" alt="summary-page-banner" src="https://github.com/uktrade/data-hub-frontend/assets/964268/827fe400-fd9b-46a7-91af-575f09f7b306">
...
<img width="1004" alt="contact-links" src="https://github.com/uktrade/data-hub-frontend/assets/964268/30947e7d-812b-48f6-846d-1f3ac4d7040e">
---

### Customer details
<img width="990" alt="1" src="https://github.com/uktrade/data-hub-frontend/assets/964268/95eaba4e-016c-4989-9777-e465ceb3358e">

---

### Win details
<img width="990" alt="Screenshot 2024-03-27 at 16 27 58" src="https://github.com/uktrade/data-hub-frontend/assets/964268/0c879fb1-2b85-4d3b-bd34-e1936c6a4777">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
