### PR TITLE
Stop using ActivityStream in company activities

### DIFF
--- a/src/apps/companies/constants.js
+++ b/src/apps/companies/constants.js
@@ -35,7 +35,7 @@ const LOCAL_NAV = [
   {
     path: 'activity',
     label: 'Activity',
-    search: '?activityType%5B0%5D=dataHubActivity&page=1',
+    search: '',
     permissions: ['interaction.view_all_interaction'],
   },
   {

--- a/src/client/components/CompanyTabbedLocalNavigation/constants.js
+++ b/src/client/components/CompanyTabbedLocalNavigation/constants.js
@@ -12,7 +12,7 @@ export const localNavItems = (companyId) => {
       path: 'activity',
       url: urls.companies.activity.index(companyId),
       label: 'Activity',
-      search: '?activityType%5B0%5D=dataHubActivity&page=1',
+      search: '',
       permissions: ['interaction.view_all_interaction'],
     },
     {

--- a/src/client/modules/Companies/CompanyActivity/filters.js
+++ b/src/client/modules/Companies/CompanyActivity/filters.js
@@ -1,0 +1,85 @@
+import {
+  ACTIVITY_TYPE_OPTIONS,
+  BUSINESS_INTELLIGENCE_OPTION,
+  LABELS,
+} from '../../../components/ActivityFeed/CollectionList/constants'
+
+import {
+  buildOptionsFilter,
+  buildDatesFilter,
+  buildInputFieldFilter,
+} from '../../../filters'
+import { INCLUDE_RELATED_COMPANIES } from '../../../components/RoutedRelatedCompaniesCheckboxGroup/constants'
+
+export const buildSelectedFilters = (
+  queryParams,
+  selectedAdvisers,
+  currentAdviserId
+) => ({
+  advisers: {
+    queryParam: 'dit_participants__adviser',
+    options: selectedAdvisers.map((adviser) => ({
+      label: adviser.name,
+      value: adviser.id,
+      categoryLabel: LABELS.advisers,
+    })),
+  },
+  createdByOthers: {
+    queryParam: 'createdByOthers',
+    options: buildOptionsFilter({
+      options: [
+        {
+          label: LABELS.others,
+          value: currentAdviserId,
+        },
+      ],
+      value: queryParams.createdByOthers,
+      categoryLabel: LABELS.createdBy,
+    }),
+  },
+  subject: {
+    queryParam: 'subject',
+    options: buildInputFieldFilter({
+      value: queryParams.subject,
+      categoryLabel: LABELS.subject,
+    }),
+  },
+  datesAfter: {
+    queryParam: 'date_after',
+    options: buildDatesFilter({
+      value: queryParams.date_after,
+      categoryLabel: LABELS.dateAfter,
+    }),
+  },
+  datesBefore: {
+    queryParam: 'date_before',
+    options: buildDatesFilter({
+      value: queryParams.date_before,
+      categoryLabel: LABELS.dateBefore,
+    }),
+  },
+  activityType: {
+    queryParam: 'activityTypeFilter',
+    options: buildOptionsFilter({
+      options: ACTIVITY_TYPE_OPTIONS,
+      value: queryParams.activityType,
+      categoryLabel: LABELS.activityType,
+    }),
+  },
+  businessIntelligence: {
+    queryParam: 'was_policy_feedback_provided',
+    options: buildOptionsFilter({
+      options: BUSINESS_INTELLIGENCE_OPTION,
+      value: queryParams.was_policy_feedback_provided,
+      categoryLabel: LABELS.businessIntelligence,
+    }),
+  },
+  includeRelatedCompanies: {
+    queryParam: 'include_related_companies',
+    options: buildOptionsFilter({
+      options: INCLUDE_RELATED_COMPANIES,
+      value: queryParams.include_related_companies,
+      categoryLabel: LABELS.includeRelatedCompanies,
+    }),
+  },
+})

--- a/src/client/modules/Companies/CompanyActivity/index.jsx
+++ b/src/client/modules/Companies/CompanyActivity/index.jsx
@@ -1,0 +1,237 @@
+import React from 'react'
+import { connect } from 'react-redux'
+//import styled from 'styled-components'
+import { useParams } from 'react-router-dom'
+
+import {
+  COMPANY_ACTIVITIES__LOADED,
+  COMPANY_ACTIVITIES_SELECTED_ADVISERS,
+  COMPANY_ACTIVITIES__METADATA_LOADED,
+} from '../../../actions'
+
+import { LABELS } from '../../../components/ActivityFeed/CollectionList/constants'
+
+import {
+  CollectionFilters,
+  FilteredCollectionList,
+  FilterToggleSection,
+  Filters,
+} from '../../../components'
+
+import {
+  listSkeletonPlaceholder,
+  CheckboxPlaceholder,
+  InputPlaceholder,
+  ToggleHeadingPlaceholder,
+} from '../../../components/SkeletonPlaceholder'
+
+import {
+  TASK_GET_COMPANY_ACTIVITIES_METADATA,
+  TASK_GET_COMPANY_ACTIVITIES_ADVISER_NAME,
+} from '../../../components/ActivityFeed/CollectionList/state'
+
+import { state2props, ID, TASK_GET_COMPANY_ACTIVITIES_NO_AS } from './state'
+
+import { sanitizeFilter } from '../../../../client/filters'
+
+import { CompanyResource } from '../../../components/Resource'
+import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
+import CompanyLayout from '../../../components/Layout/CompanyLayout'
+
+import {
+  StyledCollectionItem,
+  TitleRenderer,
+} from '../../Events/CollectionList'
+
+//TODO - Reinstate these filters when we have the required data in place
+/*const FiltersCheckboxGroupWithNext = styled(Filters.CheckboxGroup)({
+  marginBottom: 0,
+  paddingBottom: 0,
+})
+
+const FiltersCheckboxGroupHiddenLegend = styled(Filters.CheckboxGroup)({
+  legend: { display: 'none' },
+})*/
+
+const ItemTemplate = (item) => (
+  <StyledCollectionItem
+    dataTest="interaction"
+    headingText={item.headingText}
+    headingUrl={item.headingUrl}
+    metadata={item.metadata}
+    tags={item.tags}
+    titleRenderer={TitleRenderer}
+    showTagsInMetadata={true}
+  />
+)
+
+const CompanyActivityCollectionNoAS = ({
+  payload,
+  company,
+  optionMetadata,
+  selectedFilters,
+  currentAdviserId,
+  dnbHierarchyCount,
+  ...props
+}) => {
+  const { companyId } = useParams()
+
+  const collectionListTask = (company) => ({
+    name: TASK_GET_COMPANY_ACTIVITIES_NO_AS,
+    id: ID,
+    progressMessage: 'Loading interactions',
+    renderProgress: listSkeletonPlaceholder(),
+    startOnRender: {
+      payload: {
+        ...payload,
+        company: company.id,
+        dit_participants__adviser: createdByMeSelected
+          ? currentAdviserId
+          : undefined,
+      },
+      onSuccessDispatch: COMPANY_ACTIVITIES__LOADED,
+    },
+  })
+
+  const adviserListTask = {
+    name: TASK_GET_COMPANY_ACTIVITIES_ADVISER_NAME,
+    id: ID,
+    startOnRender: {
+      payload: payload.dit_participants__adviser,
+      onSuccessDispatch: COMPANY_ACTIVITIES_SELECTED_ADVISERS,
+    },
+  }
+
+  const collectionListMetadataTask = {
+    name: TASK_GET_COMPANY_ACTIVITIES_METADATA,
+    id: ID,
+    progressMessage: 'Loading filters',
+    renderProgress: () => (
+      <>
+        <CheckboxPlaceholder count={1} />
+        <CheckboxPlaceholder count={2} />
+        <ToggleHeadingPlaceholder />
+        <InputPlaceholder count={5} />
+        <CheckboxPlaceholder count={1} />
+        <CheckboxPlaceholder count={7} />
+        <ToggleHeadingPlaceholder count={2} />
+      </>
+    ),
+    startOnRender: {
+      onSuccessDispatch: COMPANY_ACTIVITIES__METADATA_LOADED,
+    },
+  }
+
+  const createdByMeSelected = selectedFilters.advisers.options
+    .map(({ value }) => value)
+    .includes(currentAdviserId)
+
+  /*const myInteractionsOption = {
+    label: LABELS.me,
+    value: currentAdviserId,
+  }
+
+const createdByOthersOption = {
+    label: LABELS.others,
+    value: currentAdviserId,
+  }*/
+
+  return (
+    <DefaultLayoutBase>
+      <CompanyResource id={companyId}>
+        {(company) => (
+          <CompanyLayout
+            company={company}
+            breadcrumbs={[{ text: 'Activity Feed' }]}
+            pageTitle="Activities"
+          >
+            <FilteredCollectionList
+              {...props}
+              collectionName="activities"
+              sortOptions={optionMetadata.sortOptions}
+              taskProps={collectionListTask(company)}
+              selectedFilters={selectedFilters}
+              entityName="companyActivities"
+              sanitizeFiltersForAnalytics={({ advisers, teams }) => ({
+                ...sanitizeFilter(advisers),
+                ...sanitizeFilter(teams),
+              })}
+              collectionItemTemplate={ItemTemplate}
+              showTagsInMetadata={true}
+            >
+              <CollectionFilters taskProps={collectionListMetadataTask}>
+                {/*<FiltersCheckboxGroupWithNext
+                  legend={LABELS.createdBy}
+                  name="my_interactions"
+                  qsParam="ditParticipantsAdviser"
+                  options={[myInteractionsOption]}
+                  selectedOptions={
+                    createdByMeSelected ? [myInteractionsOption] : []
+                  }
+                  data-test="my-interactions-filter"
+                />
+                <FiltersCheckboxGroupHiddenLegend
+                  legend={LABELS.createdBy}
+                  name="created_by_others"
+                  qsParam="createdByOthers"
+                  options={[createdByOthersOption]}
+                  selectedOptions={selectedFilters.createdByOthers.options}
+                  data-test="created-by-others-filter"
+                />*/}
+                <Filters.Date
+                  label={LABELS.dateAfter}
+                  name="date_after"
+                  qsParamName="date_after"
+                  data-test="date-after-filter"
+                />
+                <Filters.Date
+                  label={LABELS.dateBefore}
+                  name="date_before"
+                  qsParamName="date_before"
+                  data-test="date-before-filter"
+                />
+                {dnbHierarchyCount > 0 && (
+                  <Filters.RelatedCompaniesCheckboxGroup
+                    company={company}
+                    selectedOptions={
+                      selectedFilters.includeRelatedCompanies.options
+                    }
+                  />
+                )}
+                <FilterToggleSection
+                  id="CompanyActivityCollection.interaction-details-filters"
+                  label="Interaction details"
+                  isOpen={true}
+                >
+                  <Filters.AdvisersTypeahead
+                    taskProps={adviserListTask}
+                    isMulti={true}
+                    onlyShowActiveAdvisers={false}
+                    label={LABELS.advisers}
+                    name="advisers"
+                    qsParam="dit_participants__adviser"
+                    placeholder="Search adviser"
+                    noOptionsMessage="No advisers found"
+                    selectedOptions={selectedFilters.advisers.options}
+                    data-test="adviser-filter"
+                  />
+                </FilterToggleSection>
+                {/* TODO - reinstate this once we have initial DAGs in place for external items */}
+                {/*<Filters.CheckboxGroup
+                  legend={LABELS.activityType}
+                  name="activityType"
+                  qsParam="activityType"
+                  options={ACTIVITY_TYPE_OPTIONS}
+                  selectedOptions={selectedFilters.activityType.options}
+                  data-test="activity-type-filter"
+                />*/}
+              </CollectionFilters>
+            </FilteredCollectionList>
+          </CompanyLayout>
+        )}
+      </CompanyResource>
+    </DefaultLayoutBase>
+  )
+}
+
+export default connect(state2props)(CompanyActivityCollectionNoAS)

--- a/src/client/modules/Companies/CompanyActivity/reducer.js
+++ b/src/client/modules/Companies/CompanyActivity/reducer.js
@@ -1,0 +1,49 @@
+import {
+  COMPANY_ACTIVITIES__LOADED,
+  COMPANY_ACTIVITIES_SELECTED_ADVISERS,
+  COMPANY_ACTIVITIES_SELECTED_COMPANIES,
+  COMPANY_ACTIVITIES__METADATA_LOADED,
+  COMPANY_ACTIVITIES_SELECTED_TEAMS,
+} from '../../../actions'
+
+const initialState = {
+  results: [],
+  metadata: {},
+  selectedAdvisers: [],
+  selectedTeams: [],
+  selectedCompanies: [],
+  isComplete: false,
+}
+
+export default (state = initialState, { type, result }) => {
+  switch (type) {
+    case COMPANY_ACTIVITIES__LOADED:
+      return {
+        ...state,
+        ...result,
+        isComplete: true,
+      }
+    case COMPANY_ACTIVITIES_SELECTED_ADVISERS:
+      return {
+        ...state,
+        selectedAdvisers: result,
+      }
+    case COMPANY_ACTIVITIES_SELECTED_COMPANIES:
+      return {
+        ...state,
+        selectedCompanies: result,
+      }
+    case COMPANY_ACTIVITIES__METADATA_LOADED:
+      return {
+        ...state,
+        metadata: result,
+      }
+    case COMPANY_ACTIVITIES_SELECTED_TEAMS:
+      return {
+        ...state,
+        selectedTeams: result,
+      }
+    default:
+      return state
+  }
+}

--- a/src/client/modules/Companies/CompanyActivity/state.js
+++ b/src/client/modules/Companies/CompanyActivity/state.js
@@ -1,0 +1,44 @@
+import { buildSelectedFilters } from './filters'
+import { parseQueryString } from '../../../utils'
+import { SORT_OPTIONS } from '../../../components/ActivityFeed/CollectionList/constants'
+
+export const TASK_GET_COMPANY_ACTIVITIES_NO_AS =
+  'TASK_GET_COMPANY_ACTIVITIES_NO_AS'
+
+export const ID = 'companyActivitiesListNoAS'
+
+export const state2props = ({ router, ...state }) => {
+  const queryString = router.location.search.slice(1)
+  const queryParams = parseQueryString(queryString)
+  const { currentAdviserId } = state
+  const { metadata, selectedAdvisers, createdByOthers } = state[ID]
+
+  const selectedFilters = buildSelectedFilters(
+    queryParams,
+    selectedAdvisers,
+    currentAdviserId
+  )
+
+  queryParams.include_parent_companies =
+    selectedFilters.includeRelatedCompanies.options.some(
+      (f) => f.value === 'include_parent_companies'
+    )
+  queryParams.include_subsidiary_companies =
+    selectedFilters.includeRelatedCompanies.options.some(
+      (f) => f.value === 'include_subsidiary_companies'
+    )
+
+  return {
+    ...state[ID],
+    payload: {
+      ...queryParams,
+    },
+    optionMetadata: {
+      sortOptions: SORT_OPTIONS,
+      ...metadata,
+    },
+    selectedFilters,
+    currentAdviserId,
+    createdByOthers,
+  }
+}

--- a/src/client/modules/Companies/CompanyActivity/tasks.js
+++ b/src/client/modules/Companies/CompanyActivity/tasks.js
@@ -19,8 +19,8 @@ export const getCompanyInteractions = ({
   policy_issue_types,
   company_one_list_group_tier,
   dit_participants__team,
-}) => {
-  return apiProxyAxios
+}) =>
+  apiProxyAxios
     .post('/v3/search/interaction', {
       limit,
       offset: getPageOffset({ limit, page }),
@@ -39,4 +39,3 @@ export const getCompanyInteractions = ({
       dit_participants__team,
     })
     .then(({ data }) => transformResponseToCollection(data))
-}

--- a/src/client/modules/Companies/CompanyActivity/tasks.js
+++ b/src/client/modules/Companies/CompanyActivity/tasks.js
@@ -1,0 +1,42 @@
+import { apiProxyAxios } from '../../../components/Task/utils'
+import { getPageOffset } from '../../../utils/pagination'
+
+import { transformResponseToCollection } from './transformers'
+
+export const getCompanyInteractions = ({
+  limit = 10,
+  page = 1,
+  subject,
+  kind,
+  dit_participants__adviser,
+  company,
+  service,
+  date_before,
+  date_after,
+  sortby = 'date:desc',
+  was_policy_feedback_provided,
+  policy_areas,
+  policy_issue_types,
+  company_one_list_group_tier,
+  dit_participants__team,
+}) => {
+  return apiProxyAxios
+    .post('/v3/search/interaction', {
+      limit,
+      offset: getPageOffset({ limit, page }),
+      subject,
+      kind,
+      dit_participants__adviser,
+      company,
+      sortby,
+      date_before,
+      date_after,
+      service,
+      was_policy_feedback_provided,
+      policy_areas,
+      policy_issue_types,
+      company_one_list_group_tier,
+      dit_participants__team,
+    })
+    .then(({ data }) => transformResponseToCollection(data))
+}

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -56,7 +56,7 @@ export const transformInteractionToListItem = ({
   contacts,
   kind,
   communication_channel,
-} = {}) => ({
+}) => ({
   id,
   metadata: [
     { label: 'Date', value: formatMediumDate(date) },

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -1,0 +1,96 @@
+import React from 'react'
+import Link from '@govuk-react/link'
+
+import urls from '../../../../lib/urls'
+import { formatMediumDate } from '../../../utils/date'
+import { AdviserResource } from '../../../components/Resource'
+import { INTERACTION_NAMES } from '../../../../apps/interactions/constants'
+
+const AdviserEmail = (props) => (
+  <AdviserResource.Inline {...props}>
+    {(adviser) => adviser.email}
+  </AdviserResource.Inline>
+)
+
+const AdviserRenderer = ({ adviser, team }) => {
+  const email = <AdviserEmail id={adviser.id} />
+  const emailLink = <Link href={`mailto:${email}`}> {email}</Link>
+  const teamString = team ? `${team.name} ` : null
+  return (
+    <>
+      <span>{adviser.name}</span> {emailLink}, {teamString} <br />
+    </>
+  )
+}
+
+const formattedContacts = (contacts) =>
+  !!contacts.length &&
+  contacts.map((contact, index) => (
+    <span key={contact.name}>
+      {index ? ', ' : ''}
+      <Link
+        data-test={`contact-link-${index}`}
+        href={urls.contacts.details(contact.id)}
+      >
+        {contact.name}
+      </Link>
+    </span>
+  ))
+
+const formattedAdvisers = (advisers) =>
+  !!advisers.length &&
+  advisers.map((item) => (
+    <span key={item.adviser.name}>
+      <AdviserRenderer adviser={item.adviser} team={item.team} />
+    </span>
+  ))
+
+const verifyLabel = (array, label) => (array.length > 1 ? label + 's' : label)
+
+export const transformInteractionToListItem = ({
+  date,
+  subject,
+  dit_participants,
+  service,
+  id,
+  contacts,
+  kind,
+  communication_channel,
+} = {}) => ({
+  id,
+  metadata: [
+    { label: 'Date', value: formatMediumDate(date) },
+    {
+      label: verifyLabel(contacts, 'Contact'),
+      value: formattedContacts(contacts),
+    },
+    { label: 'Communication channel', value: communication_channel?.name },
+    {
+      label: verifyLabel(dit_participants, 'Adviser'),
+      value: formattedAdvisers(dit_participants),
+    },
+    { label: 'Service', value: service.name },
+  ].filter(({ value }) => Boolean(value)),
+  tags: [
+    {
+      text: INTERACTION_NAMES[kind],
+      colour: 'grey',
+      dataTest: 'activity-kind-label',
+    },
+    {
+      text:
+        service && service.name.includes(' : ')
+          ? service.name.split(' : ')[0]
+          : service.name,
+      colour: 'blue',
+      dataTest: 'activity-service-label',
+    },
+  ].filter(({ text }) => Boolean(text)),
+  headingUrl: urls.interactions.detail(id),
+  headingText: subject,
+})
+
+export const transformResponseToCollection = ({ count, results = [] }) => ({
+  count,
+  results: results.map(transformInteractionToListItem),
+})

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -37,7 +37,7 @@ import {
 
 import { BLUE, GREY_2 } from '../../../utils/colours'
 
-const StyledCollectionItem = styled(CollectionItem)`
+export const StyledCollectionItem = styled(CollectionItem)`
   border-bottom: 1px solid ${GREY_2};
   padding: ${SPACING.SCALE_3} 0;
 `
@@ -57,7 +57,7 @@ const StyledLinkHeader = styled('h3')`
   }
 `
 
-const TitleRenderer = (title, url, margin = { bottom: 10 }) => (
+export const TitleRenderer = (title, url, margin = { bottom: 10 }) => (
   <StyledLinkHeader margin={margin}>
     <Link as={RouterLink} to={url}>
       {title}

--- a/src/client/reducers.js
+++ b/src/client/reducers.js
@@ -180,6 +180,9 @@ import getInteractionReducer from './modules/Interactions/InteractionDetails/red
 import { PREVIEW_QUOTE_ID } from './modules/Omis/state'
 import orderQuoteReducer from './modules/Omis/reducer'
 
+import { ID as COMPANY_ACTIVITY_NO_AS_ID } from './modules/Companies/CompanyActivity/state'
+import companyActivityReducerNoAs from './modules/Companies/CompanyActivity/reducer'
+
 import { ResendExportWin } from './modules/ExportWins/Form/ResendExportWin'
 
 export const reducers = {
@@ -252,4 +255,5 @@ export const reducers = {
   [INTERACTION_ID]: getInteractionReducer,
   [PROPOSITION_COMPLETE_ID]: investmentProjectsReducer,
   [PREVIEW_QUOTE_ID]: orderQuoteReducer,
+  [COMPANY_ACTIVITY_NO_AS_ID]: companyActivityReducerNoAs,
 }

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -90,7 +90,7 @@ import CompanyOverview from './modules/Companies/CompanyOverview/CompanyOverview
 import CompanyBusinessDetails from './modules/Companies/CompanyBusinessDetails/CompanyBusinessDetails'
 import SetGlobalHQ from './modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/SetGlobalHQ'
 import RemoveGlobalHQ from './modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/RemoveGlobalHQ'
-import CompanyActivityCollection from './components/ActivityFeed/CollectionList/index'
+import CompanyActivityCollectionNoAs from './modules/Companies/CompanyActivity/index'
 import CompanyContactsCollection from './modules/Contacts/CollectionList/CompanyContactsCollection'
 import CompanyOrdersCollection from './modules/Omis/CollectionList/CompanyOrdersCollection'
 import AccountManagement from './modules/Companies/AccountManagement'
@@ -274,7 +274,7 @@ function Routes() {
       path: '/companies/:companyId/activity',
       element: (
         <ProtectedRoute module={'datahub:companies'}>
-          <CompanyActivityCollection />
+          <CompanyActivityCollectionNoAs />
         </ProtectedRoute>
       ),
     },

--- a/src/client/tasks.js
+++ b/src/client/tasks.js
@@ -457,6 +457,9 @@ import {
   getExportWin,
 } from '../client/modules/ExportWins/Form/tasks'
 
+import { TASK_GET_COMPANY_ACTIVITIES_NO_AS } from './modules/Companies/CompanyActivity/state.js'
+import { getCompanyInteractions } from './modules/Companies/CompanyActivity/tasks.js'
+
 export const tasks = {
   'Create list': createList,
   'Edit company': editCompany,
@@ -540,6 +543,7 @@ export const tasks = {
   [TASK_GET_INTERACTIONS_COMPANY_NAME]: getCompanyNames,
   [TASK_GET_INTERACTIONS_METADATA]: getInteractionsMetadata,
   [TASK_GET_COMPANY_ACTIVITIES_LIST]: getCompanyActivities,
+  [TASK_GET_COMPANY_ACTIVITIES_NO_AS]: getCompanyInteractions,
   [TASK_GET_COMPANY_ACTIVITIES_METADATA]: getCompanyActivitiesMetadata,
   [TASK_GET_COMPANY_ACTIVITIES_ADVISER_NAME]: getAdviserNames,
   [TASK_GET_COMPANY_ACTIVITIES_COMPANY_NAME]: getCompanyNames,

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -62,7 +62,8 @@ describe('DBT Permission', () => {
         'Orders',
       ])
     })
-    it('when on the activity tab, internal activity should be selected', () => {
+    //TODO - Unskip when the internal activity filter has been restored
+    it.skip('when on the activity tab, internal activity should be selected', () => {
       cy.get('[data-test="tabbedLocalNavList"]').contains('Activity').click()
       assertActivitytab('#field-activityType-1')
     })

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -4,8 +4,13 @@ const { assertCompanyBreadcrumbs } = require('../../support/assertions')
 
 const company = fixtures.company.allActivitiesCompany
 
+/*
+ * Parts of this test are being skipped as we aren't pulling in this data from ActivityStream any more
+ * We will be able to gradually unskip the individual contexts once we have the new integrations in place.
+ */
+
 describe('Company activity feed', () => {
-  context('Companies House Company', () => {
+  context.skip('Companies House Company', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -27,7 +32,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Export Support Service', () => {
+  context.skip('Export Support Service', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -75,7 +80,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Companies House Account', () => {
+  context.skip('Companies House Account', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -91,7 +96,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('HMRC Exporter', () => {
+  context.skip('HMRC Exporter', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -105,7 +110,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Orders (OMIS)', () => {
+  context.skip('Orders (OMIS)', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -153,7 +158,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Investment project', () => {
+  context.skip('Investment project', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -212,7 +217,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Referrals project', () => {
+  context.skip('Referrals project', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -243,7 +248,7 @@ describe('Company activity feed', () => {
     })
   })
 
-  context('Aventri', () => {
+  context.skip('Aventri', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
@@ -302,7 +307,7 @@ describe('Company activity feed', () => {
     )
   })
 
-  context('Email Campaign (Maxemail)', () => {
+  context.skip('Email Campaign (Maxemail)', () => {
     before(() => {
       const companyId = fixtures.company.externalActivitiesLtd.id
       const url = urls.companies.activity.index(companyId)
@@ -319,7 +324,7 @@ describe('Company activity feed', () => {
   })
 })
 
-context('Export Support Service No Title', () => {
+context.skip('Export Support Service No Title', () => {
   before(() => {
     cy.visit(urls.companies.activity.index(fixtures.company.essNoTitle.id))
   })


### PR DESCRIPTION
## Description of change

Following on from #6802, the ActivityStream integration on the company activity tab has been removed. The existing `CollectionList` has been updated to only show company interactions. This is temporary until we get the replacement data integrations in place.

## Test instructions

The company activity tab should show company interactions only. Retained filters should work as normal.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
