### PR TITLE
Styling of the FieldAddAnother component.

### DIFF
--- a/src/client/components/Form/elements/FieldAddAnother/FieldAddAnother.jsx
+++ b/src/client/components/Form/elements/FieldAddAnother/FieldAddAnother.jsx
@@ -21,12 +21,11 @@ const StyledChildren = styled('div')`
 `
 
 const StyledGroup = styled('div')`
-  padding-left: ${SPACING.SCALE_2};
   padding-bottom: ${SPACING.SCALE_3};
 `
 
-const StyledButton = styled('div')`
-  padding-left: ${SPACING.SCALE_2};
+const SecondaryButtonContainer = styled('div')`
+  margin-top: ${SPACING.SCALE_4};
 `
 
 const StyledLink = styled('div')`
@@ -89,7 +88,7 @@ const FieldAddAnother = ({
           </StyledGroup>
         ))}
         {fieldGroupIds.length < limitChildGroupCount && (
-          <StyledButton>
+          <SecondaryButtonContainer>
             <SecondaryButton
               data-test="add-another"
               onClick={addAnotherHandler}
@@ -100,7 +99,7 @@ const FieldAddAnother = ({
             >
               {buttonText ? buttonText : `Add another ${itemName}`}
             </SecondaryButton>
-          </StyledButton>
+          </SecondaryButtonContainer>
         )}
       </FieldWrapper>
     </>

--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -165,7 +165,7 @@ const ExportsIndex = () => {
             >
               Add export win
             </Button>
-            <Details summary="What is an Export Win">
+            <Details summary="What is an export win">
               <p>
                 Export wins capture the export deals that Department for
                 Business and Trade (DBT) support and quantify their expected

--- a/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
+++ b/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
@@ -17,14 +17,18 @@ import {
   FieldAdvisersTypeahead,
 } from '../../../components'
 
-const Container = styled('div')({
+const FieldAddAnotherContainer = styled('div')({
   borderLeft: `3px solid ${MID_GREY}`,
   marginLeft: 18,
   paddingLeft: 34,
 })
 
 const StyledFieldRadios = styled(FieldRadios)({
-  marginBottom: 0,
+  marginBottom: ({ marginBottom }) => marginBottom,
+})
+
+const Container = styled('div')({
+  marginTop: 25,
 })
 
 const CreditForThisWinStep = () => {
@@ -38,7 +42,7 @@ const CreditForThisWinStep = () => {
   return (
     <Step name={steps.CREDIT_FOR_THIS_WIN}>
       <H3 data-test="step-heading">Credit for this win</H3>
-      <StyledHintParagraph data-test="hint">
+      <StyledHintParagraph data-test="hint" widthPercent={60}>
         Other teams that helped with this win should be added so they can be
         credited, this will not reduce your credit for this win.
       </StyledHintParagraph>
@@ -48,9 +52,10 @@ const CreditForThisWinStep = () => {
         inline={true}
         options={OPTIONS_YES_NO}
         required="Select Yes or No"
+        marginBottom={values.credit_for_win === OPTION_YES ? 0 : 25}
       />
       {values.credit_for_win === OPTION_YES && (
-        <Container>
+        <FieldAddAnotherContainer>
           <FieldAddAnother
             name="addAnother"
             label="Contributing advisers"
@@ -62,7 +67,7 @@ const CreditForThisWinStep = () => {
             initialChildGroupCount={officerCount || 1}
           >
             {({ groupIndex }) => (
-              <>
+              <Container>
                 <FieldAdvisersTypeahead
                   name={`contributing_officer_${groupIndex}`}
                   label="Contributing officer"
@@ -82,22 +87,24 @@ const CreditForThisWinStep = () => {
                   // want the previous selection displayed after they've changed the team type.
                   // To ensure this happens we've added a key prop and set it to the team type
                   // id, when the id changes the component updates.
-                  <HQTeamRegionOrPost.FieldTypeahead
-                    key={values[`team_type_${groupIndex}`].value}
-                    name={`hq_team_${groupIndex}`}
-                    id={`contributors-${groupIndex}`}
-                    fullWidth={true}
-                    label="HQ team, region or post"
-                    required="Enter a HQ team, region or post"
-                    payload={{
-                      team_type: values[`team_type_${groupIndex}`].value,
-                    }}
-                  />
+                  <Container>
+                    <HQTeamRegionOrPost.FieldTypeahead
+                      key={values[`team_type_${groupIndex}`].value}
+                      name={`hq_team_${groupIndex}`}
+                      id={`contributors-${groupIndex}`}
+                      fullWidth={true}
+                      label="HQ team, region or post"
+                      required="Enter a HQ team, region or post"
+                      payload={{
+                        team_type: values[`team_type_${groupIndex}`].value,
+                      }}
+                    />
+                  </Container>
                 )}
-              </>
+              </Container>
             )}
           </FieldAddAnother>
-        </Container>
+        </FieldAddAnotherContainer>
       )}
     </Step>
   )

--- a/src/client/modules/ExportWins/Form/styled.jsx
+++ b/src/client/modules/ExportWins/Form/styled.jsx
@@ -1,7 +1,11 @@
+import { MEDIA_QUERIES } from '@govuk-react/constants'
 import styled from 'styled-components'
 
 import { DARK_GREY } from '../../../utils/colours'
 
 export const StyledHintParagraph = styled('p')({
   color: DARK_GREY,
+  [MEDIA_QUERIES.DESKTOP]: {
+    width: ({ widthPercent }) => `${widthPercent}%` || '100%',
+  },
 })

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -126,8 +126,8 @@ describe('Company Export tab', () => {
           )
       })
 
-      it('should render the "What is an Export Win" details', () => {
-        cy.contains('What is an Export Win')
+      it('should render the "What is an export win" details', () => {
+        cy.contains('What is an export win')
         cy.contains(
           'Export wins capture the export deals that Department for Business and Trade (DBT)'
         )


### PR DESCRIPTION
## Description of change
Improved the spacing and alignment of children within the `FieldAddAnother` component.

## Test instructions
Go to a company and add an export win.

## Screenshots

### Before
<img width="900" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/43e4f7ed-7982-4a84-94f3-01bedcc1d8d4">

### After
<img width="900" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/02cb3e4e-06a0-4b5a-8e8f-3b0a03dc5b50">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
