### PR TITLE
Make level of investor involvement field mandatory when project is in active stage

### DIFF
--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -106,6 +106,7 @@ export const INCOMPLETE_FIELDS = {
   uk_company: 'UK recipient company',
   investor_type: 'Investor type',
   specific_programme: 'Specific investment programme',
+  level_of_involvement: 'Level of investor involvement',
 }
 
 export const STAGE_TAG_COLOURS = {

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -73,6 +73,7 @@ export const mapFieldToUrl = (field, projectId) => {
     'FDI type',
     'Specific investment programme',
     'Investor type',
+    'Level of investor involvement',
   ]
   const valueFields = [
     'Can client provide total investment value?',

--- a/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
@@ -60,6 +60,7 @@ const activeIncompleteFields = [
   'uk_company',
   'investor_type',
   'specific_programme',
+  'level_of_involvement',
 ]
 
 const buildAndMountComponent = (
@@ -235,6 +236,7 @@ describe('ProjectIncompleteFields', () => {
         assertLink('UK recipient company', recipientCompanyLink)
         assertLink('Investor type', detailsLink)
         assertLink('Specific investment programme', detailsLink)
+        assertLink('Level of investor involvement', detailsLink)
       })
     }
   )


### PR DESCRIPTION
## Description of change

The changes in this PR makes the 'Level of investor involvement' field mandatory when moving an investment project from the 'Active' stage to the 'Verify Win' stage. 

## Test instructions

When viewing the details page of an investment project that is in the 'Active' stage and 'Level of investor involvement' has not been entered in the 'Edit Summary' page. In order to move to the Verify win stage, the 'Level of investor involvement' field has to be completed from the blue box above the 'Investment project summary' section. 

## Screenshots

### Before

<img width="1087" alt="Screenshot 2024-06-05 at 15 11 38" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/545a709f-ad7f-4af7-9d0c-fd049dbe1a4a">

### After

<img width="1073" alt="Screenshot 2024-06-05 at 15 09 58" src="https://github.com/uktrade/data-hub-frontend/assets/103272709/93c0cfae-d02a-4606-813b-ffbed4119cec">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
