### PR TITLE
Filter out More Sectors from the list of sectors

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -12,6 +12,7 @@ import { getStartDateOfTwelveMonthsAgo } from '../../../utils/date'
 import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
 import { validateWinDate, validateTextField } from './validators'
+import { idNamesToValueLabels } from '../../../utils'
 import { StyledHintParagraph } from './styled'
 import { Breakdowns } from './Breakdowns'
 import urls from '../../../../lib/urls'
@@ -241,6 +242,11 @@ const WinDetailsStep = ({ isEditing }) => {
         name="sector"
         label="Sector"
         required="Enter a sector"
+        resultToOptions={(result) =>
+          idNamesToValueLabels(
+            result.filter(({ name }) => name !== 'More Sectors')
+          )
+        }
       />
 
       <Details


### PR DESCRIPTION
## Description of change
Filters out the **More Sectors** option from the list of sectors.

## Test instructions
1. Go to: `/companies/<company-uuid>/exportwins/<export-win-uuid>/edit?step=summary`.
2. Click **edit** on the **win details** section.
3. Scroll down to the sector field
4. Search for `More Sectors` will yield 0 results

## Screenshots

### Before
<img width="987" alt="Screenshot 2024-09-05 at 12 26 48" src="https://github.com/user-attachments/assets/79370e0e-7a86-481b-a247-dbf740af8efa">

### After
<img width="987" alt="Screenshot 2024-09-05 at 12 27 34" src="https://github.com/user-attachments/assets/5efefa94-d195-494a-96b3-1c3133a56888">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
