### PR TITLE
Fix disabled regions not filtering

### DIFF
--- a/src/client/components/Form/elements/UKRegionOptions.jsx
+++ b/src/client/components/Form/elements/UKRegionOptions.jsx
@@ -5,10 +5,8 @@ import FieldTypeahead from './FieldTypeahead'
 import ResourceOptionsField from './ResourceOptionsField'
 import { idNamesToValueLabels } from '../../../utils'
 
-const filterActiveRegions = (regions) => {
-  const activeRegions = regions.filter((region) => region.disabledOn === null)
-  return idNamesToValueLabels(activeRegions)
-}
+const filterActiveRegions = (regions) =>
+  idNamesToValueLabels(regions.filter((region) => !region.disabledOn))
 
 const UKRegionOptions = (props) => (
   <ResourceOptionsField

--- a/src/client/components/Form/elements/UKRegionOptions.jsx
+++ b/src/client/components/Form/elements/UKRegionOptions.jsx
@@ -3,6 +3,12 @@ import React from 'react'
 import { UKRegionsResource } from '../../Resource'
 import FieldTypeahead from './FieldTypeahead'
 import ResourceOptionsField from './ResourceOptionsField'
+import { idNamesToValueLabels } from '../../../utils'
+
+const filterActiveRegions = (regions) => {
+  const activeRegions = regions.filter((region) => region.disabledOn === null)
+  return idNamesToValueLabels(activeRegions)
+}
 
 const UKRegionOptions = (props) => (
   <ResourceOptionsField
@@ -11,6 +17,7 @@ const UKRegionOptions = (props) => (
     aria-label="Select a uk region"
     {...props}
     resource={UKRegionsResource}
+    resultToOptions={filterActiveRegions}
   />
 )
 

--- a/src/client/modules/Omis/CollectionList/tasks.js
+++ b/src/client/modules/Omis/CollectionList/tasks.js
@@ -95,7 +95,7 @@ export const getOrdersMetadata = () =>
       },
     }),
     getMetadataOptions(metadata.omisMarket()),
-    getMetadataOptions(metadata.ukRegion()),
+    getMetadataOptions(metadata.ukRegion(), { filterDisabled: false }),
   ])
     .then(([sectorOptions, omisMarketOptions, ukRegionOptions]) => ({
       sectorOptions,

--- a/src/client/tasks.js
+++ b/src/client/tasks.js
@@ -519,7 +519,8 @@ export const tasks = {
   [TASK_GET_COMPANIES_METADATA]: getCompaniesMetadata,
   [TASK_GET_INVESTMENTS_PROJECTS_ADVISER_NAME]: getAdviserNames,
   [TASK_GET_COMPANIES_LEAD_ITA_OR_GLOBAL_ACCOUNT_MANAGER_NAME]: getAdviserNames,
-  [TASK_GET_INVESTMENTS_PROJECTS_METADATA]: investmentProjectTasks.getMetadata,
+  [TASK_GET_INVESTMENTS_PROJECTS_METADATA]:
+    investmentProjectTasks.getProjectMetadata,
   [TASK_EDIT_PROJECT_TEAM_MEMBERS]: updateTeamMembers,
   [TASK_SAVE_CLIENT_RELATIONSHIP_MANAGER]:
     investmentProjectTasks.updateInvestmentProject,

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -453,6 +453,26 @@ describe('Companies Collections Filter', () => {
       uk_region: [ukRegion.id],
     }
 
+    it('should display all UK regions (active & disabled) in the filter list', () => {
+      const ukRegionsIndependent = [
+        ...ukRegionListFaker(2),
+        ...ukRegionListFaker(2, { disabled_on: '2018-01-01' }),
+      ]
+      const queryString = buildQueryString()
+      cy.intercept('GET', ukRegionsEndpoint, ukRegionsIndependent).as(
+        'ukRegionsIndependentApiRequest'
+      )
+      cy.visit(`/companies?${queryString}`)
+      cy.wait('@ukRegionsIndependentApiRequest')
+      cy.get('[data-test="toggle-section-button"]')
+        .contains('Location details')
+        .click()
+      testTypeaheadOptionsLength({
+        element,
+        length: ukRegionsIndependent.length,
+      })
+    })
+
     it('should filter from the url', () => {
       const queryString = buildQueryString({
         uk_region: [ukRegion.id],

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -323,6 +323,26 @@ describe('Investments Collections Filter', () => {
       uk_region_location: [ukRegion.id],
     }
 
+    it('should display all UK regions (active & disabled) in the filter list', () => {
+      const ukRegionsIndependent = [
+        ...ukRegionListFaker(2),
+        ...ukRegionListFaker(2, { disabled_on: '2018-01-01' }),
+      ]
+      const queryString = buildQueryString()
+      cy.intercept('GET', ukRegionsEndpoint, ukRegionsIndependent).as(
+        'ukRegionsIndependentApiRequest'
+      )
+      cy.visit(`${urls.investments.projects.index()}?${queryString}`)
+      cy.wait('@ukRegionsIndependentApiRequest')
+      cy.get('[data-test="toggle-section-button"]')
+        .contains('Location details')
+        .click()
+      testTypeaheadOptionsLength({
+        element,
+        length: ukRegionsIndependent.length,
+      })
+    })
+
     it('should filter from the url', () => {
       const queryString = buildQueryString({
         uk_region_location: [ukRegion.id],

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -1,3 +1,6 @@
+import { testTypeaheadOptionsLength } from '../../support/tests'
+import { ukRegionListFaker } from '../../fakers/regions'
+
 const urls = require('../../../../../src/lib/urls')
 
 const expandToggleSections = () =>
@@ -341,5 +344,20 @@ describe('Investor profiles filters', () => {
         expectedNumberOfResults: 3,
       },
     ],
+  })
+
+  it('should display all UK regions (active & disabled) in the filter list', () => {
+    const element = '[data-test="uk-regions-of-interest"]'
+    const ukRegions = [
+      ...ukRegionListFaker(2),
+      ...ukRegionListFaker(2, { disabled_on: '2018-01-01' }),
+    ]
+    cy.intercept('GET', urls.metadata.ukRegion(), ukRegions).as(
+      'ukRegionsApiRequest'
+    )
+    cy.visit(urls.investments.profiles.index())
+    cy.wait('@ukRegionsApiRequest')
+    cy.get('[data-test="toggle-section-button"]').contains('Location').click()
+    testTypeaheadOptionsLength({ element, length: ukRegions.length })
   })
 })

--- a/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
@@ -107,9 +107,7 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
   })
 
   it('should only display active UK regions when the possible UK locations field is selected', () => {
-    const activeUkRegions = ukRegions.filter(
-      (region) => region.disabled_on === null
-    )
+    const activeUkRegions = ukRegions.filter((region) => !region.disabled_on)
     cy.get('[data-test="field-uk_region_locations"]').as('typeaheadField')
     cy.get('@typeaheadField').find('input').first().click()
     cy.get('[data-test="typeahead-menu-option"]').should('be.visible')
@@ -186,9 +184,7 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
     })
 
     it('should only display active UK regions when the landed regions field is selected', () => {
-      const activeUkRegions = ukRegions.filter(
-        (region) => region.disabled_on === null
-      )
+      const activeUkRegions = ukRegions.filter((region) => !region.disabled_on)
       cy.get('[data-test="field-actual_uk_regions"]').as('typeaheadField')
       cy.get('@typeaheadField').find('input').first().click()
       cy.get('[data-test="typeahead-menu-option"]').should('be.visible')

--- a/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
@@ -11,6 +11,7 @@ const { investments } = require('../../../../../src/lib/urls')
 
 const projectNoExistingRequirements = require('../../fixtures/investment/investment-no-existing-requirements.json')
 const projectHasExistingRequirements = require('../../fixtures/investment/investment-has-existing-requirements.json')
+const ukRegions = require('../../../../sandbox/fixtures/metadata/uk-region.json')
 
 const navigateToForm = ({ project }, dataTest = 'edit') => {
   cy.visit(investments.projects.details(project.id))
@@ -105,6 +106,19 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
     })
   })
 
+  it('should only display active UK regions when the possible UK locations field is selected', () => {
+    const activeUkRegions = ukRegions.filter(
+      (region) => region.disabled_on === null
+    )
+    cy.get('[data-test="field-uk_region_locations"]').as('typeaheadField')
+    cy.get('@typeaheadField').find('input').first().click()
+    cy.get('[data-test="typeahead-menu-option"]').should('be.visible')
+    cy.get('[data-test="typeahead-menu-option"]').should(
+      'have.length',
+      activeUkRegions.length
+    )
+  })
+
   it('should display the site decided field', () => {
     cy.get('[data-test="field-site_decided"]').then((element) => {
       assertFieldRadios({
@@ -159,20 +173,35 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
         cy.get('[data-test="field-address"]').should('not.exist')
       })
 
-  project.site_decided
-    ? it('should render the landed regions field', () => {
-        cy.get('[data-test="field-actual_uk_regions"]').then((element) => {
-          assertFieldTypeahead({
-            element,
-            label: 'UK regions landed',
-            placeholder: 'Select a UK region',
-            values: project.actual_uk_regions,
-          })
+  if (project.site_decided) {
+    it('should render the landed regions field', () => {
+      cy.get('[data-test="field-actual_uk_regions"]').then((element) => {
+        assertFieldTypeahead({
+          element,
+          label: 'UK regions landed',
+          placeholder: 'Select a UK region',
+          values: project.actual_uk_regions,
         })
       })
-    : it('should not display the landed regions field', () => {
-        cy.get('[data-test="field-actual_uk_regions"]').should('not.exist')
-      })
+    })
+
+    it('should only display active UK regions when the landed regions field is selected', () => {
+      const activeUkRegions = ukRegions.filter(
+        (region) => region.disabled_on === null
+      )
+      cy.get('[data-test="field-actual_uk_regions"]').as('typeaheadField')
+      cy.get('@typeaheadField').find('input').first().click()
+      cy.get('[data-test="typeahead-menu-option"]').should('be.visible')
+      cy.get('[data-test="typeahead-menu-option"]').should(
+        'have.length',
+        activeUkRegions.length
+      )
+    })
+  } else {
+    it('should not display the landed regions field', () => {
+      cy.get('[data-test="field-actual_uk_regions"]').should('not.exist')
+    })
+  }
 
   it('should render the delivery partners field', () => {
     cy.get('[data-test="field-delivery_partners"]').then((element) => {

--- a/test/functional/cypress/specs/omis/filter-react-spec.js
+++ b/test/functional/cypress/specs/omis/filter-react-spec.js
@@ -17,7 +17,8 @@ import {
   assertQueryParams,
   assertCheckboxGroupOption,
 } from '../../support/assertions'
-import { testTypeahead } from '../../support/tests'
+import { testTypeahead, testTypeaheadOptionsLength } from '../../support/tests'
+import { ukRegionListFaker } from '../../fakers/regions'
 import { randomChoice } from '../../fakers/utils'
 
 const buildQueryString = (queryParams = {}) =>
@@ -62,6 +63,7 @@ const statuses = [
 ]
 
 const searchEndpoint = '/api-proxy/v3/search/order'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
 
 describe('Orders Collections Filter', () => {
   context('Default Params', () => {
@@ -508,6 +510,20 @@ describe('Orders Collections Filter', () => {
       ...minimumPayload,
       uk_region: [londonId],
     }
+
+    it('should display all UK regions (active & disabled) in the filter list', () => {
+      const ukRegions = [
+        ...ukRegionListFaker(2),
+        ...ukRegionListFaker(2, { disabled_on: '2018-01-01' }),
+      ]
+      const queryString = buildQueryString()
+      cy.intercept('GET', ukRegionsEndpoint, ukRegions).as(
+        'ukRegionsApiRequest'
+      )
+      cy.visit(`/omis?${queryString}`)
+      cy.wait('@ukRegionsApiRequest')
+      testTypeaheadOptionsLength({ element, length: ukRegions.length })
+    })
 
     it('should filter from the url', () => {
       const queryString = buildQueryString({


### PR DESCRIPTION
## Description of change

It was reported that inactive UK Regions were showing through into UK region filter lists and form typeahead fields. After some discussion (see ticket CLS2-765), it was decided that instead of fixing this across Data Hub, a more focused solution was preferred: you should be able to filter by all regions (including disabled ones), but when adding new records, you should only be able to select active regions.

This PR:

- Adds functionality to the `FieldUKRegionTypeahead` component to filter disabled UK regions;
- Reintroduces disabled UK regions to the `InvestmentProject` and `Order` collections list region filters.

## Test instructions

- Everywhere you can **filter** by UK region, you should be able to continue to filter by disabled regions for historical reasons;
- Everywhere you can **input** a UK region into a new instance (e.g. project etc), you should be able to only select _active_ regions.

## Screenshots

When editing an investment project's requirements (before and after):

<img width="1506" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/069bc3ed-ff2b-4967-bba4-674ae2b63ac4">

<img width="1506" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/bddae8c1-42f3-488d-93c4-7afdf3c10aa6">

When filtering the list of investment projects (before and after):

<img width="1506" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/2faebcd2-160a-488c-9dc7-f81dfea10029">

<img width="1506" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/7913007f-0475-479b-95ca-246279b2d343">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
