### PR TITLE
Require uk recipient company before project can move to verify win stage

### DIFF
--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -103,6 +103,7 @@ export const INCOMPLETE_FIELDS = {
   foreign_equity_investment: 'Foreign equity investment',
   associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
   fdi_type: 'FDI type',
+  uk_company: 'UK recipient company',
 }
 
 export const STAGE_TAG_COLOURS = {

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -99,6 +99,7 @@ export const mapFieldToUrl = (field, projectId) => {
     'Project Assurance Adviser',
     'Project Manager',
   ]
+  const recipientCompanyFields = ['UK recipient company']
 
   if (detailsFields.includes(field)) {
     return urls.investments.projects.editDetails(projectId)
@@ -114,6 +115,10 @@ export const mapFieldToUrl = (field, projectId) => {
 
   if (projectManagementFields.includes(field)) {
     return urls.investments.projects.editProjectManagement(projectId)
+  }
+
+  if (recipientCompanyFields.includes(field)) {
+    return urls.investments.projects.recipientCompany(projectId)
   }
 
   return urls.investments.projects.findAssociatedProject(projectId)

--- a/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
@@ -20,6 +20,8 @@ const projectManagementLink =
   urls.investments.projects.editProjectManagement(projectId)
 const associatedLink =
   urls.investments.projects.findAssociatedProject(projectId)
+const recipientCompanyLink =
+  urls.investments.projects.recipientCompany(projectId)
 const evidenceLink = urls.investments.projects.evidence.index(projectId)
 
 const prospectIncompleteFields = [
@@ -55,6 +57,7 @@ const activeIncompleteFields = [
   'foreign_equity_investment',
   'average_salary',
   'associated_non_fdi_r_and_d_project',
+  'uk_company',
 ]
 
 const buildAndMountComponent = (
@@ -227,6 +230,7 @@ describe('ProjectIncompleteFields', () => {
         assertLink('Foreign equity investment', valueLink)
         assertLink('Average salary of new jobs', valueLink)
         assertLink('Non-FDI R&D project', associatedLink)
+        assertLink('UK recipient company', recipientCompanyLink)
       })
     }
   )


### PR DESCRIPTION
## Description of change

Investment projects now require the `uk_company` field (which indicates the UK recipient company) to be populated before moving to the verify win stage. This PR adds the frontend part of that functionality.

[Link to API PR](https://github.com/uktrade/data-hub-api/pull/5461)

## Test instructions

When viewing an investment project that is currently in the active stage, it should indicate the "UK recipient company" field is required before it can be moved to the verify win stage.

## Screenshots

<img width="994" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/13ffb5f0-be11-48b9-9650-197873610154">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
