### PR TITLE
Export win, support given page styling

### DIFF
--- a/src/client/components/Form/elements/FieldCheckboxes/index.jsx
+++ b/src/client/components/Form/elements/FieldCheckboxes/index.jsx
@@ -15,6 +15,10 @@ const StyledOr = styled('div')({
   marginBottom: SPACING.SCALE_2,
 })
 
+const StyledLabel = styled('span')({
+  fontWeight: 'bold',
+})
+
 /**
  * Checkboxes for use in forms and filters.
  */
@@ -25,6 +29,7 @@ const FieldCheckboxes = ({
   label,
   legend,
   bigLegend,
+  boldLabel = false,
   hint,
   options = [],
   initialValue = [],
@@ -108,7 +113,11 @@ const FieldCheckboxes = ({
                 aria-label={optionLabel}
                 {...optionProps}
               >
-                {optionLabel}
+                {boldLabel ? (
+                  <StyledLabel>{optionLabel}</StyledLabel>
+                ) : (
+                  optionLabel
+                )}
               </Checkbox>
               {value.includes(optionValue) && !!children ? children : null}
             </Fragment>

--- a/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
+++ b/src/client/modules/ExportWins/Form/SupportProvidedStep.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { H3 } from '@govuk-react/heading'
+import styled from 'styled-components'
 
 import { Step, FieldCheckboxes } from '../../../components'
 import { OPTION_YES } from '../../../../common/constants'
@@ -9,6 +10,10 @@ import { steps } from './constants'
 import AssociatedProgramme from '../../../components/Resource/AssociatedProgramme'
 import SupportType from '../../../components/Resource/SupportType'
 import Hvc from '../../../components/Resource/Hvc'
+
+const StyledFieldCheckboxes = styled(FieldCheckboxes)({
+  marginBottom: 0,
+})
 
 const SupportProvidedStep = () => (
   <Step name={steps.SUPPORT_PROVIDED}>
@@ -46,9 +51,10 @@ const SupportProvidedStep = () => (
         value?.length > 5 && 'Select a maximum of 5 DBT campaigns or events'
       }
     />
-    <FieldCheckboxes
+    <StyledFieldCheckboxes
       name="is_personally_confirmed"
       required="Confirm that this information is complete and accurate"
+      boldLabel={true}
       options={[
         {
           value: OPTION_YES,
@@ -59,6 +65,7 @@ const SupportProvidedStep = () => (
     <FieldCheckboxes
       name="is_line_manager_confirmed"
       required="Confirm your line manager has agreed that this win should be recorded"
+      boldLabel={true}
       options={[
         {
           value: OPTION_YES,


### PR DESCRIPTION
## Description of change
Styling of the Export Wins support given page:
1. Ensure the labels are bold
2. Bring both checkboxes closer together

## Test instructions
Go to a company and add an Export Win and continue to support given.

## Screenshots

### Before
<img width="877" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/63578cc8-34bf-4c05-bf04-38e068a11b34">

### After
<img width="877" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/6f89806c-dd9f-4d34-949e-90f172edbd68">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
