### PR TITLE
Add validation to ensure actual land date is not in the future

### DIFF
--- a/src/client/components/Form/validators.js
+++ b/src/client/components/Form/validators.js
@@ -1,3 +1,6 @@
+import { isDateInFuture } from '../../utils/date'
+import { transformDateObjectToDateString } from '../../transformers'
+
 const EMAIL_PATTERN =
   /(?:[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?\.)+[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-zA-Z0-9-]*[a-zA-Z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/
 
@@ -10,3 +13,8 @@ export const email = (x) =>
 
 export const number = (x, errorMessage) =>
   !x || IS_NUMBER.test(x) ? null : errorMessage
+
+export const validateIfDateInPast = (values) =>
+  isDateInFuture(transformDateObjectToDateString(values))
+    ? 'Actual land date cannot be in the future'
+    : null

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -36,6 +36,7 @@ import {
 import { GREY_2 } from '../../../utils/colours'
 import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
+import { validateIfDateInPast } from '../../../components/Form/validators'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -278,6 +279,7 @@ export const FieldActualLandDate = ({ initialValue = null }) => (
     hint="The date investment project activities started"
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
+    validate={validateIfDateInPast}
   />
 )
 

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -429,4 +429,12 @@ describe('Validation error messages', () => {
       validationErrorMessageOtherBusinessActivities
     )
   })
+
+  it('should display a validation error message if a future date is entered as the actual land date', () => {
+    cy.get('[data-test="actual_land_date-day"]').type('04')
+    cy.get('[data-test="actual_land_date-month"]').type('02')
+    cy.get('[data-test="actual_land_date-year"]').type('2350')
+    cy.get('[data-test="submit"]').click()
+    cy.contains('Actual land date cannot be in the future')
+  })
 })

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -9,6 +9,7 @@ const {
   assertFieldDate,
   assertFieldDateShort,
   assertFieldRadios,
+  assertErrorSummary,
 } = require('../../support/assertions')
 
 const project = require('../../fixtures/investment/investment-no-existing-requirements.json')
@@ -280,5 +281,13 @@ describe('Editing the project summary', () => {
   it('should display the form submit and back buttons', () => {
     cy.get('[data-test="submit-button"]').should('be.visible')
     cy.get('[data-test="cancel-button"]').should('be.visible')
+  })
+
+  it('should not allow a future actual land date to be entered', () => {
+    cy.get('[data-test="actual_land_date-day"]').type('04')
+    cy.get('[data-test="actual_land_date-month"]').type('02')
+    cy.get('[data-test="actual_land_date-year"]').type('2350')
+    cy.get('[data-test="submit-button"]').click()
+    assertErrorSummary(['Actual land date cannot be in the future'])
   })
 })


### PR DESCRIPTION
## Description of change

Added validation to ensure users cannot add a future date to the 'actual land date' field when creating, or editing an investment. The date entered must be the present day or a day in the past.
Added tests to ensure this behaviour

## Test instructions

1. When creating an investment project, if you set the 'actual land date' to the present day or a date in the past, then click submit, no validation error message is displayed for this field.
If you set the 'actual land date' to a date in the future and click submit, a validation message is displayed that states "Actual land date cannot be in the future".
<img width="1037" alt="Screenshot 2024-05-02 at 12 06 52" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/eb9a5442-fa39-41e5-a4a3-c7f803491e0b">

<img width="1037" alt="Screenshot 2024-05-02 at 12 07 02" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/cbead401-1f37-4f69-81be-42c49f2e652a">

2. Go to an investment project. Select 'Edit Summary'. Set 'Actual land date' to a date in the future and click 'save'. A validation message is displayed that states "Actual land date cannot be in the future".
<img width="1037" alt="Screenshot 2024-05-02 at 12 08 08" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/778812df-2e7b-4804-828b-ed7edcdc4b5f">

<img width="1037" alt="Screenshot 2024-05-02 at 12 08 16" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/e18777f1-096d-4cbb-978b-874264a002a8">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
