### PR TITLE
Run e2e tests against migration branch

### DIFF
--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -5,7 +5,7 @@ services:
       - api
 
   api:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:migration-deploy
     env_file: .env
     environment:
       DEBUG: 'False'
@@ -33,7 +33,7 @@ services:
     command: /app/setup-uat.sh || echo "all good"
 
   rq:
-    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:main
+    image: gcr.io/sre-docker-registry/github.com/uktrade/data-hub-api:migration-deploy
     env_file: .env
     depends_on:
       - postgres

--- a/docker-compose.e2e.backend.yml
+++ b/docker-compose.e2e.backend.yml
@@ -21,6 +21,8 @@ services:
       ACTIVITY_STREAM_OUTGOING_SECRET_ACCESS_KEY: incoming-some-secret-1
       ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
       ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
+      ACTIVITY_STREAM_INCOMING_SECRET_ACCESS_KEY: some-secret
+      DATABASE_CREDENTIALS: '{"username": "postgres", "password": "datahub", "engine": "postgres", "port": 5432, "dbname": "datahub", "host": "postgres", "dbInstanceIdentifier": "db-instance"}'
     ports:
       - 8000:8000
     depends_on:
@@ -41,6 +43,8 @@ services:
       - redis
     entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://opensearch:9200 -wait tcp://redis:6379 -timeout 5m
     command: python short-running-worker.py long-running-worker.py
+    environment:
+      DATABASE_CREDENTIALS: '{"username": "postgres", "password": "datahub", "engine": "postgres", "port": 5432, "dbname": "datahub", "host": "postgres", "dbInstanceIdentifier": "db-instance"}'
 
   postgres:
     image: postgres:16
@@ -50,6 +54,7 @@ services:
       POSTGRES_DB: datahub
       POSTGRES_USER: user
       POSTGRES_PASSWORD: password
+      DATABASE_CREDENTIALS: '{"username": "postgres", "password": "datahub", "engine": "postgres", "port": 5432, "dbname": "datahub", "host": "postgres", "dbInstanceIdentifier": "db-instance"}'
 
   opensearch:
     image: opensearchproject/opensearch:2.11.0

--- a/docker-compose.services.yml
+++ b/docker-compose.services.yml
@@ -31,6 +31,10 @@ services:
       MAXEMAIL_USERNAME: dummyUser
       MAXEMAIL_PASSWORD: dummyPassword
       ELASTIC_APM_DISABLE_SEND: 1
+      DYNAMICS_INSTANCE_URI: https://localhost
+      DYNAMICS_TENANT_ID: xxx
+      DYNAMICS_APPLICATION_ID: xxx
+      DYNAMICS_CLIENT_SECRET: xxx
     ports:
       - 8001:8001
     depends_on:
@@ -44,3 +48,4 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_DB: legal-basis
+      POSTGRES_PASSWORD: password


### PR DESCRIPTION
## Description of change

The e2e suite in the migration branch is currently running against the API `main` branch, which isn't ideal. I have updated the `docker-compose` file so this now points at the correct `migration-deploy` branch.

## Test instructions

The e2e tests should run against the API's `migration-deploy` branch

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
