### PR TITLE
Rename previous and next to previous page and next page

### DIFF
--- a/src/client/components/Pagination/constants.js
+++ b/src/client/components/Pagination/constants.js
@@ -1,6 +1,6 @@
-export const PAGINATION_PIECE_PREVIOUS = 'Previous'
+export const PAGINATION_PIECE_PREVIOUS = 'Previous page'
 export const PAGINATION_PIECE_ELLIPSIS = 'ellipsis'
 export const PAGINATION_PIECE_PAGE_NUMBER = 'page-number'
-export const PAGINATION_PIECE_NEXT = 'Next'
+export const PAGINATION_PIECE_NEXT = 'Next page'
 
 export const DEFAULT_MAX_PAGE_NUMBER_LINKS = 5

--- a/src/client/components/Pagination/index.jsx
+++ b/src/client/components/Pagination/index.jsx
@@ -112,7 +112,7 @@ function Pagination({
                     onClick={onClick}
                     href={getPageUrl(pageNumber)}
                   >
-                    Previous
+                    Previous page
                   </StyledPaginationLink>
                 )}
 
@@ -141,7 +141,7 @@ function Pagination({
                     onClick={onClick}
                     href={getPageUrl(pageNumber)}
                   >
-                    Next
+                    Next page
                   </StyledPaginationLink>
                 )}
               </StyledPaginationPiece>

--- a/src/templates/_macros/common/pagination.njk
+++ b/src/templates/_macros/common/pagination.njk
@@ -27,7 +27,7 @@
       aria-label="pagination: total {{ pagination.totalPages }} pages"
     >
       {% if pagination.prev -%}
-        <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous</a>
+        <a href="{{ pagination.prev }}" class="c-pagination__label c-pagination__label--prev">Previous page</a>
       {%- endif %}
       {% if showPages -%}
         <ul class="c-pagination__list">
@@ -47,7 +47,7 @@
         </ul>
       {%- endif %}
       {% if pagination.next -%}
-        <a href="{{ pagination.next }}" class="c-pagination__label c-pagination__label--next">Next</a>
+        <a href="{{ pagination.next }}" class="c-pagination__label c-pagination__label--next">Next page</a>
       {%- endif %}
     </nav>
   {% endif %}

--- a/test/component/cypress/specs/Resource/Paginated.cy.jsx
+++ b/test/component/cypress/specs/Resource/Paginated.cy.jsx
@@ -52,7 +52,7 @@ describe.skip('Resource/Paginated', () => {
       cy.get('@page').should('have.text', JSON.stringify(page))
     })
 
-    // Go through pages backwards by clicking Previous
+    // Go through pages backwards by clicking Previous page
     PAGES.slice(0, -1)
       .toReversed()
       .forEach((page) => {

--- a/test/component/cypress/specs/components/Pagination.cy.jsx
+++ b/test/component/cypress/specs/components/Pagination.cy.jsx
@@ -46,7 +46,7 @@ describe('Pagination', () => {
       cy.mount(<Component items={150} />)
     })
     it('should render a page link', () => {
-      assertVisiblePageLinks(['Next'])
+      assertVisiblePageLinks(['Next page'])
     })
   })
   context('when on MOBILE and you click next', () => {
@@ -56,7 +56,7 @@ describe('Pagination', () => {
       cy.get('[data-test="pagination"] ul li a').last().click()
     })
     it('should render two page links', () => {
-      assertVisiblePageLinks(['Previous', 'Next'])
+      assertVisiblePageLinks(['Previous page', 'Next page'])
     })
     it('should have an active page link', () => {
       assertActivePageLink('next')
@@ -77,7 +77,7 @@ describe('Pagination', () => {
       cy.get('[data-test="pagination"] ul li a').first().click()
     })
     it('should render two page links', () => {
-      assertVisiblePageLinks(['Previous', 'Next'])
+      assertVisiblePageLinks(['Previous page', 'Next page'])
     })
     it('should have an active page link', () => {
       assertActivePageLink('previous')
@@ -94,7 +94,7 @@ describe('Pagination', () => {
       cy.mount(<Component items={150} initialPage={15} />)
     })
     it('should render one page link', () => {
-      assertVisiblePageLinks(['Previous'])
+      assertVisiblePageLinks(['Previous page'])
     })
   })
   context('when on MOBILE and you only have one page', () => {
@@ -122,7 +122,7 @@ describe('Pagination', () => {
         '8',
         '9',
         '10',
-        'Next',
+        'Next page',
       ])
     })
     it('should have an active page link', () => {
@@ -135,7 +135,7 @@ describe('Pagination', () => {
       cy.mount(<Component items={15} />)
     })
     it('should render page links', () => {
-      assertPageLinks(['1', '2', 'Next'])
+      assertPageLinks(['1', '2', 'Next page'])
     })
     it('should have an active page link', () => {
       assertActivePageLink(1)
@@ -149,7 +149,7 @@ describe('Pagination', () => {
     })
     it('should render page links', () => {
       assertPageLinks([
-        'Previous',
+        'Previous page',
         '1',
         '2',
         '3',
@@ -160,7 +160,7 @@ describe('Pagination', () => {
         '8',
         '9',
         '10',
-        'Next',
+        'Next page',
       ])
     })
     it('should have an active page link', () => {
@@ -173,7 +173,7 @@ describe('Pagination', () => {
       cy.window().its('scrollY').should('equal', 0)
     })
   })
-  context('when you navigate to page 2 by clicking the Next link', () => {
+  context('when you navigate to page 2 by clicking the next page link', () => {
     beforeEach(() => {
       cy.viewport(1000, 1000)
       cy.mount(<Component items={1000} />)
@@ -181,7 +181,7 @@ describe('Pagination', () => {
     })
     it('should render page links', () => {
       assertPageLinks([
-        'Previous',
+        'Previous page',
         '1',
         '2',
         '3',
@@ -192,7 +192,7 @@ describe('Pagination', () => {
         '8',
         '9',
         '10',
-        'Next',
+        'Next page',
       ])
     })
     it('should have an active page link', () => {
@@ -226,7 +226,7 @@ describe('Pagination', () => {
           '8',
           '9',
           '10',
-          'Next',
+          'Next page',
         ])
       })
       it('should have an active page link', () => {
@@ -248,7 +248,7 @@ describe('Pagination', () => {
     })
     it('should display the next 10 page links', () => {
       assertPageLinks([
-        'Previous',
+        'Previous page',
         '2',
         '3',
         '4',
@@ -259,7 +259,7 @@ describe('Pagination', () => {
         '9',
         '10',
         '11',
-        'Next',
+        'Next page',
       ])
     })
   })
@@ -270,7 +270,7 @@ describe('Pagination', () => {
     })
     it('should render page links', () => {
       assertPageLinks([
-        'Previous',
+        'Previous page',
         '1',
         '2',
         '3',
@@ -281,7 +281,7 @@ describe('Pagination', () => {
         '8',
         '9',
         '10',
-        'Next',
+        'Next page',
       ])
     })
     it('should have an active page link', () => {
@@ -296,7 +296,7 @@ describe('Pagination', () => {
     })
     it('should render page links', () => {
       assertPageLinks([
-        'Previous',
+        'Previous page',
         '1',
         '2',
         '3',

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -123,8 +123,8 @@ describe('Company Export tab - Export countries history', () => {
         ])
       })
 
-      it('should display the next button', () => {
-        cy.get('[data-test="next"]').should('have.text', 'Next')
+      it('should display the next page button', () => {
+        cy.get('[data-test="next"]').should('have.text', 'Next page')
       })
 
       it('should not display the previous button', () => {
@@ -151,14 +151,14 @@ describe('Company Export tab - Export countries history', () => {
         ])
       })
 
-      it('should not display the next button', () => {
+      it('should not display the next page button', () => {
         cy.get('[aria-label="Page 2"]').click()
         cy.get('[data-test="next"]').should('not.exist')
       })
 
-      it('should display the previous button', () => {
+      it('should display the previous page button', () => {
         cy.get('[aria-label="Page 2"]').click()
-        cy.get('[data-test="prev"]').should('have.text', 'Previous')
+        cy.get('[data-test="prev"]').should('have.text', 'Previous page')
       })
     })
 

--- a/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
@@ -250,7 +250,7 @@ describe('Exports New Interaction Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -260,7 +260,7 @@ describe('Exports no recent Interaction Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-estimated-land-dates-list-spec.js
@@ -186,7 +186,7 @@ describe('Estimated Land Date Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-no-recent-interactions-list-spec.js
@@ -187,7 +187,7 @@ describe('No Recent Interaction Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
+++ b/test/functional/cypress/specs/reminders/investment-outstanding-reminders-list-spec.js
@@ -197,7 +197,7 @@ describe('Outstanding Proposition Reminders', () => {
         .as('paginationItems')
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
-      cy.get('@paginationItems').eq(2).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(2).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
@@ -184,7 +184,7 @@ describe('My Tasks Due Date Approaching Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
@@ -181,7 +181,7 @@ describe('My Tasks Task Overdue Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
@@ -185,7 +185,7 @@ describe('Task Amended By Others Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
@@ -185,7 +185,7 @@ describe('My Tasks Task Assigned To Me From Others Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {

--- a/test/functional/cypress/specs/reminders/task-completed-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-completed-list-spec.js
@@ -181,7 +181,7 @@ describe('My Tasks Task Completed Reminders', () => {
       cy.get('@paginationItems').eq(0).should('have.text', '1')
       cy.get('@paginationItems').eq(1).should('have.text', '2')
       cy.get('@paginationItems').eq(2).should('have.text', '3')
-      cy.get('@paginationItems').eq(3).should('have.text', 'Next')
+      cy.get('@paginationItems').eq(3).should('have.text', 'Next page')
     })
 
     it('should navigate to another page when clicked', () => {


### PR DESCRIPTION
## Description of change

**Accessibility issue**
The ‘Next’ link contained within the pagination section on the ‘Companies’ page does not inform users of the links purpose nor function when navigating the page out of context. This is due to the word ‘Next’ being read out without any additional context, such as being followed by the word ‘page’. This means that screen reader users are not given the full
context of the links function or purpose while navigating the page out of context. This is consistent for all pagination links throughout the service.

**Accessibility fix**
Ensure that all links are descriptive of their function and purpose with link text alone and users are not required to navigate or read surrounding context to get the context needed for the links. In this instance, adding the suffix of ‘page’ to the ‘Next’ link will be sufficient.

## Test instructions
Go to any paginated list on Data Hub to view the changes.

## Screenshots

### Before
<img width="641" alt="before" src="https://github.com/user-attachments/assets/41b9a3c4-bced-40e2-b9ab-392d92e771db">

### After
<img width="641" alt="after" src="https://github.com/user-attachments/assets/7f183f6a-ef7d-43f3-8828-d98a9f7935d6">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
