### PR TITLE
DPM 616 filters on investment profiles

### DIFF
--- a/src/client/modules/Investments/Profiles/tasks.js
+++ b/src/client/modules/Investments/Profiles/tasks.js
@@ -1,4 +1,6 @@
+import urls from '../../../../lib/urls'
 import { apiProxyAxios } from '../../../components/Task/utils'
+import { getMetadataOptions } from '../../../metadata'
 
 import transformLargeCapitalProfiles from './transformers'
 
@@ -67,63 +69,53 @@ export function getLargeCapitalProfiles({
     }))
 }
 
-const idName2valueLabel = ({ id, name }) => ({ value: id, label: name })
-
-const mapOptionsWithCategory = (options, category) =>
-  options.map((option) =>
-    Object.assign(idName2valueLabel(option), { categoryLabel: category })
-  )
-
 export const loadFilterOptions = () =>
   Promise.all([
-    apiProxyAxios.get('/v4/metadata/country'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/asset-class-interest'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/investor-type'),
-    apiProxyAxios.get(
-      '/v4/metadata/capital-investment/required-checks-conducted'
+    getMetadataOptions(urls.metadata.country()),
+    getMetadataOptions(urls.metadata.capitalInvestmentAssetClassInterest()),
+    getMetadataOptions(urls.metadata.capitalInvestmentInvestorType()),
+    getMetadataOptions(
+      urls.metadata.capitalInvestmentRequiredChecksConducted()
     ),
-    apiProxyAxios.get('/v4/metadata/capital-investment/deal-ticket-size'),
-    apiProxyAxios.get(
-      'v4/metadata/capital-investment/large-capital-investment-type'
+    getMetadataOptions(urls.metadata.capitalInvestmentDealTicketSize()),
+    getMetadataOptions(
+      urls.metadata.capitalInvestmentLargeCapitalInvestmentType()
     ),
-    apiProxyAxios.get('/v4/metadata/capital-investment/return-rate'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/time-horizon'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/restriction'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/construction-risk'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/equity-percentage'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/desired-deal-role'),
-    apiProxyAxios.get('/v4/metadata/uk-region'),
+    getMetadataOptions(urls.metadata.capitalInvestmentReturnRate()),
+    getMetadataOptions(urls.metadata.capitalInvestmentTimeHorizon()),
+    getMetadataOptions(urls.metadata.capitalInvestmentRestriction()),
+    getMetadataOptions(urls.metadata.capitalInvestmentConstructionRisk()),
+    getMetadataOptions(urls.metadata.capitalInvestmentEquityPercentage()),
+    getMetadataOptions(urls.metadata.capitalInvestmentDesiredDealRole()),
+    getMetadataOptions(urls.metadata.ukRegion(), { filterDisabled: false }),
   ]).then(
     ([
-      { data: countries },
-      { data: classes },
-      { data: investorTypes },
-      { data: requiredChecksConducted },
-      { data: ticketSizes },
-      { data: investmentTypes },
-      { data: returnRates },
-      { data: timeHorizons },
-      { data: restrictions },
-      { data: constructionRisks },
-      { data: equityPercentages },
-      { data: dealRoles },
-      { data: ukRegionsOfInterest },
+      countries,
+      assetClassesOfInterest,
+      investorTypes,
+      requiredChecksConducted,
+      dealTicketSize,
+      investmentTypes,
+      minimumReturnRate,
+      timeHorizon,
+      restrictions,
+      constructionRisk,
+      minimumEquityPercentage,
+      desiredDealRole,
+      ukRegionsOfInterest,
     ]) => ({
-      countries: countries.map(idName2valueLabel),
-      assetClassesOfInterest: classes.map(idName2valueLabel),
-      investorTypes: investorTypes.map(idName2valueLabel),
-      requiredChecksConducted: requiredChecksConducted.map(idName2valueLabel),
-      dealTicketSize: ticketSizes.map(idName2valueLabel),
-      investmentTypes: investmentTypes.map(idName2valueLabel),
-      minimumReturnRate: mapOptionsWithCategory(returnRates, 'Min Return Rate'),
-      timeHorizon: timeHorizons.map(idName2valueLabel),
-      restrictions: restrictions.map(idName2valueLabel),
-      constructionRisk: constructionRisks.map(idName2valueLabel),
-      minimumEquityPercentage: mapOptionsWithCategory(
-        equityPercentages,
-        'Min Equity %'
-      ),
-      desiredDealRole: dealRoles.map(idName2valueLabel),
-      ukRegionsOfInterest: ukRegionsOfInterest.map(idName2valueLabel),
+      countries,
+      assetClassesOfInterest,
+      investorTypes,
+      requiredChecksConducted,
+      dealTicketSize,
+      investmentTypes,
+      minimumReturnRate,
+      timeHorizon,
+      restrictions,
+      constructionRisk,
+      minimumEquityPercentage,
+      desiredDealRole,
+      ukRegionsOfInterest,
     })
   )

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -627,6 +627,10 @@ module.exports = {
       '/api-proxy/v4/metadata/capital-investment',
       '/large-capital-investment'
     ),
+    capitalInvestmentLargeCapitalInvestmentType: url(
+      '/api-proxy/v4/metadata/capital-investment',
+      '/large-capital-investment-type'
+    ),
     capitalInvestmentReturnRate: url(
       '/api-proxy/v4/metadata/capital-investment',
       '/return-rate'

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -199,6 +199,9 @@ export const urlTestExclusions = [
   {
     url: '/api-proxy/v4/metadata/capital-investment/large-capital-investment',
   },
+  {
+    url: '/api-proxy/v4/metadata/capital-investment/large-capital-investment-type',
+  },
   { url: '/api-proxy/v4/metadata/capital-investment/return-rate' },
   { url: '/api-proxy/v4/metadata/capital-investment/time-horizon' },
   { url: '/api-proxy/v4/metadata/capital-investment/restriction' },

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -352,7 +352,7 @@ describe('Investor profiles filters', () => {
       ...ukRegionListFaker(2),
       ...ukRegionListFaker(2, { disabled_on: '2018-01-01' }),
     ]
-    cy.intercept('GET', urls.metadata.ukRegion(), ukRegions).as(
+    cy.intercept('GET', `${urls.metadata.ukRegion()}*`, ukRegions).as(
       'ukRegionsApiRequest'
     )
     cy.visit(urls.investments.profiles.index())


### PR DESCRIPTION
## Description of change

Fix loading of metadata for filters on [Investments > Profiles > Investor profiles](http://localhost:3000/investments/profiles?page=1) on DBT Platform

## Test instructions

Filters should load correctly on the page.

## Screenshots

### Before

![image](https://github.com/uktrade/data-hub-frontend/assets/699259/b8adba2c-e962-42d1-8a3b-264d019909c4)

### After

![image](https://github.com/uktrade/data-hub-frontend/assets/699259/475511c0-76fe-4a5d-b7d3-0aea98d78f6c)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to migration-deploy?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
