### PR TITLE
Change 'Total export value' to 'Total value'

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -211,8 +211,8 @@ const WinDetailsStep = ({ isEditing }) => {
       )}
 
       {!isEditing && values?.win_type?.length > 1 && (
-        <StyledExportTotal data-test="total-export-value">
-          Total export value:{' '}
+        <StyledExportTotal data-test="total-value">
+          Total value:{' '}
           {formatValue(sumAllWinTypeYearlyValues(values?.win_type, values))}
         </StyledExportTotal>
       )}

--- a/test/functional/cypress/specs/export-win/constants.js
+++ b/test/functional/cypress/specs/export-win/constants.js
@@ -74,7 +74,7 @@ export const formFields = {
     winTypeValuesExport: '[data-test="win-type-values-export_win"]',
     winTypeValuesBusSupp: '[data-test="win-type-values-business_success_win"]',
     winTypeValuesODI: '[data-test="win-type-values-odi_win"]',
-    totalExportValue: '[data-test="total-export-value"]',
+    totalValue: '[data-test="total-value"]',
   },
   supportProvided: {
     heading: '[data-test="step-heading"]',

--- a/test/functional/cypress/specs/export-win/win-details-spec.js
+++ b/test/functional/cypress/specs/export-win/win-details-spec.js
@@ -193,10 +193,10 @@ describe('Win details', () => {
       values: ['3000000', '3000000', '3000000', '3000000', '3000000'], // 15M
     })
 
-    // Assert the total export value
-    cy.get(winDetails.totalExportValue).should(
+    // Assert the total value
+    cy.get(winDetails.totalValue).should(
       'have.text',
-      'Total export value: £30,000,000' // 5M + 10M + 15M
+      'Total value: £30,000,000' // 5M + 10M + 15M
     )
   })
 


### PR DESCRIPTION
## Description of change
Content update: changed _Total export value_ to _**Total value**_

## Screenshots

### Win details page
<img width="1009" alt="win-values" src="https://github.com/uktrade/data-hub-frontend/assets/964268/50f3ca25-fec5-49bd-8979-be81e1d460ce">

### Summary page
<img width="994" alt="summary-page" src="https://github.com/uktrade/data-hub-frontend/assets/964268/05d590eb-a6b6-4125-9297-b28900d07e94">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
