### PR TITLE
Add sorting capabilities to Resource/Paginated

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsConfirmedTable.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedTable.jsx
@@ -7,7 +7,7 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { sumExportValues } from './utils'
-import { WIN_STATUS } from './constants'
+import { SORT_OPTIONS, WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 const NoWrapCell = styled(Table.Cell)`
@@ -70,6 +70,7 @@ export default () => (
     shouldPluralize={false}
     noResults="You don't have any confirmed export wins."
     payload={{ confirmed: WIN_STATUS.CONFIRMED }}
+    sortOptions={SORT_OPTIONS}
   >
     {(page) => <WinsConfirmedTable exportWins={page} />}
   </ExportWinsResource.Paginated>

--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -6,7 +6,7 @@ import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { sumExportValues } from './utils'
-import { WIN_STATUS } from './constants'
+import { SORT_OPTIONS, WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 export const WinsPendingList = ({ exportWins = [] }) => {
@@ -23,16 +23,22 @@ export const WinsPendingList = ({ exportWins = [] }) => {
             subheading={item.company.name}
             subheadingUrl={urls.companies.overview.index(item.company.id)}
             metadata={[
-              {
-                label: 'Contact name:',
-                value: (
-                  <Link
-                    href={urls.contacts.details(item.company_contacts[0].id)}
-                  >
-                    {item.company_contacts[0].name}
-                  </Link>
-                ),
-              },
+              ...(item.company_contacts[0]
+                ? [
+                    {
+                      label: 'Contact name:',
+                      value: (
+                        <Link
+                          href={urls.contacts.details(
+                            item.company_contacts[0].id
+                          )}
+                        >
+                          {item.company_contacts[0].name}
+                        </Link>
+                      ),
+                    },
+                  ]
+                : []),
               {
                 label: 'Total value:',
                 value: currencyGBP(sumExportValues(item)),
@@ -66,7 +72,10 @@ export default () => (
     noResults="You don't have any pending export wins."
     // We have to send null as a string otherwise
     // it's stripped out of the payload by Axois
-    payload={{ confirmed: String(WIN_STATUS.PENDING) }}
+    payload={{
+      confirmed: String(WIN_STATUS.PENDING),
+    }}
+    sortOptions={SORT_OPTIONS}
   >
     {(page) => <WinsPendingList exportWins={page} />}
   </ExportWinsResource.Paginated>

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -6,7 +6,7 @@ import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { sumExportValues } from './utils'
-import { WIN_STATUS } from './constants'
+import { SORT_OPTIONS, WIN_STATUS } from './constants'
 import urls from '../../../../lib/urls'
 
 export const WinsRejectedList = ({ exportWins }) => {
@@ -57,6 +57,7 @@ export default () => (
     shouldPluralize={false}
     noResults="You don't have any rejected export wins."
     payload={{ confirmed: WIN_STATUS.REJECTED }}
+    sortOptions={SORT_OPTIONS}
   >
     {(page) => <WinsRejectedList exportWins={page} />}
   </ExportWinsResource.Paginated>

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -9,3 +9,10 @@ export const WIN_STATUS_MAP_TO_LABEL = {
   [WIN_STATUS.CONFIRMED]: 'Confirmed',
   [WIN_STATUS.REJECTED]: 'Rejected',
 }
+
+export const SORT_OPTIONS = [
+  { name: 'Newest', value: '-created_on' },
+  { name: 'Oldest', value: 'created_on' },
+  { name: 'Company name A-Z', value: 'company__name' },
+  { name: 'Company name Z-A', value: '-company__name' },
+]

--- a/test/component/cypress/specs/Resource/Paginated.cy.jsx
+++ b/test/component/cypress/specs/Resource/Paginated.cy.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import _ from 'lodash'
 import React from 'react'
 
@@ -147,5 +148,61 @@ describe('Resource/Paginated', () => {
       'have.text',
       "You don't have any sent export wins."
     )
+  })
+
+  it('Should forward selected sortby option to the task payload', () => {
+    const SORT_OPTIONS = [
+      {name: 'Foo', value: 'foo'},
+      {name: 'Bar', value: 'bar'},
+      {name: 'Baz', value: 'baz'},
+    ]
+
+    const stub = cy.stub().returns({
+      count: 1,
+      results: ['blah'],
+    })
+
+    cy.mountWithProvider(
+      <PaginatedResource
+        name="foo"
+        id="whatever"
+        pageSize={PAGE_SIZE}
+        noResults="You don't have any sent export wins."
+        sortOptions={SORT_OPTIONS}
+      >
+        {(page) => <pre>{JSON.stringify(page)}</pre>}
+      </PaginatedResource>,
+      {
+        tasks: {
+          foo: stub,
+        },
+      }
+    )
+      .then(() => {
+        expect(stub).to.have.been.calledOnceWith({
+          limit: 10,
+          offset: 0,
+          sortby: 'foo',
+        }, 'whatever')
+      })
+
+    cy.get('select option')
+      .then($selection => {
+        expect($selection.toArray().map(({innerText, value}) => ({
+          name: innerText,
+          value,
+        }))).to.deep.eq(SORT_OPTIONS)
+      })
+
+    SORT_OPTIONS.forEach(({name, value}) => {
+      cy.get('select').select(name)
+        .then(() => {
+          expect(stub).to.have.been.calledWith({
+            limit: 10,
+            offset: 0,
+            sortby: value,
+          }, 'whatever')
+        })
+    })
   })
 })


### PR DESCRIPTION
## Description of change

Adds sort options to the Export Wins dashboard. This is achieved by allowing `sortOptions` to be specified on `Resource/Paginated` component.

## Test instructions

1. Go to `/exportwins`
2. You should see a dropdown labeled _Sort by_ with these options:
  * _Newest_ (should be selected by default)
  * _Oldest_
  * _Company name A-Z_
  * _Company name Z-A_
3. Select one of the options
4. The list of export wins should reload
5. The results should be ordered according to the selected option
6. The same should apply for the _Confirmed_ and _Rejected_ tabs of the tab navigation

## Screenshots

### Before

<img width="660" alt="Screenshot 2024-06-07 at 17 14 36" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/21fefb1d-5d5c-4f7b-b379-525d74207acf">


### After

<img width="660" alt="Screenshot 2024-06-07 at 17 13 52" src="https://github.com/uktrade/data-hub-frontend/assets/2333157/e4b5a285-f9c2-4e82-940d-00a415525502">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
