### PR TITLE
Point activities to new endpoint for showing all activities

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/tasks.js
+++ b/src/client/modules/Companies/CompanyActivity/tasks.js
@@ -61,7 +61,7 @@ export const getCompanyInteractions = ({
   dit_participants__team,
 }) =>
   apiProxyAxios
-    .post('/v3/search/interaction', {
+    .post('/v4/search/activity', {
       limit,
       offset: getPageOffset({ limit, page }),
       subject,

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/tasks.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/tasks.js
@@ -9,7 +9,7 @@ export const getCompanyOverviewActivities = ({
   sortby = 'date:desc',
 }) =>
   apiProxyAxios
-    .post('/v3/search/interaction', {
+    .post('/v4/search/activity', {
       limit,
       company,
       sortby,

--- a/src/middleware/api-proxy.js
+++ b/src/middleware/api-proxy.js
@@ -46,6 +46,7 @@ const ALLOWLIST = [
   '/v4/dnb/company-change-request',
   '/v4/large-investor-profile',
   '/v4/large-investor-profile/:id',
+  '/v4/search/activity',
   '/v3/search/investment_project',
   '/v4/search/large-investor-profile',
   '/v4/large-capital-opportunity/:id',

--- a/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
@@ -50,7 +50,7 @@ const minimumRequest = {
 }
 
 describe('Company Activity Feed Filter', () => {
-  const companyActivitiesEndPoint = '/api-proxy/v3/search/interaction'
+  const companyActivitiesEndPoint = '/api-proxy/v4/search/activity'
 
   context('Default Params', () => {
     it('should set the default params in the get request url', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -276,7 +276,7 @@ describe('Company overview page', () => {
     const interactionsList = interactionsListFaker(3)
     beforeEach(() => {
       collectionListRequest(
-        'v3/search/interaction',
+        'v4/search/activity',
         interactionsList,
         urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
       )
@@ -310,7 +310,7 @@ describe('Company overview page', () => {
     const interactionsList = interactionsListFaker(2)
     beforeEach(() => {
       collectionListRequest(
-        'v3/search/interaction',
+        'v4/search/activity',
         interactionsList,
         urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
       )
@@ -345,7 +345,7 @@ describe('Company overview page', () => {
     () => {
       beforeEach(() => {
         collectionListRequest(
-          'v3/search/interaction',
+          'v4/search/activity',
           [],
           urls.companies.overview.index(fixtures.company.noOverviewDetails.id)
         )
@@ -405,7 +405,7 @@ describe('Company overview page', () => {
     const interactionsList = [interaction]
     beforeEach(() => {
       collectionListRequest(
-        'v3/search/interaction',
+        'v4/search/activity',
         interactionsList,
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )

--- a/test/sandbox/fixtures/v4/activity/activity-by-company-id.json
+++ b/test/sandbox/fixtures/v4/activity/activity-by-company-id.json
@@ -1,0 +1,73 @@
+{
+  "id": "9eb0b11d-384a-4225-9ee1-1ea79efd695f",
+  "companies": [
+      {
+        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+      }
+  ],
+  "contact": {
+      "name": "Bob lawson",
+      "first_name": "Bob",
+      "last_name": "lawson",
+      "job_title": "Magician",
+      "id": "0e75d636-1d24-416a-aaf0-3fb220d594ce"
+  },
+  "contacts": [
+      {
+          "name": "Bob lawson",
+          "first_name": "Bob",
+          "last_name": "lawson",
+          "job_title": "Magician",
+          "id": "0e75d636-1d24-416a-aaf0-3fb220d594ce"
+      }
+  ],
+  "created_on": "2019-02-17T18:23:48.013961Z",
+  "created_by": {
+      "name": "DBT Staff",
+      "first_name": "DBT",
+      "last_name": "Staff",
+      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+  },
+  "event": null,
+  "is_event": null,
+  "status": "complete",
+  "kind": "interaction",
+  "modified_by": {
+      "name": "DBT Staff",
+      "first_name": "DBT",
+      "last_name": "Staff",
+      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+  },
+  "modified_on": "2019-02-17T18:23:48.013992Z",
+  "date": "2019-02-11",
+  "dit_adviser": {
+      "name": "DBT Staff",
+      "first_name": "DBT",
+      "last_name": "Staff",
+      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+  },
+  "dit_team": {
+      "name": "UKTI Team East Midlands - International Trade Team",
+      "id": "9010dd28-9798-e211-a939-e4115bead28a"
+  },
+  "communication_channel": {
+      "name": "Letter/Fax",
+      "id": "74c226d7-5d95-e211-a939-e4115bead28a"
+  },
+  "grant_amount_offered": null,
+  "investment_project": null,
+  "net_company_receipt": null,
+  "service": {
+      "name": "Account Managment: Northern Powerhouse",
+      "id": "a4a733b6-eb95-e611-be23-e4115bead28a"
+  },
+  "service_delivery_status": null,
+  "subject": "sadfdsf",
+  "notes": "asdfsd",
+  "archived_documents_url_path": "",
+  "policy_areas": [],
+  "policy_feedback_notes": "",
+  "policy_issue_types": [],
+  "was_policy_feedback_provided": false
+}

--- a/test/sandbox/fixtures/v4/activity/activity-by-company-id.json
+++ b/test/sandbox/fixtures/v4/activity/activity-by-company-id.json
@@ -1,66 +1,66 @@
 {
   "id": "9eb0b11d-384a-4225-9ee1-1ea79efd695f",
   "companies": [
-      {
-        "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
-        "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
-      }
+    {
+      "name": "Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978",
+      "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018"
+    }
   ],
   "contact": {
+    "name": "Bob lawson",
+    "first_name": "Bob",
+    "last_name": "lawson",
+    "job_title": "Magician",
+    "id": "0e75d636-1d24-416a-aaf0-3fb220d594ce"
+  },
+  "contacts": [
+    {
       "name": "Bob lawson",
       "first_name": "Bob",
       "last_name": "lawson",
       "job_title": "Magician",
       "id": "0e75d636-1d24-416a-aaf0-3fb220d594ce"
-  },
-  "contacts": [
-      {
-          "name": "Bob lawson",
-          "first_name": "Bob",
-          "last_name": "lawson",
-          "job_title": "Magician",
-          "id": "0e75d636-1d24-416a-aaf0-3fb220d594ce"
-      }
+    }
   ],
   "created_on": "2019-02-17T18:23:48.013961Z",
   "created_by": {
-      "name": "DBT Staff",
-      "first_name": "DBT",
-      "last_name": "Staff",
-      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+    "name": "DBT Staff",
+    "first_name": "DBT",
+    "last_name": "Staff",
+    "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
   },
   "event": null,
   "is_event": null,
   "status": "complete",
   "kind": "interaction",
   "modified_by": {
-      "name": "DBT Staff",
-      "first_name": "DBT",
-      "last_name": "Staff",
-      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+    "name": "DBT Staff",
+    "first_name": "DBT",
+    "last_name": "Staff",
+    "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
   },
   "modified_on": "2019-02-17T18:23:48.013992Z",
   "date": "2019-02-11",
   "dit_adviser": {
-      "name": "DBT Staff",
-      "first_name": "DBT",
-      "last_name": "Staff",
-      "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
+    "name": "DBT Staff",
+    "first_name": "DBT",
+    "last_name": "Staff",
+    "id": "7d19d407-9aec-4d06-b190-d3f404627f21"
   },
   "dit_team": {
-      "name": "UKTI Team East Midlands - International Trade Team",
-      "id": "9010dd28-9798-e211-a939-e4115bead28a"
+    "name": "UKTI Team East Midlands - International Trade Team",
+    "id": "9010dd28-9798-e211-a939-e4115bead28a"
   },
   "communication_channel": {
-      "name": "Letter/Fax",
-      "id": "74c226d7-5d95-e211-a939-e4115bead28a"
+    "name": "Letter/Fax",
+    "id": "74c226d7-5d95-e211-a939-e4115bead28a"
   },
   "grant_amount_offered": null,
   "investment_project": null,
   "net_company_receipt": null,
   "service": {
-      "name": "Account Managment: Northern Powerhouse",
-      "id": "a4a733b6-eb95-e611-be23-e4115bead28a"
+    "name": "Account Managment: Northern Powerhouse",
+    "id": "a4a733b6-eb95-e611-be23-e4115bead28a"
   },
   "service_delivery_status": null,
   "subject": "sadfdsf",

--- a/test/sandbox/routes/v4/search/activity.js
+++ b/test/sandbox/routes/v4/search/activity.js
@@ -1,0 +1,5 @@
+import activity from '../../../fixtures/v4/activity/activity-by-company-id.json' assert { type: 'json' }
+
+export const searchActivities = function (req, res) {
+  return res.json(activity)
+}

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -139,6 +139,7 @@ import { order } from './routes/v3/search/order.js'
 import { searchInteraction } from './routes/v3/search/interaction.js'
 
 // V4
+import { searchActivities } from './routes/v4/search/activity.js'
 import { company } from './routes/v4/ch-company/company.js'
 import {
   getReferralDetails,
@@ -870,6 +871,7 @@ app.get('/v4/project')
 app.get('/v4/reminder/summary', getSummary)
 
 // V4 Search
+app.post('/v4/search/activity', searchActivities)
 app.post('/v4/search/company', __companies)
 app.post('/v4/search/large-investor-profile', _largeInvestorProfile)
 app.get('/v4/search/company/autocomplete', companiesAutocomplete)


### PR DESCRIPTION
## Description of change

There is a new API endpoint in the backend for showing activities. This is currently a copy of the interactions endpoint but will be extended in upcoming work. As it is a copy of the interactions endpoint for now, all existing data and functionality will be the same.

Backend PR for new endpoint: https://github.com/uktrade/data-hub-api/pull/5589

## Test instructions

Activities showing as they were before.

## Checklist

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
