### PR TITLE
change specific programmes field default to empty array

### DIFF
--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -334,7 +334,7 @@ export const FieldLevelOfInvolvement = ({ initialValue = null }) => (
 )
 
 export const FieldSpecificProgramme = ({
-  initialValue = null,
+  initialValue = [],
   optionalText = true,
 }) => (
   <ResourceOptionsField


### PR DESCRIPTION
## Description of change

Change initial value for the specific programmes field to an empty array, to remove not null error we are getting now due to changing it from a one-to-many relationship to a many-to-many relationship with an investment project

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
