### PR TITLE
Fix/api proxy transfer encoding

### DIFF
--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -105,7 +105,9 @@ module.exports = (app) => {
         )
 
         // This is required, otherwise the API hosted on AWS responds with 403
-        proxyReq.setHeader('transfer-encoding', 'chunked')
+        if (config.isProd) {
+          proxyReq.setHeader('transfer-encoding', 'chunked')
+        }
 
         proxyReq.setHeader('authorization', `Bearer ${req.session.token}`)
         // this is required to be able to handle POST requests and avoid a conflict with bodyParser

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -104,6 +104,9 @@ module.exports = (app) => {
           }
         )
 
+        // This is required, otherwise the API hosted on AWS responds with 403
+        proxyReq.setHeader('transfer-encoding', 'chunked')
+
         proxyReq.setHeader('authorization', `Bearer ${req.session.token}`)
         // this is required to be able to handle POST requests and avoid a conflict with bodyParser
         // issue here -> https://github.com/chimurai/http-proxy-middleware/issues/320


### PR DESCRIPTION
## Description of change

Adds the `transfer-encoding: chunked` HTTP header to `/api-proxy` headers. Without this, some endpoints were responding with 403 when deployed to AWS.
