### PR TITLE
Form/submission task result to values

### DIFF
--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -82,7 +82,11 @@ const FieldSelect = ({
           </option>
         )}
         {options.map(({ label: optionLabel, value: optionValue }) => (
-          <option key={optionValue} value={optionValue}>
+          <option
+            key={optionValue}
+            value={optionValue}
+            selected={value === optionValue}
+          >
             {optionLabel}
           </option>
         ))}

--- a/src/client/components/Form/index.jsx
+++ b/src/client/components/Form/index.jsx
@@ -71,6 +71,7 @@ const _Form = ({
   reactRouterRedirect,
   transformInitialValues = (x) => x,
   transformPayload = (x) => x,
+  submissionTaskResultToValues,
   onSuccess,
   onError,
   submitButtonLabel = 'Save',
@@ -324,6 +325,16 @@ const _Form = ({
                                 }
                               }}
                             />
+                            {submissionTaskResultToValues && result && (
+                              <Effect
+                                dependencyList={[result]}
+                                effect={() => {
+                                  props.setValues(
+                                    submissionTaskResultToValues?.(result)
+                                  )
+                                }}
+                              />
+                            )}
                             <Effect
                               dependencyList={[submissionTask.hasError]}
                               effect={() => {
@@ -429,6 +440,11 @@ const dispatchToProps = (dispatch) => ({
       type: 'FORM__FIELD_SET_VALUE',
       fieldName,
       fieldValue,
+    }),
+  setValues: (values) =>
+    dispatch({
+      type: 'FORM__FIELD_SET_VALUES',
+      values,
     }),
   setFieldTouched: (fieldName) =>
     dispatch({
@@ -574,6 +590,10 @@ const dispatchToProps = (dispatch) => ({
  * property in the form's state.
  * @param {Props['scrollToTopOnStep']} [props.scrollToTopOnStep] - Whether or not page
  * should scroll to the top when navigating between steps.
+ * @param {Props['submissionTaskResultToValues']} [props.submissionTaskResultToValues] -
+ * Use this to update form values with the submission task result.
+ * It will be called with the submission task result and should return an object
+ * mapping field names to their values. If not set, the task result will be ignored.
  * */
 const Form = multiInstance({
   name: 'Form',

--- a/src/client/components/Form/reducer.js
+++ b/src/client/components/Form/reducer.js
@@ -98,6 +98,14 @@ export default (
           [action.fieldName]: action.fieldValue,
         },
       }
+    case 'FORM__FIELD_SET_VALUES':
+      return {
+        ...state,
+        values: {
+          ...state.values,
+          ...action.values,
+        },
+      }
     case FORM__FIELD_TOUCHED:
       return {
         ...state,

--- a/src/client/components/Form/types.d.ts
+++ b/src/client/components/Form/types.d.ts
@@ -38,6 +38,7 @@ export type Props = {
   onSuccess?: (successActionResult: any, values: Values, actions: OnSuccessActions) => any,
   transformInitialValues?: (initialValuesTaskResult: any) => Values,
   transformPayload?: (values: Values) => any,
+  submissionTaskResultToValues?: (result: any) => Values,
   children?: Children,
   submitButtonLabel?: string,
   submitButtonColour?: string,

--- a/test/component/cypress/specs/components/Form/submissionTaskResultToValues.cy.jsx
+++ b/test/component/cypress/specs/components/Form/submissionTaskResultToValues.cy.jsx
@@ -1,0 +1,93 @@
+import React from 'react'
+
+import {
+  Form,
+  FieldInput,
+  FieldSelect,
+  FieldCheckboxes,
+  FieldRadios,
+} from '../../../../../../src/client/components'
+
+describe('submissionTaskResultToValues', () => {
+  context('When there are no steps', () => {
+    it('should render a save button', () => {
+      cy.mountWithProvider(
+        <Form
+          id="my-form"
+          submissionTaskName="myTask"
+          submissionTaskResultToValues={(result) => result}
+        >
+          <FieldInput name="input" />
+          <FieldSelect
+            name="select"
+            options={[
+              { label: 'Foo', value: 'foo' },
+              { label: 'Bar', value: 'bar' },
+              { label: 'Baz', value: 'baz' },
+            ]}
+          />
+          <FieldCheckboxes
+            name="checkboxes"
+            options={[
+              { label: 'Foo', value: 'foo' },
+              { label: 'Bar', value: 'bar' },
+              { label: 'Baz', value: 'baz' },
+            ]}
+          />
+          <FieldRadios
+            name="radios"
+            options={[
+              { label: 'Foo', value: 'foo' },
+              { label: 'Bar', value: 'bar' },
+              { label: 'Baz', value: 'baz' },
+            ]}
+          />
+        </Form>,
+        {
+          tasks: {
+            myTask: (payload) => ({
+              input: payload.input.toUpperCase(),
+              select: 'bar',
+              checkboxes: ['foo', 'baz'],
+              radios: 'bar',
+            }),
+          },
+        }
+      )
+
+      // FieldInput
+      const INPUT_TEXT = 'abcdefg'
+      cy.get('[name=input]').type(INPUT_TEXT).should('have.value', INPUT_TEXT)
+
+      // FieldSelect
+      cy.get('#select').select('baz')
+
+      // FieldCheckboxes
+      cy.get('[type=checkbox][name=bar]').check()
+      cy.get('[type=checkbox][name=foo]').should('not.be.checked')
+      cy.get('[type=checkbox][name=bar]').should('be.checked')
+      cy.get('[type=checkbox][name=baz]').should('not.be.checked')
+
+      // FieldRadios
+      cy.get('[type=radio][value=foo]').check()
+      cy.get('[type=radio][value=foo]').should('be.checked')
+      cy.get('[type=radio][value=bar]').should('not.be.checked')
+      cy.get('[type=radio][value=baz]').should('not.be.checked')
+
+      cy.get('button').contains('Save').click()
+
+      // After submission, fields should have values returned from submissionTaskResultToValues
+      cy.get('[name=input]').should('have.value', INPUT_TEXT.toUpperCase())
+
+      cy.get('#select').should('have.value', 'bar')
+
+      cy.get('[type=checkbox][name=foo]').should('be.checked')
+      cy.get('[type=checkbox][name=bar]').should('not.be.checked')
+      cy.get('[type=checkbox][name=baz]').should('be.checked')
+
+      cy.get('[type=radio][value=foo]').should('not.be.checked')
+      cy.get('[type=radio][value=bar]').should('be.checked')
+      cy.get('[type=radio][value=baz]').should('not.be.checked')
+    })
+  })
+})

--- a/test/functional/cypress/specs/companies/export/edit-spec.js
+++ b/test/functional/cypress/specs/companies/export/edit-spec.js
@@ -27,14 +27,6 @@ describe('Company Export tab - Edit exports', () => {
     )
   }
 
-  function selectOption(selector, index) {
-    cy.get(selector)
-      .find('option')
-      .then(($els) => $els.get(index).setAttribute('selected', 'selected'))
-      .parent()
-      .trigger('change')
-  }
-
   context(
     'Without an existing export win category, great profile or export potential',
     () => {
@@ -71,7 +63,7 @@ describe('Company Export tab - Edit exports', () => {
         assertButtons(minimallyMinimal.id)
 
         //selecting a real value should send the UUID
-        selectOption('#field-export_experience_category', 1)
+        cy.get('#export_experience_category').select('Export growth')
 
         cy.contains('Save and return').click()
 
@@ -126,8 +118,7 @@ describe('Company Export tab - Edit exports', () => {
       it('Should render the buttons and clicking Save should save the value', () => {
         assertButtons(dnbLimited.id)
 
-        //selecting the first value should set the category back to null
-        selectOption('#field-export_experience_category', 0)
+        cy.get('#export_experience_category').select('-- Select category --')
 
         cy.contains('Save and return').click()
 


### PR DESCRIPTION
## Description of change

This PR adds the `submissionTaskResultToValues` prop to the `Form` component to allow for the form values to be updated based on the submission task result.

## Test instructions

1. Instantiate the `Form` component
2. Set the `submissionTaskResultToValues` prop to a function which takes the task result as argument and should return an object mapping field names to their desired values
3. The function should be called wit the submission task result when the task resolves
4. If the function returns an object with property names the same as names of the form fields, the corresponding fields should be set to the value under that property (the value must be compatible with the field)

