### PR TITLE
Add form validation to Export Wins

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -11,7 +11,7 @@ import { useFormContext } from '../../../../client/components/Form/hooks'
 import { getStartDateOfTwelveMonthsAgo } from '../../../utils/date'
 import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
-import { validateWinDate } from './validators'
+import { validateWinDate, validateTextField } from './validators'
 import { StyledHintParagraph } from './styled'
 import { Breakdowns } from './Breakdowns'
 import urls from '../../../../lib/urls'
@@ -108,6 +108,7 @@ const WinDetailsStep = ({ isEditing }) => {
                 hint="Enter the customer’s name, this will be displayed on Data Hub."
                 required="Enter the name of the overseas customer"
                 placeholder="Add name"
+                validate={validateTextField("Customer's name")}
               />
             ),
           },
@@ -120,6 +121,7 @@ const WinDetailsStep = ({ isEditing }) => {
         required="Enter the type of business deal"
         hint="For example: export sales, contract, order, distributor, tender / competition win, joint venture, outward investment."
         placeholder="Enter a type of business deal"
+        validate={validateTextField('Type of business deal')}
       />
       {!isEditing && (
         <FieldCheckboxes
@@ -223,8 +225,9 @@ const WinDetailsStep = ({ isEditing }) => {
         name="name_of_export"
         label="Name of goods or services"
         required="Enter the name of goods or services"
-        hint="For instance 'shortbread biscuits'."
+        hint="For instance 'shortbread biscuits', must be 128 characters or less."
         placeholder="Enter a name for goods or services"
+        validate={validateTextField('Name of goods or services')}
       />
 
       <Sector.FieldTypeahead

--- a/src/client/modules/ExportWins/Form/validators.js
+++ b/src/client/modules/ExportWins/Form/validators.js
@@ -1,5 +1,7 @@
 import { isWithinLastTwelveMonths } from '../../../utils/date'
 
+const TEXT_FIELD_MAX_LENGTH = 128
+
 export const POSITIVE_INT_REGEX = /^[0-9]{1,19}$/
 export const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
 
@@ -12,3 +14,8 @@ export const validateWinDate = ({ month, year }) =>
   isWithinLastTwelveMonths(new Date(year, month - 1))
     ? null
     : 'Date must be in the last 12 months'
+
+export const validateTextField = (name) => (value) =>
+  value && value.length > TEXT_FIELD_MAX_LENGTH
+    ? `${name} must be 128 characters or less`
+    : null

--- a/test/functional/cypress/specs/export-win/utils.js
+++ b/test/functional/cypress/specs/export-win/utils.js
@@ -177,3 +177,6 @@ export const getDateThirteenMonthsAgo = () =>
 
 export const getDateNextMonth = () =>
   getMonthAndYearFromDate(addMonths(new Date(), 1))
+
+export const getStringWithLength = (length) =>
+  Array.from({ length }, () => 'a').join('')

--- a/test/functional/cypress/specs/export-win/win-details-spec.js
+++ b/test/functional/cypress/specs/export-win/win-details-spec.js
@@ -2,6 +2,7 @@ import { clickContinueButton } from '../../support/actions'
 import { formFields, winDetailsStep, company } from './constants'
 
 import {
+  getStringWithLength,
   populateWinWithValues,
   getDateNextMonth,
   getDateThirteenMonthsAgo,
@@ -224,7 +225,7 @@ describe('Win details', () => {
       assertFieldInput({
         element,
         label: 'Name of goods or services',
-        hint: "For instance 'shortbread biscuits'.",
+        hint: "For instance 'shortbread biscuits', must be 128 characters or less.",
         placeholder: 'Enter a name for goods or services',
       })
     })
@@ -340,6 +341,37 @@ describe('Win details', () => {
     assertFieldError(
       cy.get(winDetails.date),
       'Date must be in the last 12 months',
+      true
+    )
+  })
+
+  it("should display a validation error message when the customer's name is greater than 128 characters", () => {
+    cy.get(winDetails.nameOfCustomerConfidentialNo).click()
+    cy.get(`${winDetails.nameOfCustomer} input`).type(getStringWithLength(129))
+    clickContinueButton()
+    assertFieldError(
+      cy.get(winDetails.nameOfCustomer),
+      "Customer's name must be 128 characters or less",
+      true
+    )
+  })
+
+  it('should display a validation error message when the type of business deal is greater than 128 characters', () => {
+    cy.get(`${winDetails.businessType} input`).type(getStringWithLength(129))
+    clickContinueButton()
+    assertFieldError(
+      cy.get(winDetails.businessType),
+      'Type of business deal must be 128 characters or less',
+      true
+    )
+  })
+
+  it('should display a validation error message when goods and services is greater than 128 characters', () => {
+    cy.get(`${winDetails.nameOfExport} input`).type(getStringWithLength(129))
+    clickContinueButton()
+    assertFieldError(
+      cy.get(winDetails.nameOfExport),
+      'Name of goods or services must be 128 characters or less',
       true
     )
   })


### PR DESCRIPTION
## Description of change
Adds form validation to the win details step when adding/editing a win. The validation ensures all user input is not greater than 128 characters enforced by the API.

## Screenshots
<img width="979" alt="Screenshot 2024-04-10 at 13 54 59" src="https://github.com/uktrade/data-hub-frontend/assets/964268/64c56a79-13b3-4b8e-b17f-4866d2b1b913">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
