### PR TITLE
Only fetch a list of company contacts that are active (i.e. not archived)

### DIFF
--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -34,6 +34,7 @@ const CustomerDetailsStep = ({ companyId, isEditing }) => (
       resource={CompanyContacts}
       field={FieldTypeaheadMarginBottom}
       autoScroll={true}
+      payload={{ archived: false }}
       resultToOptions={({ results }) =>
         results.map(({ id, name, email }) => ({
           value: id,

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -52,15 +52,19 @@ const createBreakdown = ({ type, values }) =>
 describe('Adding an export win', () => {
   beforeEach(() => {
     cy.intercept('GET', `/api-proxy/v4/company/${company.id}`, company)
-    cy.intercept('GET', `/api-proxy/v4/contact?company_id=${company.id}`, {
-      results: [
-        contactFaker({
-          name: 'Joseph Barker',
-          email: 'joseph.barker@test.com',
-          id: '000',
-        }),
-      ],
-    })
+    cy.intercept(
+      'GET',
+      `/api-proxy/v4/contact?company_id=${company.id}&archived=false`,
+      {
+        results: [
+          contactFaker({
+            name: 'Joseph Barker',
+            email: 'joseph.barker@test.com',
+            id: '000',
+          }),
+        ],
+      }
+    )
     cy.intercept('/api-proxy/adviser/?*', {
       results: [
         { id: '100', name: 'David Meyer' },


### PR DESCRIPTION
## Description of change
When adding an Export Win to Data Hub we were incorrectly showing a list of company contacts that includes archived contacts. This PR simply applies a query param `archived: false` to the API call to ensure we only fetch active contacts for any given company.

## Test instructions

**To archive a contact**
1. Go to: `/companies/<company-uuid>/contacts?archived%5B0%5D=false&sortby=modified_on%3Adesc&page=1`
2. Select a contact and click **Archive**
3. Now go to: `/companies/<company-uuid>/exportwins/create?step=customer_details` and from the company contacts dropdown there should be a list of active company contacts (you shouldn't see the contact you've just archived)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
