### PR TITLE
Add proposition evidence bucket to CSP headers

### DIFF
--- a/src/middleware/__test__/headers.test.js
+++ b/src/middleware/__test__/headers.test.js
@@ -9,7 +9,8 @@ describe('headers middleware', () => {
     const resMock = { set: sinon.spy() }
     const nextMock = sinon.spy()
 
-    const INVESTMENT_DOCUMENT_BUCKET = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
+    const INVESTMENT_DOCUMENT_BUCKET_PROJECT = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
+    const INVESTMENT_DOCUMENT_BUCKET_PROPOSITION = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/propositiondocument/`
 
     headers(reqMock, resMock, nextMock, () => NONCE)
 
@@ -21,7 +22,7 @@ describe('headers middleware', () => {
             `frame-ancestors 'none'`,
             `script-src 'self' 'nonce-${NONCE}' https://*.googletagmanager.com`,
             `img-src 'self' https://*.google-analytics.com https://*.googletagmanager.com`,
-            `connect-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET} https://raven.ci.uktrade.io`,
+            `connect-src 'self' https://*.google-analytics.com https://*.googletagmanager.com https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET_PROJECT} https://raven.ci.uktrade.io ${INVESTMENT_DOCUMENT_BUCKET_PROPOSITION}`,
           ].join(';'),
           'Cache-Control': 'no-cache, no-store',
           Pragma: 'no-cache',

--- a/src/middleware/headers.js
+++ b/src/middleware/headers.js
@@ -6,7 +6,8 @@ const config = require('../config')
 const STS_MAX_AGE = 180 * 24 * 60 * 60
 const GOOGLE_TAG_MNGR = 'https://*.googletagmanager.com'
 const GOOGLE_ANALYTICS = 'https://*.google-analytics.com'
-const INVESTMENT_DOCUMENT_BUCKET = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
+const INVESTMENT_DOCUMENT_BUCKET_PROJECT = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/evidencedocument/`
+const INVESTMENT_DOCUMENT_BUCKET_PROPOSITION = `https://s3.${config.s3Buckets.investmentDocuments.region}.amazonaws.com/${config.s3Buckets.investmentDocuments.bucket}/propositiondocument/`
 
 module.exports = function headers(
   req,
@@ -27,7 +28,7 @@ module.exports = function headers(
       // Taken from https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics
       `script-src ${selfAndNonce} ${GOOGLE_TAG_MNGR}`,
       `img-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR}`,
-      `connect-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR} https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET} https://raven.ci.uktrade.io`,
+      `connect-src 'self' ${GOOGLE_ANALYTICS} ${GOOGLE_TAG_MNGR} https://*.analytics.google.com ${INVESTMENT_DOCUMENT_BUCKET_PROJECT} https://raven.ci.uktrade.io ${INVESTMENT_DOCUMENT_BUCKET_PROPOSITION}`,
     ].join(';'),
     // This is equivalent to `frame-ancestors 'none'` in the above CSP policy,
     // but keeping it here for older browsers


### PR DESCRIPTION
## Description of change

Currently it's not possible to upload evidence for propositions due to our CSP. Using the same approach as #6881, this is now possible.

## Test instructions

It should be possible to upload evidence for propositions.

Note that you'll need to have the correct values set for `INVESTMENT_DOCUMENT_BUCKET` and `INVESTMENT_DOCUMENT_AWS_REGION` or this will not work.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
