### PR TITLE
Add `FieldChoice` boolean component

### DIFF
--- a/src/client/components/Form/elements/FieldChoice/index.jsx
+++ b/src/client/components/Form/elements/FieldChoice/index.jsx
@@ -8,9 +8,15 @@ import { isArray, isEqual } from 'lodash'
 import { useField, useFormContext } from '../../hooks'
 import FieldWrapper from '../FieldWrapper'
 
-const RADIO = 'radio'
+const TYPE = {
+  RADIO: 'radio',
+  CHECKBOX: 'checkbox',
+}
 
-const isRadio = (type) => type === RADIO
+const NO = 'No'
+const YES = 'Yes'
+
+const isRadio = (type) => type === TYPE.RADIO
 
 const FieldChoice = ({
   name,
@@ -71,12 +77,30 @@ const FieldChoice = ({
   )
 }
 
-FieldChoice.Checkbox = (props) => <FieldChoice {...props} type="checkbox" />
-FieldChoice.Radio = (props) => <FieldChoice {...props} type="radio" />
+FieldChoice.Checkbox = (props) => (
+  <FieldChoice {...props} type={TYPE.CHECKBOX} />
+)
+FieldChoice.Radio = (props) => <FieldChoice {...props} type={TYPE.RADIO} />
+FieldChoice.Boolean = ({ yesLabel = YES, noLabel = NO, ...props }) => (
+  <FieldChoice
+    {...props}
+    type={TYPE.RADIO}
+    options={[
+      {
+        value: true,
+        label: yesLabel,
+      },
+      {
+        value: false,
+        label: noLabel,
+      },
+    ]}
+  />
+)
 
 FieldChoice.propTypes = {
   name: PropTypes.string.isRequired,
-  type: PropTypes.oneOf(['radio', 'checkbox']).isRequired,
+  type: PropTypes.oneOf([TYPE.RADIO, TYPE.CHECKBOX]).isRequired,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string,
@@ -88,6 +112,11 @@ FieldChoice.propTypes = {
   label: PropTypes.string,
   legend: PropTypes.node,
   hint: PropTypes.string,
+}
+
+FieldChoice.Boolean.propTypes = {
+  yesLabel: PropTypes.string,
+  noLabel: PropTypes.string,
 }
 
 export default FieldChoice

--- a/src/client/components/Form/elements/FieldWrapper/index.jsx
+++ b/src/client/components/Form/elements/FieldWrapper/index.jsx
@@ -198,7 +198,12 @@ const FieldWrapper = ({
           >
             {label && (
               <StyledLegendNoStyle>
-                <StyledLabel boldLabel={boldLabel} error={error} htmlFor={name}>
+                <StyledLabel
+                  data-test="field-label"
+                  boldLabel={boldLabel}
+                  error={error}
+                  htmlFor={name}
+                >
                   {label}
                 </StyledLabel>
               </StyledLegendNoStyle>

--- a/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
+++ b/src/client/components/Form/elements/__stories__/FieldChoice.stories.jsx
@@ -23,6 +23,10 @@ const FieldChoiceRadioInline = styled(FieldChoice.Radio)`
   ${inline}
 `
 
+const FieldChoiceBooleanInline = styled(FieldChoice.Boolean)`
+  ${inline}
+`
+
 const countryOptions = [
   {
     value: '0',
@@ -447,6 +451,167 @@ CheckboxPreselected.parameters = {
         ],
         props: {
           name: 'country',
+        },
+      }),
+    },
+  },
+}
+
+// Boolean
+const BOOLEAN_COMMENT =
+  "There's no need to set the options as the component does this internally."
+
+export const Boolean = Template.bind({})
+Boolean.storyName = 'Boolean radios'
+Boolean.args = {
+  name: 'has_changed_name',
+  component: FieldChoice.Boolean,
+}
+Boolean.parameters = {
+  docs: {
+    description: {
+      story: GDS_DOCS_RADIOS_URL,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoice.Boolean',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          options: [],
+        },
+      }),
+    },
+  },
+}
+
+export const BooleanLabel = Template.bind({})
+BooleanLabel.storyName = 'Boolean radios with label'
+BooleanLabel.args = {
+  ...Boolean.args,
+  label: 'Have you changed your name?',
+}
+BooleanLabel.parameters = {
+  docs: {
+    description: {
+      story: GDS_DOCS_RADIOS_URL,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoice.Boolean',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          label: 'Have you changed your name?',
+          options: [],
+        },
+      }),
+    },
+  },
+}
+
+export const BooleanLabelAndHint = Template.bind({})
+BooleanLabelAndHint.storyName = 'Boolean radios with label and hint'
+const labelAndHint = {
+  label: 'Have you changed your name?',
+  hint: 'This includes changing your last name or spelling your name differently.',
+}
+BooleanLabelAndHint.args = {
+  ...Boolean.args,
+  ...labelAndHint,
+}
+BooleanLabelAndHint.parameters = {
+  docs: {
+    description: {
+      story: GDS_DOCS_RADIOS_URL,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoice.Boolean',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          ...labelAndHint,
+          options: [],
+        },
+      }),
+    },
+  },
+}
+
+export const BooleanCustomOptionLabels = Template.bind({})
+BooleanCustomOptionLabels.storyName = 'Boolean radios with custom labels'
+const customOptionLabels = {
+  label: 'Have you changed your name?',
+  yesLabel: 'Agree',
+  noLabel: 'Disagree',
+}
+BooleanCustomOptionLabels.args = {
+  ...Boolean.args,
+  ...customOptionLabels,
+}
+BooleanCustomOptionLabels.parameters = {
+  docs: {
+    description: {
+      story: GDS_DOCS_RADIOS_URL,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoice.Boolean',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          ...customOptionLabels,
+          options: [],
+        },
+      }),
+    },
+  },
+}
+
+export const BooleanRequired = Template.bind({})
+BooleanRequired.storyName = 'Boolean radios selection required'
+BooleanRequired.args = {
+  ...Boolean.args,
+  required: 'Select at least one option',
+}
+BooleanRequired.parameters = {
+  docs: {
+    description: {
+      story: `A boolean radio group where a selection is required. Click "Save" to view an error. ${GDS_DOCS_RADIOS_URL}`,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoice.Boolean',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          required: 'Select at least one option',
+          options: [],
+        },
+      }),
+    },
+  },
+}
+
+export const BooleanInline = Template.bind({})
+BooleanInline.storyName = 'Boolean radios inline'
+BooleanInline.args = {
+  ...Boolean.args,
+  component: FieldChoiceBooleanInline,
+}
+BooleanInline.parameters = {
+  docs: {
+    description: {
+      story: GDS_DOCS_RADIOS_URL,
+    },
+    source: {
+      code: generateFormCode({
+        componentName: 'FieldChoiceBooleanInline',
+        comments: [BOOLEAN_COMMENT],
+        props: {
+          name: 'has_changed_name',
+          options: [],
         },
       }),
     },

--- a/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
+++ b/test/component/cypress/specs/components/Form/FieldChoice.cy.jsx
@@ -125,6 +125,103 @@ describe('FieldChoice', () => {
     })
   })
 
+  context('Boolean radio buttons', () => {
+    it('should render 2 radio buttons "Yes" and "No"', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice.Boolean name="has_changed_name" />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'has_changed_name',
+        options: ['Yes', 'No'],
+      })
+      assertFieldRadiosNotSelected({ inputName: 'has_changed_name' })
+    })
+
+    it('should render a label', () => {
+      const label = 'Have you changed your name?'
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice.Boolean name="has_changed_name" label={label} />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'has_changed_name',
+        options: ['Yes', 'No'],
+        label,
+      })
+    })
+
+    it('should render a label and hint', () => {
+      const label = 'Have you changed your name?'
+      const hint =
+        'This includes changing your last name or spelling your name differently.'
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice.Boolean
+            name="has_changed_name"
+            label={label}
+            hint={hint}
+          />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'has_changed_name',
+        options: ['Yes', 'No'],
+        label,
+        hint,
+      })
+    })
+
+    it('should render custom labels', () => {
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice.Boolean
+            name="has_changed_name"
+            label="Have you changed your name?"
+            yesLabel="Agree"
+            noLabel="Disagree"
+          />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'has_changed_name',
+        options: ['Agree', 'Disagree'],
+      })
+    })
+
+    it('should render a legend', () => {
+      const legend = <H1>H1 legend</H1>
+      cy.mountWithProvider(
+        <Form {...FORM_PROPS}>
+          <FieldChoice.Boolean name="has_changed_name" legend={legend} />
+        </Form>
+      )
+      assertFieldRadiosStrict({
+        inputName: 'has_changed_name',
+        options: ['Yes', 'No'],
+        legend: 'H1 legend',
+      })
+    })
+
+    it('should preselect "Yes"', () => {
+      const selectedOption = { value: true, label: 'Yes' }
+      cy.mountWithProvider(
+        <Form
+          {...FORM_PROPS}
+          initialValues={{ has_changed_name: selectedOption }}
+        >
+          <FieldChoice.Boolean name="has_changed_name" />
+        </Form>
+      )
+      assertFieldRadioSelected({
+        inputName: 'has_changed_name',
+        selectedIndex: 0,
+      })
+    })
+  })
+
   context('Checkboxes', () => {
     it('should render checkboxes', () => {
       cy.mountWithProvider(

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -276,6 +276,7 @@ const assertFieldRadiosStrict = ({
   inputName,
   options,
   legend,
+  label,
   hint,
   selectIndex,
   selectedIndex,
@@ -286,6 +287,9 @@ const assertFieldRadiosStrict = ({
     .within(() => {
       if (legend) {
         cy.get('legend').should('have.text', legend)
+      }
+      if (label) {
+        cy.get('[data-test="field-label"]').should('have.text', label)
       }
       if (hint) {
         cy.get('[data-test="hint-text"]').should('have.text', hint)


### PR DESCRIPTION
## Description of change
Adding a new `FieldChoice.Boolean` component. 

**FieldChoice.Boolean (new)**
When a user selects either _Yes_ or _No_ to a question the corresponding boolean value is now written to the form state. There's no requirement to provide options.
```
<FieldChoice.Boolean
  name: 'is_primary',
  label: 'Is this person a primary contact?'
/>
```

<img width="360" alt="Screenshot 2024-07-10 at 13 29 15" src="https://github.com/uktrade/data-hub-frontend/assets/964268/bc60fc0c-699e-4589-b441-ec1aee2a21e2">

You can also override both option labels:

```
<FieldChoice.Boolean
  name: 'inAgreement',
  label: 'Do you agree?',
  yesLabel: 'Agree',
  noLabel: 'Disagree'
/>
```

<img width="360" alt="Screenshot 2024-07-10 at 13 50 58" src="https://github.com/uktrade/data-hub-frontend/assets/964268/37b9f2d3-e228-4b29-8460-8c0c92c6ce9c">


**FieldRadio (old)**
The `FieldRadio` component requires us to pass an array of options, however, the `FieldChoice.Boolean` component doesn't have the same requirement as the component handles the options internally.
```
<FieldRadios
  name="is_primary"
  label="Is this person a primary contact?"
  options={[
    { label: 'Yes', value: 'yes' },
    { label: 'No: 'no' },
  ]}
/>
```
**Summary**
Throughout the codebase we have used the `FieldRadio` component to write `'yes'` and `'no'` to the form state. Then test for equality `formData.values.isPrimaryContact === 'yes'` to reveal a new field in the UI, upon saving the form we would then convert the string to a boolean: `{ is_primary:  values.isPrimaryContact === 'yes'}`. With the new approach we don't have to supply options or do any string to boolean conversion which should make things simpler.

## Test instructions
`npm run storybook` and click through the list of `FieldChoice.Boolean` stories. From here you can see what is written to the form state and view/copy fragments of code.

## Screenshots
<img width="287" alt="Screenshot 2024-08-30 at 16 10 20" src="https://github.com/user-attachments/assets/7ec68318-2cbd-495f-9d92-c87183238d60">

<img width="1019" alt="Screenshot 2024-08-30 at 16 07 20" src="https://github.com/user-attachments/assets/4478aee4-8427-4a85-a51a-9748b9253557">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
