### PR TITLE
Feature/CLS2-810 remove optional text from additional mandatory fields in active stage

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -175,6 +175,9 @@ const EditProjectSummaryInitialStep = ({
       />
       <FieldActualLandDate
         initialValue={transformDateStringToDateObject(project.actualLandDate)}
+        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
+          project.stage.name
+        )}
       />
       {showInvestorTypeField() ? (
         <FieldInvestmentInvestorType
@@ -187,6 +190,9 @@ const EditProjectSummaryInitialStep = ({
       ) : null}
       <FieldLevelOfInvolvement
         initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}
+        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
+          project.stage.name
+        )}
       />
       <FieldSpecificProgramme
         initialValue={transformArrayForTypeahead(project.specificProgrammes)}

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -296,10 +296,13 @@ export const FieldLikelihoodOfLanding = ({
   />
 )
 
-export const FieldActualLandDate = ({ initialValue = null }) => (
+export const FieldActualLandDate = ({
+  initialValue = null,
+  optionalText = true,
+}) => (
   <FieldDate
     name="actual_land_date"
-    label="Actual land date (optional)"
+    label={'Actual land date' + (optionalText ? ' (optional)' : '')}
     hint="The date investment project activities started"
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
@@ -322,10 +325,15 @@ export const FieldInvestmentInvestorType = ({
   />
 )
 
-export const FieldLevelOfInvolvement = ({ initialValue = null }) => (
+export const FieldLevelOfInvolvement = ({
+  initialValue = null,
+  optionalText = true,
+}) => (
   <ResourceOptionsField
     name="level_of_involvement"
-    label="Level of investor involvement (optional)"
+    label={
+      'Level of investor involvement' + (optionalText ? ' (optional)' : '')
+    }
     resource={LevelOfInvolvementResource}
     field={FieldTypeahead}
     initialValue={initialValue}

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -14,11 +14,11 @@ const {
   assertFieldRadiosWithLegend,
   assertFieldInput,
   assertFieldSelect,
-  assertFieldDate,
   assertFieldDateShort,
   assertFieldRadios,
   assertErrorSummary,
   assertFieldTypeaheadWithExactText,
+  assertFieldDateWithExactText,
 } = require('../../support/assertions')
 
 const setupProjectFaker = (overrides) =>
@@ -290,11 +290,11 @@ describe('Editing the project summary', () => {
       })
     })
 
-    it('should display the Actual land date field', () => {
+    it('should display the Actual land date field with optional text in the label', () => {
       cy.get('[data-test="field-actual_land_date"]').then((element) => {
-        assertFieldDate({
+        assertFieldDateWithExactText({
           element,
-          label: 'Actual land date',
+          label: 'Actual land date (optional)',
           hint: 'When activities under the investment project fully commenced',
         })
       })
@@ -310,11 +310,11 @@ describe('Editing the project summary', () => {
       })
     })
 
-    it('should display the level of investor involvement field', () => {
+    it('should display the level of investor involvement field with optional text in the label', () => {
       cy.get('[data-test="field-level_of_involvement"]').then((element) => {
-        assertFieldTypeahead({
+        assertFieldTypeaheadWithExactText({
           element,
-          label: 'Level of investor involvement',
+          label: 'Level of investor involvement (optional)',
           placeholder: 'Choose a level of involvement',
         })
       })
@@ -359,6 +359,26 @@ describe('Editing the project summary', () => {
           element,
           label: 'New or existing investor',
           optionsCount: 2,
+        })
+      })
+    })
+
+    it('should render the actual land date field label without the word optional', () => {
+      cy.get('[data-test="field-actual_land_date"]').then((element) => {
+        assertFieldDateWithExactText({
+          element,
+          label: 'Actual land date',
+          hint: 'When activities under the investment project fully commenced',
+        })
+      })
+    })
+
+    it('should render the level of investor involvement field label without the word optional', () => {
+      cy.get('[data-test="field-level_of_involvement"]').then((element) => {
+        assertFieldTypeaheadWithExactText({
+          element,
+          label: 'Level of investor involvement',
+          placeholder: 'Choose a level of involvement',
         })
       })
     })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -617,6 +617,21 @@ const assertFieldDate = ({ element, label, value = {} }) => {
   value.year && expect(inputs[2]).to.have.value(value.year)
 }
 
+const assertFieldDateWithExactText = ({ element, label, value = {} }) => {
+  const inputs = element.find('input')
+  const labels = element.find('label')
+
+  label && expect(labels[0]).to.have.text(label)
+
+  expect(labels[1]).to.have.text('Day')
+  expect(labels[2]).to.have.text('Month')
+  expect(labels[3]).to.have.text('Year')
+
+  value.day && expect(inputs[0]).to.have.value(value.day)
+  value.month && expect(inputs[1]).to.have.value(value.month)
+  value.year && expect(inputs[2]).to.have.value(value.year)
+}
+
 const assertFieldDateShort = ({ element, label, value = {} }) => {
   const labels = element.find('label')
   const inputs = element.find('input')
@@ -1004,6 +1019,7 @@ module.exports = {
   assertFieldUneditable,
   assertFormActions,
   assertFieldDate,
+  assertFieldDateWithExactText,
   assertFieldDateShort,
   assertFieldHidden,
   assertFormFields,


### PR DESCRIPTION
## Description of change

The 'Actual land date' and 'Level of investor involvement' fields are now mandatory when moving an investment project from the the 'Assign PM' stage to the "Active' stage. This change updates the names displayed for the field so that the text '(optional)' is removed when a project moves to the 'Active' stage to make it clearer that the fields are now mandatory.

## Test instructions
1. Select an investment project in the 'Prospect' or 'Assign PM' stage.
Select 'Edit Summary'
You should see the fields named with the '(optional)' text present
i.e. '**Actual land date (optional)**' and '**Level of investor involvement (optional)**'
<img width="736" alt="Screenshot 2024-06-26 at 09 26 53" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/d11985f1-450d-4709-9151-00c5d6d3d64a">

<img width="736" alt="Screenshot 2024-06-26 at 09 28 30" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/5d261f53-2280-4c1f-827f-dd904a84c1dc">

2. Select an investment project in the 'Active', 'Verify win' or 'Won' stage
Select 'Edit Summary'
You should see the fields named without the '(optional)' text present
i.e. '**Actual land date**' and '**Level of investor involvement**'
<img width="736" alt="Screenshot 2024-06-26 at 09 27 48" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/71c2f6b3-5882-4df6-8748-1d191ffecb17">

<img width="736" alt="Screenshot 2024-06-26 at 09 28 02" src="https://github.com/uktrade/data-hub-frontend/assets/74198488/878b7789-76c5-4496-aa9d-cce06bbf34e6">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
