### PR TITLE
Add default parameter to metadata requests to fix Hawk issue.

### DIFF
--- a/src/client/metadata.js
+++ b/src/client/metadata.js
@@ -22,7 +22,7 @@ const transformMetadataOption = ({ id, name }) => ({
  */
 async function getMetadataOptions(
   url,
-  { filterDisabled = true, params = {} } = {}
+  { filterDisabled = true, params = { _: 0 } } = {}
 ) {
   const { data } = await axios.get(url, {
     params,

--- a/test/functional/cypress/specs/companies/filter-spec.js
+++ b/test/functional/cypress/specs/companies/filter-spec.js
@@ -44,7 +44,7 @@ const activeStatusFlag = 'false'
 const inactiveStatusFlag = 'true'
 const companySearchEndpoint = '/api-proxy/v4/search/company'
 const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
-const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region*'
 const usaCountryId = '81756b9a-5d95-e211-a939-e4115bead28a'
 const canadaCountryId = '5daf72a6-5d95-e211-a939-e4115bead28a'
 const usStatesEndpoint = `/api-proxy/v4/metadata/administrative-area?country=${usaCountryId}`

--- a/test/functional/cypress/specs/contacts/filter-spec.js
+++ b/test/functional/cypress/specs/contacts/filter-spec.js
@@ -15,7 +15,7 @@ import { contactsListFaker } from '../../fakers/contacts'
 import { ukRegionListFaker } from '../../fakers/regions'
 
 const searchEndpoint = '/api-proxy/v3/search/contact'
-const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region*'
 
 const buildQueryString = (queryParams = {}) =>
   qs.stringify({

--- a/test/functional/cypress/specs/events/filter-spec.js
+++ b/test/functional/cypress/specs/events/filter-spec.js
@@ -11,8 +11,8 @@ import {
 import { ukRegionListFaker } from '../../fakers/regions'
 
 const searchEndpoint = '/api-proxy/v3/search/event'
-const eventTypeEndpoint = '/api-proxy/v4/metadata/event-type'
-const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const eventTypeEndpoint = '/api-proxy/v4/metadata/event-type*'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region*'
 
 const disabledEventType = eventTypeFaker({ disabled_on: '2020-01-01' })
 const eventTypes = [disabledEventType, ...eventTypeListFaker(2)]

--- a/test/functional/cypress/specs/export-pipeline/filter-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/filter-spec.js
@@ -291,7 +291,7 @@ describe('Export filters', () => {
           ),
         },
       }).as('apiRequestCountry')
-      cy.intercept('GET', urls.metadata.country(), countries).as(
+      cy.intercept('GET', `${urls.metadata.country()}?_=0`, countries).as(
         'apiRequestMetadataCountry'
       )
     })

--- a/test/functional/cypress/specs/interaction/filter-spec.js
+++ b/test/functional/cypress/specs/interaction/filter-spec.js
@@ -41,16 +41,16 @@ const minimumPayload = {
   sortby: 'date:desc',
 }
 
-const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction'
+const interactionsSearchEndpoint = '/api-proxy/v3/search/interaction*'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
-const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
+const adviserSearchEndpoint = '/api-proxy/v4/search/adviser*'
 const companyAutocompleteEndpoint = '/api-proxy/v4/company?autocomplete=*'
-const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service'
-const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area'
+const serviceMetadataEndpoint = '/api-proxy/v4/metadata/service*'
+const policyAreaMetadataEndpoint = '/api-proxy/v4/metadata/policy-area*'
 const policyIssueTypeMetadataEndpoint =
-  '/api-proxy/v4/metadata/policy-issue-type'
+  '/api-proxy/v4/metadata/policy-issue-type*'
 const companyOneListTierGroupMetadataEndpoint =
-  '/api-proxy/v4/metadata/one-list-tier'
+  '/api-proxy/v4/metadata/one-list-tier*'
 
 const myAdviserId = '7d19d407-9aec-4d06-b190-d3f404627f21'
 

--- a/test/functional/cypress/specs/investments/filter-spec.js
+++ b/test/functional/cypress/specs/investments/filter-spec.js
@@ -52,7 +52,7 @@ const myAdviser = {
 const searchEndpoint = '/api-proxy/v3/search/investment_project'
 const adviserSearchEndpoint = '/api-proxy/v4/search/adviser'
 const adviserAutocompleteEndpoint = '/api-proxy/adviser/?autocomplete=*'
-const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region*'
 
 describe('Investments Collections Filter', () => {
   context('Toggle groups', () => {

--- a/test/functional/cypress/specs/omis/filter-react-spec.js
+++ b/test/functional/cypress/specs/omis/filter-react-spec.js
@@ -63,7 +63,7 @@ const statuses = [
 ]
 
 const searchEndpoint = '/api-proxy/v3/search/order'
-const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region'
+const ukRegionsEndpoint = '/api-proxy/v4/metadata/uk-region*'
 
 describe('Orders Collections Filter', () => {
   context('Default Params', () => {


### PR DESCRIPTION
## Description of change

Add default parameter to metadata requests to fix Hawk issue.

## Test instructions

Pages loading metadata should load as expected. 

## Screenshots

n/a

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to migration-deploy?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
