### PR TITLE
Add cypress image diff to ignorelist

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,9 @@ updates:
   - dependency-name: "@nivo/tooltip"
     versions:
     - ">= 0"
+  - dependency-name: "cypress-image-diff-js"
+    versions:
+    - ">= 2.2.1"
   # ignore all GitHub linguist patch updates
   - dependency-name: "github-linguist"
     update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
## Description of change

We've been asked to hold off on updating `cypress-image-diff` for now. I've added it to the Dependabot ignore list so it doesn't get upgraded accidentally.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
