### PR TITLE
Tet 831 add investment project to company activity

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -60,6 +60,8 @@ export const transformActivity = (activity) => {
     return transformInteractionToListItem(activity.interaction)
   else if (activity_source === 'referral')
     return transformReferralToListItem(activity)
+  else if (activity_source === 'investment')
+    return transformInvestmentToListItem(activity)
 }
 
 export const transformInteractionToListItem = ({
@@ -142,6 +144,63 @@ export const transformReferralToListItem = (activity) => {
       referral.id
     ),
     headingText: referral.subject,
+  }
+}
+
+export const transformInvestmentToListItem = (activity) => {
+  return {
+    id: activity.investment.id,
+    metadata: [
+      { label: 'Created Date', value: formatMediumDate(activity.date) },
+      {
+        label: 'Investment Type',
+        value: activity.investment.investment_type.name,
+      },
+      {
+        label: 'Added by',
+        value: activity.investment.created_by
+          ? AdviserRenderer({
+              adviser: activity.investment.created_by,
+              team: activity.investment.created_by.dit_team,
+            })
+          : '',
+      },
+      {
+        label: 'Estimated land date',
+        value: activity.investment.estimated_land_date,
+      },
+      {
+        label: 'Company Contact',
+        value: activity.investment.clinet_contacts,
+      },
+      {
+        label: 'Total investment',
+        value: activity.investment.total_investment,
+      },
+      {
+        label: 'Capital expenditure value',
+        value: activity.investment.foreign_equity_investment,
+      },
+      {
+        label: 'Gross value added (GVA)',
+        value: activity.investment.gross_value_added,
+      },
+      { label: 'Number of jobs', value: activity.investment.number_new_jobs },
+    ].filter(({ value }) => Boolean(value)),
+    tags: [
+      {
+        text: 'Investment',
+        colour: 'default',
+        dataTest: 'investment-theme-label',
+      },
+      {
+        text: 'New Investment Project',
+        colour: 'grey',
+        dataTest: 'investment-service-label',
+      },
+    ].filter(({ text }) => Boolean(text)),
+    headingUrl: urls.investments.projects.details(activity.investment.id),
+    headingText: activity.investment.name,
   }
 }
 

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -49,6 +49,8 @@ export const transformActivity = (activity) => {
     return transformInteractionToListItem(activity.interaction)
   else if (activity_source === 'referral')
     return transformReferralToListItem(activity)
+  else if (activity_source === 'investment')
+    return transformInvestmentToListItem(activity)
 }
 
 export const transformReferralToListItem = (activity) => {
@@ -106,6 +108,29 @@ export const transformInteractionToListItem = ({
     date
   ),
 })
+
+export const transformInvestmentToListItem = (activity) => {
+  const investment = activity.investment
+  const summary = [
+    `${investment.investment_type.name} investment for ${investment.number_new_jobs} jobs added by `,
+    investment.created_by.name,
+  ]
+
+  return {
+    id: investment.id,
+    date: investment.date,
+    tags: [
+      {
+        text: 'New Investment Project',
+        colour: 'grey',
+        dataTest: 'investment-service-label',
+      },
+    ].filter(({ text }) => Boolean(text)),
+    headingUrl: urls.investments.projects.details(investment.id),
+    headingText: investment.name,
+    summary: summary,
+  }
+}
 
 export const transformResponseToCollection = (activities) => ({
   count: activities.count,

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import jsf from 'json-schema-faker'
 
 import apiSchema from '../../../api-schema.json'
+import { relativeDateFaker } from './dates'
 import { listFaker } from './utils'
 import { userFaker } from './users'
 import teamFaker from './team'
@@ -9,12 +10,21 @@ import teamFaker from './team'
 const companyActivityFaker = (overrides = {}) => ({
   ...jsf.generate(apiSchema.components.schemas.Company),
   id: faker.string.uuid(),
-  activity_source: 'interaction',
+  date: relativeDateFaker({ minDays: -100, maxDays: 365 }),
   company: {
     name: faker.word.adjective(),
     id: faker.string.uuid(),
     trading_name: faker.word.adjective(),
   },
+  referral: null,
+  interaction: null,
+  investment: null,
+  ...overrides,
+})
+
+const companyActivityInteractionFaker = (overrides = {}) => ({
+  ...companyActivityFaker(),
+  activity_source: 'interaction',
   interaction: {
     contacts: [userFaker()],
     dit_participants: [
@@ -34,13 +44,49 @@ const companyActivityFaker = (overrides = {}) => ({
       name: 'email/website',
     },
   },
-  referral: null,
   ...overrides,
 })
 
-const companyActivityListFaker = (length = 1, overrides) =>
-  listFaker({ fakerFunction: companyActivityFaker, length, overrides })
+const companyActivityInvestmentFaker = (overrides = {}) => ({
+  ...companyActivityFaker(),
+  activity_source: 'investment',
+  investment: {
+    investment_type: {
+      name: faker.company.name(),
+      id: faker.string.uuid(),
+    },
+    estimated_land_date: relativeDateFaker({ minDays: -100, maxDays: 365 }),
+    total_investment: faker.number.int(),
+    name: faker.word.words(),
+    client_contacts: [userFaker({ job_title: faker.person.jobTitle() })],
+    id: faker.string.uuid(),
+    number_new_jobs: faker.number.int({ min: 0, max: 50 }),
+    created_by: userFaker(),
+    foreign_equity_investment: faker.number.int({ min: 50, max: 1000 }),
+    gross_value_added: faker.number.int({ min: 100, max: 2000 }),
+  },
+  ...overrides,
+})
 
-export { companyActivityFaker, companyActivityListFaker }
+const companyActivityInteractionListFaker = (length = 1, overrides) =>
+  listFaker({
+    fakerFunction: companyActivityInteractionFaker,
+    length,
+    overrides,
+  })
 
-export default companyActivityListFaker
+const companyActivityInvestmentListFaker = (length = 1, overrides) =>
+  listFaker({
+    fakerFunction: companyActivityInvestmentFaker,
+    length,
+    overrides,
+  })
+
+export {
+  companyActivityInteractionFaker,
+  companyActivityInvestmentFaker,
+  companyActivityInteractionListFaker,
+  companyActivityInvestmentListFaker,
+}
+
+export default companyActivityInteractionListFaker

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -187,60 +187,34 @@ describe('Company activity feed', () => {
     })
   })
 
-  context.skip('Investment project', () => {
+  context('Investment project', () => {
     beforeEach(() => {
       cy.visit(urls.companies.activity.index(company.id))
     })
 
     it('displays the correct activity type label', () => {
-      cy.get('[data-test="investment-activity"]').within(() =>
-        cy
-          .get('[data-test="activity-kind-label"]')
-          .contains('New Investment Project', {
-            matchCase: false,
-          })
+      cy.get('[data-test="investment-service-label"]').contains(
+        'New Investment Project',
+        {
+          matchCase: false,
+        }
       )
     })
 
     it('displays the correct topic label', () => {
-      cy.get('[data-test="investment-activity"]').within(() =>
-        cy.get('[data-test="activity-theme-label"]').contains('Investment', {
-          matchCase: false,
-        })
-      )
+      cy.get('[data-test="investment-theme-label"]').contains('Investment', {
+        matchCase: false,
+      })
     })
-
-    it('displays the correct sub-topic label', () => {
-      cy.get('[data-test="investment-activity"]').within(() =>
-        cy
-          .get('[data-test="activity-service-label"]')
-          .contains('Project - FDI', {
-            matchCase: false,
-          })
-      )
-    })
-
-    it('displays the correct sub-topic label', () => {
-      cy.get('[data-test="investment-activity"]').within(() =>
-        cy
-          .get('[data-test="activity-service-label"]')
-          .contains('Project - FDI', {
-            matchCase: false,
-          })
-      )
-    })
-
     it('displays the investment project name with link', () => {
-      cy.get('[data-test="investment-activity"]').within(() =>
+      cy.get('[data-test="collection-item"]').each(() =>
         cy
-          .get('[data-test="investment-activity-card-subject"]')
-          .should('exist')
-          .should('have.text', 'Marshmellow UK Takeover')
           .get('a')
+          .contains('Bo Oh O Wa er')
           .should(
             'have.attr',
             'href',
-            'https://www.datahub.trade.gov.uk/investments/projects/d9e25847-6199-e211-a939-e4115bead28a/details'
+            '/investments/projects/9a824ef8-207e-4f6b-9205-91a42c1c77ef/details'
           )
       )
     })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -5,7 +5,9 @@ import {
 } from '../../fakers/companies'
 import { getCollectionList } from '../../support/collection-list-assertions'
 import { collectionListRequest } from '../../support/actions'
-import companyActivityListFaker from '../../fakers/company-activity'
+import companyActivityListFaker, {
+  companyActivityInvestmentListFaker,
+} from '../../fakers/company-activity'
 
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
@@ -386,6 +388,7 @@ describe('Company overview page', () => {
   // TODO - Unskip relevant parts of this test when we have the associated DAGs in place
   context('when viewing all activity cards types', () => {
     const interactionsList = companyActivityListFaker(1)
+    const investmentsList = companyActivityInvestmentListFaker(1)
     beforeEach(() => {
       collectionListRequest(
         'v4/search/company-activity',
@@ -496,6 +499,21 @@ describe('Company overview page', () => {
         `${activity.interaction.dit_participants[0].adviser.name} had ${activity.interaction.communication_channel.name} contact with ${activity.interaction.contacts[0].name}`
       )
     })
+    it('should display Data Hub investment activity', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        investmentsList,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      const activity = investmentsList[0]
+      cy.get('[data-test="investment-service-label"]').contains(
+        'New Investment Project'
+      )
+      cy.get('[data-test="activity-summary"]').contains(
+        `${activity.investment.investment_type.name} investment for ${activity.investment.number_new_jobs} jobs added by ${activity.investment.created_by.name}`
+      )
+    })
+
     it.skip('should display Data Hub event', () => {
       cy.get('[data-test="data-hub-event-summary"]')
         .children()

--- a/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
+++ b/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
@@ -123,6 +123,46 @@
         "trading_names": []
       },
       "interaction": null
-    }
+    },
+        {
+          "id": "bf07ba14-5540-4298-aa3d-a4e21911e178",
+          "date": "2024-09-11T00:00:00+00:00",
+          "referral": null,
+          "activity_source": "investment",
+          "company": {
+            "name": "Zboncak Group",
+            "id": "4cd4128b-1bad-4f1e-9146-5d4678c6a018",
+            "trading_names": []
+          },
+          "interaction": null,
+          "investment" :  {
+                "investment_type": {
+                    "name": "Commitment to invest",
+                    "id": "031269ab-b7ec-40e9-8a4e-7371404f0622"
+                },
+                "estimated_land_date": "2024-08-11T00:00:00+00:00",
+                "total_investment": "5000",
+                "name": "Bo Oh O Wa er",
+                "client_contacts": [
+                    {
+                        "name": "Johnny Cakeman",
+                        "last_name": "Cakeman",
+                        "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef",
+                        "first_name": "Johnny",
+                        "job_title": "Smell"
+                    }
+                ],
+                "id": "9a824ef8-207e-4f6b-9205-91a42c1c77ef",
+                "number_new_jobs": "100",
+                "created_by": {
+                    "name": "",
+                    "last_name": "",
+                    "id": "9d704966-c5ff-4e37-976e-47e623764b47",
+                    "first_name": ""
+                },
+                "foreign_equity_investment": 234432,
+                "gross_value_added": "2000"
+            }
+        }
   ]
 }


### PR DESCRIPTION
## Description of change

Add investment project data into company activity for Overview and Activity tabs

## Test instructions

Investment projects displayed in overview and activity

## Screenshots

### After
<img width="1441" alt="image" src="https://github.com/user-attachments/assets/50b4fc8f-a4e0-407a-ba07-f78ab9454a14">

<img width="1441" alt="image" src="https://github.com/user-attachments/assets/7245db72-b6a6-4437-a00a-f07739518418">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
