### PR TITLE
Add default id to ResourceOptionsField to stop console warnings

### DIFF
--- a/src/client/components/Form/elements/ResourceOptionsField/index.jsx
+++ b/src/client/components/Form/elements/ResourceOptionsField/index.jsx
@@ -41,7 +41,7 @@ import Resource from '../../../Resource/Resource'
  *  />
  */
 const ResourceOptionsField = ({
-  id,
+  id = '__RESOURCE_OPTIONS__',
   field: Field,
   resource: Rsrc = Resource,
   payload,


### PR DESCRIPTION
## Description of change

When viewing the edit project summary page in localhost, the following console warning is logged:

```console
Resource.jsx:157 Warning: Failed prop type: The prop `id` is marked as required in `Connect(Component)`, but its value is `undefined`.
```

This PR adds a default ID value to the ResourceOptionsField to stop the warning.

## Test instructions

The warning should no longer appear when editing a project's summary in localhost. All tests should pass as normal and no functional changes should be observed.

## Screenshots

### Before

<img width="1490" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/8de74609-6f76-4b01-85cf-fb8bf23f8733">

### After

<img width="1490" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/d3035728-aa0b-4dc8-aec8-2554361b3c64">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
