### PR TITLE
Fixes a bug when a user creates an ODI Export Win

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -4,8 +4,46 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
+import { sumExportValues } from './utils'
 import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
+
+export const WinsRejectedList = ({ exportWins }) => {
+  return exportWins.length === 0 ? null : (
+    <ul>
+      {exportWins.map((item) => (
+        <li key={item.id}>
+          <CollectionItem
+            headingText={`${item.name_of_export} to ${item?.country?.name}`}
+            headingUrl={urls.companies.exportWins.editSummary(
+              item.company.id,
+              item.id
+            )}
+            subheading={item.company.name}
+            subheadingUrl={urls.companies.overview.index(item.company.id)}
+            metadata={[
+              {
+                label: 'Contact name:',
+                // TODO: This needs to be a link, the MetadataItem
+                // needs to take a JSX element as a parameter.
+                value: item.company_contacts[0].name,
+              },
+              {
+                label: 'Total value:',
+                value: currencyGBP(sumExportValues(item)),
+              },
+              { label: 'Date won:', value: formatMediumDate(item.date) },
+              {
+                label: 'Date modified:',
+                value: formatMediumDate(item.modified_on),
+              },
+            ]}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}
 
 export default () => (
   <ExportWinsResource.Paginated
@@ -15,39 +53,6 @@ export default () => (
     noResults="You don't have any rejected export wins."
     payload={{ confirmed: WIN_STATUS.REJECTED }}
   >
-    {(page) => (
-      <ul>
-        {page.map((item) => (
-          <li key={item.id}>
-            <CollectionItem
-              headingText={`${item.name_of_export} to ${item?.country?.name}`}
-              headingUrl={urls.companies.exportWins.editSummary(
-                item.company.id,
-                item.id
-              )}
-              subheading={item.company.name}
-              subheadingUrl={urls.companies.overview.index(item.company.id)}
-              metadata={[
-                {
-                  label: 'Contact name:',
-                  // TODO: This needs to be a link, the MetadataItem
-                  // needs to take a JSX element as a parameter.
-                  value: item.company_contacts[0].name,
-                },
-                {
-                  label: 'Total value:',
-                  value: currencyGBP(item.total_expected_export_value),
-                },
-                { label: 'Date won:', value: formatMediumDate(item.date) },
-                {
-                  label: 'Date modified:',
-                  value: formatMediumDate(item.modified_on),
-                },
-              ]}
-            />
-          </li>
-        ))}
-      </ul>
-    )}
+    {(page) => <WinsRejectedList exportWins={page} />}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/WinsSentList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsSentList.jsx
@@ -4,8 +4,54 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
+import { sumExportValues } from './utils'
 import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
+
+export const WinsSentList = ({ exportWins = [] }) => {
+  return exportWins.length === 0 ? null : (
+    <ul>
+      {exportWins.map((item) => (
+        <li key={item.id}>
+          <CollectionItem
+            headingText={`${item.name_of_export} to ${item?.country?.name}`}
+            headingUrl={urls.companies.exportWins.editSummary(
+              item.company.id,
+              item.id
+            )}
+            subheading={item.company.name}
+            subheadingUrl={urls.companies.overview.index(item.company.id)}
+            metadata={[
+              {
+                label: 'Contact name:',
+                // TODO: This needs to be a link, the MetadataItem
+                // needs to take a JSX element
+                value: item.company_contacts[0].name,
+              },
+              {
+                label: 'Total value:',
+                value: currencyGBP(sumExportValues(item)),
+              },
+              { label: 'Date won:', value: formatMediumDate(item.date) },
+              {
+                label: 'Date modified:',
+                value: formatMediumDate(item.modified_on),
+              },
+              {
+                label: 'First sent:',
+                value: formatMediumDateTime(item.first_sent),
+              },
+              {
+                label: 'Last sent:',
+                value: formatMediumDateTime(item.last_sent),
+              },
+            ]}
+          />
+        </li>
+      ))}
+    </ul>
+  )
+}
 
 export default () => (
   <ExportWinsResource.Paginated
@@ -17,47 +63,6 @@ export default () => (
     // it's stripped out of the payload by Axois
     payload={{ confirmed: String(WIN_STATUS.SENT) }}
   >
-    {(page) => (
-      <ul>
-        {page.map((item) => (
-          <li key={item.id}>
-            <CollectionItem
-              headingText={`${item.name_of_export} to ${item?.country?.name}`}
-              headingUrl={urls.companies.exportWins.editSummary(
-                item.company.id,
-                item.id
-              )}
-              subheading={item.company.name}
-              subheadingUrl={urls.companies.overview.index(item.company.id)}
-              metadata={[
-                {
-                  label: 'Contact name:',
-                  // TODO: This needs to be a link, the MetadataItem
-                  // needs to take a JSX element
-                  value: item.company_contacts[0].name,
-                },
-                {
-                  label: 'Total value: ',
-                  value: currencyGBP(item.total_expected_export_value),
-                },
-                { label: 'Date won: ', value: formatMediumDate(item.date) },
-                {
-                  label: 'Date modified: ',
-                  value: formatMediumDate(item.modified_on),
-                },
-                {
-                  label: 'First sent: ',
-                  value: formatMediumDateTime(item.first_sent),
-                },
-                {
-                  label: 'Last sent: ',
-                  value: formatMediumDateTime(item.last_sent),
-                },
-              ]}
-            />
-          </li>
-        ))}
-      </ul>
-    )}
+    {(page) => <WinsSentList exportWins={page} />}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/WinsWonTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsWonTable.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components'
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
+import { sumExportValues } from './utils'
 import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
@@ -13,7 +14,7 @@ const NoWrapCell = styled(Table.Cell)`
   white-space: nowrap;
 `
 
-export const WinsWonTable = ({ exportWins }) => {
+export const WinsWonTable = ({ exportWins = [] }) => {
   return exportWins.length === 0 ? null : (
     <Table
       head={
@@ -27,41 +28,37 @@ export const WinsWonTable = ({ exportWins }) => {
         </Table.Row>
       }
     >
-      {exportWins.map(
-        ({
-          id,
-          company,
-          country,
-          date,
-          total_expected_export_value,
-          customer_response,
-        }) => (
-          <Table.Row key={id}>
-            <Table.Cell>
-              <Link
-                as={ReactRouterLink}
-                to={urls.companies.overview.index(company.id)}
-              >
-                {company.name}
-              </Link>
-            </Table.Cell>
-            <Table.Cell>{country.name}</Table.Cell>
-            <Table.Cell>{currencyGBP(total_expected_export_value)}</Table.Cell>
-            <NoWrapCell>{formatMediumDate(date)}</NoWrapCell>
-            <NoWrapCell>
-              {formatMediumDate(customer_response.responded_on)}
-            </NoWrapCell>
-            <NoWrapCell>
-              <Link
-                as={ReactRouterLink}
-                to={urls.companies.exportWins.editSummary(company.id, id)}
-              >
-                View details
-              </Link>
-            </NoWrapCell>
-          </Table.Row>
-        )
-      )}
+      {exportWins.map((item) => (
+        <Table.Row key={item.id}>
+          <Table.Cell>
+            <Link
+              as={ReactRouterLink}
+              to={urls.companies.overview.index(item.company.id)}
+            >
+              {item.company.name}
+            </Link>
+          </Table.Cell>
+          <Table.Cell>{item.country.name}</Table.Cell>
+          <Table.Cell data-test="sum-total-value">
+            {currencyGBP(sumExportValues(item))}
+          </Table.Cell>
+          <NoWrapCell>{formatMediumDate(item.date)}</NoWrapCell>
+          <NoWrapCell>
+            {formatMediumDate(item.customer_response.responded_on)}
+          </NoWrapCell>
+          <NoWrapCell>
+            <Link
+              as={ReactRouterLink}
+              to={urls.companies.exportWins.editSummary(
+                item.company.id,
+                item.id
+              )}
+            >
+              View details
+            </Link>
+          </NoWrapCell>
+        </Table.Row>
+      ))}
     </Table>
   )
 }

--- a/src/client/modules/ExportWins/Status/utils.js
+++ b/src/client/modules/ExportWins/Status/utils.js
@@ -1,0 +1,8 @@
+export const sumExportValues = ({
+  total_expected_export_value,
+  total_expected_non_export_value,
+  total_expected_odi_value,
+}) =>
+  total_expected_export_value +
+  total_expected_non_export_value +
+  total_expected_odi_value

--- a/test/component/cypress/specs/ExportWins/WinWonTable.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinWonTable.cy.jsx
@@ -1,23 +1,24 @@
 import React from 'react'
 
-import DataHubProvider from '../provider'
 import { WinsWonTable } from '../../../../../src/client/modules/ExportWins/Status/WinsWonTable'
+import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
+import { assertGovReactTable } from '../../../../functional/cypress/support/assertions'
 import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
 import { currencyGBP } from '../../../../../src/client/utils/number-utils'
 import { formatMediumDate } from '../../../../../src/client/utils/date'
-import { assertGovReactTable } from '../../../../functional/cypress/support/assertions'
+import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
 const exportWinToRow = (exportWin) => [
   exportWin.company.name,
   exportWin.country.name,
-  currencyGBP(exportWin.total_expected_export_value),
+  currencyGBP(sumExportValues(exportWin)),
   formatMediumDate(exportWin.date),
   formatMediumDate(exportWin.customer_response.responded_on),
   'View details',
 ]
 
-describe('Export wins table', () => {
+describe('WinsWonTable', () => {
   it('should render Export wins table', () => {
     const EXPORT_WINS = [
       {
@@ -28,7 +29,9 @@ describe('Export wins table', () => {
         country: {
           name: 'Slovakia',
         },
-        total_expected_export_value: 1111111,
+        total_expected_export_value: 1000000,
+        total_expected_non_export_value: 2000000,
+        total_expected_odi_value: 3000000,
         date: '1111-11-11',
         customer_response: {
           responded_on: '1212-12-12',
@@ -42,7 +45,9 @@ describe('Export wins table', () => {
         country: {
           name: 'Czech Republic',
         },
-        total_expected_export_value: 222222,
+        total_expected_export_value: 4000000,
+        total_expected_non_export_value: 5000000,
+        total_expected_odi_value: 6000000,
         date: '0101-01-01',
         customer_response: {
           responded_on: '0202-02-02',
@@ -51,10 +56,16 @@ describe('Export wins table', () => {
       exportWinsFaker(),
     ]
 
+    const Provider = createTestProvider({
+      'Export Wins': () => Promise.resolve(wins),
+      Company: () => Promise.resolve({ id: 123 }),
+      TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+    })
+
     cy.mount(
-      <DataHubProvider>
+      <Provider>
         <WinsWonTable exportWins={EXPORT_WINS} />
-      </DataHubProvider>
+      </Provider>
     )
 
     assertGovReactTable({

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import { WinsRejectedList } from '../../../../../src/client/modules/ExportWins/Status/WinsRejectedList'
+import { createTestProvider } from '../provider'
+
+describe('WinsRejectedList', () => {
+  it('should render Export wins list', () => {
+    const wins = [
+      {
+        id: '123',
+        company: {
+          id: '456',
+          name: 'Foo Ltd',
+        },
+        name_of_export: 'Rolls Reese',
+        company_contacts: [
+          {
+            name: 'David Test',
+          },
+        ],
+        country: {
+          name: 'USA',
+        },
+        date: '2023-05-01',
+        customer_response: {
+          responded_on: '2024-04-18T12:15:49.361611Z',
+        },
+        total_expected_export_value: 1000,
+        total_expected_non_export_value: 2000,
+        total_expected_odi_value: 3000,
+      },
+    ]
+    const Provider = createTestProvider({
+      'Export Wins': () => Promise.resolve(wins),
+      Company: () => Promise.resolve({ id: 123 }),
+      TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+    })
+
+    cy.mount(
+      <Provider>
+        <WinsRejectedList exportWins={wins} />
+      </Provider>
+    )
+
+    cy.get('[data-test="metadata-item"]')
+      .eq(1)
+      .should('have.text', 'Total value: £6,000')
+  })
+})

--- a/test/component/cypress/specs/ExportWins/WinsSentList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsSentList.cy.jsx
@@ -1,0 +1,49 @@
+import React from 'react'
+
+import { WinsSentList } from '../../../../../src/client/modules/ExportWins/Status/WinsSentList'
+import { createTestProvider } from '../provider'
+
+describe('WinsSentList', () => {
+  it('should render Export wins list', () => {
+    const wins = [
+      {
+        id: '123',
+        company: {
+          id: '456',
+          name: 'Foo Ltd',
+        },
+        name_of_export: 'Rolls Reese',
+        company_contacts: [
+          {
+            name: 'David Test',
+          },
+        ],
+        country: {
+          name: 'USA',
+        },
+        date: '2023-05-01',
+        customer_response: {
+          responded_on: '2024-04-18T12:15:49.361611Z',
+        },
+        total_expected_export_value: 1000,
+        total_expected_non_export_value: 2000,
+        total_expected_odi_value: 3000,
+      },
+    ]
+    const Provider = createTestProvider({
+      'Export Wins': () => Promise.resolve(wins),
+      Company: () => Promise.resolve({ id: 123 }),
+      TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+    })
+
+    cy.mount(
+      <Provider>
+        <WinsSentList exportWins={wins} />
+      </Provider>
+    )
+
+    cy.get('[data-test="metadata-item"]')
+      .eq(1)
+      .should('have.text', 'Total value: £6,000')
+  })
+})

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -113,6 +113,14 @@ export const exportWinsFaker = () => ({
     min: 10_000,
     max: 10_000_000,
   }),
+  total_expected_non_export_value: faker.number.int({
+    min: 10_000,
+    max: 10_000_000,
+  }),
+  total_expected_odi_value: faker.number.int({
+    min: 10_000,
+    max: 10_000_000,
+  }),
   date: faker.date.anytime().toISOString(),
   customer_response: {
     agree_with_win: null, // Sent


### PR DESCRIPTION
## Description of change
When a user adds an export win and the win type is either ODI or business success  the value shows up as `0` in the UI. This is because we were incorrectly referencing the field `total_expected_export_value` within the export win object. We should have been aggregating all 3 win types fields instead:

1.   `total_expected_export_value` (export value)
2.   `total_expected_non_export_value` (business success)
3.   `total_expected_odi_value` (ODI)

`const totalValue =  total_expected_export_value + total_expected_non_export_value + total_expected_odi_value`

The bug was only reported in the won tab. However, the fix is more comprehensive in that it also fixes the same bug in the other 2 tabs, rejected and sent.

## Test instructions
1. Go to a company and click `Add export win`.
2. Fill out the form and continue until the win details page. 
3. Ensure the win type is either business success or ODI and enter one or more yearly values.
4. Continue to the success page and save.
5. Go the `/exportwins/rejected` and ensure the total aggregated value matches your input values across all win types.
6. Go the `/exportwins/sent` and ensure the total aggregated value matches your input values across all win types.
7. Go the `/exportwins/won` and ensure the total aggregated value matches your input values across all win types.

## Screenshots

### Before
<img width="998" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/a6f0a867-8ac8-4531-8a26-de8bc98044c8">

### After
<img width="998" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b7d0b3c1-b85c-42a9-bf3a-2b66d19221cb">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
