### PR TITLE
Added field checkboxes option link props to render type of win summary details

### DIFF
--- a/src/client/components/Form/elements/FieldCheckboxes/index.jsx
+++ b/src/client/components/Form/elements/FieldCheckboxes/index.jsx
@@ -120,9 +120,7 @@ const FieldCheckboxes = ({
                   <Fragment key={optionLabel}>
                     {optionLabel}
                     {optionLink && (
-                      <Fragment key={`option-link-for-${optionLabel}`}>
-                        {optionLink}
-                      </Fragment>
+                      <Fragment key={optionLink}>{optionLink}</Fragment>
                     )}
                   </Fragment>
                 )}

--- a/src/client/components/Form/elements/FieldCheckboxes/index.jsx
+++ b/src/client/components/Form/elements/FieldCheckboxes/index.jsx
@@ -97,6 +97,7 @@ const FieldCheckboxes = ({
               value: optionValue,
               label: optionLabel,
               children,
+              link: optionLink,
               ...optionProps
             },
             index
@@ -116,7 +117,14 @@ const FieldCheckboxes = ({
                 {boldLabel ? (
                   <StyledLabel>{optionLabel}</StyledLabel>
                 ) : (
-                  optionLabel
+                  <Fragment key={optionLabel}>
+                    {optionLabel}
+                    {optionLink && (
+                      <Fragment key={`option-link-for-${optionLabel}`}>
+                        {optionLink}
+                      </Fragment>
+                    )}
+                  </Fragment>
                 )}
               </Checkbox>
               {value.includes(optionValue) && !!children ? children : null}

--- a/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldCheckboxes.stories.jsx
@@ -1,8 +1,14 @@
 import React from 'react'
 import { H1 } from '@govuk-react/heading'
+import { Details, ListItem, UnorderedList } from 'govuk-react'
+import styled from 'styled-components'
 
 import FieldCheckboxes from '../FieldCheckboxes'
 import Form from '../../../Form'
+
+const StyledDetails = styled(Details)({
+  margin: 0,
+})
 
 const options = [
   {
@@ -133,6 +139,26 @@ export const CheckboxesExclusive = () => (
             {
               label: 'No, I will not be travelling to any of these countries',
               value: 'no',
+            },
+            {
+              label: 'Yes, I will travelling to any of these countries',
+              value: 'yes',
+              link: (
+                <StyledDetails
+                  summary="Is included a territorial independent countries?"
+                  data-test="some-list-of-territorial-countries"
+                >
+                  <p>List of territorial countries:</p>
+                  <UnorderedList listStyleType="bullet">
+                    <ListItem>French Guiana</ListItem>
+                    <ListItem>Madeira and Azores</ListItem>
+                    <ListItem>
+                      Balearic Islands(Ibiza, Formentera, Mallorca and Canary
+                      Islands)
+                    </ListItem>
+                  </UnorderedList>
+                </StyledDetails>
+              ),
             },
           ]}
         />

--- a/test/functional/cypress/specs/export-win/win-details-spec.js
+++ b/test/functional/cypress/specs/export-win/win-details-spec.js
@@ -111,7 +111,7 @@ describe('Win details', () => {
     })
   })
 
-  it('should render Type of win ', () => {
+  it('should render Type of win checkbox options', () => {
     assertFieldCheckboxes({
       element: winDetails.winType,
       legend: 'Type of win',
@@ -127,6 +127,29 @@ describe('Win details', () => {
         {
           label: 'Outward Direct Investment (ODI)',
           checked: false,
+        },
+      ],
+    })
+  })
+
+  it('should render Type of win detailed summary name', () => {
+    assertFieldCheckboxes({
+      element: winDetails.winType,
+      legend: 'Type of win',
+      options: [
+        {
+          label: 'Export',
+          checked: false,
+        },
+        {
+          label: 'Business success',
+          checked: false,
+          link: 'What is business success?',
+        },
+        {
+          label: 'Outward Direct Investment (ODI)',
+          checked: false,
+          link: 'What is an ODI?',
         },
       ],
     })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -368,10 +368,14 @@ const assertFieldCheckboxes = ({ element, legend, hint, options = [] }) => {
     .each((label, index) => {
       // Each label wraps an input
       cy.get(label)
-        .should('have.text', options[index].label)
+        .should('contain', options[index].label)
         .find('input[type="checkbox"]')
-        .should(options[index].checked ? 'be.checked' : 'not.be.checked')
         .should('have.attr', 'aria-label', options[index].label)
+        .should(options[index].checked ? 'be.checked' : 'not.be.checked')
+
+      const link = options[index].link
+      // Optional options field parameter
+      link && cy.get(label).find('summary').should('contain', link)
     })
 }
 


### PR DESCRIPTION
## Description of change

As part of the snagging there is no “what is a business success” and “what is an ODI” dropdown on the win details form.

Jira ticket reference: https://uktrade.atlassian.net/browse/RR-1405

## Test instructions

- From list of companies and company details, click add export to create export wins.
- At Win details steps, it render link information from "Type of win" field checkboxes list.

## Screenshots

### Before

<img width="403" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/28296624/262da1a9-d3fc-4525-96b8-af0c53de365e">

### After

<img width="400" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/28296624/f6fda236-8f02-419a-aca0-a635598be96d">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
