### PR TITLE
Revert to old endpoint while we wait for opensearch sync

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/tasks.js
+++ b/src/client/modules/Companies/CompanyActivity/tasks.js
@@ -61,7 +61,7 @@ export const getCompanyInteractions = ({
   dit_participants__team,
 }) =>
   apiProxyAxios
-    .post('/v4/search/activity', {
+    .post('/v3/search/interaction', {
       limit,
       offset: getPageOffset({ limit, page }),
       subject,

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/tasks.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/tasks.js
@@ -9,7 +9,7 @@ export const getCompanyOverviewActivities = ({
   sortby = 'date:desc',
 }) =>
   apiProxyAxios
-    .post('/v4/search/activity', {
+    .post('/v3/search/interaction', {
       limit,
       company,
       sortby,

--- a/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-filter-spec.js
@@ -50,7 +50,7 @@ const minimumRequest = {
 }
 
 describe('Company Activity Feed Filter', () => {
-  const companyActivitiesEndPoint = '/api-proxy/v4/search/activity'
+  const companyActivitiesEndPoint = '/api-proxy/v3/search/interaction'
 
   context('Default Params', () => {
     it('should set the default params in the get request url', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -276,7 +276,7 @@ describe('Company overview page', () => {
     const interactionsList = interactionsListFaker(3)
     beforeEach(() => {
       collectionListRequest(
-        'v4/search/activity',
+        'v3/search/interaction',
         interactionsList,
         urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
       )
@@ -310,7 +310,7 @@ describe('Company overview page', () => {
     const interactionsList = interactionsListFaker(2)
     beforeEach(() => {
       collectionListRequest(
-        'v4/search/activity',
+        'v3/search/interaction',
         interactionsList,
         urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
       )
@@ -345,7 +345,7 @@ describe('Company overview page', () => {
     () => {
       beforeEach(() => {
         collectionListRequest(
-          'v4/search/activity',
+          'v3/search/interaction',
           [],
           urls.companies.overview.index(fixtures.company.noOverviewDetails.id)
         )
@@ -405,7 +405,7 @@ describe('Company overview page', () => {
     const interactionsList = [interaction]
     beforeEach(() => {
       collectionListRequest(
-        'v4/search/activity',
+        'v3/search/interaction',
         interactionsList,
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )


### PR DESCRIPTION
## Description of change

Revert to previous endpoint while we wait for the new endpoint to sync its new opensearch index. This needs to sync interactions which have over 4million records.

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
