### PR TITLE
Make the checkboxes optional again

### DIFF
--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -198,7 +198,6 @@ const Step4 = () => (
     <FieldCheckboxes
       name="checkboxes1"
       legend="Please tick all that apply to this win:"
-      required="Select at least 1 of the 3 options below"
       options={[
         {
           label:
@@ -218,7 +217,6 @@ const Step4 = () => (
     <FieldCheckboxes
       name="checkboxes2"
       legend="Tick any that apply to this win:"
-      required="Select at least 1 of the 5 options below"
       options={[
         {
           label: 'It enabled you to expand into a new market',

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -315,24 +315,6 @@ describe('ExportWins/Review', () => {
 
       cy.get('@continue').click()
 
-      // Assert errors
-      assertErrorSummary([
-        'Select at least 1 of the 3 options below',
-        'Select at least 1 of the 5 options below',
-      ])
-
-      cy.get('@continue').click()
-
-      cy.contains(
-        'Our support was a prerequisite to generate this value'
-      ).click()
-
-      cy.contains(
-        'It enabled you to maintain or expand in an existing market'
-      ).click()
-
-      cy.get('@continue').click()
-
       cy.contains(DBT_HEADING + 'Step 4 of 5' + HEADING)
       cy.contains('h2', 'Your export experience')
 


### PR DESCRIPTION
## Description of change

This PR makes the checkboxes in the _About this win_ step of the _Review export win_ form optional again.

## Test instructions

1. Go to `/exportwins/review/<token>`
2. Select the _I confirm this information is correct_ option
3. Continue filling out the form until you come to the _About this win_ (step 3 of 5)
4. Don't select any of the checkboxes and click _Next_
5. You should be taken to the next step of the form (_Your export experience_, step 4 of 5) without any validation errors
