### PR TITLE
Add contact link to both pending and rejected wins

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -24,9 +25,13 @@ export const WinsPendingList = ({ exportWins = [] }) => {
             metadata={[
               {
                 label: 'Contact name:',
-                // TODO: This needs to be a link, the MetadataItem
-                // needs to take a JSX element
-                value: item.company_contacts[0].name,
+                value: (
+                  <Link
+                    href={urls.contacts.details(item.company_contacts[0].id)}
+                  >
+                    {item.company_contacts[0].name}
+                  </Link>
+                ),
               },
               {
                 label: 'Total value:',

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -24,9 +25,13 @@ export const WinsRejectedList = ({ exportWins }) => {
             metadata={[
               {
                 label: 'Contact name:',
-                // TODO: This needs to be a link, the MetadataItem
-                // needs to take a JSX element as a parameter.
-                value: item.company_contacts[0].name,
+                value: (
+                  <Link
+                    href={urls.contacts.details(item.company_contacts[0].id)}
+                  >
+                    {item.company_contacts[0].name}
+                  </Link>
+                ),
               },
               {
                 label: 'Total value:',

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { WinsPendingList } from '../../../../../src/client/modules/ExportWins/Status/WinsPendingList'
 import { createTestProvider } from '../provider'
+import urls from '../../../../../src/lib/urls'
 
 describe('WinsPendingList', () => {
   it('should render Export wins list', () => {
@@ -16,6 +17,7 @@ describe('WinsPendingList', () => {
         company_contacts: [
           {
             name: 'David Test',
+            id: 123,
           },
         ],
         country: {
@@ -42,8 +44,18 @@ describe('WinsPendingList', () => {
       </Provider>
     )
 
-    cy.get('[data-test="metadata-item"]')
-      .eq(1)
-      .should('have.text', 'Total value: £6,000')
+    cy.get('[data-test="metadata-item"]').as('metadataItems')
+
+    cy.get('@metadataItems')
+      .eq(0)
+      .should('have.text', 'Contact name: David Test')
+      .find('a')
+      .should(
+        'have.attr',
+        'href',
+        urls.contacts.details(wins[0].company_contacts[0].id)
+      )
+
+    cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { WinsRejectedList } from '../../../../../src/client/modules/ExportWins/Status/WinsRejectedList'
 import { createTestProvider } from '../provider'
+import urls from '../../../../../src/lib/urls'
 
 describe('WinsRejectedList', () => {
   it('should render Export wins list', () => {
@@ -15,7 +16,8 @@ describe('WinsRejectedList', () => {
         name_of_export: 'Rolls Reese',
         company_contacts: [
           {
-            name: 'David Test',
+            name: 'James Dean',
+            id: '345',
           },
         ],
         country: {
@@ -42,8 +44,18 @@ describe('WinsRejectedList', () => {
       </Provider>
     )
 
-    cy.get('[data-test="metadata-item"]')
-      .eq(1)
-      .should('have.text', 'Total value: £6,000')
+    cy.get('[data-test="metadata-item"]').as('metadataItems')
+
+    cy.get('@metadataItems')
+      .eq(0)
+      .should('have.text', 'Contact name: James Dean')
+      .find('a')
+      .should(
+        'have.attr',
+        'href',
+        urls.contacts.details(wins[0].company_contacts[0].id)
+      )
+
+    cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
   })
 })


### PR DESCRIPTION
## Description of change
Adds a contact link to both _Pending_ and _Rejected_ export wins.

## Test instructions
1. Go to `/exportswins`
2. Under the _Pending_ tab all wins should have a contact name that links to the contact details page.
3. Under the _Rejected_ tab all wins should have a contact name that links to the contact details page

## Screenshots

### Before
<img width="419" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/6e749b9d-fe93-4822-904d-84af9c5f80cc">

### After
<img width="419" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/2b1c150b-81f0-4448-b163-eaeb1b0cdddb">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
