### PR TITLE
CLS2-976 Add country filter to EYB leads collection

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -103,7 +103,7 @@ const EYBLeadCollection = ({
     <>
       <FilteredCollectionList
         {...props}
-        collectionName="EYB Lead"
+        collectionName="EYB lead"
         taskProps={collectionListTask}
         entityName="eybLead"
         defaultQueryParams={{

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -25,7 +25,12 @@ import {
   InputPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
-const EYBLeadCollection = ({ filterOptions, payload, ...props }) => {
+const EYBLeadCollection = ({
+  filterOptions,
+  payload,
+  optionMetadata,
+  ...props
+}) => {
   const location = useLocation()
   const qsParams = useMemo(
     () => qs.parse(location.search.slice(1)),
@@ -40,6 +45,13 @@ const EYBLeadCollection = ({ filterOptions, payload, ...props }) => {
     options.filter(({ value }) => values.includes(value))
 
   const setupSelectedFilters = (qsParams, filterOptions) => ({
+    countryId: {
+      queryParam: QS_PARAMS.countryId,
+      options: resolveSelectedOptions(
+        qsParams[QS_PARAMS.countryId],
+        filterOptions.countries
+      ),
+    },
     companyName: {
       queryParam: QS_PARAMS.companyName,
       options: resolveCompanyName(),
@@ -79,7 +91,7 @@ const EYBLeadCollection = ({ filterOptions, payload, ...props }) => {
     progressMessage: 'Loading filters',
     renderProgress: () => (
       <>
-        <InputPlaceholder count={2} />
+        <InputPlaceholder count={3} />
         <CheckboxPlaceholder count={2} />
       </>
     ),
@@ -108,6 +120,16 @@ const EYBLeadCollection = ({ filterOptions, payload, ...props }) => {
             options={VALUE_OPTIONS}
             selectedOptions={selectedFilters.valueOfLead.options}
             data-test="lead-value-filter"
+          />
+          <Filters.Typeahead
+            isMulti={true}
+            label="Country"
+            name="country"
+            qsParam={QS_PARAMS.countryId}
+            placeholder="Search country"
+            options={filterOptions.countries}
+            selectedOptions={selectedFilters.countryId.options}
+            data-test="eyb-country-filter"
           />
           <Filters.Typeahead
             isMulti={true}

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -129,7 +129,7 @@ const EYBLeadCollection = ({
             placeholder="Search country"
             options={filterOptions.countries}
             selectedOptions={selectedFilters.countryId.options}
-            data-test="eyb-country-filter"
+            data-test="lead-country-filter"
           />
           <Filters.Typeahead
             isMulti={true}

--- a/src/client/modules/Investments/EYBLeads/constants.js
+++ b/src/client/modules/Investments/EYBLeads/constants.js
@@ -1,4 +1,5 @@
 export const QS_PARAMS = {
+  countryId: 'country',
   companyName: 'company',
   sectorId: 'sector',
   valueOfLead: 'value',

--- a/src/client/modules/Investments/EYBLeads/reducer.js
+++ b/src/client/modules/Investments/EYBLeads/reducer.js
@@ -8,6 +8,7 @@ const initialState = {
   results: [],
   isComplete: false,
   filterOptions: {
+    countries: [],
     sectors: [],
   },
 }

--- a/src/client/modules/Investments/EYBLeads/tasks.js
+++ b/src/client/modules/Investments/EYBLeads/tasks.js
@@ -9,6 +9,7 @@ export const getEYBLeads = ({
   limit = 10,
   page = 1,
   company,
+  country,
   sector,
   value,
 }) => {
@@ -17,6 +18,8 @@ export const getEYBLeads = ({
     offset: limit * (parseInt(page, 10) - 1) || 0,
     ...(company ? { company } : null),
   })
+  if (country)
+    country.forEach((countryId) => params.append('country', countryId))
   if (sector) sector.forEach((sectorId) => params.append('sector', sectorId))
   if (value) value.forEach((valueOfLead) => params.append('value', valueOfLead))
   return apiProxyAxios
@@ -29,9 +32,10 @@ export const getEYBLeads = ({
 
 export const loadEYBLeadFilterOptions = () =>
   Promise.all([
+    getMetadataOptions(urls.metadata.country()),
     getMetadataOptions(urls.metadata.sector(), {
       params: {
         level__lte: '0',
       },
     }),
-  ]).then(([sectors]) => ({ sectors }))
+  ]).then(([countries, sectors]) => ({ countries, sectors }))

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -22,6 +22,7 @@ const FILTER_ELEMENTS = {
   company: '[data-test="company-name-filter"]',
   sector: '[data-test="sector-filter"]',
   value: '[data-test="lead-value-filter"]',
+  country: '[data-test="lead-country-filter"}',
 }
 
 const DATE_TIME_STRING = '2024-09-25T08:30:00.000000Z'
@@ -33,6 +34,8 @@ const HIGH_VALUE = 'high'
 const HIGH_VALUE_LABEL = 'High value'
 const LOW_VALUE = 'low'
 const LOW_VALUE_LABEL = 'Low value'
+const COUNTRY_NAME = 'Canada'
+const COUNTRY_ID = '5daf72a6-5d95-e211-a939-e4115bead28a'
 
 const EYB_LEAD_LIST = Array(
   eybLeadFaker({
@@ -60,6 +63,7 @@ const PAYLOADS = {
   sectorFilter: { sector: SECTOR_ID },
   highValueFilter: { value: HIGH_VALUE },
   lowValueFilter: { value: LOW_VALUE },
+  countryFilter: { country: COUNTRY_ID },
 }
 
 const buildQueryString = (queryParams = {}) =>
@@ -131,9 +135,10 @@ describe('EYB leads collection page', () => {
     })
 
     it('should render the filters', () => {
-      cy.get('[data-test="company-name-filter"]').should('be.visible')
-      cy.get('[data-test="sector-filter"]').should('be.visible')
+      cy.get('[data-test="lead-country-filter"]').should('be.visible')
       cy.get('[data-test="lead-value-filter"]').should('be.visible')
+      cy.get('[data-test="sector-filter"]').should('be.visible')
+      cy.get('[data-test="company-name-filter"]').should('be.visible')
     })
 
     it('should display the leads correctly', () => {
@@ -353,4 +358,23 @@ describe('EYB leads collection page', () => {
       })
     }
   )
+
+  context('When filtering the EYB leads collection by country', () => {
+    let expectedPayload = {
+      ...PAYLOADS.minimum,
+      ...PAYLOADS.country,
+    }
+
+    it('should filter from the url', () => {
+      let queryString = buildQueryString({ 'country[0]': COUNTRY_ID })
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
+      cy.visit(`${investments.eybLeads.index()}?${queryString}`)
+      cy.wait('@apiRequest')
+        .its('request.query')
+        .should('include', expectedPayload)
+    })
+    // TODO: test that it
+    // 'should filter from user input'
+    // 'should return and display the filtered collection'
+  })
 })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -22,7 +22,7 @@ const FILTER_ELEMENTS = {
   company: '[data-test="company-name-filter"]',
   sector: '[data-test="sector-filter"]',
   value: '[data-test="lead-value-filter"]',
-  country: '[data-test="lead-country-filter"}',
+  country: '[data-test="lead-country-filter"]',
 }
 
 const DATE_TIME_STRING = '2024-09-25T08:30:00.000000Z'
@@ -373,8 +373,28 @@ describe('EYB leads collection page', () => {
         .its('request.query')
         .should('include', expectedPayload)
     })
-    // TODO: test that it
-    // 'should filter from user input'
-    // 'should return and display the filtered collection'
+    it('should filter from user input', () => {
+      cy.visit(`${investments.eybLeads.index()}`)
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
+      assertTypeaheadHints({
+        element: FILTER_ELEMENTS.country,
+        label: 'Country',
+        placeholder: 'Search country',
+      })
+      selectFirstTypeaheadOption({
+        element: FILTER_ELEMENTS.country,
+        input: 'cana',
+      })
+      assertTypeaheadOptionSelected({
+        element: FILTER_ELEMENTS.country,
+        expectedOption: COUNTRY_NAME,
+      })
+      cy.wait('@apiRequest')
+        .its('request.query')
+        .should('include', expectedPayload)
+      assertQueryParams('country', Array(COUNTRY_ID))
+      assertChipExists({ label: COUNTRY_NAME, position: 1 })
+    })
+    // TODO: test that it 'should return and display the filtered collection'
   })
 })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -264,7 +264,7 @@ describe('EYB leads collection page', () => {
       cy.wait('@apiRequest')
         .its('request.query')
         .should('include', expectedPayload)
-      assertQueryParams('sector', Array(SECTOR_ID))
+      assertQueryParams('sector[0]', SECTOR_ID)
       assertChipExists({ label: SECTOR_NAME, position: 1 })
     })
 
@@ -342,7 +342,7 @@ describe('EYB leads collection page', () => {
           cy.wait('@apiRequest')
             .its('request.query')
             .should('include', testCase.expectedPayload)
-          assertQueryParams('value', Array(testCase.queryParamValue))
+          assertQueryParams('value[0]', testCase.queryParamValue)
           assertChipExists({ label: testCase.chipsLabel, position: 1 })
         })
 
@@ -404,7 +404,7 @@ describe('EYB leads collection page', () => {
       cy.wait('@apiRequest')
         .its('request.query')
         .should('include', expectedPayload)
-      assertQueryParams('country', Array(COUNTRY_ID_1))
+      assertQueryParams('country[0]', COUNTRY_ID_1)
       assertChipExists({ label: COUNTRY_NAME_1, position: 1 })
     })
 


### PR DESCRIPTION
## Description of change

Adds a country filter to the EYB leads collection allowing users to filter by company country location

This frontend PR depends on this api PR: https://github.com/uktrade/data-hub-api/pull/5691

## Test instructions
To test locally:
Populate the database with EYB Lead instances:

- In Docker, go to the api container
- Go to the 'Exec' tab
- Run the following commands

```
python manage.py shell
from datahub.investment_lead.test.factories import EYBLeadFactory
EYBLeadFactory.create_batch(10)
```

- On the frontend:
- Navigate to the the **EYB leads** tab in the **Investments** area of Data Hub http://localhost:3000/investments/eyb-leads
- The **Country** filter should be visible in the left **Filters** menu
- You should be able to select and filter the EYB Leads collection list by country
- The country chip should display above the filter dropdown box and under the total number of leads which is displayed above the collections list

## Screenshots

<img width="684" alt="Screenshot 2024-10-29 at 15 39 54" src="https://github.com/user-attachments/assets/e70697b7-d8f6-400f-9fd0-b581aaf2e3b7">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
