### PR TITLE
Make the export wins moved banner only appear on the Export tab

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -129,9 +129,9 @@ const DATA_HUB_HAS_MOVED_MESSAGE = (
       href={DATA_HUB_HAS_MOVED_LINK}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label="Find out more about historic wins moved to Data Hub"
+      aria-label="See the export wins announcement"
     >
-      find out more
+      see the export wins announcement
     </Link>
     .
   </>
@@ -151,7 +151,11 @@ const CompanyLocalHeader = ({
           company.id,
           company.name
         )}
-        flashMessages={[[DATA_HUB_HAS_MOVED_MESSAGE, ...flashMessages]]}
+        flashMessages={
+          breadcrumbs[0].text === 'Exports'
+            ? [[DATA_HUB_HAS_MOVED_MESSAGE, ...flashMessages]]
+            : flashMessages
+        }
       >
         <GridRow>
           <GridCol setWidth="two-thirds">

--- a/test/functional/cypress/specs/companies/export-wins-moved-spec.js
+++ b/test/functional/cypress/specs/companies/export-wins-moved-spec.js
@@ -3,19 +3,43 @@ const urls = require('../../../../../src/lib/urls')
 
 describe('Export wins moved banner', () => {
   it('There should be a banner informing about export wins moving to Data Hub on the company page', () => {
-    cy.visit(urls.companies.detail(company.dnbCorp.id))
+    cy.visit(urls.companies.exports.index(company.dnbCorp.id))
 
     cy.get('[data-test="status-message"')
       .should(
         'have.text',
-        'Historic export wins have now moved to Data Hub, find out more.'
+        'Historic export wins have now moved to Data Hub, see the export wins announcement.'
       )
       .within(() => {
-        cy.contains('a', 'find out more').should(
+        cy.contains('a', 'see the export wins announcement').should(
           'have.attr',
           'href',
           'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/'
         )
       })
+  })
+
+  describe("There should't be a banner in the other tabs", () => {
+    ;[
+      'overview',
+      'activity',
+      'business-details',
+      'contacts',
+      'account-management',
+      'investments/projects',
+      'orders',
+    ].forEach((slug) =>
+      it(slug, () => {
+        cy.visit(`/companies/${company.dnbCorp.id}/${slug}`)
+
+        // We need to wait for company name appear...
+        cy.contains(company.dnbCorp.name)
+
+        // ...so that this waits for whent the data has been loaded and rendered
+        cy.contains('Historic export wins have now moved to Data Hub').should(
+          'not.exist'
+        )
+      })
+    )
   })
 })


### PR DESCRIPTION
## Description of change

This PR fixes these shortcomings of #7137
* The banner should only appear on the _Export_ tab
* The link text and aria label should read "see the export wins announcement"

## Test instructions

1. Go to `/companies/<id>`
2. Click through all of the tabs in the main tab nav, e.g. _Overview_, _Activity_, _Business detail_, etc.
3. The banner should only appear when the _Export_ tab is selected
4. The banner's link text and aria label should read "see the export wins announcement".

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
