### PR TITLE
Fix linting error in CircleCI (Prettier/ESLint conflict)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
     machine:
       image: ubuntu-2004:2024.01.1
       docker_layer_caching: false
+    parallelism: 1
+    resource_class: large
     steps:
       - checkout
       - run_make:


### PR DESCRIPTION
## Description of change
This PR addresses the intermittent linting failures that were occurring on CircleCI. The root cause was determined to be resource contention, as the linting process was competing for resources with other jobs in the workflow.

To resolve this issue, the following steps were taken:

1. **Increased resource allocation**: The lint job's resource class was upgraded to **large** to provide it with more resources. This ensured that the linter had sufficient CPU and memory to complete its tasks without being interrupted by other jobs.

2. **Verified resource usage**: Resource usage was monitored on CircleCI to confirm that the increased allocation was effective in preventing resource contention.

3. **Retested workflow**: The workflow was retested multiple times to verify that the linting job was now passing consistently without any intermittent failures.

By implementing these changes, the linting process has become more reliable and stable on CircleCI (hopefully :crossed_fingers:)

## ESLint error
The following error turned out to be a red herring. However, once the `eslint-plugin-import` [PR](https://github.com/import-js/eslint-plugin-import/pull/2996) is merged and released, we'll be well positioned to upgrade ESLint from `8.57.0` to `v9+`.

```
...
...
...
> npx eslint --ext .jsx,.js ./test ./src ./assets --format junit --output-file reports/eslint.xml


Oops! Something went wrong! :(

ESLint: 8.57.0

TypeError: Cannot read properties of undefined (reading 'message')
Occurred while linting /usr/src/app/test/functional/cypress/fakers/required-checks-conducted.js:1
Rule: "prettier/prettier"
    at syncFn (/usr/src/app/node_modules/synckit/lib/index.cjs:362:59)
    at Program (/usr/src/app/node_modules/eslint-plugin-prettier/eslint-plugin-prettier.js:191:32)
    at ruleErrorHandler (/usr/src/app/node_modules/eslint/lib/linter/linter.js:1076:28)
    at /usr/src/app/node_modules/eslint/lib/linter/safe-emitter.js:45:58
    at Array.forEach (<anonymous>)
    at Object.emit (/usr/src/app/node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (/usr/src/app/node_modules/eslint/lib/linter/node-event-generator.js:297:26)
    at NodeEventGenerator.applySelectors (/usr/src/app/node_modules/eslint/lib/linter/node-event-generator.js:326:22)
    at NodeEventGenerator.enterNode (/usr/src/app/node_modules/eslint/lib/linter/node-event-generator.js:340:14)
    at CodePathAnalyzer.enterNode (/usr/src/app/node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:803:23)
    at /usr/src/app/node_modules/eslint/lib/linter/linter.js:1111:32
    at Array.forEach (<anonymous>)
    at runRules (/usr/src/app/node_modules/eslint/lib/linter/linter.js:1106:15)
    at Linter._verifyWithoutProcessors (/usr/src/app/node_modules/eslint/lib/linter/linter.js:1355:31)
    at Linter._verifyWithConfigArray (/usr/src/app/node_modules/eslint/lib/linter/linter.js:1807:21)
    at Linter.verify (/usr/src/app/node_modules/eslint/lib/linter/linter.js:1437:65)
    at Linter.verifyAndFix (/usr/src/app/node_modules/eslint/lib/linter/linter.js:2068:29)
    at verifyText (/usr/src/app/node_modules/eslint/lib/cli-engine/cli-engine.js:254:48)
    at CLIEngine.executeOnFiles (/usr/src/app/node_modules/eslint/lib/cli-engine/cli-engine.js:834:28)
    at ESLint.lintFiles (/usr/src/app/node_modules/eslint/lib/eslint/eslint.js:551:23)
    at Object.execute (/usr/src/app/node_modules/eslint/lib/cli.js:421:36)
    at async main (/usr/src/app/node_modules/eslint/bin/eslint.js:152:22)
make: *** [Makefile:88: lint] Error 2

Exited with code exit status 2
```

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
