### PR TITLE
Add rule for capital only projects

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -29,6 +29,7 @@ import { currencyGBP } from '../../../../utils/number-utils'
 import { idNamesToValueLabels } from '../../../../utils'
 import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
+import { capitalExpenditureValidator } from './validators'
 
 // For projects landing after 01/04/2020, the FDI value field is not needed
 const showFDIValueField = (project) =>
@@ -115,6 +116,11 @@ const EditProjectValue = () => {
                           initialValue={project.foreignEquityInvestment}
                           type="text"
                           required="Enter the capital expenditure"
+                          validate={(value) => {
+                            return project.fdiType?.name === 'Capital only'
+                              ? capitalExpenditureValidator(value)
+                              : null
+                          }}
                         />
                         {project.investmentType.name === 'FDI' &&
                           project.gvaMultiplier

--- a/src/client/modules/Investments/Projects/Details/validators.js
+++ b/src/client/modules/Investments/Projects/Details/validators.js
@@ -1,0 +1,8 @@
+export const capitalExpenditureValidator = (value) => {
+  const minCapitalExpenditure = 15000000
+  if (parseInt(value) < minCapitalExpenditure) {
+    return 'Capital expenditure must be >= £15,000,000 for capital only project'
+  } else {
+    return null
+  }
+}

--- a/src/client/modules/Investments/Projects/Details/validators.js
+++ b/src/client/modules/Investments/Projects/Details/validators.js
@@ -2,7 +2,6 @@ export const capitalExpenditureValidator = (value) => {
   const minCapitalExpenditure = 15000000
   if (parseInt(value) < minCapitalExpenditure) {
     return 'Capital expenditure must be >= £15,000,000 for capital only project'
-  } else {
-    return null
   }
+  return null
 }

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -525,14 +525,17 @@ describe('Edit the value details of a project', () => {
       ).as('editValueSubmissionRequest')
       cy.visit(investments.projects.editValue(capitalOnlyFDIProject.id))
       cy.wait('@getProjectValue')
+      cy.get('[data-test="total-investment-input"]')
+        .clear()
+        .type(`${capitalOnlyFDIProject.total_investment}`)
+      cy.get('[data-test="foreign-equity-investment-input"]')
+        .clear()
+        .type(`${capitalOnlyFDIProject.foreign_equity_investment}`)
     })
 
     it('should raise an error when entered capital expenditure value is < £15m', () => {
       const capitalExpenditureErrorMessage =
         'Capital expenditure must be >= £15,000,000 for capital only project'
-      cy.get('[data-test="total-investment-input"]')
-        .clear()
-        .type(`${capitalOnlyFDIProject.total_investment}`)
       cy.get('[data-test="foreign-equity-investment-input"]')
         .clear()
         .type('15000')
@@ -545,12 +548,6 @@ describe('Edit the value details of a project', () => {
     })
 
     it('should not raise en error when entered capital expenditure value is >= £15m', () => {
-      cy.get('[data-test="total-investment-input"]')
-        .clear()
-        .type(`${capitalOnlyFDIProject.total_investment}`)
-      cy.get('[data-test="foreign-equity-investment-input"]')
-        .clear()
-        .type(`${capitalOnlyFDIProject.foreign_equity_investment}`)
       clickButton('Save')
       cy.wait('@editValueSubmissionRequest')
         .its('request.body')
@@ -617,13 +614,16 @@ describe('Edit the value details of a project', () => {
       ).as('editValueSubmissionRequest')
       cy.visit(investments.projects.editValue(nonCapitalOnlyFDIProject.id))
       cy.wait('@getProjectValue')
+      cy.get('[data-test="total-investment-input"]')
+        .clear()
+        .type(`${nonCapitalOnlyFDIProject.total_investment}`)
+      cy.get('[data-test="foreign-equity-investment-input"]')
+        .clear()
+        .type(`${nonCapitalOnlyFDIProject.foreign_equity_investment}`)
     })
 
     it('should not raise an error when capital expenditure is < £15m', () => {
       const newCapitalExpenditureValue = '2000000'
-      cy.get('[data-test="total-investment-input"]')
-        .clear()
-        .type(`${nonCapitalOnlyFDIProject.total_investment}`)
       cy.get('[data-test="foreign-equity-investment-input"]')
         .clear()
         .type(newCapitalExpenditureValue)


### PR DESCRIPTION
## Description of change

Capital only FDI investment projects must have a capital expenditure greater than, or equal to, £15,000,000.

## Test instructions

The above rule should be applicable to capital only projects when editing a project's value. An error should be raised upon submission if this condition is not met. Non capital only projects should _not_ raise this error.

## Screenshots

<img width="745" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/5296f1dd-7d14-426b-a7fc-49bf54f4dfec">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
