### PR TITLE
Fixed a broken activity link from company details page

### DIFF
--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Link as RouterLink } from 'react-router-dom'
 import { Link } from 'govuk-react'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
@@ -57,11 +56,11 @@ const StyledLinkHeader = styled('h3')`
   }
 `
 
+// FIXME: This should be a component
+// e.g. the positional arguments should be passed as an object
 export const TitleRenderer = (title, url, margin = { bottom: 10 }) => (
   <StyledLinkHeader margin={margin}>
-    <Link as={RouterLink} to={url}>
-      {title}
-    </Link>
+    <Link href={url}>{title}</Link>
   </StyledLinkHeader>
 )
 


### PR DESCRIPTION
## Description of change

Fixes broken `/interactions/<id>` links on `/companies/<id>/overview` page. The problem was that the link was a React Router link, but there was no route specified for it so it rendered nothing (hence the blank page).

## Test instructions

1. Navigate to `/companies/<id>/overview` of a company which has at least one activity
2. In the _Recent activity_ or _Upcoming activity_ panels click on the activity title (if any)
3. It should load (actually load, not just push to history) you to `/interactions/<id>`
4. On the `/interactions/<id>` page, you should see the interaction details and not a completely blank page

