### PR TITLE
Conditionally read sector classification attribute when multiplier is null

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -124,7 +124,7 @@ const EditProjectValue = () => {
                         />
                         {project.investmentType.name === 'FDI' &&
                           project.gvaMultiplier
-                            .sectorClassificationGvaMultiplier ===
+                            ?.sectorClassificationGvaMultiplier ===
                             'capital' && (
                             <FieldUneditable
                               label="Gross value added (GVA)"
@@ -151,7 +151,7 @@ const EditProjectValue = () => {
                     initialValue={project.numberNewJobs?.toString()}
                   />
                   {project.investmentType.name === 'FDI' &&
-                    project.gvaMultiplier.sectorClassificationGvaMultiplier ===
+                    project.gvaMultiplier?.sectorClassificationGvaMultiplier ===
                       'labour' && (
                       <FieldUneditable
                         label="Gross value added (GVA)"

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -198,7 +198,7 @@ export const setGVAMessage = ({
   gvaMultiplier,
 }) => {
   const { stringValue, valueExists } =
-    gvaMultiplier.sectorClassificationGvaMultiplier === 'capital'
+    gvaMultiplier?.sectorClassificationGvaMultiplier === 'capital'
       ? {
           stringValue: 'capital expenditure value',
           valueExists: !!foreignEquityInvestment,


### PR DESCRIPTION
## Description of change

If `project.gvaMultiplier` is null (which would only happen if a sector is disabled, and thus, wouldn't have a current multiplier) an error is raised when loading the project edit-value form. This PR adds a conditional check before reading the `sectorClassificationGvaMultiplier` attribute to gracefully handle the edge cases where this error raises.

There is probably some further work required to check if only `active` sectors are shown in the drop down when assigning a project sector.

## Test instructions

All tests should pass as normal. In the subsequent investigation work, additional test should be added to check if only `active` sectors are being shown.

## Screenshots

This error was raised after having assigned the `Waste to Energy` sector (97e61afa-5f95-e211-a939-e4115bead28a) to an investment project in the staging environment. This sector has been disabled since Nov 2023.

<img width="1482" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/788547be-d623-4a31-a6d8-81441afc7e0f">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
