### PR TITLE
CLS2-927 Create EYB leads tab

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -135,6 +135,7 @@ const reactRoutes = [
   '/omis/reconciliation',
   '/companies/:companyId/edit-history',
   '/investments/projects/:projectId/propositions/:propositionId/document',
+  '/investments/eyb-leads',
 ]
 
 reactRoutes.forEach((path) => {

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -15,20 +15,26 @@ import {
 import { sanitizeFilter } from '../../../filters'
 
 const QS_PARAMS = {
-  eybLeadCompanyName: 'eybLead_company_name',
+  eybLeadCompanyName: 'eyb_lead_company_name',
+  // assetClassesOfInterest: 'asset_classes_of_interest',
 }
 
-const resolveSelectedOptions = (values = [], options = []) =>
-  values
-    .map((id) => options.filter(({ value }) => value === id)[0])
-    .filter(Boolean)
+// const resolveSelectedOptions = (values = [], options = []) =>
+//   values
+//     .map((id) => options.filter(({ value }) => value === id)[0])
+//     .filter(Boolean)
 
 const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
   const qsParams = qs.parse(location.search.slice(1))
-  const selectedAssetClassesOfInterest = resolveSelectedOptions(
-    qsParams[QS_PARAMS.assetClassesOfInterest],
-    filterOptions.assetClassesOfInterest
-  )
+  // const selectedAssetClassesOfInterest = resolveSelectedOptions(
+  //   qsParams[QS_PARAMS.assetClassesOfInterest],
+  //   filterOptions.assetClassesOfInterest
+  // )
+
+  const resolveSelectedEYBLeadCompanyName = () => {
+    const companyName = qsParams[QS_PARAMS.eybLeadCompanyName]
+    return companyName ? [{ label: companyName, value: companyName }] : []
+  }
   return (
     <FilteredCollectionList
       count={count}
@@ -39,9 +45,9 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
         ...sanitizeFilter(eybLeadCompanyName, 'Company name'),
       })}
       taskProps={{
-        name: TASK_GET_PROFILES_LIST,
-        id: ID,
-        progressMessage: 'Loading profiles',
+        // name: TASK_GET_PROFILES_LIST,
+        // id: ID,
+        progressMessage: 'Loading EYB leads',
         renderProgress: listSkeletonPlaceholder({
           listItemFields: 2,
         }),
@@ -51,26 +57,26 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
             assetClassesOfInterest: qsParams[QS_PARAMS.assetClassesOfInterest],
             eybLeadCompanyName: qsParams[QS_PARAMS.eybLeadCompanyName],
           },
-          onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
+          // onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
         },
       }}
-      baseDownloadLink="/investments/profiles/export"
+      // baseDownloadLink="/investments/profiles/export"
       entityName="eybLead"
       selectedFilters={{
         eybLeadCompanyName: {
-          queryParam: QS_PARAMS.investorCompanyName,
+          queryParam: QS_PARAMS.eybLeadCompanyName,
           options: resolveSelectedEYBLeadCompanyName(),
         },
-        assetClassesOfInterest: {
-          queryParam: QS_PARAMS.assetClassesOfInterest,
-          options: selectedAssetClassesOfInterest,
-        },
+        //   assetClassesOfInterest: {
+        //     queryParam: QS_PARAMS.assetClassesOfInterest,
+        //     options: selectedAssetClassesOfInterest,
+        //   },
       }}
     >
       <CollectionFilters
         taskProps={{
-          name: 'Large investment profiles filters',
-          id: 'investments/profiles',
+          name: 'EYB leads filters',
+          id: 'investments/eyb-leads',
           progressMessage: 'Loading filters',
           renderProgress: () => (
             <>
@@ -83,10 +89,10 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
         }}
       >
         <FilterToggleSection
-          id="FilteredLargeCapitalProfileCollection.core-filters"
+          id="FilteredEYBLeadCollection.core-filters"
           label="Core filters"
         >
-          <Filters.Typeahead
+          {/* <Filters.Typeahead
             isMulti={true}
             label="Sector of interest"
             name="asset-class"
@@ -95,158 +101,13 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
             options={filterOptions.assetClassesOfInterest}
             selectedOptions={selectedAssetClassesOfInterest}
             data-test="asset-class-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Country of company origin"
-            name="country"
-            qsParam={QS_PARAMS.countryOfOrigin}
-            placeholder="Search country"
-            options={filterOptions.countries}
-            selectedOptions={selectedCountries}
-            data-test="country-filter"
-          />
+          /> */}
           <Filters.Input
-            id="LargeCapitalProfileCollection.investor-company-name"
-            qsParam="investor_company_name"
-            name="investor-company-name"
+            id="EYBLeadCollection.eyb-lead-company-name"
+            qsParam="eyb_lead_company_name"
+            name="eyb-lead-company-name"
             label="Company name"
             placeholder="Search company name"
-          />
-        </FilterToggleSection>
-        <FilterToggleSection
-          id="FilteredLargeCapitalProfileCollection.investor-details-filters"
-          label="Investor details"
-        >
-          <Filters.Typeahead
-            isMulti={true}
-            label="Investor type"
-            name="investor-type"
-            qsParam={QS_PARAMS.investorTypes}
-            placeholder="Search investor type"
-            options={filterOptions.investorTypes}
-            selectedOptions={selectedInvestorTypes}
-            data-test="investor-type-filter"
-          />
-          <Filters.NumericRange
-            qsParam={QS_PARAMS.globalAssetsUnderManagement}
-            id="LargeCapitalProfileCollection.global-assets-under-management"
-            label="Global assets under management £"
-          />
-          <Filters.NumericRange
-            qsParam={QS_PARAMS.investableCapital}
-            id="LargeCapitalProfileCollection.investable-capital"
-            label="Investable capital £"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Check clearance"
-            name="required-checks-conducted"
-            qsParam={QS_PARAMS.requiredChecksConducted}
-            placeholder="Search clearance"
-            options={filterOptions.requiredChecksConducted}
-            selectedOptions={selectedRequiredChecksConducted}
-            data-test="required-checks-conducted-filter"
-          />
-        </FilterToggleSection>
-        <FilterToggleSection
-          id="FilteredLargeCapitalProfileCollection.investor-requirements-filters"
-          label="Investor requirements"
-        >
-          <Filters.Typeahead
-            isMulti={true}
-            label="Deal ticket size"
-            name="deal-ticket-size"
-            qsParam={QS_PARAMS.dealTicketSize}
-            placeholder="Search deal ticket size"
-            options={filterOptions.dealTicketSize}
-            selectedOptions={selectedDealTicketSize}
-            data-test="deal-ticket-size-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Types of investment"
-            name="types-of-investment"
-            qsParam={QS_PARAMS.investmentTypes}
-            placeholder="Search types of investment"
-            options={filterOptions.investmentTypes}
-            selectedOptions={selectedInvestmentTypes}
-            data-test="types-of-investment-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Minimum return rate"
-            name="minimum-return-rate"
-            qsParam={QS_PARAMS.minimumReturnRate}
-            placeholder="Search return rate"
-            options={filterOptions.minimumReturnRate}
-            selectedOptions={selectedMinimumReturnRate}
-            data-test="minimum-return-rate-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Time horizon"
-            name="time-horizon-tenor"
-            qsParam={QS_PARAMS.timeHorizon}
-            placeholder="Search time horizon"
-            options={filterOptions.timeHorizon}
-            selectedOptions={selectedTimeHorizon}
-            data-test="time-horizon-tenor-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Restrictions and conditions"
-            name="restrictions-conditions"
-            qsParam={QS_PARAMS.restrictions}
-            placeholder="Search restrictions"
-            options={filterOptions.restrictions}
-            selectedOptions={selectedRestrictions}
-            data-test="restrictions-conditions-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Construction risk"
-            name="construction-risk"
-            qsParam={QS_PARAMS.constructionRisk}
-            placeholder="Search construction risk"
-            options={filterOptions.constructionRisk}
-            selectedOptions={selectedConstructionRisk}
-            data-test="construction-risk-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Minimum equity percentage"
-            name="minimum-equity-percentage"
-            qsParam={QS_PARAMS.minimumEquityPercentage}
-            placeholder="Search equity percentage"
-            options={filterOptions.minimumEquityPercentage}
-            selectedOptions={selectedMinimumEquityPercentage}
-            data-test="minimum-equity-percentage-filter"
-          />
-          <Filters.Typeahead
-            isMulti={true}
-            label="Desired deal role"
-            name="desired-deal-role"
-            qsParam={QS_PARAMS.desiredDealRole}
-            placeholder="Search desired deal role"
-            options={filterOptions.desiredDealRole}
-            selectedOptions={selectedDesiredDealRole}
-            data-test="desired-deal-role-filter"
-          />
-        </FilterToggleSection>
-        <FilterToggleSection
-          id="FilteredLargeCapitalProfileCollection.location-filters"
-          label="Location"
-        >
-          <Filters.Typeahead
-            isMulti={true}
-            label="UK regions of interest"
-            name="uk-regions-of-interest"
-            qsParam={QS_PARAMS.ukRegionsOfInterest}
-            placeholder="Search UK region"
-            options={filterOptions.ukRegionsOfInterest}
-            selectedOptions={selectedUkRegionsOfInterest}
-            data-test="uk-regions-of-interest"
           />
         </FilterToggleSection>
       </CollectionFilters>

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -1,13 +1,23 @@
 import React from 'react'
 
-import { FilteredCollectionList } from '../../../components'
+import { FilteredCollectionList, StatusMessage } from '../../../components'
 
 const EYBLeadCollection = () => {
   return (
-    <FilteredCollectionList
-      collectionName="eybLead"
-      entityName="eybLead"
-    ></FilteredCollectionList>
+    <>
+      <StatusMessage>
+        <strong>Work in progress</strong>
+        <p>
+          {' '}
+          We are working to add Expand Your Business (EYB) data to Data Hub and
+          it will be available here soon.
+        </p>
+      </StatusMessage>
+      <FilteredCollectionList
+        collectionName="eybLead"
+        entityName="eybLead"
+      ></FilteredCollectionList>
+    </>
   )
 }
 

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -1,116 +1,13 @@
 import React from 'react'
-import qs from 'qs'
 
-import {
-  CollectionFilters,
-  FilteredCollectionList,
-  Filters,
-} from '../../../components'
-import {
-  listSkeletonPlaceholder,
-  ToggleHeadingPlaceholder,
-} from '../../../components/SkeletonPlaceholder'
+import { FilteredCollectionList } from '../../../components'
 
-import { sanitizeFilter } from '../../../filters'
-
-const QS_PARAMS = {
-  eybLeadCompanyName: 'eyb_lead_company_name',
-  // assetClassesOfInterest: 'asset_classes_of_interest',
-}
-
-// const resolveSelectedOptions = (values = [], options = []) =>
-//   values
-//     .map((id) => options.filter(({ value }) => value === id)[0])
-//     .filter(Boolean)
-
-const EYBLeadCollection = ({
-  count,
-  results,
-  isComplete,
-  // filterOptions,
-}) => {
-  const qsParams = qs.parse(location.search.slice(1))
-  // const selectedAssetClassesOfInterest = resolveSelectedOptions(
-  //   qsParams[QS_PARAMS.assetClassesOfInterest],
-  //   filterOptions.assetClassesOfInterest
-  // )
-
-  const resolveSelectedEYBLeadCompanyName = () => {
-    const companyName = qsParams[QS_PARAMS.eybLeadCompanyName]
-    return companyName ? [{ label: companyName, value: companyName }] : []
-  }
+const EYBLeadCollection = () => {
   return (
     <FilteredCollectionList
-      count={count}
-      results={results}
-      isComplete={isComplete}
       collectionName="eybLead"
-      sanitizeFiltersForAnalytics={({ eybLeadCompanyName }) => ({
-        ...sanitizeFilter(eybLeadCompanyName, 'Company name'),
-      })}
-      taskProps={{
-        // name: TASK_GET_PROFILES_LIST,
-        // id: ID,
-        progressMessage: 'Loading EYB leads',
-        renderProgress: listSkeletonPlaceholder({
-          listItemFields: 2,
-        }),
-        startOnRender: {
-          payload: {
-            page: parseInt(qsParams.page, 10),
-            // assetClassesOfInterest: qsParams[QS_PARAMS.assetClassesOfInterest],
-            eybLeadCompanyName: qsParams[QS_PARAMS.eybLeadCompanyName],
-          },
-          // onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
-        },
-      }}
       entityName="eybLead"
-      selectedFilters={{
-        eybLeadCompanyName: {
-          queryParam: QS_PARAMS.eybLeadCompanyName,
-          options: resolveSelectedEYBLeadCompanyName(),
-        },
-        //   assetClassesOfInterest: {
-        //     queryParam: QS_PARAMS.assetClassesOfInterest,
-        //     options: selectedAssetClassesOfInterest,
-        //   },
-      }}
-    >
-      <CollectionFilters
-        taskProps={{
-          name: 'EYB leads filters',
-          id: 'investments/eyb-leads',
-          progressMessage: 'Loading filters',
-          renderProgress: () => (
-            <>
-              <ToggleHeadingPlaceholder count={4} />
-            </>
-          ),
-          startOnRender: {
-            onSuccessDispatch: 'INVESTMENTS_PROFILES__FILTER_OPTIONS_LOADED',
-          },
-        }}
-      >
-        <br></br>
-        <Filters.Input
-          id="EYBLeadCollection.eyb-lead-company-name"
-          qsParam="eyb_lead_company_name"
-          name="eyb-lead-company-name"
-          label="Company name"
-          placeholder="Search company name"
-        />
-        {/* <Filters.Typeahead
-            isMulti={true}
-            label="Sector of interest"
-            name="asset-class"
-            qsParam={QS_PARAMS.assetClassesOfInterest}
-            placeholder="Search sector of interest"
-            options={filterOptions.assetClassesOfInterest}
-            selectedOptions={selectedAssetClassesOfInterest}
-            data-test="asset-class-filter"
-          /> */}
-      </CollectionFilters>
-    </FilteredCollectionList>
+    ></FilteredCollectionList>
   )
 }
 

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const TestPage = () => {
+  return <h1>Test Page</h1>
+}
+
+export default TestPage

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -5,7 +5,6 @@ import {
   CollectionFilters,
   FilteredCollectionList,
   Filters,
-  FilterToggleSection,
 } from '../../../components'
 import {
   listSkeletonPlaceholder,
@@ -24,7 +23,12 @@ const QS_PARAMS = {
 //     .map((id) => options.filter(({ value }) => value === id)[0])
 //     .filter(Boolean)
 
-const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
+const EYBLeadCollection = ({
+  count,
+  results,
+  isComplete,
+  // filterOptions,
+}) => {
   const qsParams = qs.parse(location.search.slice(1))
   // const selectedAssetClassesOfInterest = resolveSelectedOptions(
   //   qsParams[QS_PARAMS.assetClassesOfInterest],
@@ -40,7 +44,7 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
       count={count}
       results={results}
       isComplete={isComplete}
-      collectionName="eybLeads"
+      collectionName="eybLead"
       sanitizeFiltersForAnalytics={({ eybLeadCompanyName }) => ({
         ...sanitizeFilter(eybLeadCompanyName, 'Company name'),
       })}
@@ -54,13 +58,12 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
         startOnRender: {
           payload: {
             page: parseInt(qsParams.page, 10),
-            assetClassesOfInterest: qsParams[QS_PARAMS.assetClassesOfInterest],
+            // assetClassesOfInterest: qsParams[QS_PARAMS.assetClassesOfInterest],
             eybLeadCompanyName: qsParams[QS_PARAMS.eybLeadCompanyName],
           },
           // onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
         },
       }}
-      // baseDownloadLink="/investments/profiles/export"
       entityName="eybLead"
       selectedFilters={{
         eybLeadCompanyName: {
@@ -88,11 +91,15 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
           },
         }}
       >
-        <FilterToggleSection
-          id="FilteredEYBLeadCollection.core-filters"
-          label="Core filters"
-        >
-          {/* <Filters.Typeahead
+        <br></br>
+        <Filters.Input
+          id="EYBLeadCollection.eyb-lead-company-name"
+          qsParam="eyb_lead_company_name"
+          name="eyb-lead-company-name"
+          label="Company name"
+          placeholder="Search company name"
+        />
+        {/* <Filters.Typeahead
             isMulti={true}
             label="Sector of interest"
             name="asset-class"
@@ -102,14 +109,6 @@ const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
             selectedOptions={selectedAssetClassesOfInterest}
             data-test="asset-class-filter"
           /> */}
-          <Filters.Input
-            id="EYBLeadCollection.eyb-lead-company-name"
-            qsParam="eyb_lead_company_name"
-            name="eyb-lead-company-name"
-            label="Company name"
-            placeholder="Search company name"
-          />
-        </FilterToggleSection>
       </CollectionFilters>
     </FilteredCollectionList>
   )

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -9,8 +9,8 @@ const EYBLeadCollection = () => {
         <strong>Work in progress</strong>
         <p>
           {' '}
-          We are working to add Expand Your Business (EYB) data to Data Hub and
-          it will be available here soon.
+          We are working to add Expand Your Business (EYB) data to Data Hub. It
+          will be available here soon.
         </p>
       </StatusMessage>
       <FilteredCollectionList

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -1,7 +1,257 @@
 import React from 'react'
+import qs from 'qs'
 
-const TestPage = () => {
-  return <h1>Test Page</h1>
+import {
+  CollectionFilters,
+  FilteredCollectionList,
+  Filters,
+  FilterToggleSection,
+} from '../../../components'
+import {
+  listSkeletonPlaceholder,
+  ToggleHeadingPlaceholder,
+} from '../../../components/SkeletonPlaceholder'
+
+import { sanitizeFilter } from '../../../filters'
+
+const QS_PARAMS = {
+  eybLeadCompanyName: 'eybLead_company_name',
 }
 
-export default TestPage
+const resolveSelectedOptions = (values = [], options = []) =>
+  values
+    .map((id) => options.filter(({ value }) => value === id)[0])
+    .filter(Boolean)
+
+const EYBLeadCollection = ({ count, results, isComplete, filterOptions }) => {
+  const qsParams = qs.parse(location.search.slice(1))
+  const selectedAssetClassesOfInterest = resolveSelectedOptions(
+    qsParams[QS_PARAMS.assetClassesOfInterest],
+    filterOptions.assetClassesOfInterest
+  )
+  return (
+    <FilteredCollectionList
+      count={count}
+      results={results}
+      isComplete={isComplete}
+      collectionName="eybLeads"
+      sanitizeFiltersForAnalytics={({ eybLeadCompanyName }) => ({
+        ...sanitizeFilter(eybLeadCompanyName, 'Company name'),
+      })}
+      taskProps={{
+        name: TASK_GET_PROFILES_LIST,
+        id: ID,
+        progressMessage: 'Loading profiles',
+        renderProgress: listSkeletonPlaceholder({
+          listItemFields: 2,
+        }),
+        startOnRender: {
+          payload: {
+            page: parseInt(qsParams.page, 10),
+            assetClassesOfInterest: qsParams[QS_PARAMS.assetClassesOfInterest],
+            eybLeadCompanyName: qsParams[QS_PARAMS.eybLeadCompanyName],
+          },
+          onSuccessDispatch: INVESTMENTS__PROFILES_LOADED,
+        },
+      }}
+      baseDownloadLink="/investments/profiles/export"
+      entityName="eybLead"
+      selectedFilters={{
+        eybLeadCompanyName: {
+          queryParam: QS_PARAMS.investorCompanyName,
+          options: resolveSelectedEYBLeadCompanyName(),
+        },
+        assetClassesOfInterest: {
+          queryParam: QS_PARAMS.assetClassesOfInterest,
+          options: selectedAssetClassesOfInterest,
+        },
+      }}
+    >
+      <CollectionFilters
+        taskProps={{
+          name: 'Large investment profiles filters',
+          id: 'investments/profiles',
+          progressMessage: 'Loading filters',
+          renderProgress: () => (
+            <>
+              <ToggleHeadingPlaceholder count={4} />
+            </>
+          ),
+          startOnRender: {
+            onSuccessDispatch: 'INVESTMENTS_PROFILES__FILTER_OPTIONS_LOADED',
+          },
+        }}
+      >
+        <FilterToggleSection
+          id="FilteredLargeCapitalProfileCollection.core-filters"
+          label="Core filters"
+        >
+          <Filters.Typeahead
+            isMulti={true}
+            label="Sector of interest"
+            name="asset-class"
+            qsParam={QS_PARAMS.assetClassesOfInterest}
+            placeholder="Search sector of interest"
+            options={filterOptions.assetClassesOfInterest}
+            selectedOptions={selectedAssetClassesOfInterest}
+            data-test="asset-class-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Country of company origin"
+            name="country"
+            qsParam={QS_PARAMS.countryOfOrigin}
+            placeholder="Search country"
+            options={filterOptions.countries}
+            selectedOptions={selectedCountries}
+            data-test="country-filter"
+          />
+          <Filters.Input
+            id="LargeCapitalProfileCollection.investor-company-name"
+            qsParam="investor_company_name"
+            name="investor-company-name"
+            label="Company name"
+            placeholder="Search company name"
+          />
+        </FilterToggleSection>
+        <FilterToggleSection
+          id="FilteredLargeCapitalProfileCollection.investor-details-filters"
+          label="Investor details"
+        >
+          <Filters.Typeahead
+            isMulti={true}
+            label="Investor type"
+            name="investor-type"
+            qsParam={QS_PARAMS.investorTypes}
+            placeholder="Search investor type"
+            options={filterOptions.investorTypes}
+            selectedOptions={selectedInvestorTypes}
+            data-test="investor-type-filter"
+          />
+          <Filters.NumericRange
+            qsParam={QS_PARAMS.globalAssetsUnderManagement}
+            id="LargeCapitalProfileCollection.global-assets-under-management"
+            label="Global assets under management £"
+          />
+          <Filters.NumericRange
+            qsParam={QS_PARAMS.investableCapital}
+            id="LargeCapitalProfileCollection.investable-capital"
+            label="Investable capital £"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Check clearance"
+            name="required-checks-conducted"
+            qsParam={QS_PARAMS.requiredChecksConducted}
+            placeholder="Search clearance"
+            options={filterOptions.requiredChecksConducted}
+            selectedOptions={selectedRequiredChecksConducted}
+            data-test="required-checks-conducted-filter"
+          />
+        </FilterToggleSection>
+        <FilterToggleSection
+          id="FilteredLargeCapitalProfileCollection.investor-requirements-filters"
+          label="Investor requirements"
+        >
+          <Filters.Typeahead
+            isMulti={true}
+            label="Deal ticket size"
+            name="deal-ticket-size"
+            qsParam={QS_PARAMS.dealTicketSize}
+            placeholder="Search deal ticket size"
+            options={filterOptions.dealTicketSize}
+            selectedOptions={selectedDealTicketSize}
+            data-test="deal-ticket-size-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Types of investment"
+            name="types-of-investment"
+            qsParam={QS_PARAMS.investmentTypes}
+            placeholder="Search types of investment"
+            options={filterOptions.investmentTypes}
+            selectedOptions={selectedInvestmentTypes}
+            data-test="types-of-investment-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Minimum return rate"
+            name="minimum-return-rate"
+            qsParam={QS_PARAMS.minimumReturnRate}
+            placeholder="Search return rate"
+            options={filterOptions.minimumReturnRate}
+            selectedOptions={selectedMinimumReturnRate}
+            data-test="minimum-return-rate-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Time horizon"
+            name="time-horizon-tenor"
+            qsParam={QS_PARAMS.timeHorizon}
+            placeholder="Search time horizon"
+            options={filterOptions.timeHorizon}
+            selectedOptions={selectedTimeHorizon}
+            data-test="time-horizon-tenor-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Restrictions and conditions"
+            name="restrictions-conditions"
+            qsParam={QS_PARAMS.restrictions}
+            placeholder="Search restrictions"
+            options={filterOptions.restrictions}
+            selectedOptions={selectedRestrictions}
+            data-test="restrictions-conditions-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Construction risk"
+            name="construction-risk"
+            qsParam={QS_PARAMS.constructionRisk}
+            placeholder="Search construction risk"
+            options={filterOptions.constructionRisk}
+            selectedOptions={selectedConstructionRisk}
+            data-test="construction-risk-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Minimum equity percentage"
+            name="minimum-equity-percentage"
+            qsParam={QS_PARAMS.minimumEquityPercentage}
+            placeholder="Search equity percentage"
+            options={filterOptions.minimumEquityPercentage}
+            selectedOptions={selectedMinimumEquityPercentage}
+            data-test="minimum-equity-percentage-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Desired deal role"
+            name="desired-deal-role"
+            qsParam={QS_PARAMS.desiredDealRole}
+            placeholder="Search desired deal role"
+            options={filterOptions.desiredDealRole}
+            selectedOptions={selectedDesiredDealRole}
+            data-test="desired-deal-role-filter"
+          />
+        </FilterToggleSection>
+        <FilterToggleSection
+          id="FilteredLargeCapitalProfileCollection.location-filters"
+          label="Location"
+        >
+          <Filters.Typeahead
+            isMulti={true}
+            label="UK regions of interest"
+            name="uk-regions-of-interest"
+            qsParam={QS_PARAMS.ukRegionsOfInterest}
+            placeholder="Search UK region"
+            options={filterOptions.ukRegionsOfInterest}
+            selectedOptions={selectedUkRegionsOfInterest}
+            data-test="uk-regions-of-interest"
+          />
+        </FilterToggleSection>
+      </CollectionFilters>
+    </FilteredCollectionList>
+  )
+}
+
+export default EYBLeadCollection

--- a/src/client/modules/Investments/InvestmentCollections.jsx
+++ b/src/client/modules/Investments/InvestmentCollections.jsx
@@ -12,7 +12,7 @@ const PATH = /([^\/]+$)/
 
 const pathToPageTitleMap = {
   projects: 'Projects',
-  eybLeads: 'EYB Leads',
+  'eyb-leads': 'EYB Leads',
   profiles: 'Profiles',
   opportunities: 'UK opportunities',
 }

--- a/src/client/modules/Investments/InvestmentCollections.jsx
+++ b/src/client/modules/Investments/InvestmentCollections.jsx
@@ -12,7 +12,7 @@ const PATH = /([^\/]+$)/
 
 const pathToPageTitleMap = {
   projects: 'Projects',
-  'eyb-leads': 'EYB Leads',
+  'eyb-leads': 'EYB leads',
   profiles: 'Profiles',
   opportunities: 'UK opportunities',
 }
@@ -43,7 +43,7 @@ const InvestmentCollections = ({ ...props }) => {
             content: <ProjectsCollection {...props} />,
           },
           [urls.investments.eybLeads.index()]: {
-            label: 'EYB Leads',
+            label: 'EYB leads',
             content: <EYBLeadsCollection {...props} />,
           },
           [urls.investments.profiles.index()]: {

--- a/src/client/modules/Investments/InvestmentCollections.jsx
+++ b/src/client/modules/Investments/InvestmentCollections.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { DefaultLayout } from '../../components'
 import TabNav from '../../components/TabNav'
 import urls from '../../../lib/urls'
+import EYBLeadsCollection from './EYBLeads/EYBLeadsCollection'
 import ProjectsCollection from './Projects/ProjectsCollection'
 import ProfilesCollection from './Profiles/ProfilesCollection'
 import OpportunitiesCollection from './Opportunities/CollectionList/OpportunitiesCollection'
@@ -11,6 +12,7 @@ const PATH = /([^\/]+$)/
 
 const pathToPageTitleMap = {
   projects: 'Projects',
+  eybLeads: 'EYB Leads',
   profiles: 'Profiles',
   opportunities: 'UK opportunities',
 }
@@ -39,6 +41,10 @@ const InvestmentCollections = ({ ...props }) => {
           [urls.investments.projects.index()]: {
             label: 'Projects',
             content: <ProjectsCollection {...props} />,
+          },
+          [urls.investments.eybLeads.index()]: {
+            label: 'EYBLeads',
+            content: <EYBLeadsCollection {...props} />,
           },
           [urls.investments.profiles.index()]: {
             label: 'Investor profiles',

--- a/src/client/modules/Investments/InvestmentCollections.jsx
+++ b/src/client/modules/Investments/InvestmentCollections.jsx
@@ -43,7 +43,7 @@ const InvestmentCollections = ({ ...props }) => {
             content: <ProjectsCollection {...props} />,
           },
           [urls.investments.eybLeads.index()]: {
-            label: 'EYBLeads',
+            label: 'EYB Leads',
             content: <EYBLeadsCollection {...props} />,
           },
           [urls.investments.profiles.index()]: {

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -1098,6 +1098,14 @@ function Routes() {
         </ProtectedRoute>
       ),
     },
+    {
+      path: '/investments/eyb-leads',
+      element: (
+        <ProtectedRoute module={'datahub:investments'}>
+          <InvestmentCollections />
+        </ProtectedRoute>
+      ),
+    },
   ])
 
   return routes

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -538,6 +538,9 @@ module.exports = {
       index: url('/investments/projects', '/:investmentId/edit-history'),
       data: url('/investments/projects', '/:investmentId/edit-history/data'),
     },
+    eybLeads: {
+      index: url('/investments', '/eyb-leads'),
+    },
   },
   metadata: {
     likelihoodToLand: url('/api-proxy/v4/metadata', '/likelihood-to-land'),

--- a/test/component/cypress/specs/components/StatusMessage.cy.jsx
+++ b/test/component/cypress/specs/components/StatusMessage.cy.jsx
@@ -14,7 +14,7 @@ describe('StatusMessage', () => {
   })
 })
 
-function assertStatusMessage(colour) {
+export function assertStatusMessage(colour) {
   beforeEach(() => {
     cy.mount(<Component colour={colour}>Status Message</Component>)
   })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -1,0 +1,33 @@
+const {
+  assertTabbedLocalNav,
+  assertLocalHeader,
+  assertBreadcrumbs,
+} = require('../../support/assertions')
+const { investments } = require('../../../../../src/lib/urls')
+
+describe('EYB leads', () => {
+  context('When visiting the EYB leads tab', () => {
+    beforeEach(() => {
+      cy.visit(investments.eybLeads.index())
+    })
+
+    it('should render the header', () => {
+      assertLocalHeader('EYB leads')
+    })
+
+    it('should render breadcrumbs', () => {
+      assertBreadcrumbs({
+        Home: '/',
+        Investments: investments.index(),
+        'EYB leads': null,
+      })
+    })
+
+    it('should render the local navigation', () => {
+      assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('EYB leads')
+      assertTabbedLocalNav('Investor profiles')
+      assertTabbedLocalNav('UK opportunities')
+    })
+  })
+})

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -29,5 +29,11 @@ describe('EYB leads', () => {
       assertTabbedLocalNav('Investor profiles')
       assertTabbedLocalNav('UK opportunities')
     })
+
+    it('should render the status message', () => {
+      cy.get('[data-test=status-message]')
+        .should('exist')
+        .should('contain', 'Work in progress')
+    })
   })
 })

--- a/test/functional/cypress/specs/investments/opportunity-list-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-list-spec.js
@@ -34,6 +34,7 @@ describe('Investment opportunities', () => {
 
     it('should render the local navigation', () => {
       assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('EYB leads')
       assertTabbedLocalNav('Investor profiles')
       assertTabbedLocalNav('UK opportunities')
     })

--- a/test/functional/cypress/specs/investments/profiles-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-spec.js
@@ -25,7 +25,9 @@ describe('Investor profiles', () => {
 
     it('should render the local navigation', () => {
       assertTabbedLocalNav('Projects')
+      assertTabbedLocalNav('EYB leads')
       assertTabbedLocalNav('Investor profiles')
+      assertTabbedLocalNav('UK opportunities')
     })
 
     it('should display download profile text', () => {


### PR DESCRIPTION
## Description of change

Creates an EYB leads page and displays it as a tab in the Investments area of Data Hub.
This is part of the wider EYB/Data Hub integration piece of work which will ultimately see EYB leads from Expand Your Business listed on this page.
Whilst this area of DataHub is under development, a status message will temporarily be displayed on the page.

## Test instructions
To test locally:
- Visit http://localhost:3000/investments/eyb-leads
- The **EYB Leads** page should display
- You should be able to see the **breadcrumbs**, **header** and **tab navigation**
- The tabs displayed should be: **Projects**, **EYB leads**, **Investor profiles**, **UK opportunities**
- The status message should be visible
<img width="1056" alt="Screenshot 2024-09-18 at 16 04 38" src="https://github.com/user-attachments/assets/b3223418-f3f8-4a63-9642-1c22f4c3bc3f">


You should also be able to visit the EYB Leads page from any of the other tabs available on the Investments page by selecting the **EYB leads** tab:
  - Projects: http://localhost:3000/investments/projects
  - Investor profiles: http://localhost:3000/investments/profiles
  - UK opportunities: http://localhost:3000/investments/opportunities
<img width="1086" alt="Screenshot 2024-09-12 at 17 06 26" src="https://github.com/user-attachments/assets/c290aa36-9f38-4158-8802-1c43ab2cfc2d">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
