### PR TITLE
Making it more explicit how to do a bulk-update

### DIFF
--- a/docs/Dependabot.md
+++ b/docs/Dependabot.md
@@ -35,6 +35,6 @@ The `react-dom` and `react` packages should, where possible, be kept at the same
 Some of the packages we use have several companion packages that should be kept at the same version in order for them to work correctly. In order to optimise the number of upgrades we perform and to prevent wastage of CircleCI resource on redundant PRs, Dependabot has been configured to only upgrade one dependency in the group with the expectation being that the others should be updated using a script.
 
 We currently have three groups of dependencies that need to be updated in this manner:
-- Nivo (`dependabot:update-nivo`)
-- Sentry (`dependabot:update-sentry`)
-- Storybook (`dependabot:update-storybook`)
+- Nivo (`npm run dependabot:update-nivo`)
+- Sentry (`npm run dependabot:update-sentry`)
+- Storybook (`npm run dependabot:update-storybook`)


### PR DESCRIPTION
## Description of change

This PR adds a small change to the `Dependabot.md` file to make it more explicit how to run bulk dependencies updates when needed

## Test instructions

Updated commands for `dependabot:update-*` dependencies now featuring the missing `npm run ...` part

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
