### PR TITLE
Remove component defaultProps and use JavaScript default parameters instead

### DIFF
--- a/src/apps/company-lists/client/CreateListForm.jsx
+++ b/src/apps/company-lists/client/CreateListForm.jsx
@@ -8,7 +8,7 @@ import { FORM_LAYOUT } from '../../../common/constants'
 const CreateListForm = ({
   id,
   name,
-  hint,
+  hint = '',
   label,
   cancelUrl,
   maxLength,
@@ -54,10 +54,6 @@ CreateListForm.propTypes = {
   cancelUrl: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
   maxLength: PropTypes.number.isRequired,
-}
-
-CreateListForm.defaultProps = {
-  hint: '',
 }
 
 export default CreateListForm

--- a/src/apps/company-lists/client/EditCompanyList.jsx
+++ b/src/apps/company-lists/client/EditCompanyList.jsx
@@ -53,8 +53,4 @@ EditCompanyList.propTypes = {
   csrfToken: PropTypes.string.isRequired,
 }
 
-EditCompanyList.defaultProps = {
-  hint: '',
-}
-
 export default EditCompanyList

--- a/src/client/components/ActivityFeed/Activity.jsx
+++ b/src/client/components/ActivityFeed/Activity.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 
 import activities from './activities'
 
-function Activity({ activity, showDetails, filter, isOverview }) {
+function Activity({ activity, showDetails = false, filter = [], isOverview }) {
   const ActivityToRender = find(activities, (a) => {
     if (a.canRender && typeof a.canRender == 'function') {
       return a.canRender(activity, filter)
@@ -30,11 +30,6 @@ Activity.propTypes = {
   activity: PropTypes.object.isRequired,
   showDetails: PropTypes.bool,
   filter: PropTypes.array,
-}
-
-Activity.defaultProps = {
-  showDetails: false,
-  filter: [],
 }
 
 export default Activity

--- a/src/client/components/ActivityFeed/ActivityFeedHeader.jsx
+++ b/src/client/components/ActivityFeed/ActivityFeedHeader.jsx
@@ -42,7 +42,7 @@ const HeaderActions = styled('div')`
   }
 `
 
-const ActivityFeedHeader = ({ totalActivities, actions }) => {
+const ActivityFeedHeader = ({ totalActivities = 0, actions }) => {
   const headerText = totalActivities
     ? pluralize('activity', totalActivities, true)
     : 'Activities'
@@ -60,11 +60,6 @@ const ActivityFeedHeader = ({ totalActivities, actions }) => {
 ActivityFeedHeader.propTypes = {
   totalActivities: PropTypes.number,
   actions: PropTypes.node,
-}
-
-ActivityFeedHeader.defaultProps = {
-  totalActivities: 0,
-  actions: null,
 }
 
 export default ActivityFeedHeader

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardLabels.jsx
@@ -24,7 +24,12 @@ const ThemeServiceContainer = styled('div')({
   ...flexMixin,
 })
 
-const ActivityCardLabels = ({ isExternalActivity, theme, service, kind }) => (
+const ActivityCardLabels = ({
+  isExternalActivity = false,
+  theme,
+  service,
+  kind,
+}) => (
   <Container>
     {(kind || theme || service) && (
       <ThemeServiceContainer>
@@ -59,10 +64,6 @@ ActivityCardLabels.propTypes = {
   service: PropTypes.string,
   kind: PropTypes.string.isRequired,
   isExternalActivity: PropTypes.bool,
-}
-
-ActivityCardLabels.defaultProps = {
-  isExternalActivity: false,
 }
 
 export default ActivityCardLabels

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardNotes.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardNotes.jsx
@@ -10,7 +10,7 @@ const StyledCardNotes = styled('div')`
   margin-bottom: ${SPACING.SCALE_1};
 `
 
-const ActivityCardNotes = ({ notes, maxLength }) => (
+const ActivityCardNotes = ({ notes, maxLength = 255 }) => (
   <StyledCardNotes data-test="activity-card-notes">
     {notes.length < maxLength
       ? notes
@@ -22,10 +22,6 @@ const ActivityCardNotes = ({ notes, maxLength }) => (
 ActivityCardNotes.propTypes = {
   notes: PropTypes.string.isRequired,
   maxLength: PropTypes.number,
-}
-
-ActivityCardNotes.defaultProps = {
-  maxLength: 255,
 }
 
 export default ActivityCardNotes

--- a/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
+++ b/src/client/components/ActivityFeed/activities/card/ActivityCardSubject.jsx
@@ -38,8 +38,5 @@ ActivityCardSubject.propTypes = {
     bottom: PropTypes.number.isRequired,
   }),
 }
-ActivityCardSubject.defaultProps = {
-  isOverview: false,
-}
 
 export default ActivityCardSubject

--- a/src/client/components/ActivityFeed/activities/card/CardDetailsList.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardDetailsList.jsx
@@ -33,8 +33,4 @@ CardDetailsList.propTypes = {
   itemPropName: PropTypes.string,
 }
 
-CardDetailsList.defaultProps = {
-  itemPropName: null,
-}
-
 export default CardDetailsList

--- a/src/client/components/CollectionList/CollectionHeader.jsx
+++ b/src/client/components/CollectionList/CollectionHeader.jsx
@@ -69,8 +69,4 @@ CollectionHeader.propTypes = {
   addItemUrl: PropTypes.string,
 }
 
-CollectionHeader.defaultProps = {
-  addItemUrl: null,
-}
-
 export default CollectionHeader

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -29,7 +29,12 @@ const StyledActions = styled('div')`
   }
 `
 
-const CollectionHeaderRow = ({ primary, actions, children, ...rest }) => {
+const CollectionHeaderRow = ({
+  primary = false,
+  actions,
+  children,
+  ...rest
+}) => {
   return (
     <StyledRowWrapper primary={primary} {...rest}>
       {children}
@@ -43,11 +48,6 @@ CollectionHeaderRow.propTypes = {
   primary: PropTypes.bool,
   actions: PropTypes.node,
   children: PropTypes.node.isRequired,
-}
-
-CollectionHeaderRow.defaultProps = {
-  primary: false,
-  actions: null,
 }
 
 export default CollectionHeaderRow

--- a/src/client/components/CompanyLists/DeleteCompanyListSection.jsx
+++ b/src/client/components/CompanyLists/DeleteCompanyListSection.jsx
@@ -71,8 +71,4 @@ DeleteCompanyListSection.propTypes = {
   returnUrl: PropTypes.string.isRequired,
 }
 
-DeleteCompanyListSection.defaultProps = {
-  errorMessage: null,
-}
-
 export default DeleteCompanyListSection

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -296,9 +296,4 @@ CompanyLocalHeader.propTypes = {
   dnbRelatedCompaniesCount: PropTypes.number,
 }
 
-CompanyLocalHeader.defaultProps = {
-  flashMessages: null,
-  dnbRelatedCompaniesCount: null,
-}
-
 export default connect(companyState2Props)(CompanyLocalHeader)

--- a/src/client/components/Dashboard/my-companies/MyCompaniesFilters.jsx
+++ b/src/client/components/Dashboard/my-companies/MyCompaniesFilters.jsx
@@ -46,10 +46,6 @@ InlineLabel.propTypes = {
   children: PropTypes.node,
 }
 
-InlineLabel.defaultProps = {
-  children: null,
-}
-
 function MyCompaniesFilters() {
   const { dispatch } = useMyCompaniesContext()
 

--- a/src/client/components/EntityList/EntityListItem.jsx
+++ b/src/client/components/EntityList/EntityListItem.jsx
@@ -59,7 +59,14 @@ const StyledInsetText = styled(InsetText)`
   }
 `
 
-const EntityListItem = ({ id, onEntityClick, data, text, heading, meta }) => {
+const EntityListItem = ({
+  id,
+  onEntityClick,
+  data = {},
+  text,
+  heading,
+  meta = [],
+}) => {
   const isClickable = !!onEntityClick
   return (
     <StyledEntity
@@ -87,14 +94,6 @@ EntityListItem.propTypes = {
   text: PropTypes.node,
   heading: PropTypes.string,
   meta: PropTypes.array,
-}
-
-EntityListItem.defaultProps = {
-  text: null,
-  onEntityClick: null,
-  data: {},
-  heading: null,
-  meta: [],
 }
 
 export default EntityListItem

--- a/src/client/components/EntityList/index.jsx
+++ b/src/client/components/EntityList/index.jsx
@@ -21,7 +21,7 @@ const EntityList = ({ entities, entityRenderer: EntityRenderer }) => (
         data-test="entity-list-item"
         key={`entity-list-item_${entity.id}`}
       >
-        <EntityRenderer {...entity} />
+        {(EntityRenderer || EntityListItem)({ ...entity })}
       </StyledEntityListItem>
     ))}
   </StyledEntityList>
@@ -37,10 +37,6 @@ EntityList.propTypes = {
     })
   ).isRequired,
   entityRenderer: PropTypes.func,
-}
-
-EntityList.defaultProps = {
-  entityRenderer: EntityListItem,
 }
 
 export default EntityList

--- a/src/client/components/Form/elements/FieldAdvisersTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldAdvisersTypeahead/index.jsx
@@ -8,7 +8,7 @@ import { apiProxyAxios } from '../../../Task/utils'
 
 const FieldAdvisersTypeahead = ({
   name,
-  label,
+  label = '',
   required,
   isMulti,
   onlyShowActiveAdvisers = true,
@@ -47,7 +47,5 @@ FieldAdvisersTypeahead.propTypes = {
   isMulti: PropTypes.bool,
   placeholder: PropTypes.string,
 }
-FieldAdvisersTypeahead.defaultProps = {
-  label: '',
-}
+
 export default FieldAdvisersTypeahead

--- a/src/client/components/Form/elements/FieldCurrency/index.jsx
+++ b/src/client/components/Form/elements/FieldCurrency/index.jsx
@@ -79,15 +79,15 @@ const StyledCurrencyWrapper = styled('div')`
  */
 const FieldCurrency = ({
   name,
-  validate,
+  validate = (value) => number(value, 'Value must be a number'),
   required,
   label,
   text,
   legend,
   hint,
-  initialValue,
-  reduced,
-  boldLabel,
+  initialValue = '',
+  reduced = false,
+  boldLabel = true,
   currencySymbol = '£',
   ...rest
 }) => {
@@ -216,17 +216,6 @@ FieldCurrency.propTypes = {
    * Sets the value for the currency prefix
    */
   currencySymbol: PropTypes.string,
-}
-
-FieldCurrency.defaultProps = {
-  validate: (value) => number(value, 'Value must be a number'),
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  initialValue: '',
-  reduced: false,
-  boldLabel: true,
 }
 
 export default FieldCurrency

--- a/src/client/components/Form/elements/FieldDate/index.jsx
+++ b/src/client/components/Form/elements/FieldDate/index.jsx
@@ -100,11 +100,15 @@ const FieldDate = ({
   hint,
   validate,
   initialValue,
-  labels,
+  labels = {
+    day: 'Day',
+    month: 'Month',
+    year: 'Year',
+  },
   required,
   invalid,
-  format,
-  reduced,
+  format = FORMAT_LONG,
+  reduced = false,
   ...props
 }) => {
   const { value, error, touched, onBlur } = useField({
@@ -248,23 +252,6 @@ FieldDate.propTypes = {
    * Toggles wether the element is a filter or not
    */
   reduced: PropTypes.bool,
-}
-
-FieldDate.defaultProps = {
-  label: null,
-  legend: null,
-  hint: null,
-  required: null,
-  invalid: null,
-  format: FORMAT_LONG,
-  validate: null,
-  initialValue: null,
-  labels: {
-    day: 'Day',
-    month: 'Month',
-    year: 'Year',
-  },
-  reduced: false,
 }
 
 export default FieldDate

--- a/src/client/components/Form/elements/FieldDnbCompany/index.jsx
+++ b/src/client/components/Form/elements/FieldDnbCompany/index.jsx
@@ -43,6 +43,9 @@ const validateMaxLength = (maxLength) => (value) =>
     ? `${pluralize('character', value.length - maxLength, true)} too long`
     : null
 
+const SEARCH_RESULTS_MESSAGE =
+  'The search results below are verified company records from an external and verified source of company information.'
+
 const FieldDnbCompany = ({
   name,
   label,
@@ -50,10 +53,10 @@ const FieldDnbCompany = ({
   hint,
   country,
   apiEndpoint,
-  queryParams,
+  queryParams = {},
   entityRenderer,
   onCannotFind,
-  searchResultsMessage,
+  searchResultsMessage = SEARCH_RESULTS_MESSAGE,
   features,
 }) => {
   const { values, goBack, validateForm, setIsLoading } = useFormContext()
@@ -188,18 +191,6 @@ FieldDnbCompany.propTypes = {
   entityRenderer: PropTypes.func,
   onCannotFind: PropTypes.func,
   searchResultsMessage: PropTypes.string,
-}
-
-FieldDnbCompany.defaultProps = {
-  label: null,
-  legend: null,
-  hint: null,
-  country: null,
-  queryParams: {},
-  entityRenderer: undefined,
-  onCannotFind: null,
-  searchResultsMessage:
-    'The search results below are verified company records from an external and verified source of company information.',
 }
 
 export default FieldDnbCompany

--- a/src/client/components/Form/elements/FieldHelp/index.jsx
+++ b/src/client/components/Form/elements/FieldHelp/index.jsx
@@ -19,7 +19,7 @@ const FieldHelp = ({
   helpText,
   footerUrl,
   footerUrlDescription,
-  open,
+  open = false,
 }) => {
   return (
     <ItemWrapper>
@@ -45,10 +45,6 @@ FieldHelp.propTypes = {
   footerUrl: PropTypes.string,
   footerDescription: PropTypes.string,
   open: PropTypes.bool,
-}
-
-FieldHelp.defaultProps = {
-  open: false,
 }
 
 export default FieldHelp

--- a/src/client/components/Form/elements/FieldInput/index.jsx
+++ b/src/client/components/Form/elements/FieldInput/index.jsx
@@ -49,8 +49,8 @@ const FieldInput = ({
   legend,
   hint,
   initialValue,
-  reduced,
-  dataTest = null,
+  reduced = false,
+  dataTest,
   ...rest
 }) => {
   const { value, error, touched, onChange, onBlur } = useField({
@@ -130,16 +130,6 @@ FieldInput.propTypes = {
    * Sets the data-test ID if the name isn't suitable
    */
   dataTest: PropTypes.string,
-}
-
-FieldInput.defaultProps = {
-  validate: null,
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  initialValue: '',
-  reduced: false,
 }
 
 export default FieldInput

--- a/src/client/components/Form/elements/FieldRadios/index.jsx
+++ b/src/client/components/Form/elements/FieldRadios/index.jsx
@@ -30,9 +30,9 @@ const FieldRadios = ({
   legend,
   bigLegend,
   hint,
-  inline,
+  inline = false,
   initialValue,
-  options,
+  options = [],
   ...props
 }) => {
   const { value, error, touched, onChange, onBlur } = useField({
@@ -108,17 +108,6 @@ FieldRadios.propTypes = {
       children: PropTypes.node,
     })
   ),
-}
-
-FieldRadios.defaultProps = {
-  validate: null,
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  inline: false,
-  initialValue: '',
-  options: [],
 }
 
 export default FieldRadios

--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -49,10 +49,10 @@ const FieldSelect = ({
   validate,
   required,
   initialValue,
-  options,
-  emptyOption,
-  fullWidth,
-  boldLabel,
+  options = [],
+  emptyOption = 'Please select',
+  fullWidth = false,
+  boldLabel = true,
   ...rest
 }) => {
   const { error, touched, value, onChange, onBlur } = useField({
@@ -145,19 +145,6 @@ FieldSelect.propTypes = {
    * Boolean for rendering the label in bold or not
    */
   boldLabel: PropTypes.bool,
-}
-
-FieldSelect.defaultProps = {
-  validate: null,
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  initialValue: '',
-  options: [],
-  emptyOption: 'Please select',
-  fullWidth: false,
-  boldLabel: true,
 }
 
 export default FieldSelect

--- a/src/client/components/Form/elements/FieldTextarea/index.jsx
+++ b/src/client/components/Form/elements/FieldTextarea/index.jsx
@@ -122,14 +122,4 @@ FieldTextarea.propTypes = {
   maxWords: PropTypes.number,
 }
 
-FieldTextarea.defaultProps = {
-  validate: null,
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  initialValue: '',
-  maxWords: null,
-}
-
 export default FieldTextarea

--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -37,9 +37,9 @@ const FieldTypeahead = ({
   label,
   legend,
   hint,
-  initialValue,
+  initialValue = null,
   options,
-  autoScroll,
+  autoScroll = false,
   className,
   ...props
 }) => {
@@ -115,16 +115,6 @@ FieldTypeahead.propTypes = {
    * Whether the window should auto scroll into view this component
    */
   autoScroll: PropTypes.bool,
-}
-
-FieldTypeahead.defaultProps = {
-  validate: null,
-  required: null,
-  label: null,
-  legend: null,
-  hint: null,
-  initialValue: null,
-  autoScroll: false,
 }
 
 export default FieldTypeahead

--- a/src/client/components/Form/elements/FieldUneditable/index.jsx
+++ b/src/client/components/Form/elements/FieldUneditable/index.jsx
@@ -34,11 +34,4 @@ FieldUneditable.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-FieldUneditable.defaultProps = {
-  label: null,
-  legend: null,
-  hint: null,
-  onChangeClick: null,
-}
-
 export default FieldUneditable

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -128,9 +128,9 @@ const StyledHint = styled(HintText)`
 const FieldInner = ({
   legend,
   error,
-  showBorder,
+  showBorder = false,
   children,
-  bigLegend,
+  bigLegend = false,
   groupId,
 }) =>
   legend ? (
@@ -163,12 +163,12 @@ const FieldWrapper = ({
   bigLegend,
   hint,
   error,
-  showBorder,
+  showBorder = false,
   children,
   reduced,
   groupId,
-  boldLabel,
-  autoScroll,
+  boldLabel = true,
+  autoScroll = false,
   ...rest
 }) => {
   const styledWrapperRef = React.useRef(null)
@@ -244,14 +244,6 @@ FieldInner.propTypes = {
   children: PropTypes.node,
 }
 
-FieldInner.defaultProps = {
-  legend: null,
-  error: null,
-  showBorder: false,
-  bigLegend: false,
-  children: null,
-}
-
 FieldWrapper.propTypes = {
   /**
    * Text for name attribute value
@@ -293,17 +285,6 @@ FieldWrapper.propTypes = {
    * Whether the window should auto scroll into view this component
    */
   autoScroll: PropTypes.bool,
-}
-
-FieldWrapper.defaultProps = {
-  label: null,
-  legend: null,
-  hint: null,
-  error: null,
-  showBorder: false,
-  children: null,
-  boldLabel: true,
-  autoScroll: false,
 }
 
 export default FieldWrapper

--- a/src/client/components/Form/elements/Step.jsx
+++ b/src/client/components/Form/elements/Step.jsx
@@ -105,10 +105,4 @@ Step.propTypes = {
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 }
 
-Step.defaultProps = {
-  backButton: undefined,
-  forwardButton: undefined,
-  children: null,
-}
-
 export default Step

--- a/src/client/components/InlineLabel.jsx
+++ b/src/client/components/InlineLabel.jsx
@@ -24,7 +24,7 @@ const StyledLabelText = styled(LabelText)(({ theme }) => ({
   },
 }))
 
-const InlineLabel = ({ text, children, justifyRight, name }) => (
+const InlineLabel = ({ text, children, justifyRight = false, name }) => (
   <StyledLabel justifyRight={justifyRight} htmlFor={name}>
     <StyledLabelText>{text}</StyledLabelText>
     {children}
@@ -35,10 +35,6 @@ InlineLabel.propTypes = {
   text: PropTypes.string.isRequired,
   children: PropTypes.node,
   justifyRight: PropTypes.bool,
-}
-
-InlineLabel.defaultProps = {
-  justifyRight: false,
 }
 
 export default InlineLabel

--- a/src/client/components/Main/index.jsx
+++ b/src/client/components/Main/index.jsx
@@ -46,8 +46,4 @@ Main.propTypes = {
   children: PropTypes.node,
 }
 
-Main.defaultProps = {
-  children: undefined,
-}
-
 export default Main

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -25,8 +25,4 @@ MetadataItem.propTypes = {
   children: PropTypes.node.isRequired,
 }
 
-MetadataItem.defaultProps = {
-  label: null,
-}
-
 export default MetadataItem

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -35,8 +35,4 @@ Metadata.propTypes = {
   ),
 }
 
-Metadata.defaultProps = {
-  rows: null,
-}
-
 export default Metadata

--- a/src/client/components/Panel/index.jsx
+++ b/src/client/components/Panel/index.jsx
@@ -56,8 +56,4 @@ Panel.propTypes = {
   children: PropTypes.element,
 }
 
-Panel.defaultProps = {
-  children: null,
-}
-
 export default Panel

--- a/src/client/components/RoutedAdvisersTypeahead/index.jsx
+++ b/src/client/components/RoutedAdvisersTypeahead/index.jsx
@@ -28,7 +28,7 @@ const fetchAdvisers = (onlyShowActiveAdvisers) => {
 
 const RoutedAdvisersTypeahead = ({
   taskProps,
-  closeMenuOnSelect,
+  closeMenuOnSelect = true,
   onlyShowActiveAdvisers = true,
   loadOptions = fetchAdvisers(onlyShowActiveAdvisers),
   ...props
@@ -53,7 +53,5 @@ RoutedAdvisersTypeahead.propTypes = {
   }).isRequired,
   closeMenuOnSelect: PropTypes.bool,
 }
-
-RoutedAdvisersTypeahead.defaultProps = { closeMenuOnSelect: true }
 
 export default RoutedAdvisersTypeahead

--- a/src/client/components/RoutedCompanyTypeahead/index.jsx
+++ b/src/client/components/RoutedCompanyTypeahead/index.jsx
@@ -33,7 +33,7 @@ const fetchCompanies = () => {
 const RoutedCompanyTypeahead = ({
   taskProps,
   loadOptions = fetchCompanies(),
-  closeMenuOnSelect,
+  closeMenuOnSelect = true,
   ...props
 }) => (
   <Task.Status {...taskProps} progressOverlay={true}>
@@ -56,7 +56,5 @@ RoutedCompanyTypeahead.propTypes = {
   }).isRequired,
   closeMenuOnSelect: PropTypes.bool,
 }
-
-RoutedCompanyTypeahead.defaultProps = { closeMenuOnSelect: true }
 
 export default RoutedCompanyTypeahead

--- a/src/client/components/RoutedTeamsTypeahead/index.jsx
+++ b/src/client/components/RoutedTeamsTypeahead/index.jsx
@@ -30,7 +30,7 @@ const fetchTeams = () =>
 
 const RoutedTeamsTypeahead = ({
   taskProps,
-  closeMenuOnSelect,
+  closeMenuOnSelect = true,
   loadOptions = fetchTeams(),
   ...props
 }) => (
@@ -53,7 +53,5 @@ RoutedTeamsTypeahead.propTypes = {
   }).isRequired,
   closeMenuOnSelect: PropTypes.bool,
 }
-
-RoutedTeamsTypeahead.defaultProps = { closeMenuOnSelect: true }
 
 export default RoutedTeamsTypeahead

--- a/src/client/components/RoutedTypeahead/index.jsx
+++ b/src/client/components/RoutedTypeahead/index.jsx
@@ -36,7 +36,7 @@ const RoutedTypeahead = ({
   loadOptions,
   noOptionsMessage,
   options,
-  labelAsQueryParam,
+  labelAsQueryParam = false,
   ...props
 }) => {
   const location = useLocation()
@@ -81,7 +81,4 @@ RoutedTypeahead.propTypes = {
   labelAsQueryParam: PropTypes.bool,
 }
 
-RoutedTypeahead.defaultProps = {
-  labelAsQueryParam: false,
-}
 export default RoutedTypeahead

--- a/src/client/components/StatusMessage/index.jsx
+++ b/src/client/components/StatusMessage/index.jsx
@@ -5,7 +5,11 @@ import { FOCUSABLE, SPACING } from '@govuk-react/constants'
 
 import { BLUE } from '../../../client/utils/colours'
 
-const StatusMessage = styled('div')`
+const StatusMessage = styled('div').attrs((props) => ({
+  colour: props.colour || BLUE,
+  role: 'alert',
+  'data-test': 'status-message',
+}))`
   border: ${({ colour }) => `${SPACING.SCALE_1} solid ${colour}`};
   color: ${({ colour }) => colour};
   font-weight: bold;
@@ -18,12 +22,6 @@ const StatusMessage = styled('div')`
 StatusMessage.propTypes = {
   colour: PropTypes.string,
   children: PropTypes.node.isRequired,
-}
-
-StatusMessage.defaultProps = {
-  colour: BLUE,
-  role: 'alert',
-  'data-test': 'status-message',
 }
 
 export default StatusMessage

--- a/src/client/components/SummaryList/index.jsx
+++ b/src/client/components/SummaryList/index.jsx
@@ -63,8 +63,4 @@ SummaryList.propTypes = {
   ),
 }
 
-SummaryList.defaultProps = {
-  rows: null,
-}
-
 export default SummaryList

--- a/src/client/components/SummaryTable/index.jsx
+++ b/src/client/components/SummaryTable/index.jsx
@@ -109,7 +109,7 @@ SummaryTable.CurrencyRow = ({ heading, value }) => (
   </SummaryTable.Row>
 )
 
-SummaryTable.ListRow = ({ heading, value, emptyValue, ...rest }) => (
+SummaryTable.ListRow = ({ heading, value = [], emptyValue, ...rest }) => (
   <SummaryTable.Row heading={heading} {...rest}>
     {value && value.length ? (
       <ul>
@@ -131,20 +131,9 @@ SummaryTable.propTypes = {
   children: PropTypes.node,
 }
 
-SummaryTable.defaultProps = {
-  caption: null,
-  actions: null,
-  children: null,
-}
-
 SummaryTable.Row.propTypes = {
   heading: PropTypes.string,
   children: PropTypes.node,
-}
-
-SummaryTable.Row.defaultProps = {
-  heading: null,
-  children: null,
 }
 
 SummaryTable.TextRow.propTypes = {
@@ -156,19 +145,9 @@ SummaryTable.TextRow.propTypes = {
   ]),
 }
 
-SummaryTable.TextRow.defaultProps = {
-  heading: null,
-  value: null,
-}
-
 SummaryTable.CurrencyRow.propTypes = {
   heading: PropTypes.string,
   value: PropTypes.number,
-}
-
-SummaryTable.CurrencyRow.defaultProps = {
-  heading: null,
-  value: null,
 }
 
 SummaryTable.ListRow.propTypes = {
@@ -179,11 +158,6 @@ SummaryTable.ListRow.propTypes = {
       value: PropTypes.string,
     })
   ),
-}
-
-SummaryTable.ListRow.defaultProps = {
-  heading: null,
-  value: [],
 }
 
 export default SummaryTable

--- a/src/client/components/Tag/index.jsx
+++ b/src/client/components/Tag/index.jsx
@@ -19,7 +19,7 @@ const StyledTag = styled(GovUkTag)`
  *
  * If no colour is specified the tag will default to a blue background and white text.
  */
-const Tag = ({ colour, children, ...props }) => (
+const Tag = ({ colour = 'default', children, ...props }) => (
   <StyledTag colour={colour} {...props}>
     {children}
   </StyledTag>
@@ -34,10 +34,6 @@ Tag.propTypes = {
    * Text of tag
    */
   children: PropTypes.node.isRequired,
-}
-
-Tag.defaultProps = {
-  colour: 'default',
 }
 
 export default Tag

--- a/src/client/modules/Companies/CompanyBusinessDetails/SectionAddresses.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/SectionAddresses.jsx
@@ -12,7 +12,7 @@ const StyledAddressList = styled('ul')`
   margin-top: ${SPACING_POINTS[2]}px;
 `
 
-const Address = ({ address, isRegistered }) => {
+const Address = ({ address, isRegistered = false }) => {
   const renderAdministrativeArea = (address) => {
     if (address.area && address.area.name) {
       return <li>{address.area.name}</li>
@@ -38,10 +38,6 @@ const Address = ({ address, isRegistered }) => {
 Address.propTypes = {
   address: PropTypes.object.isRequired,
   isRegistered: PropTypes.bool,
-}
-
-Address.defaultProps = {
-  isRegistered: false,
 }
 
 const SectionAddresses = ({ company, isDnbCompany, isArchived }) => {

--- a/src/client/modules/Companies/CompanyBusinessDetails/WideSummaryTableRow.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/WideSummaryTableRow.jsx
@@ -8,7 +8,7 @@ const StyledTableRow = styled(Table.Cell)`
   ${({ addPadding }) => addPadding && `padding-top: ${SPACING_POINTS[6]}px;`}
 `
 
-const WideSummaryTableRow = ({ children, addPadding }) => (
+const WideSummaryTableRow = ({ children, addPadding = false }) => (
   <Table.Row>
     <StyledTableRow addPadding={addPadding} colSpan={2}>
       {children}
@@ -19,10 +19,6 @@ const WideSummaryTableRow = ({ children, addPadding }) => (
 WideSummaryTableRow.propTypes = {
   children: PropTypes.node.isRequired,
   addPadding: PropTypes.bool,
-}
-
-WideSummaryTableRow.defaultProps = {
-  addPadding: false,
 }
 
 export default WideSummaryTableRow

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -25,7 +25,7 @@ const StyledSummaryTable = styled(SummaryTable)({
 })
 
 const EventDetails = ({
-  name,
+  name = 'Event',
   eventType,
   startDate,
   endDate,
@@ -164,10 +164,6 @@ const EventDetails = ({
       </Task.Status>
     </DefaultLayout>
   )
-}
-
-EventDetails.defaultProps = {
-  name: 'Event',
 }
 
 export default connect(state2props)(EventDetails)

--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -47,7 +47,7 @@ const ExportFormFields = ({
   cancelRedirectUrl,
   redirectToUrl,
   exportItem,
-  formSubmitButtonLabel,
+  formSubmitButtonLabel = 'Save',
   taskProps = {},
 }) => (
   <Task.Status {...taskProps}>
@@ -227,13 +227,7 @@ ExportFormFields.propTypes = {
   cancelRedirectUrl: PropTypes.string.isRequired,
   redirectToUrl: PropTypes.string.isRequired,
   taskProps: PropTypes.object,
-  formDataLoaded: PropTypes.bool,
   formSubmitButtonLabel: PropTypes.string,
-}
-
-ExportFormFields.defaultProps = {
-  formDataLoaded: false,
-  formSubmitButtonLabel: 'Save',
 }
 
 export default ExportFormFields


### PR DESCRIPTION
## Description of change
As part of upgrading React to `v18.3.1` we need to remove all component `defaultProps` and use the JavaScript default parameters instead, if we don't, then we will receive a plethora of warnings in the browser console. It's worth mentioning that `defaultProps` has been deprecated for some time.

Note, `ComponentX` has been substituted for the name of the component.

```Warning: ComponentX: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead.```

There are 7 remaining occurrences of `defaultProps` in the code base, however, they live in classes and I couldn't see any warnings in the console so I presume this only affects functional components, if this turns out not to be the case we can make the necessary changes.
1. `src/client/components/ActivityFeed/ActivityFeed.jsx`
2. `src/client/components/ActivityFeed/ActivityFeedApp.jsx`
3. `src/client/components/ActivityFeed/ActivityFeedPagination.jsx`
4. `src/client/components/ActivityFeed/activities/card/Card.jsx`
5. `src/client/components/ActivityFeed/activities/card/CardDetails.jsx`
6. `src/client/components/ActivityFeed/activities/card/CardTable.jsx` x 2

Facebook PR [here](https://github.com/facebook/react/pull/25699).

## Test instructions

There are no visible changes to the UI and it should work as before.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
