### PR TITLE
Test jobs fields appear as required at verify win stage

### DIFF
--- a/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
@@ -24,7 +24,6 @@ const evidenceLink = urls.investments.projects.evidence.index(projectId)
 
 const prospectIncompleteFields = [
   'client_cannot_provide_total_investment',
-  'number_new_jobs',
   'strategic_drivers',
   'client_requirements',
   'client_considering_other_countries',
@@ -41,6 +40,7 @@ const assignPmIncompleteFields = [
 const activeIncompleteFields = [
   'client_cannot_provide_foreign_investment',
   'government_assistance',
+  'number_new_jobs',
   'number_safeguarded_jobs',
   'r_and_d_budget',
   'non_fdi_r_and_d_budget',
@@ -143,7 +143,6 @@ describe('ProjectIncompleteFields', () => {
           'Possible UK locations for this investment',
           requirementsLink
         )
-        assertLink('Number of new jobs', valueLink)
         assertLink(
           'Is the client considering other countries?',
           requirementsLink
@@ -201,6 +200,7 @@ describe('ProjectIncompleteFields', () => {
           'Is this project receiving government financial assistance?',
           valueLink
         )
+        assertLink('Number of new jobs', valueLink)
         assertLink('Number of safeguarded jobs', valueLink)
         assertLink(
           'Does this project have budget for a research and development?',


### PR DESCRIPTION
## Description of change

Investment projects now require the `number_new_jobs`, `average_salary`, and `number_safeguarded_jobs` fields to be populated before moving to the _verify win_ stage. This PR adds this functionality.

The `average_salary` and `number_safeguarded_jobs` fields were already required at this stage. The `number_new_jobs` field was required at the _assign PM_ stage and so this rule was amended.

Please note, the `average_salary` field is only required once `number_new_jobs` is populated.

[Link to API PR](https://github.com/uktrade/data-hub-api/pull/5463)

## Screenshots

<img width="990" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/82469d17-2494-45c3-9c7c-c8d931af1f97">

Then, once `number_new_jobs` has been populated, `average_salary` should be required:

<img width="1009" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/e07b939e-4616-48a6-9f4b-5383ae01a543">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
