### PR TITLE
Rename the export win query param check_before_sending to summary

### DIFF
--- a/src/client/modules/ExportWins/Form/EditSuccess.jsx
+++ b/src/client/modules/ExportWins/Form/EditSuccess.jsx
@@ -27,7 +27,7 @@ const EditSuccess = ({ match }) => (
         text: 'Sent',
       },
       {
-        link: urls.companies.exportWins.edit(
+        link: urls.companies.exportWins.editSummary(
           match.params.companyId,
           match.params.winId
         ),
@@ -43,7 +43,7 @@ const EditSuccess = ({ match }) => (
     <VerticalSpacer>
       <Link
         as={ReactRouterLink}
-        to={urls.companies.exportWins.edit(
+        to={urls.companies.exportWins.editSummary(
           match.params.companyId,
           match.params.winId
         )}

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -8,7 +8,7 @@ import { FONT_SIZE } from '@govuk-react/constants'
 import FlashMessages from '../../../components/LocalHeader/FlashMessages'
 import { steps, EMAIL, STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
 import { TASK_GET_EXPORT_WINS_SAVE_FORM } from './state'
-import CheckBeforeSendingStep from './CheckBeforeSendingStep'
+import SummaryStep from './SummaryStep'
 import { transformFormValuesForAPI } from './transformers'
 import CreditForThisWinStep from './CreditForThisWinStep'
 import CustomerDetailsStep from './CustomerDetailsStep'
@@ -93,7 +93,7 @@ const ExportWinForm = ({
               breadcrumbs={breadcrumbs}
               localHeaderChildren={
                 isEditing ? (
-                  currentStepName === steps.CHECK_BEFORE_SENDING ? (
+                  currentStepName === steps.SUMMARY ? (
                     <>
                       {showSuccessfullySent && (
                         <FlashMessages
@@ -157,7 +157,7 @@ const ExportWinForm = ({
                     <CustomerDetailsStep {...stepProps} />
                     <WinDetailsStep {...stepProps} />
                     <SupportProvidedStep {...stepProps} />
-                    <CheckBeforeSendingStep {...stepProps} />
+                    <SummaryStep {...stepProps} />
                   </>
                 </Form>
               </FormLayout>

--- a/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
@@ -18,7 +18,7 @@ const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
         exportId
           ? urls.exportPipeline.details(exportId)
           : exportWinId
-            ? urls.companies.exportWins.edit(companyId, exportWinId)
+            ? urls.companies.exportWins.editSummary(companyId, exportWinId)
             : companyId
               ? urls.companies.overview.index(companyId)
               : null

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -53,13 +53,13 @@ const StyledInsetText = styled(InsetText)({
   fontSize: FONT_SIZE.SIZE_14,
 })
 
-const CheckBeforeSendingStep = ({ isEditing, companyId }) => {
+const SummaryStep = ({ isEditing, companyId }) => {
   const { values, goToStep } = useFormContext()
   const props = { values, goToStep, isEditing, companyId }
 
   return (
     <Step
-      name={steps.CHECK_BEFORE_SENDING}
+      name={steps.SUMMARY}
       submitButtonLabel={isEditing ? 'Save' : 'Confirm and send to customer'}
     >
       {!isEditing && <H3 data-test="step-heading">Check before sending</H3>}
@@ -385,4 +385,4 @@ const AdditionalInformation = ({ values, isEditing }) => {
   )
 }
 
-export default CheckBeforeSendingStep
+export default SummaryStep

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -4,7 +4,7 @@ export const steps = {
   CUSTOMER_DETAILS: 'customer_details',
   WIN_DETAILS: 'win_details',
   SUPPORT_PROVIDED: 'support_provided',
-  CHECK_BEFORE_SENDING: 'check_before_sending',
+  SUMMARY: 'summary',
 }
 
 // Win Types

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -20,7 +20,7 @@ export default () => (
           <li key={item.id}>
             <CollectionItem
               headingText={`${item.name_of_export} to ${item?.country?.name}`}
-              headingUrl={urls.companies.exportWins.edit(
+              headingUrl={urls.companies.exportWins.editSummary(
                 item.company.id,
                 item.id
               )}

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -22,7 +22,7 @@ export default () => (
           <li key={item.id}>
             <CollectionItem
               headingText={`${item.name_of_export} to ${item?.country?.name}`}
-              headingUrl={urls.companies.exportWins.edit(
+              headingUrl={urls.companies.exportWins.editSummary(
                 item.company.id,
                 item.id
               )}

--- a/src/client/modules/ExportWins/Status/WinsWonTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsWonTable.jsx
@@ -54,7 +54,7 @@ export const WinsWonTable = ({ exportWins }) => {
             <NoWrapCell>
               <Link
                 as={ReactRouterLink}
-                to={urls.companies.exportWins.edit(company.id, id)}
+                to={urls.companies.exportWins.editSummary(company.id, id)}
               >
                 View details
               </Link>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -253,10 +253,9 @@ module.exports = {
         '/companies',
         '/:companyId/exportwins/:winId/edit?step=support_provided'
       ),
-      // TODO: rename this to editSummary and rename check_before_sending to summary
-      edit: url(
+      editSummary: url(
         '/companies',
-        '/:companyId/exportwins/:winId/edit?step=check_before_sending'
+        '/:companyId/exportwins/:winId/edit?step=summary'
       ),
       editSuccess: url(
         '/companies',

--- a/test/functional/cypress/specs/export-win/add-export-win-from-export-project.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-from-export-project.js
@@ -77,7 +77,7 @@ const creditForThisWinStep = `${createFromExportUrl}?step=credit_for_this_win`
 const customerDetailsStep = `${createFromExportUrl}?step=customer_details`
 const winDetailsStep = `${createFromExportUrl}?step=win_details`
 const supportProvidedStep = `${createFromExportUrl}?step=support_provided`
-const checkBeforeSendingStep = `${createFromExportUrl}?step=check_before_sending`
+const summaryStep = `${createFromExportUrl}?step=summary`
 
 describe('Adding an export win from an export project', () => {
   const { officerDetails, customerDetails, winDetails } = formFields
@@ -275,10 +275,10 @@ describe('Adding an export win from an export project', () => {
             lineManagerConfirmed: true,
           })
 
-          clickContinueAndAssertUrl(checkBeforeSendingStep)
+          clickContinueAndAssertUrl(summaryStep)
         }
       )
-      it('should have the pre-populated values on the "Check before sending" step', () => {
+      it('should have the pre-populated values on the "Summary" step', () => {
         cy.get('[data-test="officer-details"]').should(
           'contain',
           exportProject.owner.name // lead officer

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -32,7 +32,7 @@ import {
   customerDetailsStep,
   supportProvidedStep,
   creditForThisWinStep,
-  checkBeforeSendingStep,
+  summaryStep,
 } from './constants'
 
 const exportWin = {
@@ -161,7 +161,7 @@ describe('Adding an export win', () => {
           lineManagerConfirmed: true,
         })
 
-        clickContinueAndAssertUrl(checkBeforeSendingStep)
+        clickContinueAndAssertUrl(summaryStep)
       })
 
       it('should render a step heading', () => {

--- a/test/functional/cypress/specs/export-win/constants.js
+++ b/test/functional/cypress/specs/export-win/constants.js
@@ -15,7 +15,7 @@ export const creditForThisWinStep = `${create}?step=credit_for_this_win`
 export const customerDetailsStep = `${create}?step=customer_details`
 export const winDetailsStep = `${create}?step=win_details`
 export const supportProvidedStep = `${create}?step=support_provided`
-export const checkBeforeSendingStep = `${create}?step=check_before_sending`
+export const summaryStep = `${create}?step=summary`
 
 export const formFields = {
   officerDetails: {

--- a/test/functional/cypress/specs/export-win/edit-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-spec.js
@@ -130,9 +130,9 @@ describe('Editing an export win', () => {
     })
   })
 
-  context('Check before sending', () => {
+  context('Summary', () => {
     it('should render an edit status message', () => {
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
       cy.get('[data-test="status-message"]').should(
         'contain',
@@ -143,7 +143,7 @@ describe('Editing an export win', () => {
     })
 
     it('should render a customer details contact link', () => {
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
       cy.get('[data-test="customer-details-contact"]').should(
         'have.text',
@@ -153,7 +153,7 @@ describe('Editing an export win', () => {
     })
 
     it('should render a win details contact link', () => {
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
       cy.get('[data-test="win-details-contact"]').should(
         'have.text',
@@ -179,7 +179,7 @@ describe('Editing an export win', () => {
       cy.intercept('GET', '/api-proxy/v4/export-win/*', company).as(
         'apiRejectedWin'
       )
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait('@apiRejectedWin')
       cy.get('[data-test="localHeader"]').should(
         'not.contain',
@@ -190,7 +190,7 @@ describe('Editing an export win', () => {
     it('should not render a "Resend export win" button when the win has been won', () => {
       const company = getCompany({ agree_with_win: true }) // won
       cy.intercept('GET', '/api-proxy/v4/export-win/*', company).as('apiWonWin')
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait('@apiWonWin')
       cy.get('[data-test="localHeader"]').should(
         'not.contain',
@@ -203,7 +203,7 @@ describe('Editing an export win', () => {
       cy.intercept('GET', '/api-proxy/v4/export-win/*', company).as(
         'apiSentWin'
       )
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait('@apiSentWin')
       cy.get('[data-test="resend-export-win"]').should(
         'have.text',
@@ -217,7 +217,7 @@ describe('Editing an export win', () => {
         `/api-proxy/v4/export-win/${exportWin.id}/resend-win`,
         {}
       ).as('apiResendExportWin')
-      cy.visit(urls.companies.exportWins.edit(company.id, exportWin.id))
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
       cy.get('[data-test="resend-export-win"]').click()
       cy.wait('@apiResendExportWin')


### PR DESCRIPTION
## Description of change
When we add a new export win to Data Hub we ask the user to check the last page of the multipage form before saving and emailing the customer. The last page had a query param called `check_before_sending`, this identifies the page from the other pages in the form. When a user edits the same form we don't email the customer after saving and yet the query param is still the same. The change simply swaps out `check_before_sending` to `summary` so we can add and edit the same page without concerning ourselves with semantics.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
