### PR TITLE
Add optional text to investor type field at Prospect and Assign PM stage

### DIFF
--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -127,7 +127,7 @@ const InvestmentDetailsStep = ({ values, company }) => {
         <FieldEstimatedLandDate />
         <FieldLikelihoodOfLanding />
         <FieldActualLandDate />
-        <FieldInvestmentInvestorType label="Is the investor new or existing? (optional)" />
+        <FieldInvestmentInvestorType label="Is the investor new or existing?" />
         <FieldLevelOfInvolvement />
         <FieldSpecificProgramme />
       </Step>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -154,6 +154,9 @@ const EditProjectSummaryInitialStep = ({
       <FieldInvestmentInvestorType
         label="New or existing investor"
         initialValue={project.investorType?.id}
+        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
+          project.stage.name
+        )}
       />
       <FieldLevelOfInvolvement
         initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -284,14 +284,18 @@ export const FieldActualLandDate = ({ initialValue = null }) => (
   />
 )
 
-export const FieldInvestmentInvestorType = ({ label, initialValue = null }) => (
+export const FieldInvestmentInvestorType = ({
+  label,
+  initialValue = null,
+  optionalText = true,
+}) => (
   <ResourceOptionsField
     name="investor_type"
-    label={label}
+    label={label + (optionalText ? ' (optional)' : '')}
     resource={InvestmentInvestorTypesResource}
     field={FieldRadios}
     initialValue={initialValue}
-    placeholder="Choose an investor type'"
+    placeholder="Choose an investor type"
   />
 )
 

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -296,11 +296,11 @@ describe('Editing the project summary', () => {
       })
     })
 
-    it('should display the new or existing investor field', () => {
+    it('should display the new or existing investor field with (optional) text', () => {
       cy.get('[data-test="field-investor_type"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'New or existing investor',
+          label: 'New or existing investor (optional)',
           optionsCount: 2,
         })
       })
@@ -348,6 +348,17 @@ describe('Editing the project summary', () => {
         })
       )
     })
+
+    it('should display the investor type field label without the (optional) text', () => {
+      cy.get('[data-test="field-investor_type"]').then((element) => {
+        assertFieldRadios({
+          element,
+          label: 'New or existing investor',
+          optionsCount: 2,
+        })
+      })
+    })
+
     it('should render the specific programme field label without the word optional', () => {
       cy.get('[data-test="field-specific_programme"]').then((element) => {
         assertFieldTypeaheadWithExactText({


### PR DESCRIPTION
## Description of change

The _investor type_ field is now required before a project can move to the _Verify Win_ stage. This PR adds `(optional)` text to the field label at the _Prospect_ and _Assign PM_ stage, and removes it at the _Active_ stage once it becomes mandatory.

## Test instructions

1. Select an investment project in the _Prospect_ or _Assign PM_ stage. Select _Edit Summary_ and towards the bottom of the form, the _investor type_ field should have the label `New or existing investor (optional)`.

    <img width="442" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/9e55055e-fdec-44e2-a607-76b4b185fe18">

2. Select an investment project in the _Active_ or _Verify Win_ stage. Select _Edit Summary_ and towards the bottom of the form, the _investor type_ field should have the label `New or existing investor`.

    <img width="442" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/bfe307de-aa57-42ba-8a77-30bebd073176">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
