### PR TITLE
Improve vertical spacing between components

### DIFF
--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -40,6 +40,7 @@ const FieldTypeahead = ({
   initialValue,
   options,
   autoScroll,
+  className,
   ...props
 }) => {
   const { value, error, touched, onBlur } = useField({
@@ -52,7 +53,9 @@ const FieldTypeahead = ({
   const { setFieldValue } = useFormContext()
 
   return (
-    <FieldWrapper {...{ name, label, legend, hint, error, autoScroll }}>
+    <FieldWrapper
+      {...{ name, label, legend, hint, error, autoScroll, className }}
+    >
       <StyledWrapper error={error}>
         {touched && error && <ErrorText>{error}</ErrorText>}
         <Typeahead

--- a/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
+++ b/src/client/modules/ExportWins/Form/CreditForThisWinStep.jsx
@@ -27,7 +27,11 @@ const StyledFieldRadios = styled(FieldRadios)({
   marginBottom: ({ marginBottom }) => marginBottom,
 })
 
-const Container = styled('div')({
+const FieldTypeaheadMarginTop = styled(HQTeamRegionOrPost.FieldTypeahead)({
+  marginTop: 25,
+})
+
+const GroupContainer = styled('div')({
   marginTop: 25,
 })
 
@@ -67,7 +71,7 @@ const CreditForThisWinStep = () => {
             initialChildGroupCount={officerCount || 1}
           >
             {({ groupIndex }) => (
-              <Container>
+              <GroupContainer>
                 <FieldAdvisersTypeahead
                   name={`contributing_officer_${groupIndex}`}
                   label="Contributing officer"
@@ -87,21 +91,19 @@ const CreditForThisWinStep = () => {
                   // want the previous selection displayed after they've changed the team type.
                   // To ensure this happens we've added a key prop and set it to the team type
                   // id, when the id changes the component updates.
-                  <Container>
-                    <HQTeamRegionOrPost.FieldTypeahead
-                      key={values[`team_type_${groupIndex}`].value}
-                      name={`hq_team_${groupIndex}`}
-                      id={`contributors-${groupIndex}`}
-                      fullWidth={true}
-                      label="HQ team, region or post"
-                      required="Enter a HQ team, region or post"
-                      payload={{
-                        team_type: values[`team_type_${groupIndex}`].value,
-                      }}
-                    />
-                  </Container>
+                  <FieldTypeaheadMarginTop
+                    key={values[`team_type_${groupIndex}`].value}
+                    name={`hq_team_${groupIndex}`}
+                    id={`contributors-${groupIndex}`}
+                    fullWidth={true}
+                    label="HQ team, region or post"
+                    required="Enter a HQ team, region or post"
+                    payload={{
+                      team_type: values[`team_type_${groupIndex}`].value,
+                    }}
+                  />
                 )}
-              </Container>
+              </GroupContainer>
             )}
           </FieldAddAnother>
         </FieldAddAnotherContainer>

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { H3 } from '@govuk-react/heading'
+import styled from 'styled-components'
 
 import ResourceOptionsField from '../../../components/Form/elements/ResourceOptionsField'
 import ExportExperience from '../../../components/Resource/ExportExperience'
@@ -12,59 +13,65 @@ import { idNamesToValueLabels } from '../../../utils'
 import { StyledHintParagraph } from './styled'
 import { steps } from './constants'
 
-const CustomerDetailsStep = ({ companyId, isEditing }) => {
-  return (
-    <Step name={steps.CUSTOMER_DETAILS}>
-      <H3 data-test="step-heading">Customer details</H3>
-      <ResourceOptionsField
-        name="company_contacts"
-        id={companyId}
-        label="Company contacts"
-        hint="This contact will be emailed to approve the win."
-        required="Select a company contact"
-        placeholder="Select contact"
-        resource={CompanyContacts}
-        field={FieldTypeahead}
-        autoScroll={true}
-        resultToOptions={({ results }) =>
-          results.map(({ id, name, email }) => ({
-            value: id,
-            label: name,
-            email,
-          }))
-        }
+const FieldTypeaheadMarginBottom = styled(FieldTypeahead)({
+  marginBottom: 0,
+})
+
+const FieldTypeaheadMarginTop = styled(WinUKRegions.FieldTypeahead)({
+  marginTop: 35,
+})
+
+const CustomerDetailsStep = ({ companyId, isEditing }) => (
+  <Step name={steps.CUSTOMER_DETAILS}>
+    <H3 data-test="step-heading">Customer details</H3>
+    <ResourceOptionsField
+      name="company_contacts"
+      id={companyId}
+      label="Company contacts"
+      hint="This contact will be emailed to approve the win."
+      required="Select a company contact"
+      placeholder="Select contact"
+      resource={CompanyContacts}
+      field={FieldTypeaheadMarginBottom}
+      autoScroll={true}
+      resultToOptions={({ results }) =>
+        results.map(({ id, name, email }) => ({
+          value: id,
+          label: name,
+          email,
+        }))
+      }
+    />
+    <StyledHintParagraph data-test="contact-hint">
+      To select a customer contact name, it must have already been added to Data
+      Hub. If not listed, go to the company page to add them.
+    </StyledHintParagraph>
+    <FieldTypeaheadMarginTop
+      name="customer_location"
+      id="customer-location"
+      label="HQ location"
+      required="Select HQ location"
+      resultToOptions={(result) =>
+        idNamesToValueLabels(result.filter(({ name }) => name !== 'All'))
+      }
+      fullWidth={true}
+    />
+    <BusinessPotential.FieldTypeahead
+      name="business_potential"
+      id="business-potential"
+      label="Medium-sized and high potential companies"
+      required="Select medium-sized and high potential companies"
+    />
+    {!isEditing && (
+      <ExportExperience.FieldTypeahead
+        name="export_experience"
+        id="export-experience"
+        label="Export experience"
+        required="Select export experience"
+        hint="Your customer will be asked to confirm this information."
       />
-      <StyledHintParagraph data-test="contact-hint">
-        To select a customer contact name, it must have already been added to
-        Data Hub. If not listed, go to the company page to add them.
-      </StyledHintParagraph>
-      <WinUKRegions.FieldTypeahead
-        name="customer_location"
-        id="customer-location"
-        label="HQ location"
-        required="Select HQ location"
-        resultToOptions={(result) =>
-          idNamesToValueLabels(result.filter(({ name }) => name !== 'All'))
-        }
-        fullWidth={true}
-      />
-      <BusinessPotential.FieldTypeahead
-        name="business_potential"
-        id="business-potential"
-        label="Medium-sized and high potential companies"
-        required="Select medium-sized and high potential companies"
-      />
-      {!isEditing && (
-        <ExportExperience.FieldTypeahead
-          name="export_experience"
-          id="export-experience"
-          label="Export experience"
-          required="Select export experience"
-          hint="Your customer will be asked to confirm this information."
-        />
-      )}
-    </Step>
-  )
-}
+    )}
+  </Step>
+)
 
 export default CustomerDetailsStep

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -17,7 +17,7 @@ const ExportWinsTabNav = ({ location }) => {
       heading="Export wins"
       pageTitle={`Export wins ${title}`}
       breadcrumbs={[
-        { link: urls.dashboard.index(), text: 'Homes' },
+        { link: urls.dashboard.index(), text: 'Home' },
         {
           link: urls.companies.exportWins.index(),
           text: 'Export Wins',


### PR DESCRIPTION
## Description of change
Export Wins, customer details. Move the paragraph text _To select a customer contact name..._ up closer to the company contacts typeahead component.

## Test instructions
Go to a company and add an Export Win and continue to customer details.

## Screenshots

### Before
<img width="987" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/2cb02df3-eaf7-42ea-988a-a003589599e8">

### After
<img width="900" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/ec8715cd-60c5-42e0-b539-8d2214d24406">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
