### PR TITLE
Ensure Storybook Dependabot config is up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,6 @@ updates:
   - dependency-name: react-redux # TET-154
     versions:
     - "> 7.2.8"
-  - dependency-name: react-router-dom # TET-34
-    versions:
-    - "> 5.3.0"
   - dependency-name: jsdom # TET-371
     versions:
       - "> 20.0.3"
@@ -33,10 +30,10 @@ updates:
   - dependency-name: "@storybook/addon-essentials"
     versions:
     - ">= 0"
-  - dependency-name: "@storybook/react"
+  - dependency-name: "@storybook/react-webpack5"
     versions:
     - ">= 0"
-  - dependency-name: "@storybook/react-webpack5"
+  - dependency-name: "@storybook/addon-webpack5-compiler-babel"
     versions:
     - ">= 0"
   - dependency-name: "storybook"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "adr-list": "adr list",
     "adr-graph": "adr generate graph",
     "adr-toc": "adr generate toc",
-    "dependabot:update-storybook": "npm install --save-dev @storybook/addon-a11y@latest @storybook/addon-essentials@latest @storybook/manager-api@latest @storybook/react@latest @storybook/react-webpack5@latest storybook@latest",
+    "dependabot:update-storybook": "npm install --save-dev @storybook/addon-a11y@latest @storybook/addon-essentials@latest @storybook/addon-webpack5-compiler-babel@latest @storybook/manager-api@latest @storybook/react@latest @storybook/react-webpack5@latest storybook@latest",
     "dependabot:update-sentry": "npm install @sentry/browser@latest @sentry/node@latest @sentry/react@latest",
     "dependabot:update-nivo": "npm install @nivo/core@latest @nivo/pie@latest @nivo/tooltip@latest"
   },


### PR DESCRIPTION
## Description of change

The Dependabot/Storybook script and `ignore` setup was outdated so I have sorted this. I've also removed `react-router-dom` from the ignorelist as we have upgraded this now.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
