### PR TITLE
Fix security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "autoprefixer": "^10.4.20",
         "axios": "^1.7.7",
         "basic-auth": "^2.0.1",
-        "body-parser": "^1.20.2",
+        "body-parser": "^1.20.3",
         "case": "^1.6.3",
         "classlist.js": "^1.1.20150312",
         "compression": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "autoprefixer": "^10.4.20",
     "axios": "^1.7.7",
     "basic-auth": "^2.0.1",
-    "body-parser": "^1.20.2",
+    "body-parser": "^1.20.3",
     "case": "^1.6.3",
     "classlist.js": "^1.1.20150312",
     "compression": "^1.7.4",


### PR DESCRIPTION
## Description of change
`body-parser` is Node.js body parsing middleware. `body-parser` `<1.20.3` is vulnerable to denial of service when url encoding is enabled. A malicious actor using a specially crafted payload could flood the server with a large number of requests, resulting in denial of service. This issue is patched in `1.20.3`.

https://www.cvedetails.com/cve/CVE-2024-45590/

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
