### PR TITLE
Removed goods or services and added export experience row

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -31,6 +31,7 @@ const reactRoutes = [
   '/exportwins/won',
   '/exportwins/sent',
   '/exportwins/rejected',
+  // TODO: Remove
   '/exportwins/:winId/details',
   '/exportwins/:winId/success',
   '/companies/:companyId/exportwins/:winId/edit',

--- a/src/client/modules/ExportWins/Details/index.jsx
+++ b/src/client/modules/ExportWins/Details/index.jsx
@@ -1,3 +1,4 @@
+// TODO: Remove this module and all related code
 import React from 'react'
 import { Link as ReactRouterLink } from 'react-router-dom'
 import { SPACING } from '@govuk-react/constants'

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -494,6 +494,7 @@ const routes = {
       module: 'datahub:companies',
       component: ExportWinsRedirect,
     },
+    // TODO: Remove with all related code
     {
       path: '/exportwins/:winId/details',
       module: 'datahub:companies',

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -48,6 +48,7 @@ const EXPORT_WIN = {
   },
   is_personally_confirmed: false,
   description: 'Lorem ipsum dolor sit amet',
+  export_experience: 'My export experience',
   breakdowns: [
     {
       type: {
@@ -190,12 +191,15 @@ describe('ExportWins/Review', () => {
 
       assertSummaryTableStrict({
         rows: [
-          ['Goods or services', EXPORT_WIN.goods_vs_services.name],
           ['Destination country', EXPORT_WIN.country.name],
           ['Total value', '£123,456 over 1 year'],
           ['Date won', '26 Mar 2024'],
           ['Lead officer name', EXPORT_WIN.lead_officer.name],
           ['Summary of support received', EXPORT_WIN.description],
+          [
+            'Your export experience before this win can be described as',
+            EXPORT_WIN.export_experience,
+          ],
         ],
       })
 
@@ -402,12 +406,15 @@ describe('ExportWins/Review', () => {
 
       assertSummaryTableStrict({
         rows: [
-          ['Goods or services', EXPORT_WIN.goods_vs_services.name],
           ['Destination country', EXPORT_WIN.country.name],
           ['Total value', '£123,456 over 1 year'],
           ['Date won', '26 Mar 2024'],
           ['Lead officer name', EXPORT_WIN.lead_officer.name],
           ['Summary of support received', EXPORT_WIN.description],
+          [
+            'Your export experience before this win can be described as',
+            EXPORT_WIN.export_experience,
+          ],
         ],
       })
 

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -60,6 +60,7 @@ const fakeExportWin = () => ({
   },
   breakdowns: faker.helpers.multiple(fakeBreakdown),
   description: faker.lorem.lines(),
+  export_experience: faker.lorem.paragraph(),
   customer_response: {
     id: faker.string.uuid(),
     our_support: {


### PR DESCRIPTION
## Description of change

Removed goods or services and added export experience row in export wins

## Test instructions

1. Navigate to `/exportwins/review/<token>`
2. In the summary table...
3. There should be no _Goods or services_ row
4. There should be the new _Summary of support received_ row as the last one

## Screenshots

### Before

![before](https://github.com/uktrade/data-hub-frontend/assets/2333157/53a1bdc9-5d72-4052-b6d8-50ecc7566e3e)

_Add a screenshot_

![after](https://github.com/uktrade/data-hub-frontend/assets/2333157/e242189a-bae1-434f-8d8d-41d909413a2a)

_Add a screenshot_

