### PR TITLE
Add Export Win resend functionality

### DIFF
--- a/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
+++ b/src/client/modules/ExportWins/Form/CheckBeforeSendingStep.jsx
@@ -8,14 +8,14 @@ import { Link } from 'govuk-react'
 import pluralize from 'pluralize'
 
 import { Step, ButtonLink, FieldInput, SummaryTable } from '../../../components'
-import { useFormContext } from '../../../components/Form/hooks'
 import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
+import { useFormContext } from '../../../components/Form/hooks'
 import { formatMediumDateTime } from '../../../utils/date'
-import { CompanyName } from '.'
 import { WIN_STATUS } from '../Status/constants'
 import { ContactLink } from './ExportWinForm'
 import urls from '../../../../lib/urls'
 import { steps } from './constants'
+import { CompanyName } from '.'
 import {
   transformTeamsAndAdvisers,
   transformGoodsAndServices,
@@ -75,7 +75,6 @@ const CheckBeforeSendingStep = ({ isEditing, companyId }) => {
         </WarningText>
       )}
       {isEditing && <AdditionalInformation {...props} />}
-
       {/*
           TODO: We have to include this hidden field 
           otherwise we lose the previous step's state.
@@ -382,11 +381,6 @@ const AdditionalInformation = ({ values, isEditing }) => {
           </>
         )}
       </StyledSummaryTable>
-      {winStatus !== WIN_STATUS.WON && (
-        <StyledInsetText>
-          <ContactLink data-test="" shouldPluralize={false} />
-        </StyledInsetText>
-      )}
     </>
   )
 }

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -1,19 +1,23 @@
 import React from 'react'
-import { connect } from 'react-redux'
 import { Link } from 'govuk-react'
+import { connect } from 'react-redux'
 import styled from 'styled-components'
-import { FONT_SIZE } from '@govuk-react/constants'
 import pluralize from 'pluralize'
+import { FONT_SIZE } from '@govuk-react/constants'
 
-import { state2props, TASK_GET_EXPORT_WINS_SAVE_FORM } from './state'
-import { steps, EMAIL } from './constants'
+import FlashMessages from '../../../components/LocalHeader/FlashMessages'
+import { steps, EMAIL, STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
+import { TASK_GET_EXPORT_WINS_SAVE_FORM } from './state'
 import CheckBeforeSendingStep from './CheckBeforeSendingStep'
 import { transformFormValuesForAPI } from './transformers'
 import CreditForThisWinStep from './CreditForThisWinStep'
 import CustomerDetailsStep from './CustomerDetailsStep'
 import SupportProvidedStep from './SupportProvidedStep'
 import OfficerDetailsStep from './OfficerDetailsStep'
+import { ResendExportWin } from './ResendExportWin'
+import { WIN_STATUS } from '../Status/constants'
 import WinDetailsStep from './WinDetailsStep'
+import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 import {
   Form,
@@ -21,6 +25,8 @@ import {
   DefaultLayout,
   StatusMessage,
 } from '../../../components'
+
+const FORM_ID = 'export-win-form'
 
 const StyledStatusMessage = styled(StatusMessage)({
   fontSize: FONT_SIZE.SIZE_20,
@@ -45,6 +51,12 @@ export const ContactLink = ({ sections = [], shouldPluralize = true }) => {
   )
 }
 
+const ResentExportWinContainer = styled.div({
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: 15,
+})
+
 const ExportWinForm = ({
   heading,
   subheading,
@@ -53,12 +65,8 @@ const ExportWinForm = ({
   companyId,
   exportWinId,
   breadcrumbs,
-  currentStepName,
-  excludedStepFields,
   initialValuesTaskName,
   initialValuesPayload,
-  csrfToken,
-  currentAdviserId,
 }) => {
   const stepProps = {
     isEditing,
@@ -66,67 +74,96 @@ const ExportWinForm = ({
     companyId,
     exportWinId,
   }
-
   return (
-    <DefaultLayout
-      pageTitle={heading}
-      heading={heading}
-      subheading={subheading}
-      breadcrumbs={breadcrumbs}
-      localHeaderChildren={
-        isEditing ? (
-          currentStepName === steps.CHECK_BEFORE_SENDING ? (
-            <StyledStatusMessage>
-              <StyledParagraph>To edit an export win</StyledParagraph>
-              <StyledParagraph>
-                Edit each section that needs changing then return to the summary
-                page. When you are happy with all the changes save the page.
-              </StyledParagraph>
-            </StyledStatusMessage>
-          ) : excludedStepFields ? (
-            <StyledStatusMessage>
-              <ContactLink sections={excludedStepFields} />
-            </StyledStatusMessage>
-          ) : null
-        ) : null
-      }
-    >
-      <FormLayout>
-        <Form
-          id="export-win-form"
-          showStepInUrl={true}
-          cancelRedirectTo={() => urls.companies.exportWins.sent()}
-          redirectTo={(result) =>
-            isEditing
-              ? urls.companies.exportWins.editSuccess(companyId, exportWinId)
-              : urls.companies.exportWins.createSuccess(result.data.id)
-          }
-          analyticsFormName="exportWinForm"
-          submissionTaskName={TASK_GET_EXPORT_WINS_SAVE_FORM}
-          initialValuesTaskName={initialValuesTaskName}
-          transformPayload={(values) => ({
-            exportWinId,
-            payload: {
-              ...transformFormValuesForAPI(values),
-              company: companyId,
-              _csrf: csrfToken,
-              adviser: currentAdviserId,
-            },
-          })}
-          initialValuesPayload={initialValuesPayload}
-        >
+    <State>
+      {(state) => {
+        const exportWinForm = state.Form[FORM_ID]
+        const formValues = exportWinForm?.values
+        const currentStepName = exportWinForm?.currentStepName
+        const excludedStepFields = STEP_TO_EXCLUDED_FIELDS_MAP[currentStepName]
+        const winStatus = formValues?.customer_response?.agree_with_win
+        const showSuccessfullySent = state.ResendExportWin[exportWinId]?.success
+        return (
           <>
-            <OfficerDetailsStep {...stepProps} />
-            <CreditForThisWinStep {...stepProps} />
-            <CustomerDetailsStep {...stepProps} />
-            <WinDetailsStep {...stepProps} />
-            <SupportProvidedStep {...stepProps} />
-            <CheckBeforeSendingStep {...stepProps} />
+            <DefaultLayout
+              pageTitle={heading}
+              heading={heading}
+              subheading={subheading}
+              breadcrumbs={breadcrumbs}
+              localHeaderChildren={
+                isEditing ? (
+                  currentStepName === steps.CHECK_BEFORE_SENDING ? (
+                    <>
+                      {showSuccessfullySent && (
+                        <FlashMessages
+                          flashMessages={{ success: ['Successfully sent'] }}
+                        />
+                      )}
+                      <StyledStatusMessage>
+                        <StyledParagraph>To edit an export win</StyledParagraph>
+                        <StyledParagraph>
+                          Edit each section that needs changing then return to
+                          the summary page. When you are happy with all the
+                          changes save the page.
+                        </StyledParagraph>
+                      </StyledStatusMessage>
+                      {winStatus === WIN_STATUS.SENT && (
+                        <ResentExportWinContainer>
+                          <ResendExportWin id={exportWinId} />
+                        </ResentExportWinContainer>
+                      )}
+                    </>
+                  ) : excludedStepFields ? (
+                    <StyledStatusMessage>
+                      <ContactLink sections={excludedStepFields} />
+                    </StyledStatusMessage>
+                  ) : null
+                ) : null
+              }
+            >
+              <FormLayout>
+                <Form
+                  id={FORM_ID}
+                  showStepInUrl={true}
+                  cancelRedirectTo={() => urls.companies.exportWins.sent()}
+                  redirectTo={(result) =>
+                    isEditing
+                      ? urls.companies.exportWins.editSuccess(
+                          companyId,
+                          exportWinId
+                        )
+                      : urls.companies.exportWins.createSuccess(result.data.id)
+                  }
+                  analyticsFormName="exportWinForm"
+                  submissionTaskName={TASK_GET_EXPORT_WINS_SAVE_FORM}
+                  initialValuesTaskName={initialValuesTaskName}
+                  transformPayload={(values) => ({
+                    exportWinId,
+                    payload: {
+                      ...transformFormValuesForAPI(values),
+                      company: companyId,
+                      _csrf: state.csrfToken,
+                      adviser: state.currentAdviserId,
+                    },
+                  })}
+                  initialValuesPayload={initialValuesPayload}
+                >
+                  <>
+                    <OfficerDetailsStep {...stepProps} />
+                    <CreditForThisWinStep {...stepProps} />
+                    <CustomerDetailsStep {...stepProps} />
+                    <WinDetailsStep {...stepProps} />
+                    <SupportProvidedStep {...stepProps} />
+                    <CheckBeforeSendingStep {...stepProps} />
+                  </>
+                </Form>
+              </FormLayout>
+            </DefaultLayout>
           </>
-        </Form>
-      </FormLayout>
-    </DefaultLayout>
+        )
+      }}
+    </State>
   )
 }
 
-export default connect(state2props)(ExportWinForm)
+export default connect((state) => state)(ExportWinForm)

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -17,6 +17,7 @@ import OfficerDetailsStep from './OfficerDetailsStep'
 import { ResendExportWin } from './ResendExportWin'
 import { WIN_STATUS } from '../Status/constants'
 import WinDetailsStep from './WinDetailsStep'
+import { ExportWinSuccess } from './Success'
 import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 import {
@@ -96,7 +97,9 @@ const ExportWinForm = ({
                     <>
                       {showSuccessfullySent && (
                         <FlashMessages
-                          flashMessages={{ success: ['Successfully sent'] }}
+                          flashMessages={{
+                            success: [<ExportWinSuccess winId={exportWinId} />],
+                          }}
                         />
                       )}
                       <StyledStatusMessage>

--- a/src/client/modules/ExportWins/Form/ResendExportWin.jsx
+++ b/src/client/modules/ExportWins/Form/ResendExportWin.jsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import Button from '@govuk-react/button'
+import styled from 'styled-components'
+
+import { EXPORT_WIN_RESENT__SUCCESS } from '../../../actions'
+import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
+import multiInstance from '../../../utils/multiinstance'
+import { TASK_RESEND_EXPORT_WIN } from './state'
+import Task from '../../../components/Task'
+
+const StyledButton = styled(Button)({
+  margin: 0,
+})
+
+const _ResendExportWin = ({ id }) => {
+  return (
+    <Task>
+      {(getTask) => {
+        const task = getTask(TASK_RESEND_EXPORT_WIN, id)
+        return (
+          <StyledButton
+            type="button" // We don't want to submit the form
+            buttonColour={GREY_3}
+            buttonTextColour={TEXT_COLOUR}
+            disabled={task.progress}
+            data-test="resend-export-win"
+            onClick={() => {
+              task.start({
+                payload: id,
+                onSuccessDispatch: EXPORT_WIN_RESENT__SUCCESS,
+              })
+            }}
+          >
+            Resend export win
+          </StyledButton>
+        )
+      }}
+    </Task>
+  )
+}
+
+export const ResendExportWin = multiInstance({
+  name: 'ResendExportWin',
+  actionPattern: 'EXPORT_WIN_RESENT__',
+  reducer: (state, action) => {
+    switch (action.type) {
+      case EXPORT_WIN_RESENT__SUCCESS:
+        return {
+          success: true,
+        }
+      default:
+        return state
+    }
+  },
+  component: _ResendExportWin,
+})

--- a/src/client/modules/ExportWins/Form/Success.jsx
+++ b/src/client/modules/ExportWins/Form/Success.jsx
@@ -6,7 +6,7 @@ import { ExportWinsLink, VerticalSpacer } from '../Details'
 import { DefaultLayout } from '../../../components'
 import urls from '../../../../lib/urls'
 
-const ExportWinSuccess = ({ winId }) => (
+export const ExportWinSuccess = ({ winId }) => (
   <ExportWin.Inline id={winId}>
     {(exportWin) =>
       exportWin &&

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -61,6 +61,7 @@ const WinDetailsStep = ({ isEditing }) => {
           label="Destination country"
           required="Choose a destination country"
           resource={CountriesResource}
+          payload={{ is_export_win: true }}
           field={FieldTypeahead}
         />
       )}

--- a/src/client/modules/ExportWins/Form/state.js
+++ b/src/client/modules/ExportWins/Form/state.js
@@ -1,5 +1,3 @@
-import { STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
-
 export const TASK_GET_EXPORT_WINS_SAVE_FORM = 'TASK_GET_EXPORT_WINS_SAVE_FORM'
 export const ID = 'exportWinForm'
 
@@ -8,19 +6,5 @@ export const EXPORT_PROJECT_ID = 'exportProject'
 
 export const TASK_GET_EXPORT_WIN = 'TASK_GET_EXPORT_WIN'
 
-export const state2props = ({ router, ...state }) => {
-  // We need to know the name of the current step so we can show the
-  // appropriate banner for that step. All of the steps use the step
-  // name, so for consistency we shouldn't use the step index, it's one
-  // or the other. We cannot use form context as that is limited to the
-  // scope of the form and the banner is displayed as a child of
-  // LocalHeader which is a child of DefaultLayout.
-  const currentStepName = state.Form['export-win-form']?.currentStepName
-
-  return {
-    csrfToken: state.csrfToken,
-    currentAdviserId: state.currentAdviserId,
-    currentStepName,
-    excludedStepFields: STEP_TO_EXCLUDED_FIELDS_MAP[currentStepName],
-  }
-}
+export const TASK_RESEND_EXPORT_WIN = 'TASK_RESEND_EXPORT_WIN'
+export const RESEND_EXPORT_WIN_ID = 'ResendExportWin'

--- a/src/client/modules/ExportWins/Form/tasks.js
+++ b/src/client/modules/ExportWins/Form/tasks.js
@@ -25,3 +25,6 @@ export const saveExportWin = ({ exportWinId, payload }) => {
 
   return request(endpoint, payload)
 }
+
+export const resendExportWin = (id) =>
+  apiProxyAxios.post(`/v4/export-win/${id}/resend-win`)

--- a/src/client/reducers.js
+++ b/src/client/reducers.js
@@ -180,7 +180,7 @@ import getInteractionReducer from './modules/Interactions/InteractionDetails/red
 import { PREVIEW_QUOTE_ID } from './modules/Omis/state'
 import orderQuoteReducer from './modules/Omis/reducer'
 
-import { ResendExportWin } from './modules/ExportWins/Details/ResendExportWin'
+import { ResendExportWin } from './modules/ExportWins/Form/ResendExportWin'
 
 export const reducers = {
   tasks,

--- a/src/client/tasks.js
+++ b/src/client/tasks.js
@@ -439,8 +439,11 @@ import {
 import { saveTaskDetail } from './modules/Tasks/TaskForm/tasks'
 import { TASK_SAVE_TASK_DETAILS } from './modules/Tasks/TaskForm/state'
 
-import { TASK_GET_EXPORT_WINS_SAVE_FORM } from './modules/ExportWins/Form/state'
-import { saveExportWin } from './modules/ExportWins/Form/tasks'
+import {
+  TASK_RESEND_EXPORT_WIN,
+  TASK_GET_EXPORT_WINS_SAVE_FORM,
+} from './modules/ExportWins/Form/state'
+import { saveExportWin, resendExportWin } from './modules/ExportWins/Form/tasks'
 
 import { getMyTasks } from './components/Dashboard/my-tasks/tasks'
 import { TASK_GET_MY_TASKS } from './components/Dashboard/my-tasks/state'
@@ -453,9 +456,6 @@ import {
   getExportProject,
   getExportWin,
 } from '../client/modules/ExportWins/Form/tasks'
-
-import { resendExportWin } from '../client/modules/ExportWins/Details/tasks'
-import { TASK_RESEND_EXPORT_WIN } from './modules/ExportWins/Details/state'
 
 export const tasks = {
   'Create list': createList,

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -117,5 +117,8 @@ export const exportWinsFaker = () => ({
   customer_response: {
     agree_with_win: null, // Sent
     responded_on: faker.date.anytime().toISOString(),
+    expected_portion_without_help: {
+      name: '40%',
+    },
   },
 })

--- a/test/functional/cypress/specs/export-win/edit-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-spec.js
@@ -221,7 +221,10 @@ describe('Editing an export win', () => {
       cy.wait(['@apiGetExportWin'])
       cy.get('[data-test="resend-export-win"]').click()
       cy.wait('@apiResendExportWin')
-      cy.get('[data-test="flash"]').should('have.text', 'Successfully sent')
+      cy.get('[data-test="flash"]').should(
+        'have.text',
+        `The export win ${exportWin.name_of_export} to ${exportWin.country.name} has been sent to ${exportWin.company_contacts[0].email} for review and confirmation.`
+      )
     })
   })
 })


### PR DESCRIPTION
## Description of change
Add Export Win resend functionality

## Screenshots
<img width="1009" alt="Screenshot 2024-04-03 at 08 24 33" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d5a294cb-bf82-4416-ab92-597b2b6a66ed">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
