### PR TITLE
Fix/react router upgrade tests

### DIFF
--- a/src/client/createProvider.jsx
+++ b/src/client/createProvider.jsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import _ from 'lodash'
+import { configureStore } from '@reduxjs/toolkit'
+import { Provider, connect } from 'react-redux'
+import createSagaMiddleware from 'redux-saga'
+import { createReduxHistoryContext } from 'redux-first-history'
+import { Router } from 'react-router-dom'
+
+import rootSaga from './root-saga'
+import { reducers } from './reducers'
+
+const preloadedState = {
+  // Extract data provided throught the nunjucks "react-slot" macro
+  ...JSON.parse(document.getElementById('react-app')?.dataset.props || '{}'),
+  referrerUrl: window.document.referrer,
+}
+
+const ConnectedReactRouter = connect(({ router: { location, action } }) => {
+  return {
+    location,
+    navigationType: action,
+  }
+})(Router)
+
+/**
+ * Creates a context provider for all Data Hub components
+ * @param {Object} options
+ * @param {Record<string, Task>} options.tasks - Tasks required by the
+ * components wrapped with the provider
+ * @param {import('histoyr').History} options.tasks - History backend
+ * passed to the router
+ * @returns {({children: JSX.Element}) => JSX.Element} - The context provider
+ * component.
+ */
+export const createProvider = ({ tasks, history }) => {
+  const { createReduxHistory, routerMiddleware, routerReducer } =
+    createReduxHistoryContext({
+      history,
+    })
+  const sagaMiddleware = createSagaMiddleware()
+  const store = configureStore({
+    devTools: process.env.NODE_ENV === 'development',
+    middleware: () => [sagaMiddleware, routerMiddleware],
+    preloadedState,
+    reducer: {
+      // This is to prevent the silly "Unexpected key ..." error thrown by combineReducers
+      ..._.mapValues(
+        preloadedState,
+        () =>
+          (state = null) =>
+            state
+      ),
+      ...reducers,
+      router: routerReducer,
+    },
+  })
+
+  sagaMiddleware.run(rootSaga(tasks))
+
+  const reduxHistory = createReduxHistory(store)
+
+  return ({ children }) => (
+    <Provider store={store}>
+      <ConnectedReactRouter navigator={reduxHistory}>
+        {children}
+      </ConnectedReactRouter>
+    </Provider>
+  )
+}

--- a/src/client/export-win-review.jsx
+++ b/src/client/export-win-review.jsx
@@ -1,7 +1,6 @@
 /* eslint-disable prettier/prettier */
 import React from 'react'
 import ReactDOM from 'react-dom'
-import { Route, Routes } from 'react-router-dom'
 
 import DataHubProvider from './provider'
 import WithoutOurSupport from './components/Resource/WithoutOurSupport'
@@ -11,7 +10,6 @@ import Experience from './components/Resource/Experience'
 import MarketingSource from './components/Resource/MarketingSource'
 
 import Review from './modules/ExportWins/Review'
-import ThankYou from './modules/ExportWins/Review/ThankYou'
 import { patchExportWinReview } from './modules/ExportWins/tasks'
 
 window.addEventListener('DOMContentLoaded', () =>
@@ -26,10 +24,7 @@ window.addEventListener('DOMContentLoaded', () =>
         TASK_PATCH_EXPORT_WIN_REVIEW: patchExportWinReview,
       }}
     >
-      <Routes>
-        <Route path="/exportwins/review/:token" element={<Review />} />
-        <Route path="/exportwins/review-win/thankyou" element={<ThankYou />} />
-      </Routes>
+      <Review/>
     </DataHubProvider>,
     document.getElementById('react-app')
   )

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -3,9 +3,11 @@ import React from 'react'
 import { H2, H4 } from 'govuk-react'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
-import { useParams } from 'react-router-dom'
+import { useParams, Routes, Route } from 'react-router-dom'
 
 import { GREY_2 } from '../../../utils/colours'
+
+import ThankYou from './ThankYou'
 
 import Layout from './Layout'
 import {
@@ -340,4 +342,9 @@ const Review = () => {
   )
 }
 
-export default Review
+export default () => (
+  <Routes>
+    <Route path="/exportwins/review/:token" element={<Review />} />
+    <Route path="/exportwins/review-win/thankyou" element={<ThankYou />} />
+  </Routes>
+)

--- a/src/client/provider.jsx
+++ b/src/client/provider.jsx
@@ -6,7 +6,7 @@ import createSagaMiddleware from 'redux-saga'
 import { createBrowserHistory } from 'history'
 import { createReduxHistoryContext } from 'redux-first-history'
 import queryString from 'qs'
-import { MemoryRouter, Router } from 'react-router-dom'
+import { Router } from 'react-router-dom'
 
 import rootSaga from './root-saga'
 import { reducers } from './reducers'
@@ -58,40 +58,8 @@ const runMiddlewareOnce = _.once((tasks, sagaMiddleware) =>
 
 const ConnectedReactRouter = connect(({ router: { location, action } }) => ({
   location,
-  action,
+  navigationType: action,
 }))(Router)
-
-export const createProvider = ({ tasks, history, preloadedState }) => {
-  const { createReduxHistory, routerMiddleware, routerReducer } =
-    createReduxHistoryContext({
-      history: history,
-    })
-  const sagaMiddleware = createSagaMiddleware()
-  const store = configureStore({
-    devTools: process.env.NODE_ENV === 'development',
-    middleware: () => [sagaMiddleware, routerMiddleware],
-    preloadedState,
-    reducer: {
-      // This is to prevent the silly "Unexpected key ..." error thrown by combineReducers
-      ..._.mapValues(
-        preloadedState,
-        () =>
-          (state = null) =>
-            state
-      ),
-      ...reducers,
-      router: routerReducer,
-    },
-  })
-
-  sagaMiddleware.run(rootSaga(tasks))
-  const hist = createReduxHistory(store)
-  return ({ children }) => (
-    <Provider store={store}>
-      <MemoryRouter history={hist}>{children}</MemoryRouter>
-    </Provider>
-  )
-}
 
 // TODO: Re-implement this in with createProvider
 /**

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Navigate } from 'react-router-dom'
 
 import {
   assertSummaryTableStrict,
@@ -74,15 +73,17 @@ describe('ExportWins/Review', () => {
   context('If there is a problem loading the review', () => {
     it("should render not found view if token is expired or doesn't exist", () => {
       const Provider = createTestProvider({
-        'Export Win Review': () =>
-          Promise.reject({
-            httpStatusCode: 404,
-          }),
+        initialPath: '/exportwins/review/123',
+        tasks: {
+          'Export Win Review': () =>
+            Promise.reject({
+              httpStatusCode: 404,
+            }),
+        },
       })
 
       cy.mount(
         <Provider>
-          <Navigate to="/exportwins/review/123" />
           <Review />
         </Provider>
       )
@@ -100,11 +101,13 @@ describe('ExportWins/Review', () => {
 
     it("should render default error view if the review couldn't be loaded for", () => {
       const Provider = createTestProvider({
-        'Export Win Review': () => Promise.reject({}),
+        initialPath: '/exportwins/review/123',
+        tasks: {
+          'Export Win Review': () => Promise.reject({}),
+        },
       })
       cy.mount(
         <Provider>
-          <Navigate to="/exportwins/review/123" />
           <Review />
         </Provider>
       )
@@ -157,17 +160,19 @@ describe('ExportWins/Review', () => {
       ]
 
       const Provider = createTestProvider({
-        'Export Win Review': () => Promise.resolve(REVIEW),
-        WithoutOurSupport: () => Promise.resolve(WITHOUT_OUR_SUPPORT),
-        Rating: () => Promise.resolve(RATING),
-        Experience: () => Promise.resolve(EXPERIENCE),
-        MarketingSource: () => Promise.resolve(MARKETING_SOURCE),
-        TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+        initialPath: '/exportwins/review/123',
+        tasks: {
+          'Export Win Review': () => Promise.resolve(REVIEW),
+          WithoutOurSupport: () => Promise.resolve(WITHOUT_OUR_SUPPORT),
+          Rating: () => Promise.resolve(RATING),
+          Experience: () => Promise.resolve(EXPERIENCE),
+          MarketingSource: () => Promise.resolve(MARKETING_SOURCE),
+          TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+        },
       })
 
       cy.mount(
         <Provider>
-          <Navigate to="/exportwins/review/123" />
           <Review />
         </Provider>
       )
@@ -392,12 +397,14 @@ describe('ExportWins/Review', () => {
 
     it('User disagrees with win', () => {
       const Provider = createTestProvider({
-        'Export Win Review': () => Promise.resolve(REVIEW),
-        TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+        initialPath: '/exportwins/review/123',
+        tasks: {
+          'Export Win Review': () => Promise.resolve(REVIEW),
+          TASK_PATCH_EXPORT_WIN_REVIEW: () => Promise.resolve({}),
+        },
       })
       cy.mount(
         <Provider>
-          <Navigate to="/exportwins/review/123" />
           <Review />
         </Provider>
       )

--- a/test/component/cypress/specs/provider.jsx
+++ b/test/component/cypress/specs/provider.jsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { BrowserRouter, MemoryRouter } from 'react-router-dom'
+import React, { useEffect } from 'react'
+import { BrowserRouter, MemoryRouter, useNavigate } from 'react-router-dom'
 import { Provider } from 'react-redux'
 import { combineReducers, applyMiddleware, legacy_createStore } from 'redux'
 import createSagaMiddleware from 'redux-saga'
@@ -9,17 +9,44 @@ import { createMemoryHistory } from 'history'
 import rootSaga from '../../../../src/client/root-saga'
 import { reducers } from '../../../../src/client/reducers'
 import { tasks as appTasks } from '../../../../src/client/tasks'
-import { createProvider } from '../../../../src/client/provider'
+import { createProvider } from '../../../../src/client/createProvider'
 
 const sagaMiddleware = createSagaMiddleware()
 
 const history = createMemoryHistory()
 
-export const createTestProvider = (tasks) =>
-  createProvider({
+/**
+ * Creates a DataHub context provider for testing purposes configured
+ * to use memory history.
+ * @param {Object} options
+ * @param {Record<string, Task>} options.tasks - Tasks required by the
+ * components wrapped with the provider
+ * @param {string} [options.initialPath] - If defined, the provider will
+ * navigate to the path specified when mounted.
+ * @returns {({children: JSX.Element}) => JSX.Element} - The context provider
+ * component.
+ */
+export const createTestProvider = ({ tasks, initialPath }) => {
+  const Provider = createProvider({
     tasks,
     history,
   })
+
+  const NavigateToInitialPath = () => {
+    const navigate = useNavigate()
+    useEffect(() => {
+      navigate(initialPath)
+    }, [])
+    return null
+  }
+
+  return ({ children }) => (
+    <Provider>
+      {initialPath && <NavigateToInitialPath />}
+      {children}
+    </Provider>
+  )
+}
 
 const reducer = (state, action) =>
   combineReducers({


### PR DESCRIPTION
## Description of change

Fixes broken routing in component tests.

There were two main issues:

* The `<Navigate to="/exportwins/review/123" />` behaves slightly differently than `<Redirect to="/exportwins/review/123" />`, which was there before the upgrade, where it redirects on each render and when the tested component redirected to `/exportwins/review-win/thankyou`, `Navigate` re-rendered and immediately navigated back to `/exportwins/review/123`
* Routes were moved from the tested `Review` component to `export-wins-review.jsx`, so the tested component would never render the route for  `/exportwins/review-win/thankyou`