### PR TITLE
Export wins - reorder tabs

### DIFF
--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -30,10 +30,6 @@ const ExportWinsTabNav = ({ location }) => {
         label="Export wins tab nav"
         routed={true}
         tabs={{
-          [urls.companies.exportWins.rejected()]: {
-            label: 'Rejected',
-            content: <WinsRejectedList />,
-          },
           [urls.companies.exportWins.pending()]: {
             label: 'Pending',
             content: <WinsPendingList />,
@@ -41,6 +37,10 @@ const ExportWinsTabNav = ({ location }) => {
           [urls.companies.exportWins.confirmed()]: {
             label: 'Confirmed',
             content: <WinsConfirmedTable />,
+          },
+          [urls.companies.exportWins.rejected()]: {
+            label: 'Rejected',
+            content: <WinsRejectedList />,
           },
         }}
       />

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -1,11 +1,11 @@
 export const WIN_STATUS = {
-  REJECTED: false,
   PENDING: null,
   CONFIRMED: true,
+  REJECTED: false,
 }
 
 export const WIN_STATUS_MAP_TO_LABEL = {
-  [WIN_STATUS.REJECTED]: 'Rejected',
   [WIN_STATUS.PENDING]: 'Pending',
   [WIN_STATUS.CONFIRMED]: 'Confirmed',
+  [WIN_STATUS.REJECTED]: 'Rejected',
 }

--- a/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
@@ -65,11 +65,11 @@ describe('Export wins tab navigation', () => {
   })
 
   context('When rendering the TabNav component', () => {
-    it('should render three tabs: Rejected, Pending and Confirmed', () => {
+    it('should render three tabs: Pending, Confirmed and Rejected', () => {
       cy.mount(<Component />)
       cy.get('[data-test="tablist"]').should('exist')
       cy.get('[data-test="tab-item"]').as('tabItems')
-      assertLocalNav('@tabItems', ['Rejected', 'Pending', 'Confirmed'])
+      assertLocalNav('@tabItems', ['Pending', 'Confirmed', 'Rejected'])
     })
   })
 })


### PR DESCRIPTION
## Description of change
Reorder the Export Wins tabs.

## Test instructions
Go to `/exportwins`

## Screenshots

### Before
<img width="490" alt="Screenshot 2024-04-19 at 13 00 35" src="https://github.com/uktrade/data-hub-frontend/assets/964268/bc38d83b-4519-43b3-b375-cf91b32d2a01">

### After
<img width="490" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/c5e53f23-c7f4-42eb-8876-1a1cc97cccfe">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
