### PR TITLE
Export wins - rename won to confirmed

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -28,7 +28,7 @@ const reactRoutes = [
   '/exportwins',
   '/companies/:companyId/exportwins/create',
   '/companies/:companyId/export/:exportId/exportwins/create',
-  '/exportwins/won',
+  '/exportwins/confirmed',
   '/exportwins/pending',
   '/exportwins/rejected',
   '/exportwins/:winId/success',

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -365,7 +365,7 @@ const AdditionalInformation = ({ values, isEditing }) => {
             </SummaryTable.Row>
           </>
         )}
-        {winStatus === WIN_STATUS.WON && (
+        {winStatus === WIN_STATUS.CONFIRMED && (
           <>
             <SummaryTable.Row heading="Comments">
               {values.customer_response.comments || 'Not set'}

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -5,7 +5,7 @@ import { DefaultLayout } from '../../../components'
 import TabNav from '../../../components/TabNav'
 import WinsRejectedList from './WinsRejectedList'
 import WinsPendingList from './WinsPendingList'
-import WinsWonTable from './WinsWonTable'
+import WinsConfirmedTable from './WinsConfirmedTable'
 import urls from '../../../../lib/urls'
 
 const TITLE = /([^\/]+$)/
@@ -38,9 +38,9 @@ const ExportWinsTabNav = ({ location }) => {
             label: 'Pending',
             content: <WinsPendingList />,
           },
-          [urls.companies.exportWins.won()]: {
-            label: 'Won',
-            content: <WinsWonTable />,
+          [urls.companies.exportWins.confirmed()]: {
+            label: 'Confirmed',
+            content: <WinsConfirmedTable />,
           },
         }}
       />

--- a/src/client/modules/ExportWins/Status/WinsConfirmedTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedTable.jsx
@@ -14,7 +14,7 @@ const NoWrapCell = styled(Table.Cell)`
   white-space: nowrap;
 `
 
-export const WinsWonTable = ({ exportWins = [] }) => {
+export const WinsConfirmedTable = ({ exportWins = [] }) => {
   return exportWins.length === 0 ? null : (
     <Table
       head={
@@ -65,12 +65,12 @@ export const WinsWonTable = ({ exportWins = [] }) => {
 
 export default () => (
   <ExportWinsResource.Paginated
-    id="export-wins-won"
-    heading="won"
+    id="export-wins-confirmed"
+    heading="confirmed"
     shouldPluralize={false}
-    noResults="You don't have any won export wins."
-    payload={{ confirmed: WIN_STATUS.WON }}
+    noResults="You don't have any confirmed export wins."
+    payload={{ confirmed: WIN_STATUS.CONFIRMED }}
   >
-    {(page) => <WinsWonTable exportWins={page} />}
+    {(page) => <WinsConfirmedTable exportWins={page} />}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -1,11 +1,11 @@
 export const WIN_STATUS = {
   REJECTED: false,
   PENDING: null,
-  WON: true,
+  CONFIRMED: true,
 }
 
 export const WIN_STATUS_MAP_TO_LABEL = {
   [WIN_STATUS.REJECTED]: 'Rejected',
   [WIN_STATUS.PENDING]: 'Pending',
-  [WIN_STATUS.WON]: 'Won',
+  [WIN_STATUS.CONFIRMED]: 'Confirmed',
 }

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -484,7 +484,7 @@ const routes = {
       component: ExportWinsTabNav,
     },
     {
-      path: '/exportwins/won',
+      path: '/exportwins/confirmed',
       module: 'datahub:companies',
       component: ExportWinsTabNav,
     },

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -222,7 +222,7 @@ module.exports = {
     },
     exportWins: {
       index: url('/exportwins'),
-      won: url('/exportwins/won'),
+      confirmed: url('/exportwins/confirmed'),
       pending: url('/exportwins/pending'),
       rejected: url('/exportwins/rejected'),
       create: url('/companies', '/:companyId/exportwins/create'),

--- a/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
@@ -41,18 +41,18 @@ describe('Export wins tab navigation', () => {
         Pending: null,
       })
     })
-    it('should render both Home and Won', () => {
+    it('should render both Home and Confirmed', () => {
       cy.mount(
         <Component
           location={{
-            pathname: '/exportwins/won',
+            pathname: '/exportwins/confirmed',
           }}
         />
       )
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
         'Export Wins': urls.companies.exportWins.index(),
-        Won: null,
+        Confirmed: null,
       })
     })
   })
@@ -65,11 +65,11 @@ describe('Export wins tab navigation', () => {
   })
 
   context('When rendering the TabNav component', () => {
-    it('should render three tabs: Rejected, Pending and Won', () => {
+    it('should render three tabs: Rejected, Pending and Confirmed', () => {
       cy.mount(<Component />)
       cy.get('[data-test="tablist"]').should('exist')
       cy.get('[data-test="tab-item"]').as('tabItems')
-      assertLocalNav('@tabItems', ['Rejected', 'Pending', 'Won'])
+      assertLocalNav('@tabItems', ['Rejected', 'Pending', 'Confirmed'])
     })
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinConfirmedTable.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinConfirmedTable.cy.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import { WinsWonTable } from '../../../../../src/client/modules/ExportWins/Status/WinsWonTable'
+import { WinsConfirmedTable } from '../../../../../src/client/modules/ExportWins/Status/WinsConfirmedTable'
 import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
 import { assertGovReactTable } from '../../../../functional/cypress/support/assertions'
 import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
@@ -18,7 +18,7 @@ const exportWinToRow = (exportWin) => [
   'View details',
 ]
 
-describe('WinsWonTable', () => {
+describe('WinsConfirmedTable', () => {
   it('should render Export wins table', () => {
     const EXPORT_WINS = [
       {
@@ -64,7 +64,7 @@ describe('WinsWonTable', () => {
 
     cy.mount(
       <Provider>
-        <WinsWonTable exportWins={EXPORT_WINS} />
+        <WinsConfirmedTable exportWins={EXPORT_WINS} />
       </Provider>
     )
 


### PR DESCRIPTION
## Description of change
Rename _won_ to _confirmed_ within Export Wins.

## Test instructions
Go to `/exportwins/confirmed`

## Screenshots

### Before
<img width="1198" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/fc40114a-d70d-4dd5-a669-0001b411d8be">

### After
<img width="1198" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/0701c6c5-2be2-40dd-8180-219fbfd1d274">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
