### PR TITLE
Bugfix/CLS2-762 Disable the 'Add investment project Button' for UK companies

### DIFF
--- a/src/client/modules/Investments/Projects/ProjectsCollection.jsx
+++ b/src/client/modules/Investments/Projects/ProjectsCollection.jsx
@@ -126,7 +126,7 @@ const ProjectsCollection = ({
         addItemUrl={
           !company
             ? `/investments/projects/create`
-            : company.archived || company.uk_based
+            : company.archived || company.ukBased
               ? null
               : `/investments/projects/create/${company.id}`
         }

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -4,6 +4,7 @@ import {
   companyGlobalUltimateAllDetails,
   companyNoDetails,
 } from '../../fakers/companies'
+import { getCollectionList } from '../../support/collection-list-assertions'
 
 const {} = require('../../support/assertions')
 const fixtures = require('../../fixtures')
@@ -239,12 +240,14 @@ describe('Company overview page', () => {
       })
       it('Inactive projects should not include an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
+        getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('add-collection-item-button').should('not.exist')
         cy.go('back')
       })
       it('UK based Active projects should not have an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
-        cy.get('add-collection-item-button').should('not.exist')
+        getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
+        cy.get('[data-test="add-collection-item-button"]').should('not.exist')
         cy.go('back')
       })
     }


### PR DESCRIPTION
## Description of change
Only foreign companies (including Jersey, Guernsey and Isle of Man) are allowed to have a foreign investment project in the UK. It shouldn’t be possible to create an investment project for a UK company. A bug was causing the 'Add investment project' button to appear on UK based companies when navigating to the 'Investment' tab on a company page.
The fix removes the button from all UK companies.
Tests have been updated to ensure the investments collection list has fully loaded before the presence of the button is checked.

_Document what the PR does and why the change is needed_

## Test instructions

- Navigate to a [company overview page](http://localhost:3000/companies/008ba003-b528-4e79-b209-49fcfcceb371/overview) for a **foreign company**
- Click on the 'Investment' tab
- The 'Add investment project button' should be visible 

![Screenshot 2024-04-16 at 14 57 46](https://github.com/uktrade/data-hub-frontend/assets/74198488/857a56f6-ff23-413c-a1a5-5f9dab6cf254)

- Navigate to a [company overview page](https://www.datahub.uat.uktrade.io/companies/cd6e2d38-924d-48b5-b374-d09bc24d8520/overview) for a **UK based company**
- Click on the 'Investment' tab
- The 'Add investment project button' should **not** be visible 

![Screenshot 2024-04-16 at 15 15 52](https://github.com/uktrade/data-hub-frontend/assets/74198488/c071a671-6221-4fe2-9df2-90b0f416d655)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
