### PR TITLE
Remove dead code related to metadata preloading in node server

### DIFF
--- a/src/lib/__test__/metadata.test.js
+++ b/src/lib/__test__/metadata.test.js
@@ -39,26 +39,4 @@ describe('metadata', () => {
       expect(fakeOptions).to.deep.equal(undefined)
     })
   })
-
-  describe('#getMetadataItem', () => {
-    it('gets correct metadata item', async () => {
-      const getMetadataItem = metadata.__get__('exports').getMetadataItem
-
-      hawkRequest = sinon.stub().resolves([
-        { id: 1, name: 'Fake 1' },
-        { id: 2, name: 'Fake 2' },
-      ])
-      metadata.__set__('hawkRequest', hawkRequest)
-      const option = await getMetadataItem('fake', 2)
-      expect(option).to.be.deep.equal({ id: 2, name: 'Fake 2' })
-    })
-
-    it('fails to get correct metadata item when request cannot be made', async () => {
-      const getMetadataItem = metadata.__get__('exports').getMetadataItem
-
-      hawkRequest = sinon.stub().rejects()
-      metadata.__set__('hawkRequest', hawkRequest)
-      await expect(getMetadataItem('fake', 2)).to.be.rejectedWith(Error)
-    })
-  })
 })

--- a/src/lib/metadata.js
+++ b/src/lib/metadata.js
@@ -44,91 +44,12 @@ function getMetadata(path, key) {
     })
 }
 
-module.exports.getMetadataItem = function (table, id) {
-  const url = `${config.apiRoot}/v4/metadata/${table}`
-
-  return new Promise((resolve, reject) => {
-    hawkRequest(url)
-      .then((data) => {
-        data.forEach((item) => {
-          if (item.id === id) {
-            resolve(item)
-          }
-        })
-      })
-      .catch((error) => {
-        reject(error)
-      })
-  })
-}
-
 const metadataItems = [
-  ['programme', 'programmeOptions'],
-  ['event-type', 'eventTypeOptions'],
-  ['location-type', 'locationTypeOptions'],
-  ['sector', 'sectorOptions'],
-  ['turnover', 'turnoverOptions'],
-  ['uk-region', 'regionOptions'],
-  ['administrative-area', 'administrativeAreaOptions'],
   ['country', 'countryOptions'],
-  ['employee-range', 'employeeOptions'],
-  ['evidence-tag', 'evidenceTagOptions'],
-  ['business-type', 'businessTypeOptions'],
-  ['team', 'teams'],
-  ['communication-channel', 'communicationChannelOptions'],
-  ['service', 'serviceDeliveryServiceOptions'],
-  ['headquarter-type', 'headquarterOptions'],
-  ['referral-source-activity', 'referralSourceActivityOptions'],
-  ['referral-source-marketing', 'referralSourceMarketingOptions'],
-  ['referral-source-website', 'referralSourceWebsiteOptions'],
-  ['investment-business-activity', 'businessActivityOptions'],
-  ['investment-type', 'investmentTypeOptions'],
   ['investment-project-stage', 'investmentProjectStage'],
-  ['fdi-type', 'fdiOptions'],
-  ['salary-range', 'salaryRangeOptions'],
-  ['investment-strategic-driver', 'strategicDriverOptions'],
-  ['investment-project-stage', 'investmentStageOptions'],
-  ['order-service-type', 'orderServiceTypesOptions'],
-  ['order-cancellation-reason', 'orderCancellationReasons'],
-  ['omis-market', 'omisMarketOptions'],
-  ['fdi-value', 'fdiValueOptions'],
-  ['investment-specific-programme', 'investmentSpecificProgrammeOptions'],
-  ['investment-investor-type', 'investmentInvestorTypeOptions'],
-  ['investment-involvement', 'investmentInvolvementOptions'],
-  ['export-experience-category', 'exportExperienceCategory'],
-  ['likelihood-to-land', 'likelihoodToLandOptions'],
-  ['trade-agreement', 'tradeAgreementOptions'],
-  ['export-years', 'exportYears'],
-  ['export-experience', 'exportExperience'],
 ]
 
-const restrictedServiceKeys = [
-  'Account management',
-  'Bank Referral',
-  'Digital Trade Advisers one-to-one',
-  'Events – Overseas',
-  'Events - UK based',
-  'Events – Webinars',
-  'First Time Exporters - Export Insight Visits',
-  'First Time Exporters – Export Savvy',
-  'Language and Culture Advisers one-to-one',
-  'Market Selection Service (MSS)',
-  'Market visit Support (MVS)',
-  'Onward Referral',
-  'Open to Export Assist (OtE)',
-  'Outward missions',
-  'Overseas Business Network Advisers One-to-One',
-  'Overseas Market Introduction Service (OMIS)',
-  'Postgraduates for International Business - Placement',
-  'Significant assistance (PIMS)',
-  'Trade - ECR Web Action Plan',
-  'UK region local]',
-]
-
-module.exports.setRedisClient = (client) => {
-  redisClient = client
-}
-
+// TODO: Get rid of this
 module.exports.fetchAll = (cb) => {
   // todo
   // refactor to create an array of jobs to do and then use promise all
@@ -161,29 +82,5 @@ module.exports.fetchAll = (cb) => {
         caughtErrors.push(err)
         checkResults()
       })
-  }
-}
-
-module.exports.REASONS_FOR_ARCHIVE = ['Company is dissolved', 'Other']
-
-module.exports.getServices = function () {
-  return hawkRequest(`${config.apiRoot}/v4/metadata/service`)
-}
-
-module.exports.initialiseRestrictedServiceOptions = function () {
-  hawkRequest(`${config.apiRoot}/v4/metadata/service`).then((data) => {
-    module.exports.serviceDeliveryServiceOptions = data.filter((service) =>
-      restrictedServiceKeys.includes(service.name)
-    )
-  })
-}
-
-module.exports.getIdForName = function (options, name) {
-  if (!name) return null
-  const _name = name.toLowerCase()
-  for (const option of options) {
-    if (_name === option.name.toLowerCase()) {
-      return option
-    }
   }
 }


### PR DESCRIPTION
## Description of change

This PR removes dead code from `src/lib/metadata.js`. This should also make it a bit less likely that the application will crash during startup because there are now only two metadata endpoints left that are fetched out of the previous 37.

## Test instructions

All existing tests should pass.

## Screenshots

There should be no change to the application
