### PR TITLE
Restrict specific programme field to be single-select

### DIFF
--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -67,8 +67,14 @@ export const transformFormValuesToPayload = (values, csrfToken) => {
         ? INVESTOR_TYPES.existing.value
         : investor_type,
     level_of_involvement: level_of_involvement?.value,
-    specific_programmes:
-      specific_programmes && specific_programmes.map((x) => x.value),
+  }
+
+  if (Array.isArray(specific_programmes)) {
+    payload.specific_programmes = specific_programmes.map((x) => x.value)
+  } else if (typeof specific_programmes === 'object') {
+    payload.specific_programmes = [specific_programmes.value]
+  } else {
+    payload.specific_programmes = []
   }
 
   if (fdi_type?.value === FDI_TYPES.capitalOnly.value) {

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -103,7 +103,7 @@ export const INCOMPLETE_FIELDS = {
   foreign_equity_investment: 'Foreign equity investment',
   associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
   fdi_type: 'FDI type',
-  specific_programmes: 'Specific investment programmes',
+  specific_programmes: 'Specific investment programme',
   uk_company: 'UK recipient company',
   investor_type: 'Investor type',
   level_of_involvement: 'Level of investor involvement',

--- a/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
@@ -186,7 +186,7 @@ const ProjectDetails = ({ currentAdviserId }) => {
               ) : null}
               {project.specificProgrammes.length > 0 ? (
                 <SummaryTable.TextRow
-                  heading="Specific investment programmes"
+                  heading="Specific investment programme"
                   value={project.specificProgrammes
                     ?.map((programme) => programme.name)
                     .join(', ')}

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -169,8 +169,6 @@ export const transformProjectSummaryForApi = ({
         ? INVESTOR_TYPES.existing.value
         : checkIfItemHasValue(investor_type),
     level_of_involvement: checkIfItemHasValue(level_of_involvement?.value),
-    specific_programmes:
-      specific_programmes && specific_programmes.map((x) => x.value),
     other_business_activity,
     business_activities: business_activities.map((x) => x.value),
     client_contacts: client_contacts.map((x) => x.value),
@@ -183,6 +181,14 @@ export const transformProjectSummaryForApi = ({
     ),
     referral_source_activity_event: setReferralSourceEvent(values),
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
+  }
+
+  if (Array.isArray(specific_programmes)) {
+    summaryPayload.specific_programmes = specific_programmes.map((x) => x.value)
+  } else if (typeof specific_programmes === 'object') {
+    summaryPayload.specific_programmes = [specific_programmes.value]
+  } else {
+    summaryPayload.specific_programmes = []
   }
 
   if (fdi_type?.value == FDI_TYPES.capitalOnly.value) {

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -348,13 +348,13 @@ export const FieldSpecificProgramme = ({
   <ResourceOptionsField
     name="specific_programmes"
     label={
-      'Specific investment programmes' + (optionalText ? ' (optional)' : '')
+      'Specific investment programme' + (optionalText ? ' (optional)' : '')
     }
     resource={SpecificInvestmentProgrammesResource}
     field={FieldTypeahead}
-    isMulti={true}
+    isMulti={false}
     initialValue={initialValue}
-    placeholder="Choose specific programmes"
+    placeholder="Choose a specific programme"
     resultToOptions={(result) =>
       idNamesToValueLabels(result.filter((option) => !option.disabledOn))
     }

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -73,7 +73,7 @@ export const mapFieldToUrl = (field, projectId) => {
   const detailsFields = [
     'Actual land date',
     'FDI type',
-    'Specific investment programmes',
+    'Specific investment programme',
     'Investor type',
     'Level of investor involvement',
   ]

--- a/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
@@ -235,7 +235,7 @@ describe('ProjectIncompleteFields', () => {
         assertLink('Non-FDI R&D project', associatedLink)
         assertLink('UK recipient company', recipientCompanyLink)
         assertLink('Investor type', detailsLink)
-        assertLink('Specific investment programmes', detailsLink)
+        assertLink('Specific investment programme', detailsLink)
         assertLink('Level of investor involvement', detailsLink)
       })
     }

--- a/test/end-to-end/cypress/specs/DIT/investment-projects-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/investment-projects-spec.js
@@ -120,7 +120,7 @@ describe('Creating an investment project', () => {
           'Actual land date': '5 May 2031',
           'New or existing investor': 'New Investor',
           'Level of involvement': data.investorLevel,
-          'Specific investment programmes': data.specificInvestmentProgrammes,
+          'Specific investment programme': data.specificInvestmentProgrammes,
         },
       })
 
@@ -219,7 +219,7 @@ describe('Creating an investment project', () => {
           'Actual land date': '5 May 2031',
           'New or existing investor': INVESTOR_TYPES.existing.label,
           'Level of involvement': data.investorLevel,
-          'Specific investment programmes': data.specificInvestmentProgrammes,
+          'Specific investment programme': data.specificInvestmentProgrammes,
         },
       })
     })
@@ -260,7 +260,7 @@ describe('Creating an investment project', () => {
           'Actual land date': '5 May 2031',
           'New or existing investor': 'New Investor',
           'Level of involvement': data.investorLevel,
-          'Specific investment programmes': data.specificInvestmentProgrammes,
+          'Specific investment programme': data.specificInvestmentProgrammes,
         },
       })
 
@@ -329,7 +329,7 @@ describe('Creating an investment project', () => {
           'Actual land date': '5 May 2031',
           'New or existing investor': 'New Investor',
           'Level of involvement': data.investorLevel,
-          'Specific investment programmes': data.specificInvestmentProgrammes,
+          'Specific investment programme': data.specificInvestmentProgrammes,
         },
       })
 
@@ -397,7 +397,7 @@ describe('Creating an investment project', () => {
           'Actual land date': '5 May 2031',
           'New or existing investor': 'New Investor',
           'Level of involvement': data.investorLevel,
-          'Specific investment programmes': data.specificInvestmentProgrammes,
+          'Specific investment programme': data.specificInvestmentProgrammes,
         },
       })
     })
@@ -442,7 +442,7 @@ describe('Creating an investment project', () => {
             'Actual land date': '5 May 2031',
             'New or existing investor': 'New Investor',
             'Level of involvement': data.investorLevel,
-            'Specific investment programmes': data.specificInvestmentProgrammes,
+            'Specific investment programme': data.specificInvestmentProgrammes,
           },
         })
       })
@@ -489,7 +489,7 @@ describe('Creating an investment project', () => {
             'Actual land date': '5 May 2031',
             'New or existing investor': 'New Investor',
             'Level of involvement': data.investorLevel,
-            'Specific investment programmes': data.specificInvestmentProgrammes,
+            'Specific investment programme': data.specificInvestmentProgrammes,
           },
         })
       })

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -369,12 +369,12 @@ describe('Investment Detail Step Form Content', () => {
     })
   })
 
-  it('should display the specific investment programmes field', () => {
+  it('should display the specific investment programme field', () => {
     cy.get('[data-test="field-specific_programmes"]').then((element) => {
       assertFieldTypeahead({
         element,
-        label: 'Specific investment programmes (optional)',
-        placeholder: 'Choose specific programmes',
+        label: 'Specific investment programme (optional)',
+        placeholder: 'Choose a specific programme',
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -43,7 +43,7 @@ describe('Investment project details', () => {
           'Actual land date': '15 August 2023',
           'New or existing investor': 'Existing Investor',
           'Level of involvement': 'FDI Hub + HQ + LEP',
-          'Specific investment programmes': 'Advanced Engineering Supply Chain',
+          'Specific investment programme': 'Advanced Engineering Supply Chain',
         },
       })
     })

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -320,12 +320,12 @@ describe('Editing the project summary', () => {
       })
     })
 
-    it('should display the specific investment programmes field with optional text in the label', () => {
+    it('should display the specific investment programme field with optional text in the label', () => {
       cy.get('[data-test="field-specific_programmes"]').then((element) => {
         assertFieldTypeaheadWithExactText({
           element,
-          label: 'Specific investment programmes (optional)',
-          placeholder: 'Choose specific programmes',
+          label: 'Specific investment programme (optional)',
+          placeholder: 'Choose a specific programme',
         })
       })
     })
@@ -383,12 +383,12 @@ describe('Editing the project summary', () => {
       })
     })
 
-    it('should render the specific programmes field label without the word optional', () => {
+    it('should render the specific programme field label without the word optional', () => {
       cy.get('[data-test="field-specific_programmes"]').then((element) => {
         assertFieldTypeaheadWithExactText({
           element,
-          label: 'Specific investment programmes',
-          placeholder: 'Choose specific programmes',
+          label: 'Specific investment programme',
+          placeholder: 'Choose a specific programme',
         })
       })
     })


### PR DESCRIPTION
## Description of change

Stakeholders now wish to revert the changes to the `specific_programme` field and make it a single-select again (see JIRA ticket CLS2-884). There is the possibility that the field may need to be made 'multi-select' again in the future.

This PR will restrict the field in the frontend, i.e. make it 'single-select' again, with minimal code changes. This will allow it to be easily reverted to 'multi-select' again in the future when required.

## Test instructions

- Select an investment project
- Select 'Edit Summary'
- At the bottom of the form, click on the Specific Programme field - you should only be able to select one option from the drop-down menu
- Hit 'submit'
- One Specific Programme (the one you selected) should be displayed under the 'Investment Project Summary' section on the project details page

## Screenshots

The field is now back to being a single select typeahead, with a de-pluralised name.

<img width="651" alt="image" src="https://github.com/user-attachments/assets/6f52c0ff-ad23-4804-aecd-312db6357c32">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
