### PR TITLE
Prevent scrolling in a number input box from changing the input value

### DIFF
--- a/src/client/components/Form/elements/FieldInput/index.jsx
+++ b/src/client/components/Form/elements/FieldInput/index.jsx
@@ -72,6 +72,11 @@ const FieldInput = ({
           value={value}
           onChange={onChange}
           onBlur={onBlur}
+          onWheel={(event) => {
+            if (type === 'number') {
+              event.target.blur()
+            }
+          }}
           data-test={setDataTest(dataTest, name)}
           {...rest}
         />


### PR DESCRIPTION
## Description of change
When entering a numerical value into an input box of number type, it is possible to accidentally alter that number when scrolling down the page. This can result in a number being submitted that is smaller than what the user originally entered.
The code changes disable this behaviour for all number type input boxes.

_Document what the PR does and why the change is needed_

## Test instructions
To see the bug, first carry out the following steps from the main branch:
Go to an investment project. Scroll down to the **Value** section and select **Edit value**
OR
Create a new investment project. Scroll down to the **Value** section and select **Add value**
Click into the **Number of new jobs** input box, ensure your cursor is inside the box, and without moving your mouse, scroll downwards with your mouse wheel or trackpad. You will see a number appear in the box which will decrease in value until your cursor leaves the box.
You can also enter a number in the box and then repeat the scrolling exercise. The number will decrease.

Switch to this branch and repeat the steps:
If no number is entered, no number will appear.
If a number is entered first before scrolling, the number will not decrease as you scroll


## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
