### PR TITLE
Company confirmed export wins - fix content and cosmetic issues

### DIFF
--- a/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
@@ -6,9 +6,10 @@ import { currencyGBP } from '../../../../utils/number-utils'
 import { formatShortDate } from '../../../../utils/date'
 import { CollectionItem } from '../../../../components'
 import { WIN_STATUS } from '../../../../modules/ExportWins/Status/constants'
+import { BLACK } from '../../../../utils/colours'
 
-const Bold = styled('span')({
-  fontWeight: 'bold',
+const Black = styled('span')({
+  color: BLACK,
 })
 
 export const SORT_OPTIONS = [
@@ -26,41 +27,37 @@ export const ExportWinsList = ({ exportWins }) =>
           metadata={[
             {
               label: 'Lead officer name',
-              value: <Bold>{item.officer.name}</Bold>,
-            },
-            {
-              label: 'Company name',
-              value: <Bold>{item.customer || 'Not set'}</Bold>,
+              value: <Black>{item.officer.name}</Black>,
             },
             {
               label: 'Contact name',
               value: (
-                <Bold>{`${item.contact.name} (${item.contact.job_title} - ${item.contact.email})`}</Bold>
+                <Black>{`${item.contact.name} (${item.contact.job_title} - ${item.contact.email})`}</Black>
               ),
             },
             {
               label: 'Destination',
-              value: <Bold>{item.country}</Bold>,
+              value: <Black>{item.country}</Black>,
             },
             {
               label: 'Date won',
-              value: <Bold>{formatShortDate(item.date)}</Bold>,
+              value: <Black>{formatShortDate(item.date)}</Black>,
             },
             {
               label: 'Type of win',
-              value: <Bold>{item.business_type}</Bold>,
+              value: <Black>{item.business_type}</Black>,
             },
             {
               label: 'Total value',
-              value: <Bold>{currencyGBP(item.value.export.total)}</Bold>,
+              value: <Black>{currencyGBP(item.value.export.total)}</Black>,
             },
             {
               label: 'Type of goods or services',
-              value: <Bold>{item.name_of_export}</Bold>,
+              value: <Black>{item.name_of_export}</Black>,
             },
             {
               label: 'Sector',
-              value: <Bold>{item.sector}</Bold>,
+              value: <Black>{item.sector}</Black>,
             },
           ]}
         />
@@ -73,7 +70,7 @@ export default ({ companyId }) => {
     <CompanyExportWins.Paginated
       id={companyId}
       heading="Confirmed export win"
-      noResults="You don't have any confirmed export wins."
+      noResults="There are no confirmed export wins."
       payload={{ confirmed: WIN_STATUS.CONFIRMED }}
       sortOptions={SORT_OPTIONS}
     >


### PR DESCRIPTION
## Description of change
Addresses small cosmetic and content issues found on the company export page, specifically the confirmed export wins list.

## Test instructions
Go to `/companies/<company-uuid>exports/`

## Screenshots

### Before
<img width="997" alt="Screenshot 2024-09-03 at 11 52 38" src="https://github.com/user-attachments/assets/cdcc3f11-9adb-478d-a176-949008ade41f">

### After
<img width="997" alt="Screenshot 2024-09-03 at 11 53 05" src="https://github.com/user-attachments/assets/c2686743-6447-4c91-a458-2a216c521044">

### Before
<img width="726" alt="Screenshot 2024-09-03 at 11 51 35" src="https://github.com/user-attachments/assets/a5c41366-0c00-4b37-82f8-5b675cc22f08">

### After

<img width="717" alt="Screenshot 2024-09-03 at 11 50 22" src="https://github.com/user-attachments/assets/74c5fef2-4cd5-4044-afa5-567f6f4d9638">
## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
