### PR TITLE
Fixed a bug when not accessing export_experience.name

### DIFF
--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -177,7 +177,7 @@ const Step1 = ({ win, name }) => {
           {win.description}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Your export experience before this win can be described as">
-          {win?.exportExperience}
+          {win?.exportExperience.name}
         </SummaryTable.Row>
       </SummaryTable>
 

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -48,7 +48,9 @@ const EXPORT_WIN = {
   },
   is_personally_confirmed: false,
   description: 'Lorem ipsum dolor sit amet',
-  export_experience: 'My export experience',
+  export_experience: {
+    name: 'My export experience',
+  },
   breakdowns: [
     {
       type: {
@@ -198,7 +200,7 @@ describe('ExportWins/Review', () => {
           ['Summary of support received', EXPORT_WIN.description],
           [
             'Your export experience before this win can be described as',
-            EXPORT_WIN.export_experience,
+            EXPORT_WIN.export_experience.name,
           ],
         ],
       })
@@ -413,7 +415,7 @@ describe('ExportWins/Review', () => {
           ['Summary of support received', EXPORT_WIN.description],
           [
             'Your export experience before this win can be described as',
-            EXPORT_WIN.export_experience,
+            EXPORT_WIN.export_experience.name,
           ],
         ],
       })

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -60,7 +60,10 @@ const fakeExportWin = () => ({
   },
   breakdowns: faker.helpers.multiple(fakeBreakdown),
   description: faker.lorem.lines(),
-  export_experience: faker.lorem.paragraph(),
+  export_experience: {
+    id: faker.string.uuid(),
+    name: faker.lorem.paragraph(),
+  },
   customer_response: {
     id: faker.string.uuid(),
     our_support: {


### PR DESCRIPTION
## Description of change

Fixes a bug when not accessing `export_experience.name`, but just `export_experience`, which blew the whole page.

## Test instructions

1. Go to `/exportwins/review/<token>`
2. The page should not be completely blank

