### PR TITLE
Removed the getAssetPath nunjucks helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,30 @@ Use this method if you want to make backend changes or run against an API branch
 
     **In development mode:**
 
+    Just run:
+
+    ```bash
+    ./scripts/develop.sh
+    ```
+
+    The above script will first start the WebPack dev server in watch mode.
+
     ```bash
     npm run develop
     ```
 
-    The server will watch for changes and rebuild sass or compile js using webpack as
-    needed. Changes to server side code will result in the server autorestarting.
-    The server will run with the node debug flag so you can debug with Webstorm
-    or Visual Studio Code.
+    And once it detects that the static assets have been built,
+    it starts the node server. The server will watch for changes and
+    rebuild sass.
+
+    ```bash
+    npx nodemon --inspect --ignore 'src/**/__test__/**/*'
+    ```
+
+    Note that the application served by the node server will try to load static assets
+    from `./.build/*`, which is only generated when `npm run build` or `npm run develop`
+    is run at least once. Hence the convenience of `./script/develop.sh`.
+    The script is also used when running tests through _make_ and in CI.
 
 **Running with other APIs (e.g. staging)**
 

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -24,13 +24,7 @@ services:
       # Required to test Data Hub roles in e2e tests, make sure this var
       # doesn't exists in your .env file as the override below won't work
       OAUTH2_DEV_TOKEN: ${OAUTH2_DEV_TOKEN:-ditStaffToken}
-    # command: >
-    #   sh -c "
-    #     npm run build
-    #     npm start
-    #   "
-    command: sh -c "npm start && wait-for-frontend & npm run develop"
-    # command: sh -c "echo aaaaaaaaaaaaaaaaaaaaas"
+    command: ./scripts/develop.sh
 
   redis:
     image: redis:6.2.6

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -23,7 +23,7 @@ services:
       # Required to test Data Hub roles in e2e tests, make sure this var
       # doesn't exists in your .env file as the override below won't work
       OAUTH2_DEV_TOKEN: ${OAUTH2_DEV_TOKEN:-ditStaffToken}
-    command: npm run develop
+    command: npm run build && npm start
 
   redis:
     image: redis:6.2.6

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -24,11 +24,13 @@ services:
       # Required to test Data Hub roles in e2e tests, make sure this var
       # doesn't exists in your .env file as the override below won't work
       OAUTH2_DEV_TOKEN: ${OAUTH2_DEV_TOKEN:-ditStaffToken}
-    command: >
-      sh -c "
-        npm run build
-        npm start
-      "
+    # command: >
+    #   sh -c "
+    #     npm run build
+    #     npm start
+    #   "
+    command: sh -c "npm start && wait-for-frontend & npm run develop"
+    # command: sh -c "echo aaaaaaaaaaaaaaaaaaaaas"
 
   redis:
     image: redis:6.2.6

--- a/docker-compose.base.yml
+++ b/docker-compose.base.yml
@@ -19,11 +19,16 @@ services:
     env_file: .env
     user: "${CURRENT_UID}:${CURRENT_GID}"
     environment:
+      REDIS_URL: redis://redis:6379
       API_ROOT: ${API_ROOT}
       # Required to test Data Hub roles in e2e tests, make sure this var
       # doesn't exists in your .env file as the override below won't work
       OAUTH2_DEV_TOKEN: ${OAUTH2_DEV_TOKEN:-ditStaffToken}
-    command: npm run build && npm start
+    command: >
+      sh -c "
+        npm run build
+        npm start
+      "
 
   redis:
     image: redis:6.2.6

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-BACKEND_CMD="npx nodemon --inspect --ignore 'src/**/__test__/**/*'"
+BACKEND_CMD="npx nodemon --inspect --ignore 'src/**/__test__/**/*' --ignore 'src/client/**'"
 
 # Create a temporary log file
 LOG_FILE=$(mktemp)

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+BACKEND_CMD="npx nodemon --inspect --ignore 'src/**/__test__/**/*'"
+
 # Create a temporary log file
 LOG_FILE=$(mktemp)
 # Delete the temporary file when the script is terminated
@@ -9,4 +11,4 @@ trap "rm -f ${LOG_FILE}" INT TERM HUP EXIT
 npm run develop --  --color | tee "${LOG_FILE}" &
 # Subscribe to changes of the log file and
 # start the backend when "asset-manifest" is logged.
-tail -f "${LOG_FILE}" | awk '/assets-manifest/ {system("npm start")}'
+tail -f "${LOG_FILE}" | awk "/assets-manifest/ {system(\"${BACKEND_CMD}\")}"

--- a/scripts/develop.sh
+++ b/scripts/develop.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Create a temporary log file
+LOG_FILE=$(mktemp)
+# Delete the temporary file when the script is terminated
+trap "rm -f ${LOG_FILE}" INT TERM HUP EXIT
+# Duplicate output of the frontend command to the log file,
+# so that we still can see it in the console.
+npm run develop --  --color | tee "${LOG_FILE}" &
+# Subscribe to changes of the log file and
+# start the backend when "asset-manifest" is logged.
+tail -f "${LOG_FILE}" | awk '/assets-manifest/ {system("npm start")}'

--- a/src/apps/__export-wins-review/view.njk
+++ b/src/apps/__export-wins-review/view.njk
@@ -21,8 +21,8 @@
     </div>
 
     <!--[if gt IE 8]><!-->
-    <script src="{{ getAssetPath('app.js') }}"></script>
-    <script src="{{ getAssetPath('export-win-review.js') }}"></script>
+    <script src="/js/app.js"></script>
+    <script src="/js/export-win-review.js"></script>
     <!--<![endif]-->
   </body>
 </html>

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -47,7 +47,6 @@ module.exports = function locals(req, res, next) {
       })
     },
 
-    // TODO: Remove! Only used once in src/templates/_macros/form/multi-step-form.njk
     getLocal(key) {
       return res.locals[key]
     },

--- a/src/middleware/locals.js
+++ b/src/middleware/locals.js
@@ -1,15 +1,6 @@
 const { map } = require('lodash')
 
-const logger = require('../config/logger')
 const config = require('../config')
-
-let webpackManifest = {}
-
-try {
-  webpackManifest = require(`${config.buildDir}/assets-manifest.json`)
-} catch (err) {
-  logger.error('Manifest file is not found. Ensure assets are built.')
-}
 
 module.exports = function locals(req, res, next) {
   const baseUrl = `${req.encrypted ? 'https' : req.protocol}://${req.get(
@@ -56,16 +47,7 @@ module.exports = function locals(req, res, next) {
       })
     },
 
-    getAssetPath(asset) {
-      const webpackAssetPath = webpackManifest[asset]
-
-      if (webpackAssetPath) {
-        return `${baseUrl}/${webpackAssetPath}`
-      }
-
-      return `${baseUrl}/${asset}`
-    },
-
+    // TODO: Remove! Only used once in src/templates/_macros/form/multi-step-form.njk
     getLocal(key) {
       return res.locals[key]
     },

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -47,9 +47,9 @@
   {% endif %}
 
   <!-- Touch Icons - iOS and Android 2.1+ 180x180 pixels in size. -->
-  <link rel="apple-touch-icon" href="{{ getAssetPath('images/apple-touch-icon.png') }}">
+  <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
   <!-- Firefox, Chrome, Safari, IE 11+ and Opera. 192x192 pixels in size. -->
-  <link rel="icon" href="{{ getAssetPath('images/favicon-192x192.png') }}" type="image/png">
+  <link rel="icon" href="/images/favicon-192x192.png" type="image/png">
 
   <!-- opengraph -->
   <meta property="og:url" content="{{ CANONICAL_URL }}">
@@ -60,12 +60,12 @@
   {% endif -%}
   <meta property="og:type" content="website">
   <meta property="og:locale" content="en_GB">
-  <meta property="og:image" content="{{ getAssetPath('images/opengraph-image.png') }}">
+  <meta property="og:image" content="/images/opengraph-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="1200">
 
   <!-- styles -->
-  <link href="{{ getAssetPath('styles.css') }}" media="screen, print" rel="stylesheet">
+  <link href="/css/styles.css" media="screen, print" rel="stylesheet">
 
   <!-- Google Tag Manager (GTM) -->
   {% include "_includes/google-tag-manager-snippet.njk" %}
@@ -119,7 +119,7 @@
   </div>
 
   <!--[if gt IE 8]><!-->
-  <script src="{{ getAssetPath('app.js') }}"></script>
-  <script src="{{ getAssetPath('react-app.js') }}"></script>
+  <script src="/js/app.js"></script>
+  <script src="/js/react-app.js"></script>
   <!--<![endif]-->
 {% endblock %}

--- a/src/templates/react.njk
+++ b/src/templates/react.njk
@@ -18,20 +18,20 @@
   {% endif -%}
 
   <!--[if IE]>
-  <link rel="shortcut icon" href="{{ getAssetPath('images/favicon.ico') }}" type="image/x-icon"><![endif]-->
+  <link rel="shortcut icon" href="/images/favicon.ico" type="image/x-icon"><![endif]-->
   <!-- Touch Icons - iOS and Android 2.1+ 180x180 pixels in size. -->
-  <link rel="apple-touch-icon" href="{{ getAssetPath('images/apple-touch-icon.png') }}">
+  <link rel="apple-touch-icon" href="/images/apple-touch-icon.png">
   <!-- Firefox, Chrome, Safari, IE 11+ and Opera. 192x192 pixels in size. -->
-  <link rel="icon" href="{{ getAssetPath('images/favicon-192x192.png') }}" type="image/png">
+  <link rel="icon" href="/images/favicon-192x192.png" type="image/png">
 
   <!-- styles -->
-  <link href="{{ getAssetPath('styles.css') }}" media="screen, print" rel="stylesheet">
+  <link href="/css/styles.css" media="screen, print" rel="stylesheet">
 
   <!-- Google Tag Manager (GTM) -->
   {% include "_includes/google-tag-manager-snippet.njk" %}
 
   <!--[if lt IE 9]>
-  <script src="{{ getAssetPath('html5shiv.min.js') }}"></script>
+  <script src="/js/html5shiv.min.js') }}"></script>
   <![endif]-->
 
 {% endblock %}

--- a/test/unit/nunjucks.js
+++ b/test/unit/nunjucks.js
@@ -21,10 +21,6 @@ Object.keys(filters).forEach((filterName) => {
 })
 
 function render(template, options) {
-  // Stub methods set in middleware locals
-  options.getAssetPath = () => {
-    throw Error('Do not use!!!')
-  }
   options.getPageTitle = () => {}
   options.getBreadcrumbs = () => {}
   options.getMessages = () => {}

--- a/test/unit/nunjucks.js
+++ b/test/unit/nunjucks.js
@@ -22,7 +22,9 @@ Object.keys(filters).forEach((filterName) => {
 
 function render(template, options) {
   // Stub methods set in middleware locals
-  options.getAssetPath = () => {}
+  options.getAssetPath = () => {
+    throw Error('Do not use!!!')
+  }
   options.getPageTitle = () => {}
   options.getBreadcrumbs = () => {}
   options.getMessages = () => {}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,35 +1,11 @@
 const path = require('path')
-const { spawn } = require('child_process')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const WebpackAssetsManifest = require('webpack-assets-manifest')
 const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin')
 
 const config = require('./src/config')
 
-/**
- * A webpack plugin that starts a node.js server after the assets are compiled.
- * This is a required step, because the node server is parsing manifest.json
- * when booting up.
- */
-const StartServerAfterBuild = () => {
-  let server = false
-  return {
-    apply: (compiler) => {
-      compiler.hooks.done.tap('StartServerAfterBuild', () => {
-        if (server) {
-          server.stdin.write('rs\n')
-        } else {
-          server = spawn(
-            "npx nodemon --inspect --ignore 'src/**/__test__/**/*'",
-            { stdio: ['pipe', 'inherit', 'inherit'], shell: true }
-          )
-        }
-      })
-    },
-  }
-}
-
-module.exports = (env) => ({
+module.exports = () => ({
   devtool: config.isProd ? false : 'source-map',
   mode: config.isProd ? 'production' : 'development',
   entry: {
@@ -88,7 +64,6 @@ module.exports = (env) => ({
         },
       },
     }),
-    env && env.development ? StartServerAfterBuild() : null,
   ].filter(Boolean),
   resolve: {
     modules: [


### PR DESCRIPTION
## Description of change

This PR removes the mechanism which made the node server restart when React code was changed, which doesn't make any practical sense (for development) and which often resulted in the application to crash when it couldn't start because one of the metadata pre-fetches failed.

The main reason to have the backend tied to the front-end transpilation was that the node server used the `getAssetPath` function injected to Nunjucks template context to get the path of a static asset built by WebPack and that function relied on the `./.build/assets-manifest.json` file. That made the backend dependent on frontend transpilation. This PR breaks this dependency by removing the `getAssetPath` completely and hardcoding the assset paths directly in the few templates where ``getAssetPath` was used.

Unfortunatel removing the mechanism broke all tests which rely on the node server and which are run in Docker and thus CI. This is because the tests were waiting for the node server to start and if the server was started before assets were compiled, this lead to the tests to be broken. So this PR comes with a solution to start the node server in reaction to `assets-manifest.json` compilation which is not built into WebPack config, but uses available POSIX mechanism to watch for a specific string in the output of WebPack compilation to start the node server.

A much simpler solution than that `./scripts/develop.sh` would be to use `npm run build && npm start`, but I wasn't sure how many people use the docker/make setup for development so I tried to make it work with `npm run develop`.

## Test instructions

1. Start the node server and WebPack dev server as per the [README](https://github.com/uktrade/data-hub-frontend/blob/a04d2374f5cadc90ea009c09d21c072b3e33f172/README.md?plain=1#L100-L125) either separately or with the `./scripts/develop.sh`
2. Make a change to one of the files in `./src/client`
    * That should trigger a WebPack re-compilation, but
    * should **not** trigger the node server restart (you should see **no** `[nodemon] restarting due to changes...` in the console output)
3. Make a change to one of the files that constitute the node server
    * That should trigger the node server restart (you should see `[nodemon] restarting due to changes...` in console output), but
    * it should **not** trigger a WebPack re-compilation

## Screenshots

There should be changes to the application
