### PR TITLE
Left align and vertically centre the Data Hub announcement banner

### DIFF
--- a/src/client/components/LocalHeader/Banner.jsx
+++ b/src/client/components/LocalHeader/Banner.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 
-import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import { SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
 
 import { state2props } from './state'
@@ -12,30 +12,13 @@ import {
 } from '../../actions'
 import { MID_BLUE, WHITE } from '../../utils/colours'
 
-const StyledBody = styled('div')`
-  background-color: ${MID_BLUE};
+const Container = styled('div')`
   color: ${WHITE};
-  ${MEDIA_QUERIES.TABLET} {
-    height: 40px;
-  }
-  ${MEDIA_QUERIES.DESKTOP} {
-    height: 40px;
-  }
-`
-
-const StyledDiv = styled('div')`
-  text-align: center;
-  position: relative;
-  ${MEDIA_QUERIES.TABLET} {
-    padding-top: 1.5%;
-  }
-  ${MEDIA_QUERIES.DESKTOP} {
-    padding-top: 0.8%;
-  }
+  background-color: ${MID_BLUE};
+  padding: 10px 0 10px 0;
 `
 
 const StyledTextLink = styled('a')`
-  position: relative;
   color: ${WHITE};
   margin-left: ${SPACING.SCALE_1};
   &:visited,
@@ -46,9 +29,8 @@ const StyledTextLink = styled('a')`
 `
 
 const StyledDismissTextLink = styled('button')`
-  position: relative;
   color: ${WHITE};
-  margin-left: ${SPACING.SCALE_1};
+  margin-left: ${SPACING.SCALE_5};
   background: none;
   border: none;
   padding: 0;
@@ -76,17 +58,15 @@ const Banner = ({
   }
 
   return announcementLink !== latestAnnouncement.link ? (
-    <StyledBody>
-      <StyledDiv data-testid="feed-banner">
-        Update:
-        <StyledTextLink href={latestAnnouncement.link}>
-          {latestAnnouncement.heading}
-        </StyledTextLink>
-        <StyledDismissTextLink onClick={updateLocalStorage}>
-          Dismiss
-        </StyledDismissTextLink>
-      </StyledDiv>
-    </StyledBody>
+    <Container data-testid="feed-banner">
+      Update:
+      <StyledTextLink href={latestAnnouncement.link}>
+        {latestAnnouncement.heading}
+      </StyledTextLink>
+      <StyledDismissTextLink onClick={updateLocalStorage}>
+        Dismiss
+      </StyledDismissTextLink>
+    </Container>
   ) : null
 }
 

--- a/src/client/components/PersonalisedDashboard/index.jsx
+++ b/src/client/components/PersonalisedDashboard/index.jsx
@@ -8,7 +8,7 @@ import styled, { ThemeProvider } from 'styled-components'
 import { connect } from 'react-redux'
 import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
-import { BLUE } from '../../../client/utils/colours'
+import { BLUE, MID_BLUE } from '../../../client/utils/colours'
 import {
   readFromLocalStorage,
   writeToLocalStorage,
@@ -44,6 +44,10 @@ import FlashMessages from '../LocalHeader/FlashMessages'
 
 const SearchBackground = styled('div')`
   background-color: ${BLUE};
+`
+
+const BannerBackground = styled('div')`
+  background-color: ${MID_BLUE};
 `
 
 const SearchContainer = styled(CustomContainer)`
@@ -90,7 +94,11 @@ const PersonalisedDashboard = ({
 
   return (
     <ThemeProvider theme={blueTheme}>
-      <Banner items={dataHubFeed} />
+      <BannerBackground>
+        <CustomContainer width="960">
+          <Banner items={dataHubFeed} />
+        </CustomContainer>
+      </BannerBackground>
       <SearchBackground data-test="search-data-hub">
         <SearchContainer width="960">
           <Search csrfToken={csrfToken} />


### PR DESCRIPTION
## Description of change
Left align and vertically centred the Data Hub announcement banner and ensured the dismiss gap is `30px`. 

## Test instructions
Go to the dashboard `/`

## Screenshots

### Before
<img width="980" alt="after" src="https://github.com/user-attachments/assets/e4af1bca-3697-4522-90cf-99c19b509a5e">

### After
<img width="980" alt="before" src="https://github.com/user-attachments/assets/fe8b9777-d2e7-4f4a-afb1-2293a19d1efc">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
