### PR TITLE
Refactor entity resource endpoint paths

### DIFF
--- a/src/client/components/Resource/CompanyAuditHistory.js
+++ b/src/client/components/Resource/CompanyAuditHistory.js
@@ -2,5 +2,5 @@ import { createCollectionResource } from './Resource'
 
 export default createCollectionResource(
   'changes to company business details',
-  (id) => id
+  (id) => `v4/company/${id}/audit`
 )

--- a/src/client/components/Resource/ContactAuditHistory.js
+++ b/src/client/components/Resource/ContactAuditHistory.js
@@ -1,3 +1,6 @@
 import { createCollectionResource } from './Resource'
 
-export default createCollectionResource('contact change', (id) => id)
+export default createCollectionResource(
+  'contact change',
+  (id) => `v3/contact/${id}/audit`
+)

--- a/src/client/components/Resource/ProjectAuditHistory.js
+++ b/src/client/components/Resource/ProjectAuditHistory.js
@@ -1,3 +1,6 @@
 import { createCollectionResource } from './Resource'
 
-export default createCollectionResource('project change', (id) => id)
+export default createCollectionResource(
+  'project change',
+  (id) => `v3/investment/${id}/audit`
+)

--- a/src/client/components/Resource/Resource.jsx
+++ b/src/client/components/Resource/Resource.jsx
@@ -215,7 +215,7 @@ export const createEntityResource = (name, endpoint) => {
 export const createCollectionResource = (name, endpoint) => {
   const EntityResource =
     typeof endpoint === 'function'
-      ? createEntityResource(name, (endpoint) => endpoint)
+      ? createEntityResource(name, endpoint)
       : createEntityResource(name, () => endpoint)
   const transformer = (rawResult) => [
     deepKeysToCamelCase(rawResult.results),

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/CompanyEditHistory.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/CompanyEditHistory.jsx
@@ -46,7 +46,7 @@ const CompanyEditHistory = () => {
     >
       <AuditHistory
         resource={CompanyAuditHistoryResource}
-        id={`v4/company/${companyId}/audit`}
+        id={companyId}
         valueTransformer={getValue}
         fieldMapper={mapFieldNameToLabel}
         excludedFields={EXCLUDED_FIELDS}

--- a/src/client/modules/Contacts/ContactAuditHistory/ContactAuditHistory.jsx
+++ b/src/client/modules/Contacts/ContactAuditHistory/ContactAuditHistory.jsx
@@ -19,7 +19,7 @@ const ContactAuditHistory = ({ contactId, permissions }) => (
             <SectionHeader type="audit">Audit history</SectionHeader>
             <AuditHistory
               resource={ContactAuditHistoryResource}
-              id={`v3/contact/${contactId}/audit`}
+              id={contactId}
               valueTransformer={getValue}
               fieldMapper={mapFieldNameToLabel}
               excludedFields={EXCLUDED_FIELDS}

--- a/src/client/modules/Investments/Projects/EditHistory/ProjectEditHistory.jsx
+++ b/src/client/modules/Investments/Projects/EditHistory/ProjectEditHistory.jsx
@@ -24,7 +24,7 @@ const ProjectEditHistory = () => {
     >
       <AuditHistory
         resource={ProjectAuditHistoryResource}
-        id={`v3/investment/${projectId}/audit`}
+        id={projectId}
         valueTransformer={getValue}
         fieldMapper={mapFieldNameToLabel}
         auditType="the project"


### PR DESCRIPTION
## Description of change

Moved all endpoint paths from the audit history components to the corresponding entity resource so it's clear what the endpoint is for each entity resource. This is consistent with other resources and makes them reusable without having to pass the endpoint path each time, just the `id` of the entity is required.

This paves the way for a larger piece of upcoming work relating to export wins pagination.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
