### PR TITLE
Fix broken export win breadcrumb

### DIFF
--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -9,11 +9,13 @@ import WinsPendingList from './WinsPendingList'
 import WinsConfirmedTable from './WinsConfirmedTable'
 import urls from '../../../../lib/urls'
 
-const TITLE = /([^\/]+$)/
+const LAST_WORD = /([^\/]+)$/
 
 const ExportWinsTabNav = () => {
   const location = useLocation()
-  const title = TITLE.exec(location.pathname)
+  const match = LAST_WORD.exec(location.pathname)
+  const title = match?.[1] ?? ''
+
   return (
     <DefaultLayout
       heading="Export wins"

--- a/test/functional/cypress/specs/export-win/tabbed-navigation-breadcrumbs.js
+++ b/test/functional/cypress/specs/export-win/tabbed-navigation-breadcrumbs.js
@@ -1,0 +1,31 @@
+import urls from '../../../../../src/lib/urls'
+import { assertBreadcrumbs } from '../../../../functional/cypress/support/assertions'
+
+describe('Tabbed navigation breadcrumbs', () => {
+  ;[
+    {
+      name: 'Pending',
+      Pending: null,
+      url: urls.companies.exportWins.pending(),
+    },
+    {
+      name: 'Confirmed',
+      Confirmed: null,
+      url: urls.companies.exportWins.confirmed(),
+    },
+    {
+      name: 'Rejected',
+      Rejected: null,
+      url: urls.companies.exportWins.rejected(),
+    },
+  ].forEach(({ name, url }) => {
+    it(`should update the breadcrumbs to "${name}"`, () => {
+      cy.visit(url)
+      assertBreadcrumbs({
+        Home: urls.dashboard.index(),
+        'Export Wins': urls.companies.exportWins.index(),
+        [name]: null,
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Fixes the breadcrumbs on the export wins tab navigation page.

## Test instructions

Go to: `/exportwins` and click on each of the three tabs and ensure the breadcrumb updates and corresponds to the tab selection.

## Screenshots

### Before
<img width="677" alt="Screenshot 2024-07-17 at 11 28 46" src="https://github.com/user-attachments/assets/05de36e0-495d-453b-bbfd-6984972f2bb3">

### After
<img width="677" alt="Screenshot 2024-07-17 at 11 27 41" src="https://github.com/user-attachments/assets/710f1227-9a3b-4ba0-ae48-2857142b829f">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
