### PR TITLE
Fixes the edit project status flaky test

### DIFF
--- a/test/functional/cypress/specs/investments/edit-project-status-spec.js
+++ b/test/functional/cypress/specs/investments/edit-project-status-spec.js
@@ -10,6 +10,7 @@ describe('EditProjectStatus', () => {
   const project = investmentProjectFaker({
     status: 'ongoing',
     stage: 'prospect',
+    specificProgrammes: [],
   })
 
   beforeEach(() => {


### PR DESCRIPTION
## Description of change
Fixes a [flaky test](https://github.com/uktrade/data-hub-frontend/blob/main/test/functional/cypress/specs/investments/edit-project-status-spec.js#L64) that is holding up the pipeline.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
