### PR TITLE
Small styling adjustments to the export wins summary page

### DIFF
--- a/src/client/components/SummaryTable/index.jsx
+++ b/src/client/components/SummaryTable/index.jsx
@@ -21,13 +21,13 @@ const StyledTable = styled(Table)`
   }
   & > caption {
     ${typography.font({ size: 24, weight: 'bold' })};
-    margin-bottom: ${SPACING.SCALE_4};
+    margin-bottom: ${SPACING.SCALE_2};
   }
   & > tbody > tr:first-child {
     border-top: 1px solid ${GREY_2};
   }
   & > caption > * {
-    ${typography.font({ size: 19, weight: 'bold' })};
+    ${typography.font({ size: 19, weight: 'normal' })};
     float: right;
     margin-left: ${SPACING.SCALE_3};
   }

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import WarningText from '@govuk-react/warning-text'
 import InsetText from '@govuk-react/inset-text'
 import { FONT_SIZE } from '@govuk-react/constants'
-import { H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import { Link } from 'govuk-react'
 import pluralize from 'pluralize'
@@ -62,7 +61,6 @@ const SummaryStep = ({ isEditing, companyId }) => {
       name={steps.SUMMARY}
       submitButtonLabel={isEditing ? 'Save' : 'Confirm and send to customer'}
     >
-      {!isEditing && <H3 data-test="step-heading">Check before sending</H3>}
       <OfficerDetailsTable {...props} />
       <CreditForThisWinTable {...props} />
       <CustomerDetailsTable {...props} />

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -164,13 +164,6 @@ describe('Adding an export win', () => {
         clickContinueAndAssertUrl(summaryStep)
       })
 
-      it('should render a step heading', () => {
-        cy.get('[data-test="step-heading"]').should(
-          'have.text',
-          'Check before sending'
-        )
-      })
-
       it('should not render an edit status message', () => {
         cy.get('[data-test="localHeader"]').should(
           'not.contain',


### PR DESCRIPTION
## Description of change
Small styling adjustments to the export wins summary page inline with the design.

## Test instructions
Go to companies and add an Export Win then continue until you reach the summary page.

## Screenshots

### Before
<img width="929" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b5564f50-1bf0-44c2-a1d0-61c9f8f97a14">

### After
<img width="935" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/08239c70-5732-4ddd-8a2c-ddb5ff103c3a">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
