### PR TITLE
Remove superfluous `<li>` from pending and rejected export wins lists.

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -13,52 +13,51 @@ export const WinsPendingList = ({ exportWins = [] }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
-        <li key={item.id}>
-          <CollectionItem
-            headingText={`${item.name_of_export} to ${item?.country?.name}`}
-            headingUrl={urls.companies.exportWins.editSummary(
-              item.company.id,
-              item.id
-            )}
-            subheading={item.company.name}
-            subheadingUrl={urls.companies.overview.index(item.company.id)}
-            metadata={[
-              ...(item.company_contacts[0]
-                ? [
-                    {
-                      label: 'Contact name:',
-                      value: (
-                        <Link
-                          href={urls.contacts.details(
-                            item.company_contacts[0].id
-                          )}
-                        >
-                          {item.company_contacts[0].name}
-                        </Link>
-                      ),
-                    },
-                  ]
-                : []),
-              {
-                label: 'Total value:',
-                value: currencyGBP(sumExportValues(item)),
-              },
-              { label: 'Date won:', value: formatMediumDate(item.date) },
-              {
-                label: 'Date modified:',
-                value: formatMediumDate(item.modified_on),
-              },
-              {
-                label: 'First sent:',
-                value: formatMediumDateTime(item.first_sent),
-              },
-              {
-                label: 'Last sent:',
-                value: formatMediumDateTime(item.last_sent),
-              },
-            ]}
-          />
-        </li>
+        <CollectionItem
+          key={item.id}
+          headingText={`${item.name_of_export} to ${item?.country?.name}`}
+          headingUrl={urls.companies.exportWins.editSummary(
+            item.company.id,
+            item.id
+          )}
+          subheading={item.company.name}
+          subheadingUrl={urls.companies.overview.index(item.company.id)}
+          metadata={[
+            ...(item.company_contacts[0]
+              ? [
+                  {
+                    label: 'Contact name:',
+                    value: (
+                      <Link
+                        href={urls.contacts.details(
+                          item.company_contacts[0].id
+                        )}
+                      >
+                        {item.company_contacts[0].name}
+                      </Link>
+                    ),
+                  },
+                ]
+              : []),
+            {
+              label: 'Total value:',
+              value: currencyGBP(sumExportValues(item)),
+            },
+            { label: 'Date won:', value: formatMediumDate(item.date) },
+            {
+              label: 'Date modified:',
+              value: formatMediumDate(item.modified_on),
+            },
+            {
+              label: 'First sent:',
+              value: formatMediumDateTime(item.first_sent),
+            },
+            {
+              label: 'Last sent:',
+              value: formatMediumDateTime(item.last_sent),
+            },
+          ]}
+        />
       ))}
     </ul>
   )

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -13,38 +13,35 @@ export const WinsRejectedList = ({ exportWins }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
-        <li key={item.id}>
-          <CollectionItem
-            headingText={`${item.name_of_export} to ${item?.country?.name}`}
-            headingUrl={urls.companies.exportWins.editSummary(
-              item.company.id,
-              item.id
-            )}
-            subheading={item.company.name}
-            subheadingUrl={urls.companies.overview.index(item.company.id)}
-            metadata={[
-              {
-                label: 'Contact name:',
-                value: (
-                  <Link
-                    href={urls.contacts.details(item.company_contacts[0].id)}
-                  >
-                    {item.company_contacts[0].name}
-                  </Link>
-                ),
-              },
-              {
-                label: 'Total value:',
-                value: currencyGBP(sumExportValues(item)),
-              },
-              { label: 'Date won:', value: formatMediumDate(item.date) },
-              {
-                label: 'Date modified:',
-                value: formatMediumDate(item.modified_on),
-              },
-            ]}
-          />
-        </li>
+        <CollectionItem
+          key={item.id}
+          headingText={`${item.name_of_export} to ${item?.country?.name}`}
+          headingUrl={urls.companies.exportWins.editSummary(
+            item.company.id,
+            item.id
+          )}
+          subheading={item.company.name}
+          subheadingUrl={urls.companies.overview.index(item.company.id)}
+          metadata={[
+            {
+              label: 'Contact name:',
+              value: (
+                <Link href={urls.contacts.details(item.company_contacts[0].id)}>
+                  {item.company_contacts[0].name}
+                </Link>
+              ),
+            },
+            {
+              label: 'Total value:',
+              value: currencyGBP(sumExportValues(item)),
+            },
+            { label: 'Date won:', value: formatMediumDate(item.date) },
+            {
+              label: 'Date modified:',
+              value: formatMediumDate(item.modified_on),
+            },
+          ]}
+        />
       ))}
     </ul>
   )


### PR DESCRIPTION
## Description of change
Removed a superfluous `li` that was wrapping the `CollectionItem` which also happens to be an `li` (as you would expect) from both export wins pending/rejected lists.

## Test instructions

Locally, go to: `/exportwins/pending` and open Chrome DevTools where the warning below should no longer be present.

## Screenshots

### Before
<img width="708" alt="Screenshot 2024-09-12 at 13 32 28" src="https://github.com/user-attachments/assets/480e78e6-a5a7-4603-b633-80a0e56e669f">

### After
No warning

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
