### PR TITLE
Fixed broken storybook after HMR PR

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,6 +1,6 @@
 const {
   resolve
-} = require('../webpack.config')();
+} = require('../webpack.config');
 
 export default {
   addons: [
@@ -12,9 +12,7 @@ export default {
   webpackFinal: async (config) => {
     return {
       ...config,
-      resolve: {
-        ...resolve,
-      },
+      resolve,
     }
   },
   core: {

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,9 +1,13 @@
 const config = require('./src/config')
 
+// The react-refresh plugin breaks storybook so we have to exclude it
+const isStorybook = process.env.npm_lifecycle_event === 'storybook'
+const includeReactRefresh = config.isDev && !isStorybook
+
 module.exports = {
   sourceType: 'unambiguous',
   plugins: [
-    ...(config.isDev ? ['react-refresh/babel'] : []),
+    ...(includeReactRefresh ? ['react-refresh/babel'] : []),
     '@babel/plugin-syntax-import-assertions',
   ],
   env: {


### PR DESCRIPTION
## Description of change

This PR fixes the `npm storybook` command which was broken after the #7002 PR

## Test instructions

1. Run the `npm storybook` and `npm storybook:build` commands
2. Storybook should work with no errors

