### PR TITLE
Export wins - rename sent to pending

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -29,7 +29,7 @@ const reactRoutes = [
   '/companies/:companyId/exportwins/create',
   '/companies/:companyId/export/:exportId/exportwins/create',
   '/exportwins/won',
-  '/exportwins/sent',
+  '/exportwins/pending',
   '/exportwins/rejected',
   '/exportwins/:winId/success',
   '/companies/:companyId/exportwins/:winId/edit',

--- a/src/client/modules/ExportWins/Form/EditSuccess.jsx
+++ b/src/client/modules/ExportWins/Form/EditSuccess.jsx
@@ -23,8 +23,8 @@ const EditSuccess = ({ match }) => (
         text: 'Export wins',
       },
       {
-        link: urls.companies.exportWins.sent(),
-        text: 'Sent',
+        link: urls.companies.exportWins.pending(),
+        text: 'Pending',
       },
       {
         link: urls.companies.exportWins.editSummary(
@@ -34,7 +34,7 @@ const EditSuccess = ({ match }) => (
         text: <ExportWinSubTitle id={match.params.winId} />,
       },
       {
-        link: urls.companies.exportWins.sent(),
+        link: urls.companies.exportWins.pending(),
         text: 'Success',
       },
     ]}

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -112,7 +112,7 @@ const ExportWinForm = ({
                           changes save the page.
                         </StyledParagraph>
                       </StyledStatusMessage>
-                      {winStatus === WIN_STATUS.SENT && (
+                      {winStatus === WIN_STATUS.PENDING && (
                         <ResentExportWinContainer>
                           <ResendExportWin id={exportWinId} />
                         </ResentExportWinContainer>
@@ -130,7 +130,7 @@ const ExportWinForm = ({
                 <Form
                   id={FORM_ID}
                   showStepInUrl={true}
-                  cancelRedirectTo={() => urls.companies.exportWins.sent()}
+                  cancelRedirectTo={() => urls.companies.exportWins.pending()}
                   redirectTo={(result) =>
                     isEditing
                       ? urls.companies.exportWins.editSuccess(
@@ -164,7 +164,7 @@ const ExportWinForm = ({
                 </Form>
                 {currentStepName === steps.SUMMARY && (
                   <VerticalSpacerWithMarginBottom>
-                    {winStatus !== WIN_STATUS.SENT && (
+                    {winStatus !== WIN_STATUS.PENDING && (
                       <Link
                         as={ReactRouterLink}
                         to={urls.companies.exportWins.customerFeedback(

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -352,7 +352,7 @@ const AdditionalInformation = ({ values, isEditing }) => {
             </SummaryTable.Row>
           </>
         )}
-        {winStatus === WIN_STATUS.SENT && (
+        {winStatus === WIN_STATUS.PENDING && (
           <>
             <SummaryTable.Row heading="First sent">
               {formatMediumDateTime(values.first_sent)}

--- a/src/client/modules/ExportWins/Form/index.jsx
+++ b/src/client/modules/ExportWins/Form/index.jsx
@@ -88,7 +88,7 @@ export const EditExportWin = ({ match }) => (
         text: 'Home',
       },
       {
-        link: urls.companies.exportWins.sent(),
+        link: urls.companies.exportWins.pending(),
         text: 'Export wins',
       },
       { text: <ExportWinStatus id={match.params.winId} /> },

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -4,7 +4,7 @@ import { capitalize } from 'lodash'
 import { DefaultLayout } from '../../../components'
 import TabNav from '../../../components/TabNav'
 import WinsRejectedList from './WinsRejectedList'
-import WinsSentList from './WinsSentList'
+import WinsPendingList from './WinsPendingList'
 import WinsWonTable from './WinsWonTable'
 import urls from '../../../../lib/urls'
 
@@ -34,9 +34,9 @@ const ExportWinsTabNav = ({ location }) => {
             label: 'Rejected',
             content: <WinsRejectedList />,
           },
-          [urls.companies.exportWins.sent()]: {
-            label: 'Sent',
-            content: <WinsSentList />,
+          [urls.companies.exportWins.pending()]: {
+            label: 'Pending',
+            content: <WinsPendingList />,
           },
           [urls.companies.exportWins.won()]: {
             label: 'Won',

--- a/src/client/modules/ExportWins/Status/Redirect.jsx
+++ b/src/client/modules/ExportWins/Status/Redirect.jsx
@@ -3,9 +3,9 @@ import { Redirect } from 'react-router-dom'
 
 import urls from '../../../../lib/urls'
 
-// Redirect from /exportwins to /exportwins/rejected
+// Redirect from /exportwins to /exportwins/pending
 const ExportsWinsRedirect = () => (
-  <Redirect to={urls.companies.exportWins.rejected()} />
+  <Redirect to={urls.companies.exportWins.pending()} />
 )
 
 export default ExportsWinsRedirect

--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -8,7 +8,7 @@ import { sumExportValues } from './utils'
 import { WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
-export const WinsSentList = ({ exportWins = [] }) => {
+export const WinsPendingList = ({ exportWins = [] }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
@@ -55,14 +55,14 @@ export const WinsSentList = ({ exportWins = [] }) => {
 
 export default () => (
   <ExportWinsResource.Paginated
-    id="export-wins-sent"
-    heading="sent"
+    id="export-wins-pending"
+    heading="pending"
     shouldPluralize={false}
-    noResults="You don't have any sent export wins."
+    noResults="You don't have any pending export wins."
     // We have to send null as a string otherwise
     // it's stripped out of the payload by Axois
-    payload={{ confirmed: String(WIN_STATUS.SENT) }}
+    payload={{ confirmed: String(WIN_STATUS.PENDING) }}
   >
-    {(page) => <WinsSentList exportWins={page} />}
+    {(page) => <WinsPendingList exportWins={page} />}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -1,11 +1,11 @@
 export const WIN_STATUS = {
   REJECTED: false,
-  SENT: null,
+  PENDING: null,
   WON: true,
 }
 
 export const WIN_STATUS_MAP_TO_LABEL = {
   [WIN_STATUS.REJECTED]: 'Rejected',
-  [WIN_STATUS.SENT]: 'Sent',
+  [WIN_STATUS.PENDING]: 'Pending',
   [WIN_STATUS.WON]: 'Won',
 }

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -479,7 +479,7 @@ const routes = {
       component: ExportWinsTabNav,
     },
     {
-      path: '/exportwins/sent',
+      path: '/exportwins/pending',
       module: 'datahub:companies',
       component: ExportWinsTabNav,
     },

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -223,7 +223,7 @@ module.exports = {
     exportWins: {
       index: url('/exportwins'),
       won: url('/exportwins/won'),
-      sent: url('/exportwins/sent'),
+      pending: url('/exportwins/pending'),
       rejected: url('/exportwins/rejected'),
       create: url('/companies', '/:companyId/exportwins/create'),
       createFromExport: url(

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -147,7 +147,7 @@ export const urlTestExclusions = [
   { url: '/oauth/' },
   { url: '/oauth/callback/' },
   { url: '/oauth/sign-out/' },
-  { url: '/exportwins/sent/' },
+  { url: '/exportwins/pending/' },
   { url: '/exportwins/rejected/' },
   { url: '/exportwins/:winId/edit' },
   { url: '/exportwins/:winId/success' },

--- a/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
@@ -27,18 +27,18 @@ describe('Export wins tab navigation', () => {
         Rejected: null,
       })
     })
-    it('should render both Home and Sent', () => {
+    it('should render both Home and Pending', () => {
       cy.mount(
         <Component
           location={{
-            pathname: '/exportwins/sent',
+            pathname: '/exportwins/pending',
           }}
         />
       )
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
         'Export Wins': urls.companies.exportWins.index(),
-        Sent: null,
+        Pending: null,
       })
     })
     it('should render both Home and Won', () => {
@@ -65,11 +65,11 @@ describe('Export wins tab navigation', () => {
   })
 
   context('When rendering the TabNav component', () => {
-    it('should render three tabs: Rejected, Sent and Won', () => {
+    it('should render three tabs: Rejected, Pending and Won', () => {
       cy.mount(<Component />)
       cy.get('[data-test="tablist"]').should('exist')
       cy.get('[data-test="tab-item"]').as('tabItems')
-      assertLocalNav('@tabItems', ['Rejected', 'Sent', 'Won'])
+      assertLocalNav('@tabItems', ['Rejected', 'Pending', 'Won'])
     })
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -1,9 +1,9 @@
 import React from 'react'
 
-import { WinsSentList } from '../../../../../src/client/modules/ExportWins/Status/WinsSentList'
+import { WinsPendingList } from '../../../../../src/client/modules/ExportWins/Status/WinsPendingList'
 import { createTestProvider } from '../provider'
 
-describe('WinsSentList', () => {
+describe('WinsPendingList', () => {
   it('should render Export wins list', () => {
     const wins = [
       {
@@ -38,7 +38,7 @@ describe('WinsSentList', () => {
 
     cy.mount(
       <Provider>
-        <WinsSentList exportWins={wins} />
+        <WinsPendingList exportWins={wins} />
       </Provider>
     )
 


### PR DESCRIPTION
## Description of change
Rename _sent_ to _pending_ within Export Wins.

## Test instructions
Go to `/exportwins/pending`

## Screenshots

### Before
<img width="940" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/3f6e0502-1acb-40b1-b809-08e7692dc845">

### After
<img width="940" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/aba761eb-3473-4c48-afb8-4a3d24abac35">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
