### PR TITLE
Make sure legacy OMIS orders still load

### DIFF
--- a/src/client/modules/Omis/OMISLocalHeader.jsx
+++ b/src/client/modules/Omis/OMISLocalHeader.jsx
@@ -38,7 +38,7 @@ const transformStatus = (order, quote) => {
     noUnderscores.charAt(0).toUpperCase() + noUnderscores.slice(1)
   return order.status === STATUS.QUOTE_AWAITING_ACCEPTANCE
     ? transformedStatus + getExpiryDate(quote.expiresOn)
-    : order.status === STATUS.COMPLETE
+    : order.status === STATUS.COMPLETE && order.completedOn
       ? transformedStatus + getCompletionDate(order.completedOn)
       : transformedStatus
 }

--- a/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
@@ -120,6 +120,18 @@ const completeOrder = orderFaker({
   completedOn: '2023-11-06T14:18:28.328729',
 })
 
+const completeOrderNoDate = orderFaker({
+  id: 111,
+  primaryMarket: {
+    name: 'The Bahamas',
+  },
+  status: STATUS.COMPLETE,
+  createdOn: '2021-07-26T14:08:36.380979',
+  modifiedOn: '2022-08-16T14:18:28.328729',
+  ukRegion: { name: 'East of England' },
+  completedOn: null,
+})
+
 const cancelledOrder = orderFaker({
   id: 111,
   primaryMarket: {
@@ -333,6 +345,24 @@ describe('OMISLocalHeader', () => {
     assertCompanyLink(completeOrder.company.id)
     assertReceiptLink(completeOrder.id)
     assertViewQuoteLink(completeOrder.id)
+  })
+
+  context('When the order is a legacy order and the status is complete', () => {
+    beforeEach(() => {
+      cy.viewport(1024, 768)
+      cy.mountWithProvider(
+        <OMISLocalHeader order={completeOrderNoDate} quote={null} />
+      )
+    })
+
+    it('should render the order details', () => {
+      assertCompany(completeOrderNoDate.company.name)
+      assertMarket(completeOrderNoDate.primaryMarket.name)
+      assertUkRegion(completeOrderNoDate.ukRegion.name)
+      assertCreatedOn(3, completeOrderNoDate.createdOn)
+      assertUpdatedOn(4, completeOrderNoDate.modifiedOn)
+      assertStatus(5, 'Complete')
+    })
   })
 
   context('When the order status is cancelled', () => {


### PR DESCRIPTION
## Description of change

A Sentry issue has been identified where certain OMIS orders were not loading anymore (for example, `8996/16` in production). This is because when an order is marked as 'complete', the page relies on a completion date. However, it appears that for some orders the completion date was not saved, which caused the function that rendered the completion date to blow up.

This has been fixed by updating the function to check whether a completion date exists before it runs. For these cases, only the `Complete` status will show without a `x days ago` date.

## Test instructions

It's not easy to test this locally as the non-prod environments no longer contain any orders that will cause this bug and it will take too much time to mess around with Sandbox for a PR of this size. You can revert the change made in `OMISLocalHeader` and run the component tests to see the error.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
