### PR TITLE
Add hint text to `Capital only` option in FDI type dropdown

### DIFF
--- a/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
+++ b/src/apps/investments/client/projects/create/InvestmentDetailsStep.jsx
@@ -128,8 +128,8 @@ const InvestmentDetailsStep = ({ values, company }) => {
         <FieldEstimatedLandDate />
         <FieldLikelihoodOfLanding />
         <FieldActualLandDate />
-        {values.fdi_type?.label ===
-        FDI_TYPES.expansionOfExistingSiteOrActivity.label ? null : (
+        {values.fdi_type?.value ===
+        FDI_TYPES.expansionOfExistingSiteOrActivity.value ? null : (
           <FieldInvestmentInvestorType label="Is the investor new or existing?" />
         )}
         <FieldLevelOfInvolvement />

--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -63,14 +63,14 @@ export const transformFormValuesToPayload = (values, csrfToken) => {
     estimated_land_date: formatEstimatedLandDate(estimated_land_date),
     actual_land_date: formatActualLandDate(actual_land_date),
     investor_type:
-      fdi_type?.label === FDI_TYPES.expansionOfExistingSiteOrActivity.label
+      fdi_type?.value === FDI_TYPES.expansionOfExistingSiteOrActivity.value
         ? INVESTOR_TYPES.existing.value
         : investor_type,
     level_of_involvement: level_of_involvement?.value,
     specific_programme: specific_programme?.value,
   }
 
-  if (fdi_type?.label === FDI_TYPES.capitalOnly.label) {
+  if (fdi_type?.value === FDI_TYPES.capitalOnly.value) {
     payload.number_new_jobs = 0
     payload.average_salary = null
     payload.number_safeguarded_jobs = 0

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummary.jsx
@@ -62,7 +62,7 @@ const EditProjectSummary = ({ currentAdviserId, autoScroll }) => {
                 backButton={cancelButtonLabel}
                 cancelUrl={cancelRedirectTo}
               />
-              {selectedFDIType?.label === FDI_TYPES.capitalOnly.label ? (
+              {selectedFDIType?.value === FDI_TYPES.capitalOnly.value ? (
                 <ConfirmFDITypeChangeStep project={project} />
               ) : null}
             </Form>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -67,11 +67,10 @@ const EditProjectSummaryInitialStep = ({
 }) => {
   const showInvestorTypeField = () => {
     const isProjectFDITypeExpansion =
-      project.fdiType?.name ===
-      FDI_TYPES.expansionOfExistingSiteOrActivity.label
+      project.fdiType?.id === FDI_TYPES.expansionOfExistingSiteOrActivity.value
     const isChangingToFDITypeExpansion =
-      selectedFDIType?.label ===
-      FDI_TYPES.expansionOfExistingSiteOrActivity.label
+      selectedFDIType?.value ===
+      FDI_TYPES.expansionOfExistingSiteOrActivity.value
     if (isProjectFDITypeExpansion) {
       if (isNull(selectedFDIType) || isChangingToFDITypeExpansion) {
         // FDI type is remaining expansion

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -73,7 +73,7 @@ const EditProjectValue = () => {
                 transformProjectValueForApi({
                   projectId,
                   values,
-                  fdiTypeName: project.fdiType?.name,
+                  fdiTypeId: project.fdiType?.id,
                 })
               }
             >

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -165,7 +165,7 @@ export const transformProjectSummaryForApi = ({
     sector: checkIfItemHasValue(sector?.value),
     likelihood_to_land: checkIfItemHasValue(likelihood_to_land?.value),
     investor_type:
-      fdi_type?.label === FDI_TYPES.expansionOfExistingSiteOrActivity.label
+      fdi_type?.value === FDI_TYPES.expansionOfExistingSiteOrActivity.value
         ? INVESTOR_TYPES.existing.value
         : checkIfItemHasValue(investor_type),
     level_of_involvement: checkIfItemHasValue(level_of_involvement?.value),
@@ -184,7 +184,7 @@ export const transformProjectSummaryForApi = ({
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
   }
 
-  if (fdi_type?.label == FDI_TYPES.capitalOnly.label) {
+  if (fdi_type?.value == FDI_TYPES.capitalOnly.value) {
     summaryPayload.number_new_jobs = 0
     summaryPayload.average_salary = null
     summaryPayload.number_safeguarded_jobs = 0
@@ -219,7 +219,7 @@ export const setGVAMessage = ({
 export const transformProjectValueForApi = ({
   projectId,
   values,
-  fdiTypeName,
+  fdiTypeId,
 }) => {
   const {
     average_salary,
@@ -274,7 +274,7 @@ export const transformProjectValueForApi = ({
     ),
   }
 
-  if (fdiTypeName == FDI_TYPES.capitalOnly.label) {
+  if (fdiTypeId == FDI_TYPES.capitalOnly.value) {
     valuePayload.number_new_jobs = 0
     valuePayload.average_salary = null
     valuePayload.number_safeguarded_jobs = 0

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -37,6 +37,7 @@ import { GREY_2 } from '../../../utils/colours'
 import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
 import { validateIfDateInPast } from '../../../components/Form/validators'
+import { FDI_TYPES } from './constants'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -58,18 +59,40 @@ const StyledFieldInput = styled(FieldInput)({
   width: '100%',
 })
 
-export const FieldFDIType = ({ initialValue = null, onChange = null }) => (
-  <ResourceOptionsField
-    name="fdi_type"
-    label="Type of foreign direct investment (FDI)"
-    resource={FDITypesResource}
-    field={FieldTypeahead}
-    initialValue={initialValue}
-    placeholder="Select an FDI type"
-    required="Select the FDI type"
-    onChange={onChange}
-  />
-)
+export const FieldFDIType = ({ initialValue = null, onChange = null }) => {
+  /*
+  The result of this modified transformer is:
+  only the field state will contain the additional text
+  i.e. selectedFDIType.label === FDI_TYPES.capitalOnly.labelWithHintText;
+  the project attribute and other data populated directly from the API will remain unchanged
+  i.e. project.fdiType.name === FDI_TYPES.capitalOnly.label.
+  In both cases, its recommended to compare the fdiType id/value attribute instead
+  */
+  const fdiTypeIdNamesToValueLabels = (result) => {
+    return result.map((option) => {
+      return {
+        value: option.id,
+        label:
+          option.id === FDI_TYPES.capitalOnly.value
+            ? FDI_TYPES.capitalOnly.labelWithHintText
+            : option.name,
+      }
+    })
+  }
+  return (
+    <ResourceOptionsField
+      name="fdi_type"
+      label="Type of foreign direct investment (FDI)"
+      resource={FDITypesResource}
+      resultToOptions={fdiTypeIdNamesToValueLabels}
+      field={FieldTypeahead}
+      initialValue={initialValue}
+      placeholder="Select an FDI type"
+      required="Select the FDI type"
+      onChange={onChange}
+    />
+  )
+}
 
 export const FieldProjectName = ({ initialValue = '', placeholder = null }) => (
   <FieldInput

--- a/src/client/modules/Investments/Projects/constants.js
+++ b/src/client/modules/Investments/Projects/constants.js
@@ -107,6 +107,7 @@ export const FDI_TYPES = {
   capitalOnly: {
     value: '840f62c1-bbcb-44e4-b6d4-a258d2ffa07d',
     label: 'Capital only',
+    labelWithHintText: 'Capital only (minimum investment value is £15 million)',
   },
   expansionOfExistingSiteOrActivity: {
     value: 'd08a2f07-c366-4133-9a7e-35b6c88a3270',


### PR DESCRIPTION
## Description of change

To improve data quality, we have enforced a validation rule that states _Capital Only_ FDI investment projects must have an investment value >= £15 million. However, this validation only occurs when editing a project's value (which is done via a separate form that appears after the project has been created). 

So that users are aware of this rule earlier on in the journey, the team want to add the text `(minimum investment value is £15 million)` to the _Capital Only_ option within the FDI type dropdown (field is visible/used when creating and editing an FDI project).

After some deliberation, there seemed to be two approaches:

1. Rename the FDI type instance so the additional text appears across both the API and Frontend
2. Modify the data that is rendered by the Frontend `FieldFDIType` component to include the additional text

It was decided to go with option 2, modifying the Frontend only, so the hint text would not feed into downstream datasets/reporting, despite the introduction of slight inconsistency.

In this PR, a custom transformer is added to the `FieldFDIType`, which adds the hint text to the `Capital only` option. The result of this modified transformer is only the field state will contain the additional text; the project attribute, and elsewhere the data is populated from the API will remain unchanged. The PR also refactors code where FDIType objects are used to ensure that id/value attributes are being compared instead of name/label.

## Test instructions

The hint text should only be visible in the FDI type dropdown when creating a new project, or editing an existing project's details.

## Screenshots

When creating a new project:

<img width="905" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/d3fbfef2-d941-41bf-a144-adba6ea5186c">

>The help text should not show when moving to the second step of the create a project form:
><img width="676" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/20b48bba-0c0b-47d5-b108-810c18a8b5a4">

When editing a project's details:

<img width="728" alt="image" src="https://github.com/uktrade/data-hub-frontend/assets/47334342/bf65c6f4-afe8-4c10-8ad8-9c2caa819c5e">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
