### PR TITLE
Use metadata resource form fields within Export Wins

### DIFF
--- a/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
+++ b/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
@@ -2,20 +2,17 @@ import React from 'react'
 import { H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 
-import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
+import HQTeamRegionOrPost from '../../../components/Resource/HQTeamRegionOrPost'
+import TeamType from '../../../components/Resource/TeamType'
 import { useFormContext } from '../../../../client/components/Form/hooks'
 import { OPTION_YES, OPTIONS_YES_NO } from '../../../../common/constants'
 import { MID_GREY } from '../../../../client/utils/colours'
 import { StyledHintParagraph } from './styled'
 import { steps } from './constants'
-import {
-  TeamTypeResource,
-  HQTeamRegionOrPostsResource,
-} from '../../../components/Resource'
+
 import {
   Step,
   FieldRadios,
-  FieldTypeahead,
   FieldAddAnother,
   FieldAdvisersTypeahead,
 } from '../../../components'
@@ -71,11 +68,9 @@ const CreditForThisWinStep = () => {
                   label="Contributing officer"
                   required="Enter a contributing officer"
                 />
-                <ResourceOptionsField
+                <TeamType.FieldTypeahead
                   name={`team_type_${groupIndex}`}
                   id={`contributors-${groupIndex}`}
-                  resource={TeamTypeResource}
-                  field={FieldTypeahead}
                   fullWidth={true}
                   label="Team type"
                   required="Enter a team type"
@@ -87,12 +82,10 @@ const CreditForThisWinStep = () => {
                   // want the previous selection displayed after they've changed the team type.
                   // To ensure this happens we've added a key prop and set it to the team type
                   // id, when the id changes the component updates.
-                  <ResourceOptionsField
+                  <HQTeamRegionOrPost.FieldTypeahead
                     key={values[`team_type_${groupIndex}`].value}
                     name={`hq_team_${groupIndex}`}
                     id={`contributors-${groupIndex}`}
-                    resource={HQTeamRegionOrPostsResource}
-                    field={FieldTypeahead}
                     fullWidth={true}
                     label="HQ team, region or post"
                     required="Enter a HQ team, region or post"

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -2,16 +2,15 @@ import React from 'react'
 import { H3 } from '@govuk-react/heading'
 
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
+import ExportExperience from '../../../components/Resource/ExportExperience'
+import BusinessPotential from '../../../components/Resource/BusinessPotential'
+import CompanyContacts from '../../../components/Resource/CompanyContacts' // Refactor to CompanyContacts.FieldTypeahead
+import WinUKRegions from '../../../components/Resource/WinUKRegions'
+
 import { Step, FieldTypeahead } from '../../../components'
 import { idNamesToValueLabels } from '../../../utils'
 import { StyledHintParagraph } from './styled'
 import { steps } from './constants'
-import {
-  CompanyContactsResource,
-  ExportExperienceResource,
-  BusinessPotentialResource,
-  WinUKRegions,
-} from '../../../components/Resource'
 
 const CustomerDetailsStep = ({ companyId, isEditing }) => {
   return (
@@ -24,7 +23,7 @@ const CustomerDetailsStep = ({ companyId, isEditing }) => {
         hint="This contact will be emailed to approve the win."
         required="Select a company contact"
         placeholder="Select contact"
-        resource={CompanyContactsResource}
+        resource={CompanyContacts}
         field={FieldTypeahead}
         autoScroll={true}
         resultToOptions={({ results }) =>
@@ -49,23 +48,19 @@ const CustomerDetailsStep = ({ companyId, isEditing }) => {
         }
         fullWidth={true}
       />
-      <ResourceOptionsField
+      <BusinessPotential.FieldTypeahead
         name="business_potential"
         id="business-potential"
         label="Medium-sized and high potential companies"
         required="Select medium-sized and high potential companies"
-        field={FieldTypeahead}
-        resource={BusinessPotentialResource}
       />
       {!isEditing && (
-        <ResourceOptionsField
+        <ExportExperience.FieldTypeahead
           name="export_experience"
           id="export-experience"
           label="Export experience"
           required="Select export experience"
           hint="Your customer will be asked to confirm this information."
-          field={FieldTypeahead}
-          resource={ExportExperienceResource}
         />
       )}
     </Step>

--- a/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
@@ -1,21 +1,13 @@
 import React from 'react'
 import { H3 } from '@govuk-react/heading'
 
-import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
-import * as validators from './validators'
+import HQTeamRegionOrPost from '../../../components/Resource/HQTeamRegionOrPost'
+import TeamType from '../../../components/Resource/TeamType'
 import { useFormContext } from '../../../../client/components/Form/hooks'
-
+import { Step, FieldAdvisersTypeahead } from '../../../components'
+import * as validators from './validators'
 import urls from '../../../../lib/urls'
 import { steps } from './constants'
-import {
-  TeamTypeResource,
-  HQTeamRegionOrPostsResource,
-} from '../../../components/Resource'
-import {
-  Step,
-  FieldAdvisersTypeahead,
-  FieldTypeahead,
-} from '../../../components'
 
 const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
   const { values } = useFormContext()
@@ -38,11 +30,9 @@ const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
         label="Lead officer name"
         required="Enter a lead officer"
       />
-      <ResourceOptionsField
+      <TeamType.FieldTypeahead
         name="team_type"
         id="team-type"
-        resource={TeamTypeResource}
-        field={FieldTypeahead}
         fullWidth={true}
         label="Team type"
         required="Select a team type"
@@ -54,12 +44,10 @@ const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
         // want the previous selection displayed after they've changed the team type.
         // To ensure this happens we've added a key prop and set it to the team type
         // id, when the id changes the component updates.
-        <ResourceOptionsField
+        <HQTeamRegionOrPost.FieldTypeahead
           key={values.team_type.value}
           name="hq_team"
           id={`officer-hq-team-region-or-post`}
-          resource={HQTeamRegionOrPostsResource}
-          field={FieldTypeahead}
           fullWidth={true}
           payload={{ team_type: values.team_type.value }}
           label="HQ team, region or post"

--- a/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
+++ b/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import { H3 } from '@govuk-react/heading'
 
-import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
-import { Step, FieldTypeahead, FieldCheckboxes } from '../../../components'
+import { Step, FieldCheckboxes } from '../../../components'
 import { OPTION_YES } from '../../../../common/constants'
 import { StyledHintParagraph } from './styled'
 import { steps } from './constants'
-import {
-  HvcResource,
-  SupportTypeResource,
-  AssociatedProgrammeResource,
-} from '../../../components/Resource'
+
+import AssociatedProgramme from '../../../components/Resource/AssociatedProgramme'
+import SupportType from '../../../components/Resource/SupportType'
+import Hvc from '../../../components/Resource/Hvc'
 
 const SupportProvidedStep = () => (
   <Step name={steps.SUPPORT_PROVIDED}>
@@ -18,21 +16,17 @@ const SupportProvidedStep = () => (
     <StyledHintParagraph data-test="hint">
       Did any of these help the customer achieve this win?
     </StyledHintParagraph>
-    <ResourceOptionsField
+    <Hvc.FieldTypeahead
       id="hvc"
       name="hvc"
       label="High Value Campaign (HVC) code (optional)"
       hint="If the win was linked to a HVC, select the appropriate campaign."
-      resource={HvcResource}
-      field={FieldTypeahead}
     />
-    <ResourceOptionsField
+    <SupportType.FieldTypeahead
       name="type_of_support"
       id="type-of-support"
       label="What type of support was given?"
       hint="You can add up to 5 types of support."
-      field={FieldTypeahead}
-      resource={SupportTypeResource}
       fullWidth={true}
       isMulti={true}
       required="Select at least one type of support"
@@ -40,13 +34,11 @@ const SupportProvidedStep = () => (
         value?.length > 5 && 'Select a maximum of 5 types of support'
       }
     />
-    <ResourceOptionsField
+    <AssociatedProgramme.FieldTypeahead
       name="associated_programme"
       id="associated-programme"
       label="Was there a DBT campaign or event that contributed to this win?"
       hint="You can add up to 5 campaigns or events."
-      field={FieldTypeahead}
-      resource={AssociatedProgrammeResource}
       fullWidth={true}
       isMulti={true}
       required="Select at least one type of DBT campaign or event"

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -4,24 +4,24 @@ import { H3 } from '@govuk-react/heading'
 import Link from '@govuk-react/link'
 import styled from 'styled-components'
 
-import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
+import Countries from '../../../components/Resource/Countries'
+import Sector from '../../../components/Resource/Sector'
+
 import { useFormContext } from '../../../../client/components/Form/hooks'
 import { getStartDateOfTwelveMonthsAgo } from '../../../utils/date'
-import CountriesResource from '../../../components/Resource/Countries'
 import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
-import { SectorResource } from '../../../components/Resource'
 import { validateWinDate } from './validators'
-import { Breakdowns } from './Breakdowns'
 import { StyledHintParagraph } from './styled'
+import { Breakdowns } from './Breakdowns'
 import urls from '../../../../lib/urls'
+
 import {
   Step,
   FieldDate,
   FieldInput,
   FieldRadios,
   FieldTextarea,
-  FieldTypeahead,
   FieldCheckboxes,
 } from '../../../components'
 import {
@@ -58,14 +58,12 @@ const WinDetailsStep = ({ isEditing }) => {
         The customer will be asked to confirm this information.
       </StyledHintParagraph>
       {!isEditing && (
-        <ResourceOptionsField
+        <Countries.FieldTypeahead
           name="country"
           id="country"
           label="Destination country"
           required="Choose a destination country"
-          resource={CountriesResource}
           payload={{ is_export_win: true }}
-          field={FieldTypeahead}
         />
       )}
       {!isEditing && (
@@ -229,7 +227,7 @@ const WinDetailsStep = ({ isEditing }) => {
         placeholder="Enter a name for goods or services"
       />
 
-      <SectorResource.FieldTypeahead
+      <Sector.FieldTypeahead
         id="sector"
         name="sector"
         label="Sector"


### PR DESCRIPTION
## Description of change
Small refactor to use the new metadata resource form fields.

## Test instructions
There are no visual changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
