### PR TITLE
Use no cookies on Export Wins Review

### DIFF
--- a/src/apps/__export-wins-review/index.js
+++ b/src/apps/__export-wins-review/index.js
@@ -1,14 +1,28 @@
-/* eslint-disable prettier/prettier */
-const express = require('express')
+const { createProxyMiddleware } = require('http-proxy-middleware')
 
-const router = express.Router()
+const config = require('../../config')
 
-router.get(
-  [
-    '/exportwins/review/:id',
-    '/exportwins/review-win/thankyou',
-  ],
-  (req, res) => res.render('__export-wins-review/view')
-)
+module.exports = (app) => {
+  // We have to specially treat this endpoint as it doesn't require an access token nor
+  // any other authorization and we don't want any cookie to be set
+  app.use(
+    '/api-proxy/v4/export-win/review/',
+    createProxyMiddleware({
+      target: config.apiRoot,
+      changeOrigin: true,
+      pathRewrite: {
+        '^/api-proxy': '',
+      },
+    })
+  )
 
-module.exports = router
+  app.use((req, res, next) => {
+    if (/\/exportwins\/review/.test(req.url)) {
+      // This skips all subsequent middleware
+      res.render('__export-wins-review/view')
+    } else {
+      // Continue to the next middleware
+      next()
+    }
+  })
+}

--- a/src/client/modules/ExportWins/Review/Layout.jsx
+++ b/src/client/modules/ExportWins/Review/Layout.jsx
@@ -77,7 +77,7 @@ const Layout = ({ children, title, supertitle, headingContent }) => (
       links={{
         'Privacy Policy':
           'https://www.great.gov.uk/privacy-and-cookies/full-privacy-notice/',
-        'Accessibility Statement': 'accesibility-statement',
+        'Accessibility Statement': '/exportwins/review/accesibility-statement',
       }}
     />
   </Grid>

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -57,7 +57,6 @@ const ALLOWLIST = [
   '/v3/event/',
   '/v4/event/',
   '/v4/export-win/',
-  '/v4/export-win/review/:token',
   '/v4/export-win/:exportWinId',
   '/v4/event/:id',
   '/v3/omis/order/:id/assignee',

--- a/src/server.js
+++ b/src/server.js
@@ -143,7 +143,6 @@ app.use(userLocals)
 app.use(headers)
 app.use(store())
 apiProxy(app)
-// metadataApiProxy(app)
 helpCentreApiProxy(app)
 // csrf middleware needs to come after the proxy path as it is not needed for the proxy and would block requests
 app.use(csrf())

--- a/src/server.js
+++ b/src/server.js
@@ -45,6 +45,7 @@ const helpCentreApiProxy = require('./middleware/help-centre-api-proxy')
 const fixSlashes = require('./middleware/fix-slashes')
 
 const routers = require('./apps/routers')
+const exportWinsReview = require('./apps/__export-wins-review')
 
 const app = express()
 
@@ -114,7 +115,9 @@ app.use(
 
 app.use(locals)
 
-app.use(require('./apps/__export-wins-review'))
+metadataApiProxy(app)
+
+exportWinsReview(app)
 
 app.use(title())
 app.use(breadcrumbs.init())
@@ -140,7 +143,7 @@ app.use(userLocals)
 app.use(headers)
 app.use(store())
 apiProxy(app)
-metadataApiProxy(app)
+// metadataApiProxy(app)
 helpCentreApiProxy(app)
 // csrf middleware needs to come after the proxy path as it is not needed for the proxy and would block requests
 app.use(csrf())

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -74,41 +74,41 @@ describe('ExportWins/Review', () => {
   // TODO: This should actually be applied globally
   afterEach(() => sessionStorage.clear())
 
-  // it('Footer links', () => {
-  //   const Provider = createTestProvider({
-  //     'Export Win Review': () => Promise.resolve(REVIEW),
-  //     WithoutOurSupport: () => Promise.resolve(WITHOUT_OUR_SUPPORT),
-  //     Rating: () => Promise.resolve(RATING),
-  //     Experience: () => Promise.resolve(EXPERIENCE),
-  //     MarketingSource: () => Promise.resolve(MARKETING_SOURCE),
-  //     TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
-  //   })
-  //   cy.mount(
-  //     <Provider>
-  //       <Redirect to="/exportwins/review/123" />
-  //       <Review />
-  //     </Provider>
-  //   )
+  it('Footer links', () => {
+    const Provider = createTestProvider({
+      'Export Win Review': () => Promise.resolve(REVIEW),
+      WithoutOurSupport: () => Promise.resolve(WITHOUT_OUR_SUPPORT),
+      Rating: () => Promise.resolve(RATING),
+      Experience: () => Promise.resolve(EXPERIENCE),
+      MarketingSource: () => Promise.resolve(MARKETING_SOURCE),
+      TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+    })
+    cy.mount(
+      <Provider>
+        <Redirect to="/exportwins/review/123" />
+        <Review />
+      </Provider>
+    )
 
-  //   cy.get('footer').within(() => {
-  //     // There should be 3 links including the Crown copyright
-  //     cy.get('a').should('have.length', 3)
+    cy.get('footer').within(() => {
+      // There should be 3 links including the Crown copyright
+      cy.get('a').should('have.length', 3)
 
-  //     // Links should be in a particular order
-  //     cy.contains('Privacy Policy' + 'Accessibility Statement')
+      // Links should be in a particular order
+      cy.contains('Privacy Policy' + 'Accessibility Statement')
 
-  //     cy.contains('a', 'Privacy Policy').should(
-  //       'have.attr',
-  //       'href',
-  //       'https://www.great.gov.uk/privacy-and-cookies/full-privacy-notice/'
-  //     )
-  //     cy.contains('a', 'Accessibility Statement').should(
-  //       'have.attr',
-  //       'href',
-  //       'accesibility-statement'
-  //     )
-  //   })
-  // })
+      cy.contains('a', 'Privacy Policy').should(
+        'have.attr',
+        'href',
+        'https://www.great.gov.uk/privacy-and-cookies/full-privacy-notice/'
+      )
+      cy.contains('a', 'Accessibility Statement').should(
+        'have.attr',
+        'href',
+        '/exportwins/review/accesibility-statement'
+      )
+    })
+  })
 
   context('If there is a problem loading the review', () => {
     it("should render not found view if token is expired or doesn't exist", () => {

--- a/test/functional/cypress/specs/export-win/review-spec.js
+++ b/test/functional/cypress/specs/export-win/review-spec.js
@@ -1,0 +1,14 @@
+describe('Export wins review', () => {
+  context('Should not set any cookies on page:', () => {
+    ;[
+      '/exportwins/review/dummy-token',
+      '/exportwins/review-win/thankyou',
+      '/exportwins/review/accesibility-statement',
+    ].forEach((url) => {
+      it(url, () => {
+        cy.visit(url)
+        cy.getAllCookies().should('have.length', 0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

This PR configures all `/exportwins/review*` routes to not set any cookies, so that we don't need to introduce any complicated cookie consent mechanism.

It also fixes a small bug when the link to `/exportwins/review/accesibility-statement` in the footer was relative, which was not working on the `/exportwins/review-win/thankyou` page.

## Test instructions

1. In an incognito browser tab
2. Go to
   *  `/exportwins/review/<token>`
   *  `/exportwins/review-win/thankyou`
   * `/exportwins/review/accesibility-statement`
3. Visiting any of the above urls (or any `/exportwins/review*` really) should not set any cookies in the browser

