### PR TITLE
Add summary page additional information

### DIFF
--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -33,12 +33,17 @@ const StyledParagraph = styled('p')({
   fontWeight: 'bold',
 })
 
-export const ContactLink = ({ sections }) => (
-  <>
-    Contact <Link href={`mailto:${EMAIL}`}>{EMAIL}</Link> if you need to update
-    the {pluralize('section', sections.length)}: {sections.join(', ')}
-  </>
-)
+export const ContactLink = ({ sections = [], shouldPluralize = true }) => {
+  const section = shouldPluralize
+    ? `${pluralize('section', sections.length)}:`
+    : 'section.'
+  return (
+    <>
+      Contact <Link href={`mailto:${EMAIL}`}>{EMAIL}</Link> if you need to
+      update the {section} {sections.join(', ')}
+    </>
+  )
+}
 
 const ExportWinForm = ({
   heading,

--- a/src/client/modules/ExportWins/Form/index.jsx
+++ b/src/client/modules/ExportWins/Form/index.jsx
@@ -7,7 +7,7 @@ import { CompanyResource } from '../../../components/Resource'
 import { WIN_STATUS_MAP_TO_LABEL } from '../Status/constants'
 import urls from '../../../../lib/urls'
 
-const CompanyName = ({ companyId }) => (
+export const CompanyName = ({ companyId }) => (
   <CompanyResource.Inline id={companyId}>
     {(company) => company.name.toUpperCase()}
   </CompanyResource.Inline>

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -171,6 +171,11 @@ export const transformExportWinForForm = (exportWin) => ({
   is_line_manager_confirmed: exportWin.is_line_manager_confirmed
     ? OPTION_YES
     : OPTION_NO,
+  // Summary page
+  company: exportWin.company,
+  customer_response: exportWin.customer_response,
+  first_sent: exportWin.first_sent,
+  last_sent: exportWin.last_sent,
 })
 
 export const transformFormValuesForAPI = (values) => ({

--- a/src/client/modules/ExportWins/Form/utils.js
+++ b/src/client/modules/ExportWins/Form/utils.js
@@ -113,10 +113,4 @@ export const getYearFromWinType = (winType, values) =>
 export const getMaxYearFromWinTypes = (winTypes, values) =>
   Math.max(...winTypes.map((winType) => getYearFromWinType(winType, values)))
 
-/**
- * Tests whether a given date is within the last twelve months and not in the future.
- * @param {Date} date - The date to test.
- * @returns {boolean} True if the date is within the last twelve months and not in the future, false otherwise.
- */
-
 export const formatValue = (sum) => currencyGBP(sum)

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -213,6 +213,7 @@ describe('Adding an export win', () => {
           heading: 'Customer details',
           showEditLink: true,
           content: {
+            'Company name': company.name.toUpperCase(),
             'Contact name': 'Joseph Barker',
             'HQ location': 'Scotland',
             'Export potential': 'The company is a Medium Sized Business',


### PR DESCRIPTION
## Description of change
Adds additional information to the bottom of the summary page when editing an export win.

## Test instructions
Do any of the following and then scroll to the bottom of the summary page.
1. Go to `/exportwins/rejected` and click on a rejected win.
2. Go to `/exportwins/sent` and click on a sent win.
3. Go to `/exportwins/won` and click on a win.

## Screenshots
### Rejected
<img width="984" alt="rejected" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d94e21d3-550d-4451-9632-f8c1b4392173">

---

### Sent
<img width="985" alt="sent" src="https://github.com/uktrade/data-hub-frontend/assets/964268/e8382414-ad9b-449a-b15a-50bb866fc41b">

---

### Won
<img width="985" alt="won" src="https://github.com/uktrade/data-hub-frontend/assets/964268/c20e1a8f-e88b-4a29-9855-648ab509e960">

---

### Added company name
<img width="985" alt="Screenshot 2024-03-28 at 08 06 56" src="https://github.com/uktrade/data-hub-frontend/assets/964268/c0341b62-cf1b-4411-ac11-4585967c40eb">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
