### PR TITLE
Companies export tab - remove link from confirmed export wins

### DIFF
--- a/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
@@ -5,7 +5,6 @@ import CompanyExportWins from '../../../../components/Resource/CompanyExportWins
 import { currencyGBP } from '../../../../utils/number-utils'
 import { formatShortDate } from '../../../../utils/date'
 import { CollectionItem } from '../../../../components'
-import urls from '../../../../../lib/urls'
 import { WIN_STATUS } from '../../../../modules/ExportWins/Status/constants'
 
 const Bold = styled('span')({
@@ -17,14 +16,13 @@ export const SORT_OPTIONS = [
   { name: 'Oldest', value: 'created_on' },
 ]
 
-export const ExportWinsList = ({ exportWins, companyId }) =>
+export const ExportWinsList = ({ exportWins }) =>
   exportWins.length === 0 ? null : (
     <ul data-test="collectionItems">
       {exportWins.map((item) => (
         <CollectionItem
           key={item.id}
           headingText={`${item.name_of_export} to ${item?.country}`}
-          headingUrl={urls.companies.exportWins.editSummary(companyId, item.id)}
           metadata={[
             {
               label: 'Lead officer name',

--- a/test/functional/cypress/specs/companies/export/list-spec.js
+++ b/test/functional/cypress/specs/companies/export/list-spec.js
@@ -59,16 +59,8 @@ describe('Company export wins', () => {
     cy.get('[data-test="collection-item"]').each((item, index) => {
       cy.wrap(item).within(() => {
         // Assert the title link text
-        cy.get('h3 a')
+        cy.get('h3')
           .should('exist')
-          .should(
-            'have.attr',
-            'href',
-            urls.companies.exportWins.editSummary(
-              company.id,
-              exportWinList[index].id
-            )
-          )
           .invoke('text')
           .then((text) => {
             expect(text).to.eq(


### PR DESCRIPTION
## Description of change
Removes the confirmed export win link from all export wins on the company page.

## Test instructions
Go to the `/companies/<company-uuid>/exports` page to view a list of export wins. Each win in the list will no longer have a link to the summary page.

## Screenshots

### Before
<img width="1039" alt="before" src="https://github.com/user-attachments/assets/1484477e-d2cd-4397-a386-1a055486942b">

### After
<img width="1039" alt="after" src="https://github.com/user-attachments/assets/55d1460d-65a4-4dc4-87c9-99749ec955cb">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
