### PR TITLE
Remove Sentry request handler and error handler

### DIFF
--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -23,13 +23,7 @@ module.exports = {
 
   setup: function (app) {
     if (useSentry) {
-      app.use(Sentry.setupExpressErrorHandler(app))
-    }
-  },
-
-  handleErrors: function (app) {
-    if (useSentry) {
-      app.use(Sentry.setupExpressErrorHandler(app))
+      Sentry.setupExpressErrorHandler(app)
     }
   },
 

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -21,18 +21,6 @@ module.exports = {
     fatal: 'fatal',
   },
 
-  setup: function (app) {
-    if (useSentry) {
-      app.use(Sentry.Handlers.requestHandler())
-    }
-  },
-
-  handleErrors: function (app) {
-    if (useSentry) {
-      app.use(Sentry.Handlers.errorHandler())
-    }
-  },
-
   message: function (level, msg, extra) {
     if (useSentry) {
       Sentry.captureMessage(msg, {

--- a/src/lib/reporter.js
+++ b/src/lib/reporter.js
@@ -21,6 +21,18 @@ module.exports = {
     fatal: 'fatal',
   },
 
+  setup: function (app) {
+    if (useSentry) {
+      app.use(Sentry.setupExpressErrorHandler(app))
+    }
+  },
+
+  handleErrors: function (app) {
+    if (useSentry) {
+      app.use(Sentry.setupExpressErrorHandler(app))
+    }
+  },
+
   message: function (level, msg, extra) {
     if (useSentry) {
       Sentry.captureMessage(msg, {

--- a/src/server.js
+++ b/src/server.js
@@ -151,9 +151,6 @@ app.use(reactGlobalProps())
 app.use(fixSlashes())
 app.use(routers)
 
-// Sentry error handler must come before other error middleware
-reporter.handleErrors(app)
-
 app.use(errors.notFound)
 app.use(errors.badRequest)
 app.use(errors.catchAll)

--- a/src/server.js
+++ b/src/server.js
@@ -60,9 +60,6 @@ Joi.assert(process.env, envSchema, {
 
 app.disable('x-powered-by')
 
-// Sentry request handler must be the first middleware
-reporter.setup(app)
-
 if (!config.ci) {
   app.use(httpLogger)
 }
@@ -150,6 +147,8 @@ app.use(reactGlobalProps())
 // routing
 app.use(fixSlashes())
 app.use(routers)
+
+reporter.setup(app)
 
 app.use(errors.notFound)
 app.use(errors.badRequest)


### PR DESCRIPTION
## Description of change

This PR removes the Sentry request handler and error handler which are causing an error following an update to Sentry as `Sentry.Handlers` is no longer supported

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
