### PR TITLE
Styling of ODI, oil and gas on the win details page

### DIFF
--- a/src/client/modules/ExportWins/Form/Breakdowns.jsx
+++ b/src/client/modules/ExportWins/Form/Breakdowns.jsx
@@ -8,6 +8,7 @@ import { LIGHT_GREY } from '../../../utils/colours'
 import { FieldCurrency } from '../../../components'
 import { StyledHintParagraph } from './styled'
 import { isPositiveInteger } from './validators'
+import { winTypes } from './constants'
 import {
   formatValue,
   getYearFromWinType,
@@ -15,7 +16,10 @@ import {
 } from './utils'
 
 const WinTypeContainer = styled('div')({
+  display: 'flex',
+  flexDirection: 'column',
   marginLeft: 56,
+  marginBottom: ({ name }) => (name === winTypes.ODI ? 0 : '40px'),
 })
 
 const FieldCurrencyContainer = styled('div')({
@@ -27,7 +31,7 @@ const StyledLabel = styled(Label)({
   fontWeight: 'bold',
 })
 
-const StyledParagraph = styled('p')({
+const StyledSpan = styled('span')({
   padding: 10,
   fontWeight: 'bold',
   backgroundColor: LIGHT_GREY,
@@ -45,7 +49,7 @@ const allWinTypeYearlyValuesAreEmpty = (field, values) => {
 export const Breakdowns = ({ label, name, years = 5, values }) => {
   const year = getYearFromWinType(name, values)
   return (
-    <WinTypeContainer data-test={`breakdowns-${name}`}>
+    <WinTypeContainer data-test={`breakdowns-${name}`} name={name}>
       <StyledLabel data-test="label">{label}</StyledLabel>
       <StyledHintParagraph data-test="hint">
         (round to nearest £)
@@ -74,10 +78,10 @@ export const Breakdowns = ({ label, name, years = 5, values }) => {
           />
         ))}
       </FieldCurrencyContainer>
-      <StyledParagraph data-test="total">
+      <StyledSpan data-test="total" name={name}>
         Totalling over {year} {pluralize('year', year)}:{' '}
         {formatValue(sumWinTypeYearlyValues(name, values))}
-      </StyledParagraph>
+      </StyledSpan>
     </WinTypeContainer>
   )
 }

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -38,8 +38,9 @@ const StyledDetails = styled(Details)({
 })
 
 const StyledExportTotal = styled('p')({
-  padding: 10,
   color: WHITE,
+  padding: 10,
+  marginBottom: 30,
   backgroundColor: BLACK,
 })
 

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -44,6 +44,11 @@ const StyledExportTotal = styled('p')({
   backgroundColor: BLACK,
 })
 
+const StyledSectorFieldTypeahead = styled(Sector.FieldTypeahead)({
+  marginBottom: 0,
+  paddingBottom: 0,
+})
+
 const FOSSIL_FUEL_EMAIL = 'fossilfuelenquiries@trade.gov.uk'
 
 const WinDetailsStep = ({ isEditing }) => {
@@ -231,7 +236,7 @@ const WinDetailsStep = ({ isEditing }) => {
         validate={validateTextField('Name of goods or services')}
       />
 
-      <Sector.FieldTypeahead
+      <StyledSectorFieldTypeahead
         id="sector"
         name="sector"
         label="Sector"


### PR DESCRIPTION
## Description of change
Styling of ODI, oil and gas on the win details page.

## Test instructions
Go to a company and add an Export Win and continue to win details.

## Screenshots

### Before
<img width="1019" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/6461d01c-562b-444b-a85f-03ad863fb0ff">

### After
<img width="924" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/0f2364d7-9c14-4928-bed1-7d414f8bbc90">

### Before (oil and gas)
<img width="982" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/ac63daa6-0cfd-4c7c-b836-569992ec7db2">

### After (oil and gas)
<img width="892" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/5a9cee2e-bdd6-4885-a286-40472328d9f5">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
