### PR TITLE
Added an "export wins have now moved" banner to company page

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -160,12 +160,10 @@ const CompanyLocalHeader = ({
             </LocalHeaderHeading>
             {company?.tradingNames?.length > 0 && (
               <LocalHeaderTradingNames data-test="trading-names">
-                {' '}
-                Trading as: {company.tradingNames.join(', ')}{' '}
+                Trading as: {company.tradingNames.join(', ')}
               </LocalHeaderTradingNames>
-            )}{' '}
+            )}
             <StyledAddress data-test="address">
-              {' '}
               {addressToStringResource(company.address)}
             </StyledAddress>
             {company.dunsNumber && (

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -119,9 +119,27 @@ const hasAllocatedLeadIta = (company) =>
 const hasManagedAccountDetails = (company) =>
   company.oneListGroupTier && hasAllocatedLeadIta(company)
 
+const DATA_HUB_HAS_MOVED_LINK =
+  'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/'
+
+const DATA_HUB_HAS_MOVED_MESSAGE = (
+  <>
+    Historic export wins have now moved to Data Hub,{' '}
+    <Link
+      href={DATA_HUB_HAS_MOVED_LINK}
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Find out more about historic wins moved to Data Hub"
+    >
+      find out more
+    </Link>
+    .
+  </>
+)
+
 const CompanyLocalHeader = ({
   breadcrumbs,
-  flashMessages,
+  flashMessages = [],
   company,
   csrfToken,
 }) =>
@@ -133,7 +151,7 @@ const CompanyLocalHeader = ({
           company.id,
           company.name
         )}
-        flashMessages={flashMessages}
+        flashMessages={[[DATA_HUB_HAS_MOVED_MESSAGE, ...flashMessages]]}
       >
         <GridRow>
           <GridCol setWidth="two-thirds">
@@ -142,11 +160,12 @@ const CompanyLocalHeader = ({
             </LocalHeaderHeading>
             {company?.tradingNames?.length > 0 && (
               <LocalHeaderTradingNames data-test="trading-names">
-                Trading as: {company.tradingNames.join(', ')}
+                {' '}
+                Trading as: {company.tradingNames.join(', ')}{' '}
               </LocalHeaderTradingNames>
-            )}
-
+            )}{' '}
             <StyledAddress data-test="address">
+              {' '}
               {addressToStringResource(company.address)}
             </StyledAddress>
             {company.dunsNumber && (

--- a/test/component/cypress/specs/Companies/CompanyLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyLocalHeader.cy.jsx
@@ -179,7 +179,6 @@ describe('CompanyLocalHeader', () => {
       cy.mountWithProvider(
         <CompanyLocalHeader
           breadcrumbs={[{ text: 'Test breadcrumb' }]}
-          flashMessages={null}
           company={dnbGlobalUltimate}
           dnbRelatedCompaniesCount={12345}
           returnUrl={null}
@@ -228,7 +227,6 @@ describe('CompanyLocalHeader', () => {
       cy.mountWithProvider(
         <CompanyLocalHeader
           breadcrumbs={[{ text: 'Test breadcrumb' }]}
-          flashMessages={null}
           company={dnbUnderInvestigation}
           dnbRelatedCompaniesCount={null}
           returnUrl={null}
@@ -282,7 +280,6 @@ describe('CompanyLocalHeader', () => {
       cy.mountWithProvider(
         <CompanyLocalHeader
           breadcrumbs={[{ text: 'Test breadcrumb' }]}
-          flashMessages={null}
           company={archivedCompany}
           dnbRelatedCompaniesCount={null}
           returnUrl={null}

--- a/test/functional/cypress/specs/companies/export-wins-moved-spec.js
+++ b/test/functional/cypress/specs/companies/export-wins-moved-spec.js
@@ -1,0 +1,21 @@
+const { company } = require('../../fixtures')
+const urls = require('../../../../../src/lib/urls')
+
+describe('Export wins moved banner', () => {
+  it('There should be a banner informing about export wins moving to Data Hub on the company page', () => {
+    cy.visit(urls.companies.detail(company.dnbCorp.id))
+
+    cy.get('[data-test="status-message"')
+      .should(
+        'have.text',
+        'Historic export wins have now moved to Data Hub, find out more.'
+      )
+      .within(() => {
+        cy.contains('a', 'find out more').should(
+          'have.attr',
+          'href',
+          'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/'
+        )
+      })
+  })
+})


### PR DESCRIPTION
## Description of change

Adds a banner to `/companies/<id>/overview` page informing the users that "Historic export wins have now moved to Data Hub...".

## Test instructions

1. Go to `/companies/<id>/overview`
2. On top of the page, you should see a banner saying "Historic export wins have now moved to Data Hub, find out more."
3. Where the "find out more" part should be a link to https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/

## Screenshots

### Before
<img width="1280" alt="Screenshot 2024-09-10 at 16 34 19" src="https://github.com/user-attachments/assets/eac8c746-ed84-4c74-a6a6-36366c7be7d5">

### After
<img width="1279" alt="Screenshot 2024-09-10 at 16 33 10" src="https://github.com/user-attachments/assets/5a35e98f-bc3b-4c0b-ace9-bd9d17c463fe">


