### PR TITLE
Investor type should be `existing` for expansion projects

### DIFF
--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -34,6 +34,7 @@ import {
   OPTIONS_YES_NO,
 } from '../../../../../common/constants'
 import { TASK_REDIRECT_TO_CONTACT_FORM } from '../../../../../client/components/ContactForm/state'
+import { FDI_TYPES } from '../../../../../client/modules/Investments/Projects/constants'
 
 const findSelectedItem = (items, value) =>
   items ? items.find((type) => type.value === value) : null
@@ -43,7 +44,7 @@ const InvestmentDetailsStep = ({ values, company }) => {
     values.investmentTypes,
     values.investment_type
   )
-  const fdiType = findSelectedItem(values.fdiTypes, values.fdi_type)
+  const fdiType = findSelectedItem(values.fdiTypes, values.fdi_type?.value)
   return (
     <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
       <Step name="details">
@@ -127,7 +128,10 @@ const InvestmentDetailsStep = ({ values, company }) => {
         <FieldEstimatedLandDate />
         <FieldLikelihoodOfLanding />
         <FieldActualLandDate />
-        <FieldInvestmentInvestorType label="Is the investor new or existing?" />
+        {values.fdi_type?.label ===
+        FDI_TYPES.expansionOfExistingSiteOrActivity.label ? null : (
+          <FieldInvestmentInvestorType label="Is the investor new or existing?" />
+        )}
         <FieldLevelOfInvolvement />
         <FieldSpecificProgramme />
       </Step>

--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -1,4 +1,8 @@
 import { OPTION_NO } from '../../../../../common/constants'
+import {
+  FDI_TYPES,
+  INVESTOR_TYPES,
+} from '../../../../../client/modules/Investments/Projects/constants'
 
 const formatEstimatedLandDate = ({ year, month }) =>
   year && month ? `${year}-${month}-01` : null
@@ -58,12 +62,15 @@ export const transformFormValuesToPayload = (values, csrfToken) => {
     referral_source_activity_website: referral_source_activity_website,
     estimated_land_date: formatEstimatedLandDate(estimated_land_date),
     actual_land_date: formatActualLandDate(actual_land_date),
-    investor_type: investor_type,
+    investor_type:
+      fdi_type?.label === FDI_TYPES.expansionOfExistingSiteOrActivity.label
+        ? INVESTOR_TYPES.existing.value
+        : investor_type,
     level_of_involvement: level_of_involvement?.value,
     specific_programme: specific_programme?.value,
   }
 
-  if (fdi_type?.label == 'Capital only') {
+  if (fdi_type?.label === FDI_TYPES.capitalOnly.label) {
     payload.number_new_jobs = 0
     payload.average_salary = null
     payload.number_safeguarded_jobs = 0

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
@@ -14,6 +14,7 @@ import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
 import EditProjectSummaryInitialStep from './EditProjectSummaryInitialStep'
 import ConfirmFDITypeChangeStep from './EditProjectSummaryConfirmationStep'
+import { FDI_TYPES } from '../constants'
 
 const EditProjectSummary = ({ currentAdviserId, autoScroll }) => {
   const { projectId } = useParams()
@@ -56,11 +57,12 @@ const EditProjectSummary = ({ currentAdviserId, autoScroll }) => {
                 project={project}
                 currentAdviserId={currentAdviserId}
                 setSelectedFDIType={setSelectedFDIType}
+                selectedFDIType={selectedFDIType}
                 autoScroll={autoScroll}
                 backButton={cancelButtonLabel}
                 cancelUrl={cancelRedirectTo}
               />
-              {selectedFDIType?.label === 'Capital only' ? (
+              {selectedFDIType?.label === FDI_TYPES.capitalOnly.label ? (
                 <ConfirmFDITypeChangeStep project={project} />
               ) : null}
             </Form>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -66,32 +66,23 @@ const EditProjectSummaryInitialStep = ({
   cancelUrl,
 }) => {
   const showInvestorTypeField = () => {
-    if (
+    const isProjectFDITypeExpansion =
       project.fdiType?.name ===
       FDI_TYPES.expansionOfExistingSiteOrActivity.label
-    ) {
-      if (
-        isNull(selectedFDIType) ||
-        selectedFDIType?.label ===
-          FDI_TYPES.expansionOfExistingSiteOrActivity.label
-      ) {
+    const isChangingToFDITypeExpansion =
+      selectedFDIType?.label ===
+      FDI_TYPES.expansionOfExistingSiteOrActivity.label
+    if (isProjectFDITypeExpansion) {
+      if (isNull(selectedFDIType) || isChangingToFDITypeExpansion) {
         // FDI type is remaining expansion
         return false
-      } else if (
-        !(
-          selectedFDIType?.label ===
-          FDI_TYPES.expansionOfExistingSiteOrActivity.label
-        )
-      ) {
+      } else {
         // FDI type is changing from expansion to other
         project.investorType = null
         return true
       }
     }
-    if (
-      selectedFDIType?.label ===
-      FDI_TYPES.expansionOfExistingSiteOrActivity.label
-    ) {
+    if (isChangingToFDITypeExpansion) {
       // FDI type is changing from other to expansion
       return false
     }

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { isNull } from 'lodash'
 
 import {
   FieldInput,
@@ -34,7 +35,7 @@ import {
 import { transformDateStringToDateObject } from '../../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { GREY_2 } from '../../../../utils/colours'
-import { INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM } from '../constants'
+import { FDI_TYPES, INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM } from '../constants'
 
 const StyledFieldWrapper = styled(FieldWrapper)`
   border: 1px solid ${GREY_2};
@@ -59,10 +60,44 @@ const EditProjectSummaryInitialStep = ({
   project,
   currentAdviserId,
   setSelectedFDIType,
+  selectedFDIType,
   autoScroll,
   backButton,
   cancelUrl,
 }) => {
+  const showInvestorTypeField = () => {
+    if (
+      project.fdiType?.name ===
+      FDI_TYPES.expansionOfExistingSiteOrActivity.label
+    ) {
+      if (
+        isNull(selectedFDIType) ||
+        selectedFDIType?.label ===
+          FDI_TYPES.expansionOfExistingSiteOrActivity.label
+      ) {
+        // FDI type is remaining expansion
+        return false
+      } else if (
+        !(
+          selectedFDIType?.label ===
+          FDI_TYPES.expansionOfExistingSiteOrActivity.label
+        )
+      ) {
+        // FDI type is changing from expansion to other
+        project.investorType = null
+        return true
+      }
+    }
+    if (
+      selectedFDIType?.label ===
+      FDI_TYPES.expansionOfExistingSiteOrActivity.label
+    ) {
+      // FDI type is changing from other to expansion
+      return false
+    }
+    // FDI type is not expansion, nor changing to expansion
+    return true
+  }
   return (
     <Step name="initial-step" backButton={backButton} cancelUrl={cancelUrl}>
       <FieldProjectName initialValue={project.name} />
@@ -151,13 +186,15 @@ const EditProjectSummaryInitialStep = ({
       <FieldActualLandDate
         initialValue={transformDateStringToDateObject(project.actualLandDate)}
       />
-      <FieldInvestmentInvestorType
-        label="New or existing investor"
-        initialValue={project.investorType?.id}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
-      />
+      {showInvestorTypeField() ? (
+        <FieldInvestmentInvestorType
+          label="New or existing investor"
+          initialValue={project.investorType?.id}
+          optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
+            project.stage.name
+          )}
+        />
+      ) : null}
       <FieldLevelOfInvolvement
         initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}
       />

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -7,8 +7,7 @@ import {
 import { transformDateObjectToDateString } from '../../../../transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { transformArray } from '../../../Companies/CompanyInvestments/LargeCapitalProfile/transformers'
-
-const capitalOnlyLabel = 'Capital only'
+import { FDI_TYPES, INVESTOR_TYPES } from '../constants'
 
 const checkIfItemHasValueOrZero = (value) =>
   value === 0 ? 0 : checkIfItemHasValue(value)
@@ -165,7 +164,10 @@ export const transformProjectSummaryForApi = ({
     actual_land_date: transformDateObjectToDateString(actual_land_date),
     sector: checkIfItemHasValue(sector?.value),
     likelihood_to_land: checkIfItemHasValue(likelihood_to_land?.value),
-    investor_type: checkIfItemHasValue(investor_type),
+    investor_type:
+      fdi_type?.label === FDI_TYPES.expansionOfExistingSiteOrActivity.label
+        ? INVESTOR_TYPES.existing.value
+        : checkIfItemHasValue(investor_type),
     level_of_involvement: checkIfItemHasValue(level_of_involvement?.value),
     specific_programme: checkIfItemHasValue(specific_programme?.value),
     other_business_activity,
@@ -182,7 +184,7 @@ export const transformProjectSummaryForApi = ({
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
   }
 
-  if (fdi_type?.label == capitalOnlyLabel) {
+  if (fdi_type?.label == FDI_TYPES.capitalOnly.label) {
     summaryPayload.number_new_jobs = 0
     summaryPayload.average_salary = null
     summaryPayload.number_safeguarded_jobs = 0
@@ -272,7 +274,7 @@ export const transformProjectValueForApi = ({
     ),
   }
 
-  if (fdiTypeName == capitalOnlyLabel) {
+  if (fdiTypeName == FDI_TYPES.capitalOnly.label) {
     valuePayload.number_new_jobs = 0
     valuePayload.average_salary = null
     valuePayload.number_safeguarded_jobs = 0

--- a/src/client/modules/Investments/Projects/constants.js
+++ b/src/client/modules/Investments/Projects/constants.js
@@ -102,3 +102,25 @@ export const PROJECT_STATUS_OPTIONS = [
 ]
 
 export const ITEMS_PER_PAGE = 10
+
+export const FDI_TYPES = {
+  capitalOnly: {
+    value: '840f62c1-bbcb-44e4-b6d4-a258d2ffa07d',
+    label: 'Capital only',
+  },
+  expansionOfExistingSiteOrActivity: {
+    value: 'd08a2f07-c366-4133-9a7e-35b6c88a3270',
+    label: 'Expansion of existing site or activity',
+  },
+}
+
+export const INVESTOR_TYPES = {
+  existing: {
+    value: '40e33f91-f565-4b89-8e18-cfefae192245',
+    label: 'Existing Investor',
+  },
+  new: {
+    value: 'e6a01052-8c36-4a32-b5b9-fc2be4b34408',
+    label: 'New Investor',
+  },
+}

--- a/src/client/modules/Investments/Projects/constants.js
+++ b/src/client/modules/Investments/Projects/constants.js
@@ -112,6 +112,10 @@ export const FDI_TYPES = {
     value: 'd08a2f07-c366-4133-9a7e-35b6c88a3270',
     label: 'Expansion of existing site or activity',
   },
+  jointVenture: {
+    value: 'a7dbf6b3-9c04-43a7-9be9-d3072f138fab',
+    label: 'Joint venture',
+  },
 }
 
 export const INVESTOR_TYPES = {


### PR DESCRIPTION
## Description of change

To increase data quality, expansion FDI investment projects should have `investor_type` set as `existing`, rather than `new` or `null`. This PR adds such functionality to ensure that this field is set automatically depending on a project's FDI type, both when creating a new project and editing an existing one. It also hides the field when it has been automatically populated.

## Test instructions

1. Go to the investments page > click _Add investment project_ > select a company > select _FDI_ as the project type > and select _Expansion_ as the FDI type. Click through to the next step and the investor type field should be hidden; if you go back and change to a different FDI type, it should reappear. If you enter all the necessary details, and submit, it should crete a project with investor type set to `existing`.

    <img width="747" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/4127bccd-a075-4ac6-9a68-9855fb39f9b6">

2. Go to any existing project and select _Edit summary_. On the form that appears the following should apply.

    - When changing to an expansion project, it should hide the field from the form. Upon submission, it should overwrite the field with `existing` and not show a confirmation step (unlike when changing to a capital only project).
    - When changing to another type (other than expansion) of project, it should reshow the field, set the field to `null` and let the user re-select a value.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
