### PR TITLE
Remove the 'type of business deal' field from the win details form step

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -120,99 +120,104 @@ const WinDetailsStep = ({ isEditing }) => {
           },
         ]}
       />
-      <FieldInput
-        type="text"
-        name="business_type"
-        label="Type of business deal"
-        required="Enter the type of business deal"
-        hint="For example: export sales, contract, order, distributor, tender / competition win, joint venture, outward investment."
-        placeholder="Enter a type of business deal"
-        validate={validateTextField('Type of business deal')}
-      />
       {!isEditing && (
-        <FieldCheckboxes
-          name="win_type"
-          legend="Type of win"
-          required="Choose at least one type of win"
-          options={winTypeOptions.map((option) => ({
-            ...option,
-            ...(option.value === winTypes.EXPORT && {
-              children: (
-                <Breakdowns
-                  label="Export value over the next 5 years"
-                  name="export_win"
-                  values={values}
-                />
-              ),
-            }),
-            ...(option.value === winTypes.BUSINESS_SUCCESS && {
-              link: (
-                <StyledDetails
-                  summary="What is business success?"
-                  data-test="business-success-details"
-                >
-                  <p>Business success is defined as:</p>
-                  <UnorderedList listStyleType="bullet">
-                    <ListItem>
-                      the exchange of ownership of goods/services from a
-                      subsidiary of an eligible UK company to a non-UK resident
-                    </ListItem>
-                    <ListItem>
-                      in financial services, the value of assets under
-                      management or the value of a listing
-                    </ListItem>
-                    <ListItem>
-                      the collection of cash from an overdue invoice
-                    </ListItem>
-                    <ListItem>
-                      reduced tax burden on a customer achieved by lobbying
-                    </ListItem>
-                    <ListItem>repatriation of profits to the UK</ListItem>
-                  </UnorderedList>
-                </StyledDetails>
-              ),
-              children: (
-                <Breakdowns
-                  label="Business success over the next 5 years"
-                  name="business_success_win"
-                  values={values}
-                />
-              ),
-            }),
-            ...(option.value === winTypes.ODI && {
-              link: (
-                <StyledDetails
-                  summary="What is an ODI?"
-                  data-test="odi-details"
-                >
-                  <p>
-                    An ODI is a cross-border investment from the UK into another
-                    country, where the source of the money is the UK.
-                  </p>
-                  <p>
-                    The aim of the investment is to set up a lasting interest in
-                    a company, where the investor has a genuine influence in the
-                    management. This may involve providing capital for vehicles,
-                    machinery, buildings, and running costs to:
-                  </p>
-                  <UnorderedList listStyleType="bullet">
-                    <ListItem>set up an overseas subsidiary</ListItem>
-                    <ListItem>enter into a joint venture</ListItem>
-                    <ListItem>expand current overseas operations</ListItem>
-                  </UnorderedList>
-                </StyledDetails>
-              ),
-              children: (
-                <Breakdowns
-                  label="Outward Direct Investment over the next 5 years"
-                  name="odi_win"
-                  values={values}
-                />
-              ),
-            }),
-          }))}
-        />
+        <>
+          <FieldInput
+            type="text"
+            name="business_type"
+            label="Type of business deal"
+            required="Enter the type of business deal"
+            hint="For example: export sales, contract, order, distributor, tender / competition win, joint venture, outward investment."
+            placeholder="Enter a type of business deal"
+            validate={validateTextField('Type of business deal')}
+          />
+
+          <FieldCheckboxes
+            name="win_type"
+            legend="Type of win"
+            required="Choose at least one type of win"
+            options={winTypeOptions.map((option) => ({
+              ...option,
+              ...(option.value === winTypes.EXPORT && {
+                children: (
+                  <Breakdowns
+                    label="Export value over the next 5 years"
+                    name="export_win"
+                    values={values}
+                  />
+                ),
+              }),
+              ...(option.value === winTypes.BUSINESS_SUCCESS && {
+                link: (
+                  <StyledDetails
+                    summary="What is business success?"
+                    data-test="business-success-details"
+                  >
+                    <p>Business success is defined as:</p>
+                    <UnorderedList listStyleType="bullet">
+                      <ListItem>
+                        the exchange of ownership of goods/services from a
+                        subsidiary of an eligible UK company to a non-UK
+                        resident
+                      </ListItem>
+                      <ListItem>
+                        in financial services, the value of assets under
+                        management or the value of a listing
+                      </ListItem>
+                      <ListItem>
+                        the collection of cash from an overdue invoice
+                      </ListItem>
+                      <ListItem>
+                        reduced tax burden on a customer achieved by lobbying
+                      </ListItem>
+                      <ListItem>repatriation of profits to the UK</ListItem>
+                    </UnorderedList>
+                  </StyledDetails>
+                ),
+                children: (
+                  <Breakdowns
+                    label="Business success over the next 5 years"
+                    name="business_success_win"
+                    values={values}
+                  />
+                ),
+              }),
+              ...(option.value === winTypes.ODI && {
+                link: (
+                  <StyledDetails
+                    summary="What is an ODI?"
+                    data-test="odi-details"
+                  >
+                    <p>
+                      An ODI is a cross-border investment from the UK into
+                      another country, where the source of the money is the UK.
+                    </p>
+                    <p>
+                      The aim of the investment is to set up a lasting interest
+                      in a company, where the investor has a genuine influence
+                      in the management. This may involve providing capital for
+                      vehicles, machinery, buildings, and running costs to:
+                    </p>
+                    <UnorderedList listStyleType="bullet">
+                      <ListItem>set up an overseas subsidiary</ListItem>
+                      <ListItem>enter into a joint venture</ListItem>
+                      <ListItem>expand current overseas operations</ListItem>
+                    </UnorderedList>
+                  </StyledDetails>
+                ),
+                children: (
+                  <Breakdowns
+                    label="Outward Direct Investment over the next 5 years"
+                    name="odi_win"
+                    values={values}
+                  />
+                ),
+              }),
+            }))}
+          />
+        </>
       )}
+
       {!isEditing && values?.win_type?.length > 1 && (
         <StyledExportTotal data-test="total-value">
           Total value:{' '}

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -112,6 +112,10 @@ describe('Editing a pending export win', () => {
       cy.get(winDetails.date).should('not.exist')
     })
 
+    it('should not render the business type', () => {
+      cy.get(winDetails.businessType).should('not.exist')
+    })
+
     it('should not render the win type', () => {
       cy.get(winDetails.winType).should('not.exist')
     })


### PR DESCRIPTION
## Description of change
Remove the **type of business deal** field (win details step) from the form **when editing an export win**.

## Test instructions
1. Go to: `/companies/<company-uuid>/exportwins/<export-win-uuid>/edit?step=summary`.
2. Click **edit** on the **win details** section.
3. The **type of business deal** field should not be rendered.

## Screenshots

### Before
<img width="916" alt="before" src="https://github.com/user-attachments/assets/03a6a214-c15c-4119-9e31-6779efe0afed">

### After
<img width="1026" alt="after" src="https://github.com/user-attachments/assets/ed7c66cc-a4f2-426c-a879-ba4ec7b4330d">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
