### PR TITLE
Fix export wins content inconsistencies

### DIFF
--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -327,7 +327,9 @@ const SupportGivenTable = ({ values, goToStep }) => (
       </StyledButtonLink>
     }
   >
-    <SummaryTable.Row heading="HVC code">{values?.hvc?.label}</SummaryTable.Row>
+    <SummaryTable.Row heading="High Value Campaign (HVC) code">
+      {values?.hvc?.label}
+    </SummaryTable.Row>
     <SummaryTable.ListRow
       heading="What type of support was given?"
       value={values.type_of_support}

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -304,7 +304,7 @@ const WinDetailsTable = ({ values, goToStep, isEditing }) => {
               'Summary of the support you provided',
               'Destination',
               'Date won',
-              'Type of export win and Value',
+              'Type of win and Value',
             ]}
           />
         </StyledInsetText>

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -301,7 +301,7 @@ const WinDetailsTable = ({ values, goToStep, isEditing }) => {
         <StyledInsetText data-test="win-details-contact">
           <ContactLink
             sections={[
-              'Summary of the support you provided',
+              'Summary of the support given',
               'Destination',
               'Date won',
               'Type of win and Value',

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -104,7 +104,7 @@ const OfficerDetailsTable = ({ values, goToStep, isEditing }) => (
       <SummaryTable.Row heading="Team type">
         {values.team_type?.label}
       </SummaryTable.Row>
-      <SummaryTable.Row heading="HQ Team, region or post">
+      <SummaryTable.Row heading="HQ team, region or post">
         {values.hq_team?.label}
       </SummaryTable.Row>
       <SummaryTable.ListRow

--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -61,9 +61,11 @@ const WinDetailsStep = ({ isEditing }) => {
   return (
     <Step name={steps.WIN_DETAILS}>
       <H3 data-test="step-heading">Win details</H3>
-      <StyledHintParagraph data-test="hint">
-        The customer will be asked to confirm this information.
-      </StyledHintParagraph>
+      {!isEditing && (
+        <StyledHintParagraph data-test="hint">
+          The customer will be asked to confirm this information.
+        </StyledHintParagraph>
+      )}
       {!isEditing && (
         <Countries.FieldTypeahead
           name="country"

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -59,7 +59,7 @@ export const STEP_TO_EXCLUDED_FIELDS_MAP = {
     'Summary of the support you provided',
     'Destination',
     'Date won',
-    'Type of export win and Value',
+    'Type of win and Value',
   ],
 }
 

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -57,7 +57,7 @@ export const STEP_TO_EXCLUDED_FIELDS_MAP = {
   [steps.CUSTOMER_DETAILS]: ['Export experience'],
   [steps.WIN_DETAILS]: [
     'Summary of the support you provided',
-    'Destination',
+    'Destination country',
     'Date won',
     'Type of win and Value',
   ],

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -56,7 +56,7 @@ export const STEP_TO_EXCLUDED_FIELDS_MAP = {
   [steps.OFFICER_DETAILS]: ['Lead officer name'],
   [steps.CUSTOMER_DETAILS]: ['Export experience'],
   [steps.WIN_DETAILS]: [
-    'Summary of the support you provided',
+    'Summary of the support given',
     'Destination country',
     'Date won',
     'Type of win and Value',

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -245,7 +245,8 @@ describe('Adding an export win', () => {
           heading: 'Support given',
           showEditLink: true,
           content: {
-            'HVC code': 'Australia Consumer Goods & Retail: E004',
+            'High Value Campaign (HVC) code':
+              'Australia Consumer Goods & Retail: E004',
             'What type of support was given?':
               'Market entry advice and support – DIT/FCO in UK',
             'Was there a DBT campaign or event that contributed to this win?':

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -182,7 +182,7 @@ describe('Adding an export win', () => {
           content: {
             'Lead officer name': 'David Meyer',
             'Team type': 'Investment (ITFG or IG)',
-            'HQ Team, region or post': 'ITFG - E-Business Projects Team',
+            'HQ team, region or post': 'ITFG - E-Business Projects Team',
             'Team members (optional)': 'Not set',
           },
         })

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -96,7 +96,7 @@ describe('Editing a pending export win', () => {
         .should(
           'have.text',
           'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-            'Summary of the support you provided, Destination, Date won, Type of export win and Value'
+            'Summary of the support you provided, Destination, Date won, Type of win and Value'
         )
     })
 
@@ -175,7 +175,7 @@ describe('Editing a pending export win', () => {
       cy.get('[data-test="win-details-contact"]').should(
         'have.text',
         'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-          'Summary of the support you provided, Destination, Date won, Type of export win and Value'
+          'Summary of the support you provided, Destination, Date won, Type of win and Value'
       )
     })
 

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -96,7 +96,7 @@ describe('Editing a pending export win', () => {
         .should(
           'have.text',
           'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-            'Summary of the support you provided, Destination country, Date won, Type of win and Value'
+            'Summary of the support given, Destination country, Date won, Type of win and Value'
         )
     })
 
@@ -175,7 +175,7 @@ describe('Editing a pending export win', () => {
       cy.get('[data-test="win-details-contact"]').should(
         'have.text',
         'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-          'Summary of the support you provided, Destination, Date won, Type of win and Value'
+          'Summary of the support given, Destination, Date won, Type of win and Value'
       )
     })
 

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -96,7 +96,7 @@ describe('Editing a pending export win', () => {
         .should(
           'have.text',
           'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-            'Summary of the support you provided, Destination, Date won, Type of win and Value'
+            'Summary of the support you provided, Destination country, Date won, Type of win and Value'
         )
     })
 

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -100,6 +100,10 @@ describe('Editing a pending export win', () => {
         )
     })
 
+    it('should not render a hint', () => {
+      cy.get(winDetails.hint).should('not.exist')
+    })
+
     it('should not render summary of the support given', () => {
       cy.get(winDetails.description).should('not.exist')
     })


### PR DESCRIPTION
## Description of change
Fixes export win content inconsistencies.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
