### PR TITLE
Add FieldChoice component

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -7,25 +7,28 @@ export default {
     '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@storybook/addon-webpack5-compiler-babel',
-    '@chromatic-com/storybook'
+    '@chromatic-com/storybook',
   ],
-  webpackFinal: async config => {
+  webpackFinal: async (config) => {
     return {
       ...config,
       resolve: {
-        ...resolve
-      }
+        ...resolve,
+      },
     }
   },
   core: {
-    disableTelemetry: true
+    disableTelemetry: true,
   },
   framework: {
     name: '@storybook/react-webpack5',
-    options: {}
+    options: {},
   },
   docs: {
-    autodocs: true
+    autodocs: true,
   },
-  stories: ['../src/client/components/*/__stories__/*.stories.jsx', '../src/client/components/*/*/__stories__/*.stories.jsx'],
+  stories: [
+    '../src/client/components/*/__stories__/*.stories.jsx',
+    '../src/client/components/*/*/__stories__/*.stories.jsx',
+  ],
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -23516,13 +23516,13 @@
       }
     },
     "node_modules/pkg-types": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.1.tgz",
-      "integrity": "sha512-ko14TjmDuQJ14zsotODv7dBlwxKhUKQEhuhmbqo1uCi9BB0Z2alo/wAXg6q1dTR5TyuqYyWhjtfe/Tsh+X28jQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.1.2.tgz",
+      "integrity": "sha512-VEGf1he2DR5yowYRl0XJhWJq5ktm9gYIsH+y8sNJpHlxch7JPDaufgrsl4vYjd9hMUY8QVjoNncKbow9I7exyA==",
       "dev": true,
       "dependencies": {
         "confbox": "^0.1.7",
-        "mlly": "^1.7.0",
+        "mlly": "^1.7.1",
         "pathe": "^1.1.2"
       }
     },

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -3,19 +3,9 @@ import PropTypes from 'prop-types'
 import MultiChoice from '@govuk-react/multi-choice'
 import Checkbox from '@govuk-react/checkbox'
 import Radio from '@govuk-react/radio'
-import styled from 'styled-components'
 
 import { useField, useFormContext } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
-
-const StyledMultiChoice = styled(MultiChoice)(({ inline }) => ({
-  ...(inline
-    ? {
-        display: 'flex',
-        marginRight: '10px',
-      }
-    : {}),
-}))
 
 const isRadio = (type) => type === 'radio'
 
@@ -35,7 +25,6 @@ const FieldChoice = ({
   label,
   legend,
   hint,
-  inline,
   initialValue,
   ...props
 }) => {
@@ -69,7 +58,7 @@ const FieldChoice = ({
 
   return (
     <FieldWrapper {...{ ...props, name, label, legend, hint, error }}>
-      <StyledMultiChoice meta={{ error, touched }} inline={inline}>
+      <MultiChoice meta={{ error, touched }}>
         {options.map((option) => (
           <React.Fragment key={option.value}>
             <Component
@@ -85,7 +74,7 @@ const FieldChoice = ({
             </Component>
           </React.Fragment>
         ))}
-      </StyledMultiChoice>
+      </MultiChoice>
     </FieldWrapper>
   )
 }

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -27,8 +27,9 @@ const getInitialValue = (initialValue, type) => {
 }
 
 const FieldChoice = ({
-  type,
   name,
+  type,
+  options = [],
   validate,
   required,
   label,
@@ -36,7 +37,6 @@ const FieldChoice = ({
   hint,
   inline,
   initialValue,
-  options = [],
   ...props
 }) => {
   const { value, error, touched, onBlur } = useField({
@@ -99,8 +99,8 @@ FieldChoice.Radio = ({ type, ...rest }) => (
 )
 
 FieldChoice.propTypes = {
-  type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
   name: PropTypes.string.isRequired,
+  type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -39,12 +39,11 @@ const FieldChoice = ({
   options = [],
   ...props
 }) => {
-  const initValue = getInitialValue(initialValue, type)
   const { value, error, touched, onBlur } = useField({
     name,
     validate,
     required,
-    initialValue: initValue,
+    initialValue: getInitialValue(initialValue, type),
   })
 
   const { setFieldValue } = useFormContext()
@@ -96,6 +95,20 @@ FieldChoice.Radio = (props) => <FieldChoice {...props} type="radio" />
 
 FieldChoice.propTypes = {
   type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
+  name: PropTypes.string.isRequired,
+  validate: PropTypes.func,
+  required: PropTypes.func,
+  label: PropTypes.string,
+  legend: PropTypes.node,
+  hint: PropTypes.string,
+  inline: PropTypes.bool,
+  initialValue: PropTypes.object,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+    })
+  ).isRequired,
 }
 
 export default FieldChoice

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -90,25 +90,33 @@ const FieldChoice = ({
   )
 }
 
-FieldChoice.Checkbox = (props) => <FieldChoice {...props} type="checkbox" />
-FieldChoice.Radio = (props) => <FieldChoice {...props} type="radio" />
+FieldChoice.Checkbox = ({ type, ...rest }) => (
+  <FieldChoice {...rest} type="checkbox" />
+)
+
+FieldChoice.Radio = ({ type, ...rest }) => (
+  <FieldChoice {...rest} type="radio" />
+)
 
 FieldChoice.propTypes = {
   type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
   name: PropTypes.string.isRequired,
-  validate: PropTypes.func,
-  required: PropTypes.func,
-  label: PropTypes.string,
-  legend: PropTypes.node,
-  hint: PropTypes.string,
-  inline: PropTypes.bool,
-  initialValue: PropTypes.object,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
       value: PropTypes.string,
     })
   ).isRequired,
+  validate: PropTypes.func,
+  required: PropTypes.func,
+  label: PropTypes.string,
+  legend: PropTypes.node,
+  hint: PropTypes.string,
+  inline: PropTypes.bool,
+  initialValue: PropTypes.shape({
+    label: PropTypes.string,
+    value: PropTypes.string,
+  }),
 }
 
 export default FieldChoice

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -90,13 +90,8 @@ const FieldChoice = ({
   )
 }
 
-FieldChoice.Checkbox = ({ type, ...rest }) => (
-  <FieldChoice {...rest} type="checkbox" />
-)
-
-FieldChoice.Radio = ({ type, ...rest }) => (
-  <FieldChoice {...rest} type="radio" />
-)
+FieldChoice.Checkbox = (props) => <FieldChoice {...props} type="checkbox" />
+FieldChoice.Radio = (props) => <FieldChoice {...props} type="radio" />
 
 FieldChoice.propTypes = {
   name: PropTypes.string.isRequired,

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -108,7 +108,7 @@ FieldChoice.propTypes = {
     })
   ).isRequired,
   validate: PropTypes.func,
-  required: PropTypes.func,
+  required: PropTypes.string,
   label: PropTypes.string,
   legend: PropTypes.node,
   hint: PropTypes.string,

--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import MultiChoice from '@govuk-react/multi-choice'
+import Checkbox from '@govuk-react/checkbox'
+import Radio from '@govuk-react/radio'
+import styled from 'styled-components'
+
+import { useField, useFormContext } from '../../hooks'
+import FieldWrapper from '../FieldWrapper'
+
+const StyledMultiChoice = styled(MultiChoice)(({ inline }) => ({
+  ...(inline
+    ? {
+        display: 'flex',
+        marginRight: '10px',
+      }
+    : {}),
+}))
+
+const isRadio = (type) => type === 'radio'
+
+const getInitialValue = (initialValue, type) => {
+  if (initialValue) {
+    return initialValue
+  }
+  return isRadio(type) ? '' : []
+}
+
+const FieldChoice = ({
+  type,
+  name,
+  validate,
+  required,
+  label,
+  legend,
+  hint,
+  inline,
+  initialValue,
+  options = [],
+  ...props
+}) => {
+  const initValue = getInitialValue(initialValue, type)
+  const { value, error, touched, onBlur } = useField({
+    name,
+    validate,
+    required,
+    initialValue: initValue,
+  })
+
+  const { setFieldValue } = useFormContext()
+
+  const onChange = (option, type) => {
+    if (isRadio(type)) {
+      setFieldValue(name, option)
+    } else {
+      // Checkbox
+      setFieldValue(
+        name,
+        value.includes(option)
+          ? value.filter((v) => v !== option)
+          : [...value, option]
+      )
+    }
+  }
+
+  const checked = (option) =>
+    isRadio(type) ? value === option : value.includes(option)
+
+  const Component = isRadio(type) ? Radio : Checkbox
+
+  return (
+    <FieldWrapper {...{ ...props, name, label, legend, hint, error }}>
+      <StyledMultiChoice meta={{ error, touched }} inline={inline}>
+        {options.map((option) => (
+          <React.Fragment key={option.value}>
+            <Component
+              key={option.id}
+              value={option.value}
+              checked={checked(option, type)}
+              onChange={() => onChange(option, type)}
+              onBlur={onBlur}
+              name={name}
+              aria-label={option.label}
+            >
+              {option.label}
+            </Component>
+          </React.Fragment>
+        ))}
+      </StyledMultiChoice>
+    </FieldWrapper>
+  )
+}
+
+FieldChoice.Checkbox = (props) => <FieldChoice {...props} type="checkbox" />
+FieldChoice.Radio = (props) => <FieldChoice {...props} type="radio" />
+
+FieldChoice.propTypes = {
+  type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
+}
+
+export default FieldChoice

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -1,0 +1,133 @@
+import React from 'react'
+import { H1 } from '@govuk-react/heading'
+
+import FieldChoice from '../FieldChoice'
+import Form from '../..'
+
+const options = [
+  {
+    value: '1',
+    label: 'England',
+  },
+  {
+    value: '2',
+    label: 'Wales',
+  },
+  {
+    value: '3',
+    label: 'Scotland',
+  },
+  {
+    value: '4',
+    label: 'Northern Ireland',
+  },
+]
+
+export default {
+  title: 'Form/Form Elements/FieldChoice',
+  component: FieldChoice,
+  args: {
+    options,
+    label: 'Countries',
+    name: 'country',
+  },
+  argTypes: {
+    type: 'string',
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: `The FieldChoice component is designed to render a radio button or a checkbox by setting the prop type to either "radio" or "checkbox".
+        The component sets the entire selected option (Object) to the Form's state which is helpful on user journeys where the final page is a summary page and you
+        need pullout a name from a previous selection. At present, FieldRadio only writes the ID (String) to the form state.`,
+      },
+    },
+  },
+}
+
+const Template = (args, { story }) => (
+  <Form
+    id={story}
+    analyticsFormName="formRadio"
+    submissionTaskName="SUBMISSION"
+  >
+    {(state) => (
+      <>
+        <FieldChoice {...args} />
+        <pre>{JSON.stringify(state, null, 2)}</pre>
+      </>
+    )}
+  </Form>
+)
+
+// Radio
+export const Radio = Template.bind({})
+Radio.args = {
+  type: 'radio',
+}
+
+export const RadioInitialValue = Template.bind({})
+RadioInitialValue.args = {
+  ...Radio.args,
+  initialValue: options[1],
+}
+
+export const RadioHint = Template.bind({})
+RadioHint.args = {
+  ...Radio.args,
+  hint: 'Country hint',
+}
+
+export const RadioLegend = Template.bind({})
+RadioLegend.args = {
+  ...Radio.args,
+  legend: <H1>A H1 legend</H1>,
+}
+
+export const RadioInline = Template.bind({})
+RadioInline.args = {
+  ...Radio.args,
+  inline: true,
+}
+
+export const RadioRequired = Template.bind({})
+RadioRequired.args = {
+  ...Radio.args,
+  required: 'Select at least one country',
+}
+
+// Checkbox
+export const Checkbox = Template.bind({})
+Checkbox.args = {
+  type: 'checkbox',
+}
+
+export const CheckboxInitialValue = Template.bind({})
+CheckboxInitialValue.args = {
+  ...Checkbox.args,
+  initialValue: [options[1], options[2]],
+}
+
+export const CheckboxHint = Template.bind({})
+CheckboxHint.args = {
+  ...Checkbox.args,
+  hint: 'Country hint',
+}
+
+export const CheckboxLegend = Template.bind({})
+CheckboxLegend.args = {
+  ...Checkbox.args,
+  legend: <H1>A H1 legend</H1>,
+}
+
+export const CheckboxInline = Template.bind({})
+CheckboxInline.args = {
+  ...Checkbox.args,
+  inline: true,
+}
+
+export const CheckboxRequired = Template.bind({})
+CheckboxRequired.args = {
+  ...Checkbox.args,
+  required: 'Select at least one country',
+}

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -6,34 +6,33 @@ import Form from '../..'
 
 const options = [
   {
-    value: '1',
+    value: '0',
     label: 'England',
   },
   {
-    value: '2',
+    value: '1',
     label: 'Wales',
   },
   {
-    value: '3',
+    value: '2',
     label: 'Scotland',
   },
   {
-    value: '4',
+    value: '3',
     label: 'Northern Ireland',
   },
 ]
 
-const formatOptions = (options) =>
-  options
-    .map((option) => `{ value: '${option.value}', label: '${option.label}' }`)
-    .join(', ')
+const formatOption = (option) =>
+  `{ value: '${option.value}', label: '${option.label}' }`
+
+const formatOptions = (options) => options.map(formatOption).join(', ')
 
 export default {
   title: 'Form/Form Elements/FieldChoice',
   component: FieldChoice,
   args: {
     options,
-    label: 'Countries',
     name: 'country',
   },
   argTypes: {
@@ -65,6 +64,32 @@ const Template = (args, { story }) => (
   </Form>
 )
 
+const getForm = (type, propAndValue = '') => {
+  const props = propAndValue
+    ? `name="country"
+      ${propAndValue}` // Ensure the prop and value are on a new line
+    : `name="country"`
+  return `
+<Form
+  id="form-id"
+  analyticsFormName="formRadio"
+  submissionTaskName="SUBMISSION"
+>
+  {(state) => (
+    <FieldChoice.${type}
+      ${props}
+      options={[
+        ${formatOption(options[0])}
+        ${formatOption(options[1])}
+        ${formatOption(options[2])}
+        ${formatOption(options[3])}
+      ]}
+    />
+  )}
+</Form>
+`
+}
+
 // Radio
 export const Radio = Template.bind({})
 Radio.args = {
@@ -73,26 +98,26 @@ Radio.args = {
 Radio.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 radio buttons with a label.',
+      story: 'A group of 4 radio buttons',
     },
     source: {
-      code: `<FieldChoice.Radio name="country" label="Countries" options={${formatOptions(options)}}/>`,
+      code: getForm('Radio'),
     },
   },
 }
 
-export const RadioInitialValue = Template.bind({})
-RadioInitialValue.args = {
+export const RadioLabel = Template.bind({})
+RadioLabel.args = {
   ...Radio.args,
-  initialValue: options[0],
+  label: 'Countries',
 }
-RadioInitialValue.parameters = {
+RadioLabel.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 radio buttons where the first radio is preselected.',
+      story: 'Radio button group label',
     },
     source: {
-      code: `<FieldChoice.Radio ... initialValue={${formatOptions([options[0]])}}} />`,
+      code: getForm('Radio', 'label="Countries"'),
     },
   },
 }
@@ -105,10 +130,10 @@ RadioHint.args = {
 RadioHint.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 radio buttons with a hint.',
+      story: 'Radio button group hint text',
     },
     source: {
-      code: `<FieldChoice.Radio ... hint="Country hint" />`,
+      code: getForm('Radio', 'hint="Country hint"'),
     },
   },
 }
@@ -121,10 +146,26 @@ RadioLegend.args = {
 RadioLegend.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 radio buttons with a H1 legend.',
+      story: 'Radio button group legend',
     },
     source: {
-      code: `<FieldChoice.Radio ... legend={<H1>My H1 legend</H1>} />`,
+      code: getForm('Radio', 'legend={<H1>My H1 legend</H1>}'),
+    },
+  },
+}
+
+export const RadioInitialValue = Template.bind({})
+RadioInitialValue.args = {
+  ...Radio.args,
+  initialValue: options[0],
+}
+RadioInitialValue.parameters = {
+  docs: {
+    description: {
+      story: 'Radio button group initial value',
+    },
+    source: {
+      code: getForm('Radio', `initialValue={${formatOptions([options[0]])}}`),
     },
   },
 }
@@ -137,10 +178,10 @@ RadioInline.args = {
 RadioInline.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 inline radio buttons.',
+      story: 'Radio button group inline',
     },
     source: {
-      code: `<FieldChoice.Radio ... inline={true} />`,
+      code: getForm('Radio', 'inline={true}'),
     },
   },
 }
@@ -154,10 +195,10 @@ RadioRequired.parameters = {
   docs: {
     description: {
       story:
-        'A group of 4 inline radio buttons where a selection is mandatory. Click save to view the validation error message.',
+        'Radio button group where a selection is required. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: `<FieldChoice.Radio ... required="Select at least one country" />`,
+      code: getForm('Radio', 'required="Select at least one country"'),
     },
   },
 }
@@ -170,27 +211,26 @@ Checkbox.args = {
 Checkbox.parameters = {
   docs: {
     description: {
-      story: 'A group of 4 checkboxes with a label.',
+      story: 'A group of 4 checkboxes.',
     },
     source: {
-      code: `<FieldChoice.Checkbox name="country" label="Countries" options={${formatOptions(options)}}/>`,
+      code: getForm('Checkbox'),
     },
   },
 }
 
-export const CheckboxInitialValue = Template.bind({})
-CheckboxInitialValue.args = {
+export const CheckboxLabel = Template.bind({})
+CheckboxLabel.args = {
   ...Checkbox.args,
-  initialValue: [options[1], options[2]],
+  label: 'Countries',
 }
-CheckboxInitialValue.parameters = {
+CheckboxLabel.parameters = {
   docs: {
     description: {
-      story:
-        'A group of 4 checkboxes where the second and third checkboxes are preselected.',
+      story: 'Checkbox group label',
     },
     source: {
-      code: `<FieldChoice.Checkbox ... initialValue={${formatOptions([options[1], options[2]])}} />`,
+      code: getForm('Checkbox', 'label="Countries"'),
     },
   },
 }
@@ -203,10 +243,10 @@ CheckboxHint.args = {
 CheckboxHint.parameters = {
   docs: {
     description: {
-      story: 'Checkboxes with a hint.',
+      story: 'Checkbox group hint text',
     },
     source: {
-      code: `<FieldChoice.Checkbox ... hint="Country hint" />`,
+      code: getForm('Checkbox', 'hint="Country hint"'),
     },
   },
 }
@@ -219,10 +259,29 @@ CheckboxLegend.args = {
 CheckboxLegend.parameters = {
   docs: {
     description: {
-      story: 'Checkboxes with a H1 legend.',
+      story: 'Checkbox group legend',
     },
     source: {
-      code: `<FieldChoice.Checkbox ... legend={<H1>My H1 legend</H1>} />`,
+      code: getForm('Checkbox', 'legend={<H1>My H1 legend</H1>}'),
+    },
+  },
+}
+
+export const CheckboxInitialValue = Template.bind({})
+CheckboxInitialValue.args = {
+  ...Checkbox.args,
+  initialValue: [options[0], options[1]],
+}
+CheckboxInitialValue.parameters = {
+  docs: {
+    description: {
+      story: 'Checkbox group initial value',
+    },
+    source: {
+      code: getForm(
+        'Checkbox',
+        `initialValue={${formatOptions([options[0], options[1]])}}`
+      ),
     },
   },
 }
@@ -235,10 +294,10 @@ CheckboxInline.args = {
 CheckboxInline.parameters = {
   docs: {
     description: {
-      story: 'Inline checkboxes.',
+      story: 'Checkbox group inline',
     },
     source: {
-      code: `<FieldChoice.Checkbox ... inline={true} />`,
+      code: getForm('Checkbox', 'inline={true}'),
     },
   },
 }
@@ -252,10 +311,10 @@ CheckboxRequired.parameters = {
   docs: {
     description: {
       story:
-        'Four checkboxes where a user must choose one or more. Click save to view the validation error message.',
+        'Checkbox group where a user must choose at least one country. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: `<FieldChoice.Checkbox ... required="Choose one or more countries" />`,
+      code: getForm('Checkbox', 'required="Choose one or more countries"'),
     },
   },
 }

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -244,7 +244,7 @@ RadioSelected.parameters = {
     source: {
       code: getForm({
         component: 'FieldChoice.Radio',
-        formProp: `initialValue={{ country: ${formatOption(options[0])}}}`,
+        formProp: `initialValues={{country: ${formatOption(options[0])}}}`,
       }),
     },
   },
@@ -379,7 +379,7 @@ CheckboxChecked.parameters = {
     source: {
       code: getForm({
         component: 'FieldChoice.Checkbox',
-        formProp: `initialValue={ country: [${formatOptions([options[0], options[1]])}]}`,
+        formProp: `initialValues={{ country: [${formatOptions([options[0], options[1]])}]}}`,
       }),
     },
   },

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -23,6 +23,11 @@ const options = [
   },
 ]
 
+const formatOptions = (options) =>
+  options
+    .map((option) => `{ value: '${option.value}', label: '${option.label}' }`)
+    .join(', ')
+
 export default {
   title: 'Form/Form Elements/FieldChoice',
   component: FieldChoice,
@@ -37,9 +42,9 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: `The FieldChoice component is designed to render a group of radio buttons or checkboxes by setting the prop type to either "radio" or "checkbox".
+        component: `The <b>FieldChoice</b> component is designed to render a group of radio buttons or checkboxes by setting the prop type to either <b>"radio"</b> or <b>"checkbox"</b>.
         The component sets the entire selected option (Object) to the Form's state which is helpful on user journeys where the final page is a summary page and you
-        need to pullout a name (or any other field) from a previous selection. At present, FieldRadio only writes the ID (String) to the form state.`,
+        need to pullout a name (or any other field) from a previous selection to display it to the user. At present, <b>FieldRadio</b> only writes the ID (String) to the form state.`,
       },
     },
   },
@@ -65,11 +70,31 @@ export const Radio = Template.bind({})
 Radio.args = {
   type: 'radio',
 }
+Radio.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 radio buttons with a label.',
+    },
+    source: {
+      code: `<FieldChoice.Radio name="country" label="Countries" options={${formatOptions(options)}}/>`,
+    },
+  },
+}
 
 export const RadioInitialValue = Template.bind({})
 RadioInitialValue.args = {
   ...Radio.args,
-  initialValue: options[1],
+  initialValue: options[0],
+}
+RadioInitialValue.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 radio buttons where the first radio is preselected.',
+    },
+    source: {
+      code: `<FieldChoice.Radio ... initialValue={${formatOptions([options[0]])}}} />`,
+    },
+  },
 }
 
 export const RadioHint = Template.bind({})
@@ -77,11 +102,31 @@ RadioHint.args = {
   ...Radio.args,
   hint: 'Country hint',
 }
+RadioHint.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 radio buttons with a hint.',
+    },
+    source: {
+      code: `<FieldChoice.Radio ... hint="Country hint" />`,
+    },
+  },
+}
 
 export const RadioLegend = Template.bind({})
 RadioLegend.args = {
   ...Radio.args,
-  legend: <H1>A H1 legend</H1>,
+  legend: <h1>My H1 legend</h1>,
+}
+RadioLegend.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 radio buttons with a H1 legend.',
+    },
+    source: {
+      code: `<FieldChoice.Radio ... legend={<H1>My H1 legend</H1>} />`,
+    },
+  },
 }
 
 export const RadioInline = Template.bind({})
@@ -89,11 +134,32 @@ RadioInline.args = {
   ...Radio.args,
   inline: true,
 }
+RadioInline.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 inline radio buttons.',
+    },
+    source: {
+      code: `<FieldChoice.Radio ... inline={true} />`,
+    },
+  },
+}
 
 export const RadioRequired = Template.bind({})
 RadioRequired.args = {
   ...Radio.args,
   required: 'Select at least one country',
+}
+RadioRequired.parameters = {
+  docs: {
+    description: {
+      story:
+        'A group of 4 inline radio buttons where a selection is mandatory. Click save to view the validation error message.',
+    },
+    source: {
+      code: `<FieldChoice.Radio ... required="Select at least one country" />`,
+    },
+  },
 }
 
 // Checkbox
@@ -101,11 +167,32 @@ export const Checkbox = Template.bind({})
 Checkbox.args = {
   type: 'checkbox',
 }
+Checkbox.parameters = {
+  docs: {
+    description: {
+      story: 'A group of 4 checkboxes with a label.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox name="country" label="Countries" options={${formatOptions(options)}}/>`,
+    },
+  },
+}
 
 export const CheckboxInitialValue = Template.bind({})
 CheckboxInitialValue.args = {
   ...Checkbox.args,
   initialValue: [options[1], options[2]],
+}
+CheckboxInitialValue.parameters = {
+  docs: {
+    description: {
+      story:
+        'A group of 4 checkboxes where the second and third checkboxes are preselected.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox ... initialValue={${formatOptions([options[1], options[2]])}} />`,
+    },
+  },
 }
 
 export const CheckboxHint = Template.bind({})
@@ -113,11 +200,31 @@ CheckboxHint.args = {
   ...Checkbox.args,
   hint: 'Country hint',
 }
+CheckboxHint.parameters = {
+  docs: {
+    description: {
+      story: 'Checkboxes with a hint.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox ... hint="Country hint" />`,
+    },
+  },
+}
 
 export const CheckboxLegend = Template.bind({})
 CheckboxLegend.args = {
   ...Checkbox.args,
-  legend: <H1>A H1 legend</H1>,
+  legend: <H1>My H1 legend</H1>,
+}
+CheckboxLegend.parameters = {
+  docs: {
+    description: {
+      story: 'Checkboxes with a H1 legend.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox ... legend={<H1>My H1 legend</H1>} />`,
+    },
+  },
 }
 
 export const CheckboxInline = Template.bind({})
@@ -125,9 +232,30 @@ CheckboxInline.args = {
   ...Checkbox.args,
   inline: true,
 }
+CheckboxInline.parameters = {
+  docs: {
+    description: {
+      story: 'Inline checkboxes.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox ... inline={true} />`,
+    },
+  },
+}
 
 export const CheckboxRequired = Template.bind({})
 CheckboxRequired.args = {
   ...Checkbox.args,
-  required: 'Select at least one country',
+  required: 'Choose one or more countries',
+}
+CheckboxRequired.parameters = {
+  docs: {
+    description: {
+      story:
+        'Four checkboxes where a user must choose one or more. Click save to view the validation error message.',
+    },
+    source: {
+      code: `<FieldChoice.Checkbox ... required="Choose one or more countries" />`,
+    },
+  },
 }

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -37,9 +37,9 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: `The FieldChoice component is designed to render a radio button or a checkbox by setting the prop type to either "radio" or "checkbox".
+        component: `The FieldChoice component is designed to render a group of radio buttons or checkboxes by setting the prop type to either "radio" or "checkbox".
         The component sets the entire selected option (Object) to the Form's state which is helpful on user journeys where the final page is a summary page and you
-        need pullout a name from a previous selection. At present, FieldRadio only writes the ID (String) to the form state.`,
+        need to pullout a name (or any other field) from a previous selection. At present, FieldRadio only writes the ID (String) to the form state.`,
       },
     },
   },

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -1,8 +1,26 @@
 import React from 'react'
 import { H1 } from '@govuk-react/heading'
+import styled, { css } from 'styled-components'
 
 import FieldChoice from '../FieldChoice'
 import Form from '../..'
+
+const inline = css`
+  fieldset div {
+    display: flex;
+  }
+  fieldset div label {
+    margin-right: 10px;
+  }
+`
+
+const FieldChoiceRadioInline = styled(FieldChoice.Radio)`
+  ${inline}
+`
+
+const FieldChoiceCheckboxInline = styled(FieldChoice.Checkbox)`
+  ${inline}
+`
 
 const options = [
   {
@@ -34,6 +52,7 @@ export default {
   args: {
     options,
     name: 'country',
+    component: FieldChoice,
   },
   argTypes: {
     type: 'string',
@@ -49,7 +68,7 @@ export default {
   },
 }
 
-const Template = (args, { story }) => (
+const Template = ({ component: Component, ...args }, { story }) => (
   <Form
     id={story}
     analyticsFormName="formRadio"
@@ -57,14 +76,14 @@ const Template = (args, { story }) => (
   >
     {(state) => (
       <>
-        <FieldChoice {...args} />
+        <Component {...args} />
         <pre>{JSON.stringify(state, null, 2)}</pre>
       </>
     )}
   </Form>
 )
 
-const getForm = (type, propAndValue = '') => {
+const getForm = (component, propAndValue) => {
   const props = propAndValue
     ? `name="country"
       ${propAndValue}` // Ensure the prop and value are on a new line
@@ -76,7 +95,7 @@ const getForm = (type, propAndValue = '') => {
   submissionTaskName="SUBMISSION"
 >
   {(state) => (
-    <FieldChoice.${type}
+    <${component}
       ${props}
       options={[
         ${formatOption(options[0])}
@@ -101,7 +120,7 @@ Radio.parameters = {
       story: 'A group of 4 radio buttons',
     },
     source: {
-      code: getForm('Radio'),
+      code: getForm('FieldChoice.Radio'),
     },
   },
 }
@@ -117,7 +136,7 @@ RadioLabel.parameters = {
       story: 'Radio button group label',
     },
     source: {
-      code: getForm('Radio', 'label="Countries"'),
+      code: getForm('FieldChoice.Radio', 'label="Countries"'),
     },
   },
 }
@@ -133,7 +152,7 @@ RadioHint.parameters = {
       story: 'Radio button group hint text',
     },
     source: {
-      code: getForm('Radio', 'hint="Country hint"'),
+      code: getForm('FieldChoice.Radio', 'hint="Country hint"'),
     },
   },
 }
@@ -149,7 +168,7 @@ RadioLegend.parameters = {
       story: 'Radio button group legend',
     },
     source: {
-      code: getForm('Radio', 'legend={<H1>My H1 legend</H1>}'),
+      code: getForm('FieldChoice.Radio', 'legend={<H1>My H1 legend</H1>}'),
     },
   },
 }
@@ -165,7 +184,10 @@ RadioInitialValue.parameters = {
       story: 'Radio button group initial value',
     },
     source: {
-      code: getForm('Radio', `initialValue={${formatOptions([options[0]])}}`),
+      code: getForm(
+        'FieldChoice.Radio',
+        `initialValue={${formatOption(options[0])}}`
+      ),
     },
   },
 }
@@ -173,7 +195,7 @@ RadioInitialValue.parameters = {
 export const RadioInline = Template.bind({})
 RadioInline.args = {
   ...Radio.args,
-  inline: true,
+  component: FieldChoiceRadioInline,
 }
 RadioInline.parameters = {
   docs: {
@@ -181,7 +203,7 @@ RadioInline.parameters = {
       story: 'Radio button group inline',
     },
     source: {
-      code: getForm('Radio', 'inline={true}'),
+      code: getForm('FieldChoiceRadioInline'),
     },
   },
 }
@@ -198,7 +220,10 @@ RadioRequired.parameters = {
         'Radio button group where a selection is required. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: getForm('Radio', 'required="Select at least one country"'),
+      code: getForm(
+        'FieldChoice.Radio',
+        'required="Select at least one country"'
+      ),
     },
   },
 }
@@ -214,7 +239,7 @@ Checkbox.parameters = {
       story: 'A group of 4 checkboxes.',
     },
     source: {
-      code: getForm('Checkbox'),
+      code: getForm('FieldChoice.Checkbox'),
     },
   },
 }
@@ -230,7 +255,7 @@ CheckboxLabel.parameters = {
       story: 'Checkbox group label',
     },
     source: {
-      code: getForm('Checkbox', 'label="Countries"'),
+      code: getForm('FieldChoice.Checkbox', 'label="Countries"'),
     },
   },
 }
@@ -246,7 +271,7 @@ CheckboxHint.parameters = {
       story: 'Checkbox group hint text',
     },
     source: {
-      code: getForm('Checkbox', 'hint="Country hint"'),
+      code: getForm('FieldChoice.Checkbox', 'hint="Country hint"'),
     },
   },
 }
@@ -262,7 +287,7 @@ CheckboxLegend.parameters = {
       story: 'Checkbox group legend',
     },
     source: {
-      code: getForm('Checkbox', 'legend={<H1>My H1 legend</H1>}'),
+      code: getForm('FieldChoice.Checkbox', 'legend={<H1>My H1 legend</H1>}'),
     },
   },
 }
@@ -279,7 +304,7 @@ CheckboxInitialValue.parameters = {
     },
     source: {
       code: getForm(
-        'Checkbox',
+        'FieldChoice.Checkbox',
         `initialValue={${formatOptions([options[0], options[1]])}}`
       ),
     },
@@ -289,7 +314,7 @@ CheckboxInitialValue.parameters = {
 export const CheckboxInline = Template.bind({})
 CheckboxInline.args = {
   ...Checkbox.args,
-  inline: true,
+  component: FieldChoiceCheckboxInline,
 }
 CheckboxInline.parameters = {
   docs: {
@@ -297,7 +322,7 @@ CheckboxInline.parameters = {
       story: 'Checkbox group inline',
     },
     source: {
-      code: getForm('Checkbox', 'inline={true}'),
+      code: getForm('FieldChoiceCheckboxInline'),
     },
   },
 }
@@ -314,7 +339,10 @@ CheckboxRequired.parameters = {
         'Checkbox group where a user must choose at least one country. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: getForm('Checkbox', 'required="Choose one or more countries"'),
+      code: getForm(
+        'FieldChoice.Checkbox',
+        'required="Choose one or more countries"'
+      ),
     },
   },
 }

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -44,8 +44,6 @@ const options = [
 const formatOption = (option) =>
   `{ value: '${option.value}', label: '${option.label}' }`
 
-const formatOptions = (options) => options.map(formatOption).join(', ')
-
 export default {
   title: 'Form/Form Elements/FieldChoice',
   component: FieldChoice,
@@ -73,6 +71,9 @@ const Template = ({ component: Component, ...args }, { story }) => (
     id={story}
     analyticsFormName="formRadio"
     submissionTaskName="SUBMISSION"
+    initialValues={{
+      country: [options[0]],
+    }}
   >
     {(state) => (
       <>
@@ -173,25 +174,6 @@ RadioLegend.parameters = {
   },
 }
 
-export const RadioInitialValue = Template.bind({})
-RadioInitialValue.args = {
-  ...Radio.args,
-  initialValue: options[0],
-}
-RadioInitialValue.parameters = {
-  docs: {
-    description: {
-      story: 'Radio button group initial value',
-    },
-    source: {
-      code: getForm(
-        'FieldChoice.Radio',
-        `initialValue={${formatOption(options[0])}}`
-      ),
-    },
-  },
-}
-
 export const RadioInline = Template.bind({})
 RadioInline.args = {
   ...Radio.args,
@@ -288,25 +270,6 @@ CheckboxLegend.parameters = {
     },
     source: {
       code: getForm('FieldChoice.Checkbox', 'legend={<H1>My H1 legend</H1>}'),
-    },
-  },
-}
-
-export const CheckboxInitialValue = Template.bind({})
-CheckboxInitialValue.args = {
-  ...Checkbox.args,
-  initialValue: [options[0], options[1]],
-}
-CheckboxInitialValue.parameters = {
-  docs: {
-    description: {
-      story: 'Checkbox group initial value',
-    },
-    source: {
-      code: getForm(
-        'FieldChoice.Checkbox',
-        `initialValue={${formatOptions([options[0], options[1]])}}`
-      ),
     },
   },
 }

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -44,6 +44,8 @@ const options = [
 const formatOption = (option) =>
   `{ value: '${option.value}', label: '${option.label}' }`
 
+const formatOptions = (options) => options.map(formatOption) //.join(', ')
+
 export default {
   title: 'Form/Form Elements/FieldChoice',
   component: FieldChoice,
@@ -54,6 +56,7 @@ export default {
   },
   argTypes: {
     type: 'string',
+    initialValues: { control: 'object' },
   },
   parameters: {
     docs: {
@@ -66,14 +69,15 @@ export default {
   },
 }
 
-const Template = ({ component: Component, ...args }, { story }) => (
+const Template = (
+  { component: Component, initialValues, ...args },
+  { id: storyId }
+) => (
   <Form
-    id={story}
+    id={storyId}
     analyticsFormName="formRadio"
     submissionTaskName="SUBMISSION"
-    initialValues={{
-      country: [options[0]],
-    }}
+    initialValues={initialValues}
   >
     {(state) => (
       <>
@@ -84,20 +88,23 @@ const Template = ({ component: Component, ...args }, { story }) => (
   </Form>
 )
 
-const getForm = (component, propAndValue) => {
-  const props = propAndValue
-    ? `name="country"
-      ${propAndValue}` // Ensure the prop and value are on a new line
-    : `name="country"`
+const defaultFormProps = `\n  id="form-id"\n  analyticsFormName="formRadio"\n  submissionTaskName="SUBMISSION"`
+const defaultComponentProps = `name="country"`
+
+const getForm = ({ component, formProp, componentProp }) => {
+  const formProps = formProp
+    ? `${defaultFormProps}\n  ${formProp}`
+    : ` ${defaultFormProps}`
+
+  const componentProps = componentProp
+    ? `${defaultComponentProps}
+      ${componentProp}`
+    : `${defaultComponentProps}`
   return `
-<Form
-  id="form-id"
-  analyticsFormName="formRadio"
-  submissionTaskName="SUBMISSION"
->
+<Form ${formProps}>
   {(state) => (
     <${component}
-      ${props}
+      ${componentProps}
       options={[
         ${formatOption(options[0])}
         ${formatOption(options[1])}
@@ -121,7 +128,7 @@ Radio.parameters = {
       story: 'A group of 4 radio buttons',
     },
     source: {
-      code: getForm('FieldChoice.Radio'),
+      code: getForm({ component: 'FieldChoice.Radio' }),
     },
   },
 }
@@ -137,7 +144,10 @@ RadioLabel.parameters = {
       story: 'Radio button group label',
     },
     source: {
-      code: getForm('FieldChoice.Radio', 'label="Countries"'),
+      code: getForm({
+        component: 'FieldChoice.Radio',
+        componentProp: 'label="Countries"',
+      }),
     },
   },
 }
@@ -153,7 +163,10 @@ RadioHint.parameters = {
       story: 'Radio button group hint text',
     },
     source: {
-      code: getForm('FieldChoice.Radio', 'hint="Country hint"'),
+      code: getForm({
+        component: 'FieldChoice.Radio',
+        componentProp: 'hint="Country hint"',
+      }),
     },
   },
 }
@@ -169,7 +182,10 @@ RadioLegend.parameters = {
       story: 'Radio button group legend',
     },
     source: {
-      code: getForm('FieldChoice.Radio', 'legend={<H1>My H1 legend</H1>}'),
+      code: getForm({
+        component: 'FieldChoice.Radio',
+        componentProp: 'legend={<H1>My H1 legend</H1>}',
+      }),
     },
   },
 }
@@ -185,7 +201,9 @@ RadioInline.parameters = {
       story: 'Radio button group inline',
     },
     source: {
-      code: getForm('FieldChoiceRadioInline'),
+      code: getForm({
+        component: 'FieldChoiceRadioInline',
+      }),
     },
   },
 }
@@ -202,10 +220,32 @@ RadioRequired.parameters = {
         'Radio button group where a selection is required. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: getForm(
-        'FieldChoice.Radio',
-        'required="Select at least one country"'
-      ),
+      code: getForm({
+        component: 'FieldChoice.Radio',
+        componentProp: 'required="Select at least one country"',
+      }),
+    },
+  },
+}
+
+export const RadioSelected = Template.bind({})
+RadioSelected.args = {
+  ...Radio.args,
+  initialValues: {
+    // Radios require a single object
+    country: options[0],
+  },
+}
+RadioSelected.parameters = {
+  docs: {
+    description: {
+      story: 'Radio button group selected',
+    },
+    source: {
+      code: getForm({
+        component: 'FieldChoice.Radio',
+        formProp: `initialValue={{ country: ${formatOption(options[0])}}}`,
+      }),
     },
   },
 }
@@ -221,7 +261,9 @@ Checkbox.parameters = {
       story: 'A group of 4 checkboxes.',
     },
     source: {
-      code: getForm('FieldChoice.Checkbox'),
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+      }),
     },
   },
 }
@@ -237,7 +279,10 @@ CheckboxLabel.parameters = {
       story: 'Checkbox group label',
     },
     source: {
-      code: getForm('FieldChoice.Checkbox', 'label="Countries"'),
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+        componentProp: 'label="Countries"',
+      }),
     },
   },
 }
@@ -253,7 +298,10 @@ CheckboxHint.parameters = {
       story: 'Checkbox group hint text',
     },
     source: {
-      code: getForm('FieldChoice.Checkbox', 'hint="Country hint"'),
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+        componentProp: 'hint="Country hint"',
+      }),
     },
   },
 }
@@ -269,7 +317,10 @@ CheckboxLegend.parameters = {
       story: 'Checkbox group legend',
     },
     source: {
-      code: getForm('FieldChoice.Checkbox', 'legend={<H1>My H1 legend</H1>}'),
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+        componentProp: 'legend={<H1>My H1 legend</H1>}',
+      }),
     },
   },
 }
@@ -285,7 +336,9 @@ CheckboxInline.parameters = {
       story: 'Checkbox group inline',
     },
     source: {
-      code: getForm('FieldChoiceCheckboxInline'),
+      code: getForm({
+        component: 'FieldChoiceCheckboxInline',
+      }),
     },
   },
 }
@@ -302,10 +355,32 @@ CheckboxRequired.parameters = {
         'Checkbox group where a user must choose at least one country. Click "Save" to view the form validation error message.',
     },
     source: {
-      code: getForm(
-        'FieldChoice.Checkbox',
-        'required="Choose one or more countries"'
-      ),
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+        componentProp: 'required="Choose one or more countries"',
+      }),
+    },
+  },
+}
+
+export const CheckboxChecked = Template.bind({})
+CheckboxChecked.args = {
+  ...Checkbox.args,
+  initialValues: {
+    // Checkboxes require an array of objects
+    country: [options[0], options[1]],
+  },
+}
+CheckboxChecked.parameters = {
+  docs: {
+    description: {
+      story: 'Checkbox group checked',
+    },
+    source: {
+      code: getForm({
+        component: 'FieldChoice.Checkbox',
+        formProp: `initialValue={ country: [${formatOptions([options[0], options[1]])}]}`,
+      }),
     },
   },
 }

--- a/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
@@ -1,0 +1,252 @@
+import React from 'react'
+import { H1 } from '@govuk-react/heading'
+
+import FieldChoice from '../../../../../../src/client/components/Form/elements/FieldChoice'
+import { Form } from '../../../../../../src/client/components'
+
+import {
+  assertFieldErrorStrict,
+  assertFieldRadiosStrict,
+  assertFieldRadioSelected,
+  assertFieldCheckboxesStrict,
+  assertFieldCheckboxesChecked,
+  assertFieldRadiosNotSelected,
+} from '../../../../../functional/cypress/support/assertions'
+
+const OPTIONS = [
+  {
+    value: '1',
+    label: 'England',
+  },
+  {
+    value: '2',
+    label: 'Wales',
+  },
+  {
+    value: '3',
+    label: 'Scotland',
+  },
+  {
+    value: '4',
+    label: 'Northern Ireland',
+  },
+]
+
+describe('FieldChoice', () => {
+  const FORM_PROPS = {
+    id: 'some-form',
+    analyticsFormName: 'some-form',
+    cancelRedirectTo: () => '/',
+    submissionTaskName: 'EMPTY',
+  }
+
+  context('Radio buttons', () => {
+    it('should render radio buttons', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice type="radio" name="country" options={OPTIONS} />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+      })
+      assertFieldRadiosNotSelected({ inputName: 'country' })
+    })
+
+    it('should preselect the second radio button (Wales)', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            name="country"
+            type="radio"
+            options={OPTIONS}
+            initialValue={OPTIONS[1]} // Wales
+          />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+      })
+      assertFieldRadioSelected({
+        inputName: 'country',
+        selectedIndex: 1,
+      })
+    })
+
+    it('should render a hint', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="radio"
+            name="country"
+            options={OPTIONS}
+            hint="My hint"
+          />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+        hint: 'My hint',
+      })
+    })
+
+    it('should render a legend', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            name="country"
+            type="radio"
+            options={OPTIONS}
+            legend={<H1>My H1 legend</H1>}
+          />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+        legend: 'My H1 legend',
+      })
+    })
+
+    it('should render inline radio buttons', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="radio"
+            name="country"
+            options={OPTIONS}
+            inline={true}
+          />
+        </Form>
+      )
+
+      cy.get('[data-test="field-country"] fieldset')
+        .children()
+        .eq(0)
+        .should('have.css', 'display', 'flex')
+    })
+
+    it('should render an error when saving', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="radio"
+            name="country"
+            options={OPTIONS}
+            required="Select at least one country"
+          />
+        </Form>
+      )
+      cy.get(`[data-test="submit-button"]`).click()
+      assertFieldErrorStrict({
+        inputName: 'country',
+        errorMessage: 'Select at least one country',
+      })
+    })
+  })
+
+  context('Checkboxes', () => {
+    it('should render checkboxes', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice type="checkbox" name="country" options={OPTIONS} />
+        </Form>
+      )
+      assertFieldCheckboxesStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+      })
+    })
+
+    it('should check the first and second checkboxes', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="checkbox"
+            name="country"
+            options={OPTIONS}
+            initialValue={[OPTIONS[0], OPTIONS[1]]} // England and Wales
+          />
+        </Form>
+      )
+      assertFieldCheckboxesChecked({
+        inputName: 'country',
+        selectedIndices: [0, 1],
+      })
+    })
+
+    it('should render a hint', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="checkbox"
+            name="country"
+            options={OPTIONS}
+            hint="My hint"
+          />
+        </Form>
+      )
+      assertFieldCheckboxesStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+        hint: 'My hint',
+      })
+    })
+
+    it('should render a legend', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="checkbox"
+            name="country"
+            options={OPTIONS}
+            legend={<H1>My H1 legend</H1>}
+          />
+        </Form>
+      )
+      assertFieldCheckboxesStrict({
+        inputName: 'country',
+        options: OPTIONS.map((x) => x.label),
+        legend: 'My H1 legend',
+      })
+    })
+
+    it('should render inline checkboxes', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="checkbox"
+            name="country"
+            options={OPTIONS}
+            inline={true}
+          />
+        </Form>
+      )
+      cy.get('[data-test="field-country"] fieldset')
+        .children()
+        .eq(0)
+        .should('have.css', 'display', 'flex')
+    })
+
+    it('should render an error when saving', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice
+            type="checkbox"
+            name="country"
+            options={OPTIONS}
+            required="Choose one or more countries"
+          />
+        </Form>
+      )
+      cy.get(`[data-test="submit-button"]`).click()
+      assertFieldErrorStrict({
+        inputName: 'country',
+        errorMessage: 'Choose one or more countries',
+      })
+    })
+  })
+})

--- a/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
@@ -111,24 +111,6 @@ describe('FieldChoice', () => {
       })
     })
 
-    it('should render inline radio buttons', () => {
-      cy.mountWithProvider(
-        <Form {...FORM_PROPS}>
-          <FieldChoice
-            type="radio"
-            name="country"
-            options={OPTIONS}
-            inline={true}
-          />
-        </Form>
-      )
-
-      cy.get('[data-test="field-country"] fieldset')
-        .children()
-        .eq(0)
-        .should('have.css', 'display', 'flex')
-    })
-
     it('should render an error when saving', () => {
       cy.mountWithProvider(
         <Form {...FORM_PROPS}>
@@ -212,23 +194,6 @@ describe('FieldChoice', () => {
         options: OPTIONS.map((x) => x.label),
         legend: 'My H1 legend',
       })
-    })
-
-    it('should render inline checkboxes', () => {
-      cy.mountWithProvider(
-        <Form {...FORM_PROPS}>
-          <FieldChoice
-            type="checkbox"
-            name="country"
-            options={OPTIONS}
-            inline={true}
-          />
-        </Form>
-      )
-      cy.get('[data-test="field-country"] fieldset')
-        .children()
-        .eq(0)
-        .should('have.css', 'display', 'flex')
     })
 
     it('should render an error when saving', () => {

--- a/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
@@ -56,13 +56,8 @@ describe('FieldChoice', () => {
 
     it('should preselect the second radio button (Wales)', () => {
       cy.mountWithProvider(
-        <Form {...FORM_PROPS}>
-          <FieldChoice
-            name="country"
-            type="radio"
-            options={OPTIONS}
-            initialValue={OPTIONS[1]} // Wales
-          />
+        <Form {...FORM_PROPS} initialValues={{ country: [OPTIONS[1]] }}>
+          <FieldChoice name="country" type="radio" options={OPTIONS} />
         </Form>
       )
       assertFieldRadiosStrict({
@@ -145,13 +140,11 @@ describe('FieldChoice', () => {
 
     it('should check the first and second checkboxes', () => {
       cy.mountWithProvider(
-        <Form {...FORM_PROPS}>
-          <FieldChoice
-            type="checkbox"
-            name="country"
-            options={OPTIONS}
-            initialValue={[OPTIONS[0], OPTIONS[1]]} // England and Wales
-          />
+        <Form
+          {...FORM_PROPS}
+          initialValues={{ country: [OPTIONS[0], OPTIONS[1]] }}
+        >
+          <FieldChoice type="checkbox" name="country" options={OPTIONS} />
         </Form>
       )
       assertFieldCheckboxesChecked({

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -307,6 +307,24 @@ const assertFieldRadiosStrict = ({
         })
     })
 
+const assertFieldRadioSelected = ({ inputName, selectedIndex }) =>
+  cy
+    .get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      cy.get('input[type="radio"]').eq(selectedIndex).should('be.checked')
+    })
+
+const assertFieldRadiosNotSelected = ({ inputName }) =>
+  cy
+    .get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      cy.get('input[type="radio"]').each(($el) => {
+        cy.wrap($el).should('not.be.checked')
+      })
+    })
+
 // As part of the accessibility work, a sample of pages have been refactored to use legends instead of labels.
 // Use this assertion for radios which have legends applied.
 const assertFieldRadiosWithLegend = ({
@@ -376,6 +394,44 @@ const assertFieldCheckboxes = ({ element, legend, hint, options = [] }) => {
       const link = options[index].link
       // Optional options field parameter
       link && cy.get(label).find('summary').should('contain', link)
+    })
+}
+
+const assertFieldCheckboxesStrict = ({ inputName, options, legend, hint }) =>
+  cy
+    .get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      if (legend) {
+        cy.get('legend').should('have.text', legend)
+      }
+      if (hint) {
+        cy.get('[data-test="hint-text"]').should('have.text', hint)
+      }
+
+      cy.get('input[type="checkbox"]')
+        .should('have.length', options.length)
+        .each(($el, i) => {
+          const label = options[i]
+          cy.wrap($el)
+            .should('have.attr', 'aria-label', label)
+            .parent()
+            .should('match', 'label')
+            .should('have.text', label)
+        })
+    })
+
+const assertFieldCheckboxesChecked = ({ inputName, selectedIndices }) => {
+  cy.get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      cy.get('input[type="checkbox"]').each(($el, index) => {
+        if (selectedIndices.includes(index)) {
+          cy.wrap($el).should('be.checked')
+        } else {
+          cy.wrap($el).should('not.be.checked')
+        }
+      })
     })
 }
 
@@ -960,6 +1016,14 @@ const assertFieldError = (element, errorMessage, hasHint = true) =>
     .eq(hasHint ? 1 : 0)
     .should('have.text', errorMessage)
 
+const assertFieldErrorStrict = ({ inputName, errorMessage }) =>
+  cy
+    .get(`[data-test="field-${inputName}"]`)
+    .should('exist')
+    .within(() => {
+      cy.get('span').eq(1).should('have.text', errorMessage)
+    })
+
 /**
  * Assert the typeahead element contains a chip for each of the values
  * @param {*} selector the selector for the typeahead component
@@ -1012,9 +1076,13 @@ module.exports = {
   assertSelectOptions,
   assertFieldRadios,
   assertFieldRadiosStrict,
+  assertFieldRadiosNotSelected,
+  assertFieldRadioSelected,
   assertFieldRadiosWithLegend,
   assertFieldRadiosWithoutLabel,
   assertFieldCheckboxes,
+  assertFieldCheckboxesStrict,
+  assertFieldCheckboxesChecked,
   assertFieldAddress,
   assertFieldUneditable,
   assertFormActions,
@@ -1057,6 +1125,7 @@ module.exports = {
   assertAPIRequest,
   assertExactUrl,
   assertFieldError,
+  assertFieldErrorStrict,
   assertTypeaheadValues,
   assertLink,
   assertLinkWithText,


### PR DESCRIPTION
## Description of change
The `FieldChoice` component is designed to render a group of radio buttons or checkboxes by setting the prop type to either `"radio"` or `"checkbox".` This component updates the Form's state with the entire selected option (Object), which is useful for user journeys where the final page is a summary page, and you need to extract a name (or any other field) from a previous selection. Currently, the `FieldRadio` component only writes the ID (String) to the form state.

## Usage

```js
const OPTIONS = [
  {
    value: '0',
    label: 'England',
  },
  {
    value: '1',
    label: 'Wales',
  },
  {
    value: '2',
    label: 'Scotland',
  },
  {
    value: '3',
    label: 'Northern Ireland',
  },
]
```

**Radio buttons**
```js
<FieldChoice type="radio" name="country" label="Countries" options={OPTIONS} />
```

Or the preferred approach (`type` prop not required):

```js
<FieldChoice.Radio name="countries" label="Countries" options={OPTIONS}/>
```

<img width="266" alt="Screenshot 2024-06-26 at 09 23 11" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b31fb687-e871-4674-88fe-ad4873b2faef">

**Checkboxes**
```js
<FieldChoice type="checkbox" name="country" label="Countries" options={OPTIONS} />
```

Or the preferred approach (`type` prop not required):

```js
<FieldChoice.Checkbox name="countries" label="Countries" options={OPTIONS} />
```

<img width="264" alt="Screenshot 2024-06-26 at 09 25 47" src="https://github.com/uktrade/data-hub-frontend/assets/964268/19ec5eb5-3d01-4c19-b648-d248b05c9ad7">

## Test
`npm run storybook` and click through the list of `FieldChoice` stories. From here you can see what is written to the form state and view/copy fragments of code.

<img width="291" alt="Screenshot 2024-07-05 at 12 10 04" src="https://github.com/uktrade/data-hub-frontend/assets/964268/0c7246df-65cf-41c8-b7a0-9c2e78f8dc3a">

<img width="925" alt="Screenshot 2024-07-05 at 12 13 25" src="https://github.com/uktrade/data-hub-frontend/assets/964268/b95ce8c1-a6f1-4e4a-b1cb-a197502ed160">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
