### PR TITLE
Hide the Export Wins list

### DIFF
--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import Details from '@govuk-react/details'
 import Link from '@govuk-react/link'
-import { Button } from 'govuk-react'
+import { Button, WarningText } from 'govuk-react'
 import { H3 } from '@govuk-react/heading'
 import { SPACING } from '@govuk-react/constants'
 import { useParams } from 'react-router-dom'
@@ -10,7 +10,7 @@ import { useParams } from 'react-router-dom'
 import { GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 import { SummaryTable } from '../../../components'
 import urls from '../../../../lib/urls'
-import ExportWins from './ExportWins'
+//import ExportWins from './ExportWins'
 import GreatProfile from './GreatProfile'
 import { CompanyResource } from '../../../components/Resource'
 import CompanyLayout from '../../../components/Layout/CompanyLayout'
@@ -178,7 +178,14 @@ const ExportsIndex = () => {
                 measures export activity.
               </p>
             </Details>
-            <ExportWins companyId={companyId} companyName={company.name} />
+            <WarningText data-test="wins-unavailable">
+              This service is currently unavailable due to maintenance. Email{' '}
+              <Link href={`mailto:datahubsupport@uktrade.zendesk.com`}>
+                datahubsupport@uktrade.zendesk.com
+              </Link>{' '}
+              if you have any questions
+            </WarningText>
+            {/*<ExportWins companyId={companyId} companyName={company.name} />*/}
           </CompanyLayout>
         )}
       </CompanyResource>

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -3,9 +3,9 @@ const { assertBreadcrumbs } = require('../../../support/assertions')
 const urls = require('../../../../../../src/lib/urls')
 
 function visitExportIndex(companyId) {
-  cy.intercept('GET', '**/export-win').as('exportWinResults')
+  //cy.intercept('GET', '**/export-win').as('exportWinResults')
   cy.visit(urls.companies.exports.index(companyId))
-  cy.wait('@exportWinResults')
+  //cy.wait('@exportWinResults')
 }
 
 describe('Company Export tab', () => {
@@ -133,7 +133,16 @@ describe('Company Export tab', () => {
         )
       })
 
-      it('should render the list of Export Wins without pagination', () => {
+      it('should render the message saying wins are not available', () => {
+        cy.get('[data-test="wins-unavailable"]')
+          .should('exist')
+          .should(
+            'contain',
+            'This service is currently unavailable due to maintenance. Email datahubsupport@uktrade.zendesk.com if you have any questions'
+          )
+      })
+
+      it.skip('should render the list of Export Wins without pagination', () => {
         const LIST_ALIAS = 'export-wins-collection-list'
 
         cy.contains('8 results').parent().parent().as(LIST_ALIAS)
@@ -303,7 +312,7 @@ describe('Company Export tab', () => {
     })
   })
 
-  describe('Export Wins', () => {
+  describe.skip('Export Wins', () => {
     function visitExports(companyId) {
       cy.intercept('**/export-win').as('exportWinsResults')
       cy.visit(urls.companies.exports.index(companyId))


### PR DESCRIPTION
## Description of change

Due to numerous issues with the legacy Export Wins integration and the fact that the upcoming shutdown of the old EW service will cause us problems during hypercare, we have decided to temporarily hide the Export Wins list from users.

Once we have exited hypercare we can bring this back (provided that the legacy Export Wins site has been switched off and the replacement is ready).

## Test instructions

Go to the export tab for a company. You should see the warning message below instead of any errors or wins.

## Screenshots

<img width="641" alt="Screenshot 2024-07-16 at 15 21 00" src="https://github.com/user-attachments/assets/e55c452f-e460-4407-9b24-9947ce239bf0">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
