### PR TITLE
Fixes the broken Data Hub header story

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,7 +1,8 @@
 const {
   resolve
 } = require('../webpack.config')();
-module.exports = {
+
+export default {
   addons: [
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',

--- a/src/client/components/DataHubHeader/__stories__/DataHubHeader.stories.jsx
+++ b/src/client/components/DataHubHeader/__stories__/DataHubHeader.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 
 import DataHubHeader from '../index'
 
@@ -19,25 +19,23 @@ const Support = () => <h5>Support</h5>
 export const DataHubHeaderStory = () => {
   const [showVerticalNav, setShowVerticalNav] = useState(false)
   return (
-    <Router>
+    <>
       <DataHubHeader
         showVerticalNav={showVerticalNav}
         onShowVerticalNav={setShowVerticalNav}
       />
-      <Switch>
-        <Route exact={true} path="/" component={Dashboard} />
-        <Route path="/companies" component={Companies} />
-        <Route path="/contacts" component={Contacts} />
-        <Route path="/events" component={Events} />
-        <Route path="/interactions" component={Interactions} />
-        <Route path="/investments" component={Investments} />
-        <Route path="/omis" component={Orders} />
-        <Route path="/support" component={Support} />
-      </Switch>
-    </Router>
+      <Routes>
+        <Route path="/" element={<Dashboard />} />
+        <Route path="/companies" element={<Companies />} />
+        <Route path="/contacts" element={<Contacts />} />
+        <Route path="/events" element={<Events />} />
+        <Route path="/interactions" element={<Interactions />} />
+        <Route path="/investments" element={<Investments />} />
+        <Route path="/omis" element={<Orders />} />
+        <Route path="/support" element={<Support />} />
+      </Routes>
+    </>
   )
 }
 
-DataHubHeaderStory.story = {
-  name: 'DataHubHeader',
-}
+DataHubHeaderStory.storyName = 'DataHubHeader'


### PR DESCRIPTION
## Description of change
Fixes the broken Data Hub header Story after the [React Router upgrade](https://github.com/uktrade/data-hub-frontend/pull/6577) and the [Storybook upgrade](https://github.com/uktrade/data-hub-frontend/pull/6775).

## Test instructions

`npm run storybook` and click on DataHubHeader (left menu)

## Screenshots

### Before
<img width="1471" alt="before" src="https://github.com/uktrade/data-hub-frontend/assets/964268/f0b03874-b93c-44a5-800b-6fe61ab7b134">

### After
<img width="1470" alt="after" src="https://github.com/uktrade/data-hub-frontend/assets/964268/d578bb24-105d-4b88-abe2-6269d64ffeaf">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
