### PR TITLE
Add missing referral source activities to sandbox metadata

### DIFF
--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -325,7 +325,7 @@ describe('Investment Detail Step Form Content', () => {
         element,
         label: 'Referral source activity',
         placeholder: 'Choose a referral source activity',
-        optionsCount: 46,
+        optionsCount: 53,
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -147,7 +147,7 @@ describe('Editing the project summary', () => {
         label: 'Referral source activity',
         placeholder: 'Choose a referral source activity',
         value: 'None',
-        optionsCount: 46,
+        optionsCount: 53,
       })
     })
     cy.get('[data-test="field-referral_source_activity_event"]').should(

--- a/test/sandbox/fixtures/v4/metadata/referral-source-activity.json
+++ b/test/sandbox/fixtures/v4/metadata/referral-source-activity.json
@@ -1,242 +1,287 @@
 [
-    {
-        "id": "6fbb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Aftercare",
-        "disabled_on": null
-    },
-    {
-        "id": "69bb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Agency Visit",
-        "disabled_on": null
-    },
-    {
-        "id": "250782c0-5f95-e211-a939-e4115bead28a",
-        "name": "Bank",
-        "disabled_on": null
-    },
-    {
-        "id": "63582a51-5e73-e611-af73-e4115bead28a",
-        "name": "Barclays Bank",
-        "disabled_on": null
-    },
-    {
-        "id": "a8c966ff-59ae-e211-a646-e4115bead28a",
-        "name": "BIS Manufacturing Advice Service (MAS)",
-        "disabled_on": "2014-12-17T09:37:19Z"
-    },
-    {
-        "id": "8625f971-2c85-e411-a839-e4115bead28a",
-        "name": "Business Growth Service",
-        "disabled_on": null
-    },
-    {
-        "id": "240782c0-5f95-e211-a939-e4115bead28a",
-        "name": "Chamber of Commerce",
-        "disabled_on": null
-    },
-    {
-        "id": "0c4f8e74-d34f-4aca-b764-a44cdc2d0087",
-        "name": "Cold call",
-        "disabled_on": null
-    },
-    {
-        "id": "71bb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Devolved Administration (DA)",
-        "disabled_on": null
-    },
-    {
-        "id": "7d98f3a6-3e3f-40ac-a6f3-3f0c251ec1d2",
-        "name": "Direct enquiry",
-        "disabled_on": null
-    },
-    {
-        "id": "3816a95b-6a76-4ad0-8ae9-b0d7e7d2b79c",
-        "name": "Event",
-        "disabled_on": null
-    },
-    {
-        "id": "73bb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Exhibition",
-        "disabled_on": null
-    },
-    {
-        "id": "ff7bcab4-ffef-e411-bcbe-e4115bead28a",
-        "name": "EY EIM",
-        "disabled_on": null
-    },
-    {
-        "id": "280782c0-5f95-e211-a939-e4115bead28a",
-        "name": "FDI Hub",
-        "disabled_on": null
-    },
-    {
-        "id": "86cbf18d-ffef-e411-bcbe-e4115bead28a",
-        "name": "FT FDI Markets",
-        "disabled_on": null
-    },
-    {
-        "id": "f0c5e43a-5748-e311-a56a-e4115bead28a",
-        "name": "Growth Accelerator",
-        "disabled_on": "2014-12-16T14:03:32Z"
-    },
-    {
-        "id": "2b0782c0-5f95-e211-a939-e4115bead28a",
-        "name": "HQ",
-        "disabled_on": null
-    },
-    {
-        "id": "405b92a5-828a-e311-a3d5-e4115bead28a",
-        "name": "In Market FDI Contractor (Central Europe)",
-        "disabled_on": null
-    },
-    {
-        "id": "30968389-828a-e311-a3d5-e4115bead28a",
-        "name": "In Market FDI Contractor (Gulf)",
-        "disabled_on": null
-    },
-    {
-        "id": "808e3698-828a-e311-a3d5-e4115bead28a",
-        "name": "In Market FDI Contractor (Latin America)",
-        "disabled_on": null
-    },
-    {
-        "id": "645a5d75-828a-e311-a3d5-e4115bead28a",
-        "name": "In Market FDI Contractor (Russia)",
-        "disabled_on": null
-    },
-    {
-        "id": "500ae611-9c12-e611-9bdc-e4115bead28a",
-        "name": "IST Business Development",
-        "disabled_on": null
-    },
-    {
-        "id": "e0d48e78-b7d6-e311-8a2b-e4115bead28a",
-        "name": "LEP",
-        "disabled_on": null
-    },
-    {
-        "id": "e97c9641-5748-e311-a56a-e4115bead28a",
-        "name": "Manufacturing Advisory Service (MAS)",
-        "disabled_on": "2014-12-16T14:03:32Z"
-    },
-    {
-        "id": "0acf0e68-e09e-4e5d-92b6-e72e5a5c7ea4",
-        "name": "Marketing",
-        "disabled_on": null
-    },
-    {
-        "id": "51e609e0-61df-e411-bbc1-e4115bead28a",
-        "name": "Merger Market + ONS + Press Report",
-        "disabled_on": null
-    },
-    {
-        "id": "6e2c3b23-62df-e411-bbc1-e4115bead28a",
-        "name": "Merger Market + ONS+ Press Report + LEP",
-        "disabled_on": null
-    },
-    {
-        "id": "17e6d330-62df-e411-bbc1-e4115bead28a",
-        "name": "Merger Market + ONS+ Press Report + Post",
-        "disabled_on": null
-    },
-    {
-        "id": "14b7ac76-62df-e411-bbc1-e4115bead28a",
-        "name": "Merger Market + Press Report + LEP",
-        "disabled_on": null
-    },
-    {
-        "id": "8425fe1b-63df-e411-bbc1-e4115bead28a",
-        "name": "Merger Market + Press Report + Post",
-        "disabled_on": null
-    },
-    {
-        "id": "e95cddb3-9407-4c8a-b5a6-2616117b0aae",
-        "name": "Multiplier",
-        "disabled_on": null
-    },
-    {
-        "id": "30f1723b-9c12-e611-9bdc-e4115bead28a",
-        "name": "Multiplier via IST Business Development",
-        "disabled_on": null
-    },
-    {
-        "id": "aba8f653-264f-48d8-950e-07f9c418c7b0",
-        "name": "None",
-        "disabled_on": null
-    },
-    {
-        "id": "318e6e9e-2a0e-4e4b-a495-c48aeee4b996",
-        "name": "Other",
-        "disabled_on": null
-    },
-    {
-        "id": "c03c4043-18b4-4463-a36b-a1af1b35f95d",
-        "name": "Personal reference",
-        "disabled_on": null
-    },
-    {
-        "id": "6cbb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Post",
-        "disabled_on": null
-    },
-    {
-        "id": "414bd940-63df-e411-bbc1-e4115bead28a",
-        "name": "Press Report + LEP",
-        "disabled_on": null
-    },
-    {
-        "id": "39794782-63df-e411-bbc1-e4115bead28a",
-        "name": "Press Report + Post",
-        "disabled_on": null
-    },
-    {
-        "id": "668e999c-a669-4d9b-bfbf-6275ceed86da",
-        "name": "Relationship management activity",
-        "disabled_on": null
-    },
-    {
-        "id": "6ebb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "Science and Tech",
-        "disabled_on": null
-    },
-    {
-        "id": "290782c0-5f95-e211-a939-e4115bead28a",
-        "name": "SG Sector Champions",
-        "disabled_on": null
-    },
-    {
-        "id": "3020d154-5748-e311-a56a-e4115bead28a",
-        "name": "Technology Strategy Board",
-        "disabled_on": null
-    },
-    {
-        "id": "260782c0-5f95-e211-a939-e4115bead28a",
-        "name": "Trade Association",
-        "disabled_on": null
-    },
-    {
-        "id": "2d0782c0-5f95-e211-a939-e4115bead28a",
-        "name": "Trade Journal",
-        "disabled_on": null
-    },
-    {
-        "id": "50509a5e-5748-e311-a56a-e4115bead28a",
-        "name": "UK Export Finance (UKEF)",
-        "disabled_on": null
-    },
-    {
-        "id": "ceb61fa0-acaa-e311-a3d5-e4115bead28a",
-        "name": "UK Region",
-        "disabled_on": null
-    },
-    {
-        "id": "72bb9fc6-5f95-e211-a939-e4115bead28a",
-        "name": "UKTI Enquiry Unit",
-        "disabled_on": null
-    },
-    {
-        "id": "812b2f62-fe62-4cc8-b69c-58f3e2ebac17",
-        "name": "Website",
-        "disabled_on": null
-    }
+  {
+    "id": "6fbb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Aftercare",
+    "disabled_on": null
+  },
+  {
+    "id": "69bb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Agency Visit",
+    "disabled_on": null
+  },
+  {
+    "id": "a8c966ff-59ae-e211-a646-e4115bead28a",
+    "name": "BIS Manufacturing Advice Service (MAS)",
+    "disabled_on": "2014-12-17T09:37:19Z"
+  },
+  {
+    "id": "250782c0-5f95-e211-a939-e4115bead28a",
+    "name": "Bank",
+    "disabled_on": null
+  },
+  {
+    "id": "63582a51-5e73-e611-af73-e4115bead28a",
+    "name": "Barclays Bank",
+    "disabled_on": null
+  },
+  {
+    "id": "8625f971-2c85-e411-a839-e4115bead28a",
+    "name": "Business Growth Service",
+    "disabled_on": null
+  },
+  {
+    "id": "240782c0-5f95-e211-a939-e4115bead28a",
+    "name": "Chamber of Commerce",
+    "disabled_on": null
+  },
+  {
+    "id": "0c4f8e74-d34f-4aca-b764-a44cdc2d0087",
+    "name": "Cold call",
+    "disabled_on": null
+  },
+  {
+    "id": "9f6f34c5-a94b-446e-9702-50be3ea3eeca",
+    "name": "Commonwealth Games 2022 - BATP Programme",
+    "disabled_on": null
+  },
+  {
+    "id": "120c051b-e801-45d7-96c9-1dc9b447f387",
+    "name": "Commonwealth Games 2022 - GEP Programme",
+    "disabled_on": null
+  },
+  {
+    "id": "71bb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Devolved Administration (DA)",
+    "disabled_on": null
+  },
+  {
+    "id": "7d98f3a6-3e3f-40ac-a6f3-3f0c251ec1d2",
+    "name": "Direct enquiry",
+    "disabled_on": null
+  },
+  {
+    "id": "ff7bcab4-ffef-e411-bcbe-e4115bead28a",
+    "name": "EY EIM",
+    "disabled_on": null
+  },
+  {
+    "id": "3816a95b-6a76-4ad0-8ae9-b0d7e7d2b79c",
+    "name": "Event",
+    "disabled_on": null
+  },
+  {
+    "id": "73bb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Exhibition",
+    "disabled_on": null
+  },
+  {
+    "id": "bf61318c-f468-4d58-b6be-24b059c78a74",
+    "name": "Expand Your Business (EYB)",
+    "disabled_on": null
+  },
+  {
+    "id": "280782c0-5f95-e211-a939-e4115bead28a",
+    "name": "FDI Hub",
+    "disabled_on": null
+  },
+  {
+    "id": "86cbf18d-ffef-e411-bcbe-e4115bead28a",
+    "name": "FT FDI Markets",
+    "disabled_on": null
+  },
+  {
+    "id": "3331d692-2581-4fea-bd56-59f62c93b32a",
+    "name": "GREAT - Unicorn Kingdom Campaign - North America (2023)",
+    "disabled_on": null
+  },
+  {
+    "id": "f0c5e43a-5748-e311-a56a-e4115bead28a",
+    "name": "Growth Accelerator",
+    "disabled_on": "2014-12-16T14:03:32Z"
+  },
+  {
+    "id": "2b0782c0-5f95-e211-a939-e4115bead28a",
+    "name": "HQ",
+    "disabled_on": null
+  },
+  {
+    "id": "500ae611-9c12-e611-9bdc-e4115bead28a",
+    "name": "IST Business Development",
+    "disabled_on": null
+  },
+  {
+    "id": "405b92a5-828a-e311-a3d5-e4115bead28a",
+    "name": "In Market FDI Contractor (Central Europe)",
+    "disabled_on": null
+  },
+  {
+    "id": "30968389-828a-e311-a3d5-e4115bead28a",
+    "name": "In Market FDI Contractor (Gulf)",
+    "disabled_on": null
+  },
+  {
+    "id": "808e3698-828a-e311-a3d5-e4115bead28a",
+    "name": "In Market FDI Contractor (Latin America)",
+    "disabled_on": null
+  },
+  {
+    "id": "645a5d75-828a-e311-a3d5-e4115bead28a",
+    "name": "In Market FDI Contractor (Russia)",
+    "disabled_on": null
+  },
+  {
+    "id": "70bb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Intl Tech Promoter",
+    "disabled_on": null
+  },
+  {
+    "id": "e0d48e78-b7d6-e311-8a2b-e4115bead28a",
+    "name": "LEP",
+    "disabled_on": null
+  },
+  {
+    "id": "e97c9641-5748-e311-a56a-e4115bead28a",
+    "name": "Manufacturing Advisory Service (MAS)",
+    "disabled_on": "2014-12-16T14:03:32Z"
+  },
+  {
+    "id": "0acf0e68-e09e-4e5d-92b6-e72e5a5c7ea4",
+    "name": "Marketing",
+    "disabled_on": null
+  },
+  {
+    "id": "51e609e0-61df-e411-bbc1-e4115bead28a",
+    "name": "Merger Market + ONS + Press Report",
+    "disabled_on": null
+  },
+  {
+    "id": "6e2c3b23-62df-e411-bbc1-e4115bead28a",
+    "name": "Merger Market + ONS+ Press Report + LEP",
+    "disabled_on": null
+  },
+  {
+    "id": "17e6d330-62df-e411-bbc1-e4115bead28a",
+    "name": "Merger Market + ONS+ Press Report + Post",
+    "disabled_on": null
+  },
+  {
+    "id": "14b7ac76-62df-e411-bbc1-e4115bead28a",
+    "name": "Merger Market + Press Report + LEP",
+    "disabled_on": null
+  },
+  {
+    "id": "8425fe1b-63df-e411-bbc1-e4115bead28a",
+    "name": "Merger Market + Press Report + Post",
+    "disabled_on": null
+  },
+  {
+    "id": "e95cddb3-9407-4c8a-b5a6-2616117b0aae",
+    "name": "Multiplier",
+    "disabled_on": null
+  },
+  {
+    "id": "30f1723b-9c12-e611-9bdc-e4115bead28a",
+    "name": "Multiplier via IST Business Development",
+    "disabled_on": null
+  },
+  {
+    "id": "aba8f653-264f-48d8-950e-07f9c418c7b0",
+    "name": "None",
+    "disabled_on": null
+  },
+  {
+    "id": "ab499ca7-894c-4f6c-ac2f-e85d4deb7572",
+    "name": "Northern Ireland Investment Summit 2023",
+    "disabled_on": null
+  },
+  {
+    "id": "318e6e9e-2a0e-4e4b-a495-c48aeee4b996",
+    "name": "Other",
+    "disabled_on": null
+  },
+  {
+    "id": "c03c4043-18b4-4463-a36b-a1af1b35f95d",
+    "name": "Personal reference",
+    "disabled_on": null
+  },
+  {
+    "id": "6cbb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Post",
+    "disabled_on": null
+  },
+  {
+    "id": "414bd940-63df-e411-bbc1-e4115bead28a",
+    "name": "Press Report + LEP",
+    "disabled_on": null
+  },
+  {
+    "id": "39794782-63df-e411-bbc1-e4115bead28a",
+    "name": "Press Report + Post",
+    "disabled_on": null
+  },
+  {
+    "id": "6dbb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "RDA",
+    "disabled_on": "2017-11-24T00:00:00Z"
+  },
+  {
+    "id": "668e999c-a669-4d9b-bfbf-6275ceed86da",
+    "name": "Relationship management activity",
+    "disabled_on": null
+  },
+  {
+    "id": "300782c0-5f95-e211-a939-e4115bead28a",
+    "name": "SBS Website",
+    "disabled_on": "2017-11-24T00:00:00Z"
+  },
+  {
+    "id": "290782c0-5f95-e211-a939-e4115bead28a",
+    "name": "SG Sector Champions",
+    "disabled_on": null
+  },
+  {
+    "id": "6ebb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "Science and Tech",
+    "disabled_on": null
+  },
+  {
+    "id": "3020d154-5748-e311-a56a-e4115bead28a",
+    "name": "Technology Strategy Board",
+    "disabled_on": null
+  },
+  {
+    "id": "260782c0-5f95-e211-a939-e4115bead28a",
+    "name": "Trade Association",
+    "disabled_on": null
+  },
+  {
+    "id": "2d0782c0-5f95-e211-a939-e4115bead28a",
+    "name": "Trade Journal",
+    "disabled_on": null
+  },
+  {
+    "id": "50509a5e-5748-e311-a56a-e4115bead28a",
+    "name": "UK Export Finance (UKEF)",
+    "disabled_on": null
+  },
+  {
+    "id": "ceb61fa0-acaa-e311-a3d5-e4115bead28a",
+    "name": "UK Region",
+    "disabled_on": null
+  },
+  {
+    "id": "72bb9fc6-5f95-e211-a939-e4115bead28a",
+    "name": "UKTI Enquiry Unit",
+    "disabled_on": null
+  },
+  {
+    "id": "812b2f62-fe62-4cc8-b69c-58f3e2ebac17",
+    "name": "Website",
+    "disabled_on": null
+  },
+  {
+    "id": "a3c75ab8-99a2-11ee-b9d1-0242ac120002",
+    "name": "Women's International Network (WIN Programme)",
+    "disabled_on": null
+  }
 ]


### PR DESCRIPTION
## Description of change

This PR adds missing referral source activities to the sandbox metadata. This brings it up to date with the real API. 

This was prompted by the addition of EYB to the referral source activities in [API PR 5459](https://github.com/uktrade/data-hub-api/pull/5459).

## Test instructions

All tests should pass. You should also see the additional options in the `referral_source_activity` dropdown fields.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
