### PR TITLE
Set default values when creating/changing to capital only project

### DIFF
--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -146,7 +146,7 @@ InvestmentDetailsStep.propTypes = {
     investmentTypes: PropTypes.arrayOf(optionProp),
     investment_type: PropTypes.string,
     fdiTypes: PropTypes.arrayOf(optionProp),
-    fdi_type: PropTypes.string,
+    fdi_type: PropTypes.object,
   }),
 }
 

--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -6,37 +6,68 @@ const formatEstimatedLandDate = ({ year, month }) =>
 const formatActualLandDate = ({ year, month, day }) =>
   year && month && day ? `${year}-${month}-${day}` : null
 
-export const transformFormValuesToPayload = (values, csrfToken) => ({
-  _csrf: csrfToken,
-  investor_company: values.company.id,
-  investment_type: values.investment_type,
-  fdi_type: values.fdi_type?.value,
-  name: values.name,
-  description: values.description,
-  anonymous_description: values.anonymous_description
-    ? values.anonymous_description
-    : '',
-  sector: values.sector.value,
-  business_activities: values.business_activities.map(({ value }) => value),
-  client_contacts: values.client_contacts.map(({ value }) => value),
-  ...(values?.other_business_activity
-    ? { other_business_activity: values.other_business_activity }
-    : {}),
-  client_relationship_manager:
-    values.clientRelationshipManager === OPTION_NO
-      ? values.client_relationship_manager.value
-      : values.adviser.id,
-  referral_source_adviser:
-    values.referralSourceAdviser === OPTION_NO
-      ? values.referral_source_adviser.value
-      : values.adviser.id,
-  referral_source_activity: values.referral_source_activity,
-  referral_source_activity_event: values.referral_source_activity_event,
-  referral_source_activity_marketing: values.referral_source_activity_marketing,
-  referral_source_activity_website: values.referral_source_activity_website,
-  estimated_land_date: formatEstimatedLandDate(values.estimated_land_date),
-  actual_land_date: formatActualLandDate(values.actual_land_date),
-  investor_type: values.investor_type,
-  level_of_involvement: values.level_of_involvement?.value,
-  specific_programme: values.specific_programme?.value,
-})
+export const transformFormValuesToPayload = (values, csrfToken) => {
+  const {
+    company,
+    investment_type,
+    fdi_type,
+    name,
+    description,
+    anonymous_description,
+    sector,
+    business_activities,
+    client_contacts,
+    other_business_activity,
+    client_relationship_manager,
+    referral_source_adviser,
+    referral_source_activity,
+    referral_source_activity_event,
+    referral_source_activity_marketing,
+    referral_source_activity_website,
+    estimated_land_date,
+    actual_land_date,
+    investor_type,
+    level_of_involvement,
+    specific_programme,
+    adviser,
+  } = values
+
+  const payload = {
+    _csrf: csrfToken,
+    investor_company: company.id,
+    investment_type: investment_type,
+    fdi_type: fdi_type?.value,
+    name: name,
+    description: description,
+    anonymous_description: anonymous_description ? anonymous_description : '',
+    sector: sector.value,
+    business_activities: business_activities.map(({ value }) => value),
+    client_contacts: client_contacts.map(({ value }) => value),
+    ...(other_business_activity ? { other_business_activity } : {}),
+    client_relationship_manager:
+      values.clientRelationshipManager === OPTION_NO
+        ? client_relationship_manager.value
+        : adviser.id,
+    referral_source_adviser:
+      values.referralSourceAdviser === OPTION_NO
+        ? referral_source_adviser.value
+        : adviser.id,
+    referral_source_activity: referral_source_activity,
+    referral_source_activity_event: referral_source_activity_event,
+    referral_source_activity_marketing: referral_source_activity_marketing,
+    referral_source_activity_website: referral_source_activity_website,
+    estimated_land_date: formatEstimatedLandDate(estimated_land_date),
+    actual_land_date: formatActualLandDate(actual_land_date),
+    investor_type: investor_type,
+    level_of_involvement: level_of_involvement?.value,
+    specific_programme: specific_programme?.value,
+  }
+
+  if (fdi_type?.label == 'Capital only') {
+    payload.number_new_jobs = 0
+    payload.average_salary = null
+    payload.number_safeguarded_jobs = 0
+  }
+
+  return payload
+}

--- a/src/client/components/Form/elements/FieldTypeahead/index.jsx
+++ b/src/client/components/Form/elements/FieldTypeahead/index.jsx
@@ -41,6 +41,7 @@ const FieldTypeahead = ({
   options,
   autoScroll,
   className,
+  onChange,
   ...props
 }) => {
   const { value, error, touched, onBlur } = useField({
@@ -51,6 +52,12 @@ const FieldTypeahead = ({
   })
 
   const { setFieldValue } = useFormContext()
+  const handleChange = (newValue) => {
+    setFieldValue(name, props.isMulti ? newValue : newValue[0])
+    if (onChange) {
+      onChange(newValue)
+    }
+  }
 
   return (
     <FieldWrapper
@@ -62,9 +69,7 @@ const FieldTypeahead = ({
           name={name}
           aria-label={label || legend}
           onBlur={onBlur}
-          onChange={(newValue) =>
-            setFieldValue(name, props.isMulti ? newValue : newValue[0])
-          }
+          onChange={handleChange}
           error={error}
           value={value}
           initialOptions={options}
@@ -115,6 +120,7 @@ FieldTypeahead.propTypes = {
    * Whether the window should auto scroll into view this component
    */
   autoScroll: PropTypes.bool,
+  onChange: PropTypes.func,
 }
 
 FieldTypeahead.defaultProps = {
@@ -125,6 +131,7 @@ FieldTypeahead.defaultProps = {
   hint: null,
   initialValue: null,
   autoScroll: false,
+  onChange: null,
 }
 
 export default FieldTypeahead

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -57,6 +57,7 @@ const _Form = ({
   analyticsData,
   cancelButtonLabel = 'Cancel',
   cancelRedirectTo,
+  keepValuesOnDeregister,
   initialValuesTaskName,
   initialValuesPayload,
   redirectTo,
@@ -92,7 +93,7 @@ const _Form = ({
   const qsParams = qs.parse(location.search.slice(1))
 
   useEffect(() => {
-    onLoad(initialValues, initialStepIndex)
+    onLoad(initialValues, initialStepIndex, keepValuesOnDeregister)
   }, [])
   useEffect(() => {
     scrollToTopOnStep && window.scrollTo(0, 0)
@@ -316,7 +317,8 @@ const _Form = ({
                                 initialValues &&
                                 onLoad(
                                   transformInitialValues(initialValues),
-                                  initialStepIndex
+                                  initialStepIndex,
+                                  keepValuesOnDeregister
                                 )
                               }
                             />
@@ -393,11 +395,12 @@ const _Form = ({
 
 // TODO: Clean up this mess
 const dispatchToProps = (dispatch) => ({
-  onLoad: (initialValues, initialStepIndex) =>
+  onLoad: (initialValues, initialStepIndex, keepValuesOnDeregister) =>
     dispatch({
       type: 'FORM__LOADED',
       initialValues,
       initialStepIndex,
+      keepValuesOnDeregister,
     }),
   resetResolved: () =>
     dispatch({
@@ -590,6 +593,7 @@ Form.propTypes = {
   flashMessage: PropTypes.func,
   initialValuesTaskName: PropTypes.string,
   initialValues: PropTypes.object,
+  keepValuesOnDeregister: PropTypes.bool,
   transformInitialValues: PropTypes.func,
   transformPayload: PropTypes.func,
   initialStepIndex: PropTypes.number,

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -37,6 +37,7 @@ export default (
           ...state.values,
           ...action.initialValues,
         },
+        keepValuesOnDeregister: action.keepValuesOnDeregister ?? false,
         currentStep: action.initialStepIndex,
       }
     case FORM__FIELDS__RESET:
@@ -82,7 +83,9 @@ export default (
     case FORM__FIELD_DEREGISTER:
       return {
         ...state,
-        values: omit(state.values, action.fieldName),
+        values: state.keepValuesOnDeregister
+          ? state.values
+          : omit(state.values, action.fieldName),
         errors: omit(state.errors, action.fieldName),
         touched: omit(state.touched, action.fieldName),
         fields: omit(state.fields, action.fieldName),

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
@@ -1,73 +1,25 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { H2 } from 'govuk-react'
 import { LEVEL_SIZE } from '@govuk-react/constants'
-import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
 
-import {
-  FieldInput,
-  FieldRadios,
-  FieldWrapper,
-  Form,
-} from '../../../../components'
-import {
-  InvestmentResource,
-  InvestmentTypesResource,
-} from '../../../../components/Resource'
-import {
-  FieldActualLandDate,
-  FieldAnonDescription,
-  FieldBusinessActivity,
-  FieldClientContacts,
-  FieldEstimatedLandDate,
-  FieldFDIType,
-  FieldInvestmentInvestorType,
-  FieldLevelOfInvolvement,
-  FieldLikelihoodOfLanding,
-  FieldProjectDescription,
-  FieldProjectName,
-  FieldProjectSector,
-  FieldReferralSourceAdviser,
-  FieldReferralSourceHierarchy,
-  FieldSpecificProgramme,
-} from '../InvestmentFormFields'
+import { Form } from '../../../../components'
+import { InvestmentResource } from '../../../../components/Resource'
 import urls from '../../../../../lib/urls'
-import {
-  transformObjectForTypeahead,
-  transformArrayForTypeahead,
-  transformRadioOptionToBool,
-} from '../transformers'
 import { transformProjectSummaryForApi } from './transformers'
-import { transformDateStringToDateObject } from '../../../../../apps/transformers'
-import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
-import { GREY_2 } from '../../../../utils/colours'
 import { state2props, TASK_EDIT_INVESTMENT_PROJECT_SUMMARY } from './state'
 import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
-
-const StyledFieldWrapper = styled(FieldWrapper)`
-  border: 1px solid ${GREY_2};
-  border-radius: 5px;
-  padding: 16px 16px;
-`
-
-const checkReferralSourceAdviserIsCurrentAdviser = (
-  currentAdviser,
-  referralSourceAdviser
-) => (currentAdviser === referralSourceAdviser ? OPTION_YES : OPTION_NO)
-
-const checkReferralSourceAdviser = (currentAdviser, referralSourceAdviser) =>
-  referralSourceAdviser == null
-    ? null
-    : checkReferralSourceAdviserIsCurrentAdviser(
-        currentAdviser,
-        referralSourceAdviser
-      )
+import EditProjectSummaryInitialStep from './EditProjectSummaryInitialStep'
+import ConfirmFDITypeChangeStep from './EditProjectSummaryConfirmationStep'
 
 const EditProjectSummary = ({ currentAdviserId, autoScroll }) => {
   const { projectId } = useParams()
+  const [selectedFDIType, setSelectedFDIType] = useState(null)
+  const cancelButtonLabel = 'Back'
+  const cancelRedirectTo = urls.investments.projects.details(projectId)
   return (
     <ProjectLayoutNew
       projectId={projectId}
@@ -87,130 +39,30 @@ const EditProjectSummary = ({ currentAdviserId, autoScroll }) => {
             <Form
               id="edit-project-summary"
               analyticsFormName="editInvestmentProjectSummary"
-              cancelButtonLabel="Back"
-              cancelRedirectTo={() =>
-                urls.investments.projects.details(project.id)
-              }
               flashMessage={() => 'Investment details updated'}
               submitButtonlabel="Save"
               redirectTo={() => urls.investments.projects.details(project.id)}
               submissionTaskName={TASK_EDIT_INVESTMENT_PROJECT_SUMMARY}
-              transformPayload={(values) =>
-                transformProjectSummaryForApi({
+              keepValuesOnDeregister={true}
+              transformPayload={(values) => {
+                return transformProjectSummaryForApi({
                   projectId,
                   currentAdviserId,
                   values,
                 })
-              }
+              }}
             >
-              <FieldProjectName initialValue={project.name} />
-              <FieldProjectDescription initialValue={project.description} />
-              <FieldAnonDescription
-                initialValue={project.anonymousDescription}
+              <EditProjectSummaryInitialStep
+                project={project}
+                currentAdviserId={currentAdviserId}
+                setSelectedFDIType={setSelectedFDIType}
+                autoScroll={autoScroll}
+                backButton={cancelButtonLabel}
+                cancelUrl={cancelRedirectTo}
               />
-              <InvestmentTypesResource>
-                {(investmentTypes) => (
-                  <FieldRadios
-                    name="investment_type"
-                    label="Investment type"
-                    initialValue={project.investmentType.id}
-                    options={transformArrayForTypeahead(investmentTypes).map(
-                      (option) => ({
-                        ...option,
-                        ...(option.label === 'FDI' && {
-                          children: (
-                            <FieldFDIType
-                              initialValue={transformObjectForTypeahead(
-                                project.fdiType
-                              )}
-                            />
-                          ),
-                        }),
-                      })
-                    )}
-                  />
-                )}
-              </InvestmentTypesResource>
-              <FieldProjectSector
-                initialValue={transformObjectForTypeahead(project.sector)}
-              />
-              <StyledFieldWrapper name="businessActivitiesWrapper">
-                <FieldBusinessActivity
-                  initialValue={transformArrayForTypeahead(
-                    project.businessActivities
-                  )}
-                />
-                <FieldInput
-                  label="Other business activity (if not on list)"
-                  name="other_business_activity"
-                  type="text"
-                  initialValue={project.otherBusinessActivity || ''}
-                  placeholder="e.g. meet and greet dinner"
-                />
-              </StyledFieldWrapper>
-              <FieldClientContacts
-                companyId={project.investorCompany.id}
-                initialValue={transformArrayForTypeahead(
-                  project.clientContacts
-                )}
-              />
-              <FieldReferralSourceAdviser
-                name="is_referral_source"
-                initialValue={checkReferralSourceAdviser(
-                  currentAdviserId,
-                  project.referralSourceAdviser?.id
-                )}
-                label="Referral source adviser"
-                typeaheadInitialValue={
-                  transformRadioOptionToBool(
-                    checkReferralSourceAdviser(
-                      currentAdviserId,
-                      project.referralSourceAdviser?.id
-                    )
-                  )
-                    ? null
-                    : transformObjectForTypeahead(project.referralSourceAdviser)
-                }
-              />
-              <FieldReferralSourceHierarchy
-                initialValue={project.referralSourceActivity?.id}
-                marketingInitialValue={
-                  project.referralSourceActivityMarketing?.id
-                }
-                websiteInitialValue={project.referralSourceActivityWebsite?.id}
-                eventInitialValue={project.referralSourceActivityEvent}
-                eventPlaceholder="e.g. conversation at conference"
-              />
-              <FieldEstimatedLandDate
-                initialValue={transformDateStringToDateObject(
-                  project.estimatedLandDate
-                )}
-              />
-              <FieldLikelihoodOfLanding
-                autoScroll={!!autoScroll}
-                initialValue={transformObjectForTypeahead(
-                  project.likelihoodToLand
-                )}
-              />
-              <FieldActualLandDate
-                initialValue={transformDateStringToDateObject(
-                  project.actualLandDate
-                )}
-              />
-              <FieldInvestmentInvestorType
-                label="New or existing investor"
-                initialValue={project.investorType?.id}
-              />
-              <FieldLevelOfInvolvement
-                initialValue={transformObjectForTypeahead(
-                  project.levelOfInvolvement
-                )}
-              />
-              <FieldSpecificProgramme
-                initialValue={transformObjectForTypeahead(
-                  project.specificProgramme
-                )}
-              />
+              {selectedFDIType?.label === 'Capital only' ? (
+                <ConfirmFDITypeChangeStep project={project} />
+              ) : null}
             </Form>
           </>
         )}

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryConfirmationStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryConfirmationStep.jsx
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import InsetText from '@govuk-react/inset-text'
+import ListItem from '@govuk-react/list-item'
+import Paragraph from '@govuk-react/paragraph'
+import UnorderedList from '@govuk-react/unordered-list'
+import { WarningText } from 'govuk-react'
+
+import { Step } from '../../../../components'
+
+const ConfirmFDITypeChangeStep = ({ project }) => {
+  return (
+    <Step
+      name="confirmation-step"
+      data-test="confirmation-step-warning"
+      backButton="Cancel"
+    >
+      <WarningText mb={4} data-test="warning-title">
+        You are changing the FDI type of this project to 'Capital only'.
+      </WarningText>
+      <Paragraph data-test="warning-description">
+        Changing the FDI type to 'Capital only' will overwrite the values in the
+        following fields. These fields will also be hidden in the edit value
+        section.
+      </Paragraph>
+      <InsetText data-test="warning-fields-to-change">
+        <UnorderedList listStyleType="none" mb={0}>
+          <ListItem data-test="item-number-new-jobs">
+            Number of new jobs (currently:{' '}
+            {project.numberNewJobs
+              ? project.numberNewJobs
+              : project.numberNewJobs === 0
+                ? 0
+                : 'null'}
+            , will become: 0)
+          </ListItem>
+          <ListItem data-test="item-average-salary">
+            Average salary (currently:{' '}
+            {project.averageSalary ? project.averageSalary.name : 'null'}, will
+            become: null)
+          </ListItem>
+          <ListItem data-test="item-number-safeguarded-jobs">
+            Number of safeguarded jobs (currently:{' '}
+            {project.numberSafeguardedJobs
+              ? project.numberSafeguardedJobs
+              : project.numberSafeguardedJobs === 0
+                ? 0
+                : 'null'}
+            , will become: 0)
+          </ListItem>
+        </UnorderedList>
+      </InsetText>
+      <Paragraph data-test="warning-confirmation">
+        Are you sure you want to proceed?
+      </Paragraph>
+    </Step>
+  )
+}
+
+ConfirmFDITypeChangeStep.propTypes = {
+  project: PropTypes.object.isRequired,
+}
+
+export default ConfirmFDITypeChangeStep

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -1,0 +1,175 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+
+import {
+  FieldInput,
+  FieldRadios,
+  FieldWrapper,
+  Step,
+} from '../../../../components'
+import { InvestmentTypesResource } from '../../../../components/Resource'
+import {
+  FieldActualLandDate,
+  FieldAnonDescription,
+  FieldBusinessActivity,
+  FieldClientContacts,
+  FieldEstimatedLandDate,
+  FieldFDIType,
+  FieldInvestmentInvestorType,
+  FieldLevelOfInvolvement,
+  FieldLikelihoodOfLanding,
+  FieldProjectDescription,
+  FieldProjectName,
+  FieldProjectSector,
+  FieldReferralSourceAdviser,
+  FieldReferralSourceHierarchy,
+  FieldSpecificProgramme,
+} from '../InvestmentFormFields'
+import {
+  transformObjectForTypeahead,
+  transformArrayForTypeahead,
+  transformRadioOptionToBool,
+} from '../transformers'
+import { transformDateStringToDateObject } from '../../../../../apps/transformers'
+import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
+import { GREY_2 } from '../../../../utils/colours'
+
+const StyledFieldWrapper = styled(FieldWrapper)`
+  border: 1px solid ${GREY_2};
+  border-radius: 5px;
+  padding: 16px 16px;
+`
+
+const checkReferralSourceAdviserIsCurrentAdviser = (
+  currentAdviser,
+  referralSourceAdviser
+) => (currentAdviser === referralSourceAdviser ? OPTION_YES : OPTION_NO)
+
+const checkReferralSourceAdviser = (currentAdviser, referralSourceAdviser) =>
+  referralSourceAdviser == null
+    ? null
+    : checkReferralSourceAdviserIsCurrentAdviser(
+        currentAdviser,
+        referralSourceAdviser
+      )
+
+const EditProjectSummaryInitialStep = ({
+  project,
+  currentAdviserId,
+  setSelectedFDIType,
+  autoScroll,
+  backButton,
+  cancelUrl,
+}) => {
+  return (
+    <Step name="initial-step" backButton={backButton} cancelUrl={cancelUrl}>
+      <FieldProjectName initialValue={project.name} />
+      <FieldProjectDescription initialValue={project.description} />
+      <FieldAnonDescription initialValue={project.anonymousDescription} />
+      <InvestmentTypesResource>
+        {(investmentTypes) => (
+          <FieldRadios
+            name="investment_type"
+            label="Investment type"
+            initialValue={project.investmentType.id}
+            options={transformArrayForTypeahead(investmentTypes).map(
+              (option) => ({
+                ...option,
+                ...(option.label === 'FDI' && {
+                  children: (
+                    <FieldFDIType
+                      initialValue={transformObjectForTypeahead(
+                        project.fdiType
+                      )}
+                      onChange={(newValue) => {
+                        // TODO: investigate why newValue is an array
+                        setSelectedFDIType(newValue[0])
+                      }}
+                    />
+                  ),
+                }),
+              })
+            )}
+          />
+        )}
+      </InvestmentTypesResource>
+      <FieldProjectSector
+        initialValue={transformObjectForTypeahead(project.sector)}
+      />
+      <StyledFieldWrapper name="businessActivitiesWrapper">
+        <FieldBusinessActivity
+          initialValue={transformArrayForTypeahead(project.businessActivities)}
+        />
+        <FieldInput
+          label="Other business activity (if not on list)"
+          name="other_business_activity"
+          type="text"
+          initialValue={project.otherBusinessActivity || ''}
+          placeholder="e.g. meet and greet dinner"
+        />
+      </StyledFieldWrapper>
+      <FieldClientContacts
+        companyId={project.investorCompany.id}
+        initialValue={transformArrayForTypeahead(project.clientContacts)}
+      />
+      <FieldReferralSourceAdviser
+        name="is_referral_source"
+        initialValue={checkReferralSourceAdviser(
+          currentAdviserId,
+          project.referralSourceAdviser?.id
+        )}
+        label="Referral source adviser"
+        typeaheadInitialValue={
+          transformRadioOptionToBool(
+            checkReferralSourceAdviser(
+              currentAdviserId,
+              project.referralSourceAdviser?.id
+            )
+          )
+            ? null
+            : transformObjectForTypeahead(project.referralSourceAdviser)
+        }
+      />
+      <FieldReferralSourceHierarchy
+        initialValue={project.referralSourceActivity?.id}
+        marketingInitialValue={project.referralSourceActivityMarketing?.id}
+        websiteInitialValue={project.referralSourceActivityWebsite?.id}
+        eventInitialValue={project.referralSourceActivityEvent}
+        eventPlaceholder="e.g. conversation at conference"
+      />
+      <FieldEstimatedLandDate
+        initialValue={transformDateStringToDateObject(
+          project.estimatedLandDate
+        )}
+      />
+      <FieldLikelihoodOfLanding
+        autoScroll={!!autoScroll}
+        initialValue={transformObjectForTypeahead(project.likelihoodToLand)}
+      />
+      <FieldActualLandDate
+        initialValue={transformDateStringToDateObject(project.actualLandDate)}
+      />
+      <FieldInvestmentInvestorType
+        label="New or existing investor"
+        initialValue={project.investorType?.id}
+      />
+      <FieldLevelOfInvolvement
+        initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}
+      />
+      <FieldSpecificProgramme
+        initialValue={transformObjectForTypeahead(project.specificProgramme)}
+      />
+    </Step>
+  )
+}
+
+EditProjectSummaryInitialStep.propTypes = {
+  project: PropTypes.object.isRequired,
+  currentAdviserId: PropTypes.string.isRequired,
+  setSelectedFDIType: PropTypes.func.isRequired,
+  backButton: PropTypes.string.isRequired,
+  cancelUrl: PropTypes.string.isRequired,
+}
+
+export default EditProjectSummaryInitialStep

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -69,6 +69,7 @@ const EditProjectValue = () => {
                 transformProjectValueForApi({
                   projectId,
                   values,
+                  fdiTypeName: project.fdiType?.name,
                 })
               }
             >
@@ -135,49 +136,53 @@ const EditProjectValue = () => {
                   }),
                 }))}
               />
-              <FieldInput
-                label="Number of new jobs"
-                name="number_new_jobs"
-                type="number"
-                initialValue={project.numberNewJobs?.toString()}
-              />
-              {project.investmentType.name === 'FDI' &&
-                project.gvaMultiplier.sectorClassificationGvaMultiplier ===
-                  'labour' && (
-                  <FieldUneditable
-                    label="Gross value added (GVA)"
-                    name="gross_value_added_labour"
-                  >
-                    <>
-                      {project.grossValueAdded
-                        ? currencyGBP(project.grossValueAdded)
-                        : setGVAMessage(project)}
-                    </>
-                  </FieldUneditable>
-                )}
-              <ResourceOptionsField
-                name="average_salary"
-                label="Average salary of new jobs"
-                resource={SalaryRangeResource}
-                field={FieldRadios}
-                initialValue={project.averageSalary?.id}
-                resultToOptions={(result) =>
-                  idNamesToValueLabels(
-                    result.filter((option) =>
-                      option.disabledOn
-                        ? new Date(option.disabledOn) >
-                          new Date(project.createdOn)
-                        : true
-                    )
-                  )
-                }
-              />
-              <FieldInput
-                label="Number of safeguarded jobs"
-                name="number_safeguarded_jobs"
-                type="number"
-                initialValue={project.numberSafeguardedJobs?.toString()}
-              />
+              {project.fdiType?.name === 'Capital only' ? null : (
+                <>
+                  <FieldInput
+                    label="Number of new jobs"
+                    name="number_new_jobs"
+                    type="number"
+                    initialValue={project.numberNewJobs?.toString()}
+                  />
+                  {project.investmentType.name === 'FDI' &&
+                    project.gvaMultiplier.sectorClassificationGvaMultiplier ===
+                      'labour' && (
+                      <FieldUneditable
+                        label="Gross value added (GVA)"
+                        name="gross_value_added_labour"
+                      >
+                        <>
+                          {project.grossValueAdded
+                            ? currencyGBP(project.grossValueAdded)
+                            : setGVAMessage(project)}
+                        </>
+                      </FieldUneditable>
+                    )}
+                  <ResourceOptionsField
+                    name="average_salary"
+                    label="Average salary of new jobs"
+                    resource={SalaryRangeResource}
+                    field={FieldRadios}
+                    initialValue={project.averageSalary?.id}
+                    resultToOptions={(result) =>
+                      idNamesToValueLabels(
+                        result.filter((option) =>
+                          option.disabledOn
+                            ? new Date(option.disabledOn) >
+                              new Date(project.createdOn)
+                            : true
+                        )
+                      )
+                    }
+                  />
+                  <FieldInput
+                    label="Number of safeguarded jobs"
+                    name="number_safeguarded_jobs"
+                    type="number"
+                    initialValue={project.numberSafeguardedJobs?.toString()}
+                  />
+                </>
+              )}
               {showFDIValueField(project) &&
                 project.investmentType.name === 'FDI' && (
                   <ResourceOptionsField

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -8,6 +8,8 @@ import { transformDateObjectToDateString } from '../../../../transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { transformArray } from '../../../Companies/CompanyInvestments/LargeCapitalProfile/transformers'
 
+const capitalOnlyLabel = 'Capital only'
+
 const setConditionalArrayValue = (radioValue, array) =>
   transformRadioOptionToBool(radioValue) ? array.map((x) => x.value) : []
 
@@ -149,7 +151,7 @@ export const transformProjectSummaryForApi = ({
     referral_source_activity_website,
   } = values
 
-  return {
+  const summaryPayload = {
     id: projectId,
     name,
     description,
@@ -176,6 +178,14 @@ export const transformProjectSummaryForApi = ({
     referral_source_activity_event: setReferralSourceEvent(values),
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
   }
+
+  if (fdi_type?.label == capitalOnlyLabel) {
+    summaryPayload.number_new_jobs = 0
+    summaryPayload.average_salary = null
+    summaryPayload.number_safeguarded_jobs = 0
+  }
+
+  return summaryPayload
 }
 
 export const setGVAMessage = ({

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -10,6 +10,9 @@ import { transformArray } from '../../../Companies/CompanyInvestments/LargeCapit
 
 const capitalOnlyLabel = 'Capital only'
 
+const checkIfItemHasValueOrZero = (value) =>
+  value === 0 ? 0 : checkIfItemHasValue(value)
+
 const setConditionalArrayValue = (radioValue, array) =>
   transformRadioOptionToBool(radioValue) ? array.map((x) => x.value) : []
 
@@ -211,7 +214,11 @@ export const setGVAMessage = ({
   }
 }
 
-export const transformProjectValueForApi = ({ projectId, values }) => {
+export const transformProjectValueForApi = ({
+  projectId,
+  values,
+  fdiTypeName,
+}) => {
   const {
     average_salary,
     client_cannot_provide_foreign_investment,
@@ -229,7 +236,7 @@ export const transformProjectValueForApi = ({ projectId, values }) => {
     total_investment,
   } = values
 
-  return {
+  const valuePayload = {
     id: projectId,
     average_salary: checkIfItemHasValue(average_salary),
     client_cannot_provide_foreign_investment:
@@ -256,14 +263,22 @@ export const transformProjectValueForApi = ({ projectId, values }) => {
     non_fdi_r_and_d_budget: transformRadioOptionToBoolWithNullCheck(
       non_fdi_r_and_d_budget
     ),
-    number_new_jobs: checkIfItemHasValue(number_new_jobs),
-    number_safeguarded_jobs: checkIfItemHasValue(number_safeguarded_jobs),
+    number_new_jobs: checkIfItemHasValueOrZero(number_new_jobs),
+    number_safeguarded_jobs: checkIfItemHasValueOrZero(number_safeguarded_jobs),
     r_and_d_budget: transformRadioOptionToBoolWithNullCheck(r_and_d_budget),
     total_investment: setConditionalStringValue(
       client_cannot_provide_total_investment,
       total_investment
     ),
   }
+
+  if (fdiTypeName == capitalOnlyLabel) {
+    valuePayload.number_new_jobs = 0
+    valuePayload.average_salary = null
+    valuePayload.number_safeguarded_jobs = 0
+  }
+
+  return valuePayload
 }
 
 export const transformBusinessActivity = (

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -58,7 +58,7 @@ const StyledFieldInput = styled(FieldInput)({
   width: '100%',
 })
 
-export const FieldFDIType = ({ initialValue = null }) => (
+export const FieldFDIType = ({ initialValue = null, onChange = null }) => (
   <ResourceOptionsField
     name="fdi_type"
     label="Type of foreign direct investment (FDI)"
@@ -67,6 +67,7 @@ export const FieldFDIType = ({ initialValue = null }) => (
     initialValue={initialValue}
     placeholder="Select an FDI type"
     required="Select the FDI type"
+    onChange={onChange}
   />
 )
 

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -107,7 +107,7 @@ describe('Investment Project', () => {
       'apiRequest'
     )
     cy.wait('@apiRequest')
-    cy.get('[data-test="submit-button"]').click()
+    cy.get('[data-test="submit"]').click()
     assertFlashMessage('Investment details updated')
 
     cy.visit(urls.investments.editHistory.index(investmentProjectObj.pk))


### PR DESCRIPTION
## Description of change

Capital only FDI investment projects should have `0` new and safeguarded jobs, as well as `null` average salary. This PR adds functionality to ensure this rule is adhered to when creating new, or editing existing, projects.

## Test instructions

- When creating a new capital only FDI project, the job fields are populated with the specified default values;
- When changing an existing FDI project (of other FDI type) to capital only, a confirmation step should appear on the form, and the job fields are overwritten with the specified default values;
- When editing the value of a capital only project, the job fields are hidden from the form.

## Screenshots

<img width="987" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/9f81381c-27ca-47f6-b76b-176f756364f0">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
