### PR TITLE
Allow for parameters for metadata API calls

### DIFF
--- a/src/client/components/Form/elements/FieldInput/index.jsx
+++ b/src/client/components/Form/elements/FieldInput/index.jsx
@@ -121,7 +121,7 @@ FieldInput.propTypes = {
   /**
    * Sets initial value of the input
    */
-  initialValue: PropTypes.string,
+  initialValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   /**
    * Toggles wether the element is a filter or not
    */

--- a/src/client/modules/Investments/Opportunities/tasks.js
+++ b/src/client/modules/Investments/Opportunities/tasks.js
@@ -1,30 +1,30 @@
+import urls from '../../../../lib/urls'
 import { idNamesToValueLabels } from '../../../utils'
 import { apiProxyAxios } from '../../../components/Task/utils'
 import { transformValueForAPI } from '../../../utils/date'
+import { getMetadataOptions } from '../../../metadata'
 
 import { transformInvestmentOpportunityDetails } from './transformers'
 
 export const getOpportunityDetails = ({ opportunityId }) =>
-  apiProxyAxios
-    .get(`/v4/large-capital-opportunity/${opportunityId}`)
-    .then(({ data }) => transformInvestmentOpportunityDetails(data))
+  getMetadataOptions(
+    urls.metadata.largeCapitalOpportunityDetails(opportunityId)
+  ).then(({ data }) => transformInvestmentOpportunityDetails(data))
 
 export const getDetailsMetadata = () =>
   Promise.all([
-    apiProxyAxios.get(
-      '/v4/metadata/large-capital-opportunity/opportunity-value-type'
-    ),
+    getMetadataOptions(urls.metadata.largeCapitalOpportunityMetadata()),
   ]).then(([{ data: valueTypes }]) => ({
     valueTypes: idNamesToValueLabels(valueTypes),
   }))
 
 export const getRequirementsMetadata = () =>
   Promise.all([
-    apiProxyAxios.get(
-      'v4/metadata/capital-investment/large-capital-investment-type'
+    getMetadataOptions(
+      urls.metadata.capitalInvestmentLargeCapitalInvestmentType()
     ),
-    apiProxyAxios.get('/v4/metadata/capital-investment/return-rate'),
-    apiProxyAxios.get('/v4/metadata/capital-investment/time-horizon'),
+    getMetadataOptions.get(urls.metadata.capitalInvestmentReturnRate()),
+    getMetadataOptions.get(urls.metadata.capitalInvestmentTimeHorizon()),
   ]).then(
     ([
       { data: investmentTypes },

--- a/src/client/modules/Investments/Opportunities/tasks.js
+++ b/src/client/modules/Investments/Opportunities/tasks.js
@@ -7,9 +7,13 @@ import { getMetadataOptions } from '../../../metadata'
 import { transformInvestmentOpportunityDetails } from './transformers'
 
 export const getOpportunityDetails = ({ opportunityId }) =>
-  getMetadataOptions(
-    urls.metadata.largeCapitalOpportunityDetails(opportunityId)
-  ).then(({ data }) => transformInvestmentOpportunityDetails(data))
+  apiProxyAxios
+    .get(
+      urls.investments.opportunities.largeCapitalOpportunityDetails(
+        opportunityId
+      )
+    )
+    .then(({ data }) => transformInvestmentOpportunityDetails(data))
 
 export const getDetailsMetadata = () =>
   Promise.all([
@@ -23,19 +27,13 @@ export const getRequirementsMetadata = () =>
     getMetadataOptions(
       urls.metadata.capitalInvestmentLargeCapitalInvestmentType()
     ),
-    getMetadataOptions.get(urls.metadata.capitalInvestmentReturnRate()),
-    getMetadataOptions.get(urls.metadata.capitalInvestmentTimeHorizon()),
-  ]).then(
-    ([
-      { data: investmentTypes },
-      { data: returnRates },
-      { data: timeScales },
-    ]) => ({
-      investmentTypes: idNamesToValueLabels(investmentTypes),
-      returnRates: idNamesToValueLabels(returnRates),
-      timeScales: idNamesToValueLabels(timeScales),
-    })
-  )
+    getMetadataOptions(urls.metadata.capitalInvestmentReturnRate()),
+    getMetadataOptions(urls.metadata.capitalInvestmentTimeHorizon()),
+  ]).then(([investmentTypes, returnRates, timeScales]) => ({
+    investmentTypes: investmentTypes,
+    returnRates: returnRates,
+    timeScales: timeScales,
+  }))
 
 export function saveOpportunityDetails({ values, opportunityId }) {
   return apiProxyAxios

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -531,6 +531,10 @@ module.exports = {
         '/investments',
         '/opportunities/:opportunityId/interactions'
       ),
+      largeCapitalOpportunityDetails: url(
+        '/api-proxy/v4/large-capital-opportunity',
+        '/:opportunityId'
+      ),
       status: url('/investments', '/opportunities/:opportunityId/status'),
       create: url('/investments', '/opportunities/create'),
     },
@@ -659,12 +663,8 @@ module.exports = {
       '/api-proxy/v4/metadata/capital-investment',
       '/asset-class-interest'
     ),
-    largeCapitalOpportunityDetails: url(
-      '/v4/large-capital-opportunity',
-      '/:opportunityId'
-    ),
     largeCapitalOpportunityMetadata: url(
-      '/v4/large-capital-opportunity',
+      '/api-proxy/v4/metadata/large-capital-opportunity',
       '/opportunity-value-type'
     ),
     oneListTier: url('/api-proxy/v4/metadata', '/one-list-tier'),

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -659,6 +659,14 @@ module.exports = {
       '/api-proxy/v4/metadata/capital-investment',
       '/asset-class-interest'
     ),
+    largeCapitalOpportunityDetails: url(
+      '/v4/large-capital-opportunity',
+      '/:opportunityId'
+    ),
+    largeCapitalOpportunityMetadata: url(
+      '/v4/large-capital-opportunity',
+      '/opportunity-value-type'
+    ),
     oneListTier: url('/api-proxy/v4/metadata', '/one-list-tier'),
     tradeAgreement: url('/api-proxy/v4/metadata', '/trade-agreement'),
   },

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -209,6 +209,8 @@ export const urlTestExclusions = [
   { url: '/api-proxy/v4/metadata/capital-investment/equity-percentage' },
   { url: '/api-proxy/v4/metadata/capital-investment/desired-deal-role' },
   { url: '/api-proxy/v4/metadata/capital-investment/asset-class-interest' },
+  { url: '/api-proxy/v4/large-capital-opportunity/:opportunityId' },
+  { url: '/api-proxy/v4/large-capital-opportunity/opportunity-value-type' },
   { url: '/api-proxy/v4/metadata/one-list-tier' },
   { url: '/api-proxy/v4/metadata/trade-agreement' },
 ]

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -210,7 +210,9 @@ export const urlTestExclusions = [
   { url: '/api-proxy/v4/metadata/capital-investment/desired-deal-role' },
   { url: '/api-proxy/v4/metadata/capital-investment/asset-class-interest' },
   { url: '/api-proxy/v4/large-capital-opportunity/:opportunityId' },
-  { url: '/api-proxy/v4/large-capital-opportunity/opportunity-value-type' },
+  {
+    url: '/api-proxy/v4/metadata/large-capital-opportunity/opportunity-value-type',
+  },
   { url: '/api-proxy/v4/metadata/one-list-tier' },
   { url: '/api-proxy/v4/metadata/trade-agreement' },
 ]


### PR DESCRIPTION
## Description of change

Related to a similar PR: https://github.com/uktrade/data-hub-frontend/pull/6759/files

Fixes loading of investments on a company page.

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
