### PR TITLE
Add an "export wins have now moved" banner to company export tab

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -129,9 +129,9 @@ const DATA_HUB_HAS_MOVED_MESSAGE = (
       href={DATA_HUB_HAS_MOVED_LINK}
       target="_blank"
       rel="noopener noreferrer"
-      aria-label="Find out more about historic wins moved to Data Hub"
+      aria-label="See the export wins announcement"
     >
-      find out more
+      see the export wins announcement
     </Link>
     .
   </>
@@ -151,7 +151,11 @@ const CompanyLocalHeader = ({
           company.id,
           company.name
         )}
-        flashMessages={[[DATA_HUB_HAS_MOVED_MESSAGE, ...flashMessages]]}
+        flashMessages={
+          breadcrumbs[0].text === 'Exports'
+            ? [[DATA_HUB_HAS_MOVED_MESSAGE, ...flashMessages]]
+            : flashMessages
+        }
       >
         <GridRow>
           <GridCol setWidth="two-thirds">

--- a/test/functional/cypress/specs/companies/export-wins-moved-spec.js
+++ b/test/functional/cypress/specs/companies/export-wins-moved-spec.js
@@ -3,19 +3,43 @@ const urls = require('../../../../../src/lib/urls')
 
 describe('Export wins moved banner', () => {
   it('There should be a banner informing about export wins moving to Data Hub on the company page', () => {
-    cy.visit(urls.companies.detail(company.dnbCorp.id))
+    cy.visit(urls.companies.exports.index(company.dnbCorp.id))
 
     cy.get('[data-test="status-message"')
       .should(
         'have.text',
-        'Historic export wins have now moved to Data Hub, find out more.'
+        'Historic export wins have now moved to Data Hub, see the export wins announcement.'
       )
       .within(() => {
-        cy.contains('a', 'find out more').should(
+        cy.contains('a', 'see the export wins announcement').should(
           'have.attr',
           'href',
           'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/'
         )
       })
+  })
+
+  describe("There should't be a banner in the other tabs", () => {
+    ;[
+      'overview',
+      'activity',
+      'business-details',
+      'contacts',
+      'account-management',
+      'investments/projects',
+      'orders',
+    ].forEach((slug) =>
+      it(slug, () => {
+        cy.visit(`/companies/${company.dnbCorp.id}/${slug}`)
+
+        // We need to wait for company name appear...
+        cy.contains(company.dnbCorp.name)
+
+        // ...so that this waits for whent the data has been loaded and rendered
+        cy.contains('Historic export wins have now moved to Data Hub').should(
+          'not.exist'
+        )
+      })
+    )
   })
 })


### PR DESCRIPTION
## Description of change

Adds a banner to `/companies/<id>/export` page informing the users that "Historic export wins have now moved to Data Hub...", with a link to a [Help Centre article].

> [!NOTE]  
> The [Help Centre article] is not published yet and this PR should only be merged once it is published.

## Test instructions

1. Go to `/companies/<id>`
2. Click through all the tabs in the tab navigation just below the header
3. Only if the _Export_ tab is selected, in the page header, there should appear a banner saying "Historic export wins have now moved to Data Hub, see the export wins announcement."
4. Where the "see the export wins announcement" part should be a link to https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/

## Screenshots

### Before
<img width="1147" alt="Screenshot 2024-09-25 at 10 05 50" src="https://github.com/user-attachments/assets/e06bdaed-d1bf-47d5-9408-9a5e82033372">

### After
<img width="1149" alt="Screenshot 2024-09-25 at 10 05 06" src="https://github.com/user-attachments/assets/d7e6a5f9-ba6e-40fe-89ec-7a8c8df44e52">

[Help Centre article]: https://data-services-help.trade.gov.uk/data-hub/updates/announcements/export-wins-has-moved-to-data-hub/