### PR TITLE
Remove the lead officer name field from the officer details form step

### DIFF
--- a/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/OfficerDetailsStep.jsx
@@ -10,7 +10,12 @@ import * as validators from './validators'
 import urls from '../../../../lib/urls'
 import { steps } from './constants'
 
-const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
+const OfficerDetailsStep = ({
+  companyId,
+  exportId,
+  exportWinId,
+  isEditing,
+}) => {
   const { values } = useFormContext()
   return (
     <Step
@@ -26,11 +31,13 @@ const OfficerDetailsStep = ({ companyId, exportId, exportWinId }) => {
       }
     >
       <H3 data-test="step-heading">Officer details</H3>
-      <FieldAdvisersTypeahead
-        name="lead_officer"
-        label="Lead officer name"
-        required="Enter a lead officer"
-      />
+      {!isEditing && (
+        <FieldAdvisersTypeahead
+          name="lead_officer"
+          label="Lead officer name"
+          required="Enter a lead officer"
+        />
+      )}
       <TeamType.FieldTypeahead
         name="team_type"
         id="team-type"

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -82,35 +82,38 @@ const SummaryStep = ({ isEditing, companyId }) => {
   )
 }
 
-const OfficerDetailsTable = ({ values, goToStep }) => (
-  <SummaryTable
-    caption="Officer details"
-    data-test="officer-details"
-    actions={
-      <StyledButtonLink
-        onClick={() => {
-          goToStep(steps.OFFICER_DETAILS)
-        }}
-      >
-        Edit
-      </StyledButtonLink>
-    }
-  >
-    <SummaryTable.Row heading="Lead officer name">
-      {values.lead_officer?.label}
-    </SummaryTable.Row>
-    <SummaryTable.Row heading="Team type">
-      {values.team_type?.label}
-    </SummaryTable.Row>
-    <SummaryTable.Row heading="HQ Team, region or post">
-      {values.hq_team?.label}
-    </SummaryTable.Row>
-    <SummaryTable.ListRow
-      heading="Team members (optional)"
-      value={values.team_members}
-      emptyValue="Not set"
-    />
-  </SummaryTable>
+const OfficerDetailsTable = ({ values, goToStep, isEditing }) => (
+  <>
+    <StyledSummaryTable
+      caption="Officer details"
+      data-test="officer-details"
+      isEditing={isEditing}
+      actions={
+        <StyledButtonLink
+          onClick={() => {
+            goToStep(steps.OFFICER_DETAILS)
+          }}
+        >
+          Edit
+        </StyledButtonLink>
+      }
+    >
+      <SummaryTable.Row heading="Lead officer name">
+        {values.lead_officer?.label}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Team type">
+        {values.team_type?.label}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="HQ Team, region or post">
+        {values.hq_team?.label}
+      </SummaryTable.Row>
+      <SummaryTable.ListRow
+        heading="Team members (optional)"
+        value={values.team_members}
+        emptyValue="Not set"
+      />
+    </StyledSummaryTable>
+  </>
 )
 
 const ContributingTeamsAndAdvisers = ({ teamsAndAdvisors }) => (

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -113,6 +113,11 @@ const OfficerDetailsTable = ({ values, goToStep, isEditing }) => (
         emptyValue="Not set"
       />
     </StyledSummaryTable>
+    {isEditing && (
+      <StyledInsetText data-test="lead-officer">
+        <ContactLink sections={['Lead officer name']} />
+      </StyledInsetText>
+    )}
   </>
 )
 

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -53,6 +53,7 @@ export const bothGoodsAndServices = {
 }
 
 export const STEP_TO_EXCLUDED_FIELDS_MAP = {
+  [steps.OFFICER_DETAILS]: ['Lead officer name'],
   [steps.CUSTOMER_DETAILS]: ['Export experience'],
   [steps.WIN_DETAILS]: [
     'Summary of the support you provided',

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -145,6 +145,16 @@ describe('Editing a pending export win', () => {
       )
     })
 
+    it('should render a lead officer name contact link', () => {
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
+      cy.wait(['@apiGetExportWin'])
+      cy.get('[data-test="lead-officer"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: ' +
+          'Lead officer name'
+      )
+    })
+
     it('should render a customer details contact link', () => {
       cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -36,12 +36,15 @@ describe('Editing a pending export win', () => {
   })
 
   context('Officer details', () => {
-    it('should not render an edit status message', () => {
+    it('should render an edit status message', () => {
       cy.visit(
         urls.companies.exportWins.editOfficerDetails(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
-      cy.get('[data-test="status-message"]').should('not.exist')
+      cy.get('[data-test="status-message"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: Lead officer name'
+      )
     })
   })
 


### PR DESCRIPTION
## Description of change
Remove the **lead officer name** field (officer details step) from the form **when editing an export win**.

## Test instructions
1. Go to: `/companies/<company-uuid>/exportwins/<export-win-uuid>/edit?step=summary`.
2. Notice the new text: "Contact exportwins@businessandtrade.gov.uk if you need to update the section: Lead officer name" at the bottom of the **officer details** section.
3. Click **edit** on the **officer details** section.
4. The **lead officer name** field should not be rendered.
5. The **lead officer name** blue banner should be rendered.

## Screenshots
Path: `companies/<company-uuid>/exportwins/<export-uuuid>/edit?step=summary`
### Before
<img width="1037" alt="before" src="https://github.com/user-attachments/assets/3a55bd39-714f-4835-8bde-8e4e20f81331">

### After
<img width="1037" alt="after" src="https://github.com/user-attachments/assets/aac08482-4628-4bc5-adda-57a25b7bb75a">

### Before
Path: `/companies/<company-uuid>/exportwins/<export-win-uuid>/edit?step=officer_details`

<img width="980" alt="before" src="https://github.com/user-attachments/assets/2ddb9f45-6c77-41cb-9a36-af35c2721257">

### After
<img width="980" alt="after" src="https://github.com/user-attachments/assets/580c4317-999f-4501-9abd-d8872f865083">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
