### PR TITLE
Alter confirmation text

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryConfirmationStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryConfirmationStep.jsx
@@ -32,12 +32,12 @@ const ConfirmFDITypeChangeStep = ({ project }) => {
               : project.numberNewJobs === 0
                 ? 0
                 : 'null'}
-            , will become: 0)
+            , will change to: 0)
           </ListItem>
           <ListItem data-test="item-average-salary">
             Average salary (currently:{' '}
             {project.averageSalary ? project.averageSalary.name : 'null'}, will
-            become: null)
+            change to: null)
           </ListItem>
           <ListItem data-test="item-number-safeguarded-jobs">
             Number of safeguarded jobs (currently:{' '}
@@ -46,7 +46,7 @@ const ConfirmFDITypeChangeStep = ({ project }) => {
               : project.numberSafeguardedJobs === 0
                 ? 0
                 : 'null'}
-            , will become: 0)
+            , will change to: 0)
           </ListItem>
         </UnorderedList>
       </InsetText>

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -323,17 +323,17 @@ describe('Editing the project summary', () => {
               cy.get('[data-test="item-number-new-jobs"]')
                 .should('exist')
                 .contains(
-                  `currently: ${project.number_new_jobs}, will become: 0`
+                  `currently: ${project.number_new_jobs}, will change to: 0`
                 )
               cy.get('[data-test="item-average-salary"]')
                 .should('exist')
                 .contains(
-                  `currently: ${project.average_salary}, will become: null`
+                  `currently: ${project.average_salary}, will change to: null`
                 )
               cy.get('[data-test="item-number-safeguarded-jobs"]')
                 .should('exist')
                 .contains(
-                  `currently: ${project.number_safeguarded_jobs}, will become: 0`
+                  `currently: ${project.number_safeguarded_jobs}, will change to: 0`
                 )
             })
           cy.contains('Are you sure you want to proceed?')


### PR DESCRIPTION
## Description of change

This PR adjusts the confirmation text when changing a project FDI type to capital only. It now reads "will change to" instead of "will become".

## Test instructions

Go to any investment project, click `Edit Details`, change the FDI type to `Capital Only`, click `Continue`, and the new text on the page.

## Screenshots

<img width="692" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/2cee7e9c-d92b-4d70-803d-63511b0ab3e6">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
