### PR TITLE
Add S3 bucket and sentry to the CSP to prevent them being blocked

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -111,3 +111,7 @@ OAUTH2_AUTH_URL=http://anyurl/o/authorize
 # OAUTH2_REDIRECT_URL=http://localhost:3000/oauth/callback
 # OAUTH2_TOKEN_FETCH_URL=get-from-vault
 # OAUTH2_USER_PROFILE_URL=get-from-vault
+
+# Investment S3 Bucket for evidence uploads
+INVESTMENT_DOCUMENT_BUCKET=https://lookInVault.com/
+INVESTMENT_DOCUMENT_AWS_REGION=lookInVault

--- a/src/config/envSchema.js
+++ b/src/config/envSchema.js
@@ -192,6 +192,11 @@ const envSchema = Joi.object({
   ELASTIC_APM_SECRET_TOKEN: Joi.string().required(),
   // Elastic APM server timeout used to timeout if no response is found after 20 secs
   ELASTIC_APM_SERVER_TIMEOUT: Joi.number().integer().default(20),
+
+  // The S3 bucket for investment evidence documents
+  INVESTMENT_DOCUMENT_BUCKET: Joi.string().required(),
+  // The S3 region for investment evidence documents
+  INVESTMENT_DOCUMENT_AWS_REGION: Joi.string().required(),
 })
 /* eslint-enable prettier/prettier */
 

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -138,6 +138,12 @@ const config = {
     },
   },
   greatProfileUrl: envVars.GREAT_PROFILE_URL,
+  s3Buckets: {
+    investmentDocuments: {
+      bucket: envVars.INVESTMENT_DOCUMENT_BUCKET,
+      region: envVars.INVESTMENT_DOCUMENT_AWS_REGION,
+    },
+  },
 }
 
 module.exports = config

--- a/src/middleware/__test__/headers.test.js
+++ b/src/middleware/__test__/headers.test.js
@@ -1,4 +1,5 @@
 const headers = require('../headers')
+const config = require('../../config')
 
 const NONCE = 'DUMMY-NONCE'
 
@@ -7,6 +8,8 @@ describe('headers middleware', () => {
     const reqMock = { url: '/' }
     const resMock = { set: sinon.spy() }
     const nextMock = sinon.spy()
+
+    const INVESTMENT_DOCUMENT_BUCKET = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
 
     headers(reqMock, resMock, nextMock, () => NONCE)
 
@@ -18,7 +21,7 @@ describe('headers middleware', () => {
             `frame-ancestors 'none'`,
             `script-src 'self' 'nonce-${NONCE}' https://*.googletagmanager.com`,
             `img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com`,
-            `connect-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://*.analytics.google.com`,
+            `connect-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET} https://raven.ci.uktrade.io`,
           ].join(';'),
           'Cache-Control': 'no-cache, no-store',
           Pragma: 'no-cache',

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -1,9 +1,12 @@
 const { v4: uuid } = require('uuid')
 const _ = require('lodash')
 
+const config = require('../config')
+
 const STS_MAX_AGE = 180 * 24 * 60 * 60
 const GOOGLE_TAG_MNGR = 'https://*.googletagmanager.com'
 const GOOGLE_ANALYTICS = 'https://*.google-analytics.com'
+const INVESTMENT_DOCUMENT_BUCKET = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
 
 module.exports = function headers(
   req,
@@ -24,7 +27,7 @@ module.exports = function headers(
       // Taken from https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics
       `script-src ${selfAndNonce} ${GOOGLE_TAG_MNGR}`,
       `img-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR}`,
-      `connect-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR} https://*.analytics.google.com`,
+      `connect-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR} https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET} https://raven.ci.uktrade.io`,
     ].join(';'),
     // This is equivalent to `frame-ancestors 'none'` in the above CSP policy,
     // but keeping it here for older browsers


### PR DESCRIPTION
## Description of change

The CSP (Content Security Policy) is currently blocking evidence document uploads for investment projects. This adds the S3 bucket into the policy to allow it. Sentry is also being blocked and has been added.

## Test instructions

This is currently on UAT and can be tested there. Go to an investment project and then upload evidence and see you can now upload evidence.

## Screenshots

### Before
<img width="1512" alt="Screenshot 2024-06-04 at 17 15 30" src="https://github.com/uktrade/data-hub-frontend/assets/22541658/c75ae182-56e4-4b6a-8d44-1130507ebaf6">

### After

Now uploads document.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
