### PR TITLE
Fix broken event button

### DIFF
--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -151,7 +151,7 @@ const EventDetails = ({
                   </StyledSummaryTable>
                   {!disabledOn && (
                     <FormActions>
-                      <Button as={'a'} to={urls.events.edit(id)}>
+                      <Button as={'a'} href={urls.events.edit(id)}>
                         Edit event
                       </Button>
                     </FormActions>


### PR DESCRIPTION
## Description of change

We've had a report that the 'Edit event' button has stopped working. This has now been fixed.

## Test instructions

Go to an event and click the edit button. You should be redirected to the edit event form.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
