### PR TITLE
Add export wins role tags

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -77,6 +77,7 @@ export const renderTags = (tags) =>
     <Tag
       key={`tag_${index}`}
       colour={tag.colour}
+      textTransform={tag.textTransform}
       data-test={tag.dataTest ? tag.dataTest : 'collection-item-tag'}
     >
       {tag.text}
@@ -103,7 +104,7 @@ const CollectionItem = ({
   <ItemWrapper data-test="collection-item">
     {/* tags take precidence over badges as they are the newer style, however not all components
      have been updated so the component needs to handle rendering both props */}
-    {tags && !showTagsInMetadata && (
+    {tags && tags.length > 0 && !showTagsInMetadata && (
       <StyledBadgesWrapper data-test="collection-item-tags">
         {renderTags(tags)}
       </StyledBadgesWrapper>

--- a/src/client/components/Tag/index.jsx
+++ b/src/client/components/Tag/index.jsx
@@ -9,6 +9,8 @@ const StyledTag = styled(GovUkTag)`
   background-color: ${(props) => TAG_COLOURS[props.colour].background};
   color: ${(props) => TAG_COLOURS[props.colour].colour};
   white-space: nowrap;
+  text-transform: ${(props) =>
+    props.textTransform ? props.textTransform : 'uppercase'};
 `
 
 /**

--- a/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
@@ -5,11 +5,12 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
-import { sumExportValues } from './utils'
+import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
+import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 
-export const WinsConfirmedList = ({ exportWins = [] }) => {
+export const WinsConfirmedList = ({ exportWins = [], currentAdviserId }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
@@ -22,6 +23,7 @@ export const WinsConfirmedList = ({ exportWins = [] }) => {
           )}
           subheading={item.company.name}
           subheadingUrl={urls.companies.overview.index(item.company.id)}
+          tags={createRoleTags(item, currentAdviserId)}
           metadata={[
             {
               label: 'Contact name:',
@@ -59,6 +61,15 @@ export default () => (
     payload={{ confirmed: WIN_STATUS.CONFIRMED }}
     sortOptions={SORT_OPTIONS}
   >
-    {(page) => <WinsConfirmedList exportWins={page} />}
+    {(page) => (
+      <State>
+        {({ currentAdviserId }) => (
+          <WinsConfirmedList
+            exportWins={page}
+            currentAdviserId={currentAdviserId}
+          />
+        )}
+      </State>
+    )}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -5,11 +5,12 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
-import { sumExportValues } from './utils'
+import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
+import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 
-export const WinsPendingList = ({ exportWins = [] }) => {
+export const WinsPendingList = ({ exportWins = [], currentAdviserId }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
@@ -22,6 +23,7 @@ export const WinsPendingList = ({ exportWins = [] }) => {
           )}
           subheading={item.company.name}
           subheadingUrl={urls.companies.overview.index(item.company.id)}
+          tags={createRoleTags(item, currentAdviserId)}
           metadata={[
             ...(item.company_contacts[0]
               ? [
@@ -76,6 +78,15 @@ export default () => (
     }}
     sortOptions={SORT_OPTIONS}
   >
-    {(page) => <WinsPendingList exportWins={page} />}
+    {(page) => (
+      <State>
+        {({ currentAdviserId }) => (
+          <WinsPendingList
+            exportWins={page}
+            currentAdviserId={currentAdviserId}
+          />
+        )}
+      </State>
+    )}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -5,11 +5,12 @@ import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import { formatMediumDate } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
-import { sumExportValues } from './utils'
+import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
+import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 
-export const WinsRejectedList = ({ exportWins }) => {
+export const WinsRejectedList = ({ exportWins, currentAdviserId }) => {
   return exportWins.length === 0 ? null : (
     <ul>
       {exportWins.map((item) => (
@@ -22,6 +23,7 @@ export const WinsRejectedList = ({ exportWins }) => {
           )}
           subheading={item.company.name}
           subheadingUrl={urls.companies.overview.index(item.company.id)}
+          tags={createRoleTags(item, currentAdviserId)}
           metadata={[
             {
               label: 'Contact name:',
@@ -56,6 +58,15 @@ export default () => (
     payload={{ confirmed: WIN_STATUS.REJECTED }}
     sortOptions={SORT_OPTIONS}
   >
-    {(page) => <WinsRejectedList exportWins={page} />}
+    {(page) => (
+      <State>
+        {({ currentAdviserId }) => (
+          <WinsRejectedList
+            exportWins={page}
+            currentAdviserId={currentAdviserId}
+          />
+        )}
+      </State>
+    )}
   </ExportWinsResource.Paginated>
 )

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -16,3 +16,9 @@ export const SORT_OPTIONS = [
   { name: 'Company name A-Z', value: 'company__name' },
   { name: 'Company name Z-A', value: '-company__name' },
 ]
+
+export const ADVISER_ROLES = {
+  LEAD_OFFICER: 'lead officer',
+  TEAM_MEMBER: 'team member',
+  CONTRIBUTING_OFFICER: 'contributing officer',
+}

--- a/src/client/modules/ExportWins/Status/utils.js
+++ b/src/client/modules/ExportWins/Status/utils.js
@@ -6,3 +6,45 @@ export const sumExportValues = ({
   total_expected_export_value +
   total_expected_non_export_value +
   total_expected_odi_value
+
+const teamMembersContainCurrentAdvisor = (teamMembers = [], currentAdviserId) =>
+  teamMembers.some(({ id }) => id === currentAdviserId)
+
+const contributingOfficersContainCurrentAdvisor = (
+  contributingOfficers = [],
+  currentAdviserId
+) => contributingOfficers.some(({ adviser }) => adviser.id === currentAdviserId)
+
+const isCurrentAdviserLeadOfficer = ({ lead_officer }, currentAdviserId) =>
+  // If an export win from the old service hasn't been matched
+  // to a Data Hub lead officer, there won't be a lead officer ID.
+  // However, there will be lead officer name and email.
+  lead_officer?.id === currentAdviserId
+
+export const createRoleTags = (item, currentAdviserId) => {
+  const tag = { colour: 'blue', textTransform: 'none' }
+  const tags = []
+
+  isCurrentAdviserLeadOfficer(item, currentAdviserId) &&
+    tags.push({
+      ...tag,
+      text: 'Role: lead officer',
+    })
+
+  teamMembersContainCurrentAdvisor(item.team_members, currentAdviserId) &&
+    tags.push({
+      ...tag,
+      text: 'Role: team member',
+    })
+
+  contributingOfficersContainCurrentAdvisor(
+    item.contributing_advisers,
+    currentAdviserId
+  ) &&
+    tags.push({
+      ...tag,
+      text: 'Role: contributing officer',
+    })
+
+  return tags
+}

--- a/src/client/modules/ExportWins/Status/utils.js
+++ b/src/client/modules/ExportWins/Status/utils.js
@@ -1,3 +1,5 @@
+import { ADVISER_ROLES } from './constants'
+
 export const sumExportValues = ({
   total_expected_export_value,
   total_expected_non_export_value,
@@ -28,13 +30,13 @@ export const createRoleTags = (item, currentAdviserId) => {
   isCurrentAdviserLeadOfficer(item, currentAdviserId) &&
     tags.push({
       ...tag,
-      text: 'Role: lead officer',
+      text: `Role: ${ADVISER_ROLES.LEAD_OFFICER}`,
     })
 
   teamMembersContainCurrentAdvisor(item.team_members, currentAdviserId) &&
     tags.push({
       ...tag,
-      text: 'Role: team member',
+      text: `Role: ${ADVISER_ROLES.TEAM_MEMBER}`,
     })
 
   contributingOfficersContainCurrentAdvisor(
@@ -43,7 +45,7 @@ export const createRoleTags = (item, currentAdviserId) => {
   ) &&
     tags.push({
       ...tag,
-      text: 'Role: contributing officer',
+      text: `Role: ${ADVISER_ROLES.CONTRIBUTING_OFFICER}`,
     })
 
   return tags

--- a/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
@@ -5,6 +5,7 @@ import { WinsConfirmedList } from '../../../../../src/client/modules/ExportWins/
 import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
 import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
 import { currencyGBP } from '../../../../../src/client/utils/number-utils'
+import { exportWinsListData } from './export-wins-list-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -94,5 +95,34 @@ describe('WinsConfirmedList', () => {
       cy.get(items).eq(2).should('have.text', 'Date won: 1 May 2023')
       cy.get(items).eq(3).should('have.text', 'Date responded: 18 Apr 2024')
     })
+  })
+
+  it('should conditionally render tags', () => {
+    const createProvider = (exportWinsList) =>
+      createTestProvider({
+        'Export Wins': () => Promise.resolve(exportWinsList),
+        Company: () => Promise.resolve({ id: 123 }),
+        TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+      })
+
+    exportWinsListData.forEach(
+      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWinsList)
+        cy.mount(
+          <Provider>
+            <WinsConfirmedList
+              exportWins={exportWinsList}
+              currentAdviserId={currentAdviserId}
+            />
+          </Provider>
+        )
+
+        const assertion = shouldRenderTag ? 'exist' : 'not.exist'
+        cy.get('[data-test="collection-item-tags"]').should(assertion)
+        if (assertion === 'exist') {
+          cy.get('[data-test="collection-item-tag"]').should('have.text', role)
+        }
+      }
+    )
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
@@ -5,7 +5,7 @@ import { WinsConfirmedList } from '../../../../../src/client/modules/ExportWins/
 import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
 import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
 import { currencyGBP } from '../../../../../src/client/utils/number-utils'
-import { exportWinsListData } from './export-wins-list-data'
+import { exportWinsData } from './export-wins-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -98,20 +98,20 @@ describe('WinsConfirmedList', () => {
   })
 
   it('should conditionally render tags', () => {
-    const createProvider = (exportWinsList) =>
+    const createProvider = (exportWins) =>
       createTestProvider({
-        'Export Wins': () => Promise.resolve(exportWinsList),
+        'Export Wins': () => Promise.resolve(exportWins),
         Company: () => Promise.resolve({ id: 123 }),
         TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
       })
 
-    exportWinsListData.forEach(
-      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
-        const Provider = createProvider(exportWinsList)
+    exportWinsData.forEach(
+      ({ exportWins, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWins)
         cy.mount(
           <Provider>
             <WinsConfirmedList
-              exportWins={exportWinsList}
+              exportWins={exportWins}
               currentAdviserId={currentAdviserId}
             />
           </Provider>

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { WinsPendingList } from '../../../../../src/client/modules/ExportWins/Status/WinsPendingList'
-import { exportWinsListData } from './export-wins-list-data'
+import { exportWinsData } from './export-wins-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -61,20 +61,20 @@ describe('WinsPendingList', () => {
   })
 
   it('should conditionally render tags', () => {
-    const createProvider = (exportWinsList) =>
+    const createProvider = (exportWins) =>
       createTestProvider({
-        'Export Wins': () => Promise.resolve(exportWinsList),
+        'Export Wins': () => Promise.resolve(exportWins),
         Company: () => Promise.resolve({ id: 123 }),
         TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
       })
 
-    exportWinsListData.forEach(
-      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
-        const Provider = createProvider(exportWinsList)
+    exportWinsData.forEach(
+      ({ exportWins, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWins)
         cy.mount(
           <Provider>
             <WinsPendingList
-              exportWins={exportWinsList}
+              exportWins={exportWins}
               currentAdviserId={currentAdviserId}
             />
           </Provider>

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { WinsPendingList } from '../../../../../src/client/modules/ExportWins/Status/WinsPendingList'
+import { exportWinsListData } from './export-wins-list-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -57,5 +58,34 @@ describe('WinsPendingList', () => {
       )
 
     cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
+  })
+
+  it('should conditionally render tags', () => {
+    const createProvider = (exportWinsList) =>
+      createTestProvider({
+        'Export Wins': () => Promise.resolve(exportWinsList),
+        Company: () => Promise.resolve({ id: 123 }),
+        TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+      })
+
+    exportWinsListData.forEach(
+      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWinsList)
+        cy.mount(
+          <Provider>
+            <WinsPendingList
+              exportWins={exportWinsList}
+              currentAdviserId={currentAdviserId}
+            />
+          </Provider>
+        )
+
+        const assertion = shouldRenderTag ? 'exist' : 'not.exist'
+        cy.get('[data-test="collection-item-tags"]').should(assertion)
+        if (assertion === 'exist') {
+          cy.get('[data-test="collection-item-tag"]').should('have.text', role)
+        }
+      }
+    )
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import { WinsRejectedList } from '../../../../../src/client/modules/ExportWins/Status/WinsRejectedList'
+import { exportWinsListData } from './export-wins-list-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -57,5 +58,33 @@ describe('WinsRejectedList', () => {
       )
 
     cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
+  })
+  it('should conditionally render tags', () => {
+    const createProvider = (exportWinsList) =>
+      createTestProvider({
+        'Export Wins': () => Promise.resolve(exportWinsList),
+        Company: () => Promise.resolve({ id: 123 }),
+        TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
+      })
+
+    exportWinsListData.forEach(
+      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWinsList)
+        cy.mount(
+          <Provider>
+            <WinsRejectedList
+              exportWins={exportWinsList}
+              currentAdviserId={currentAdviserId}
+            />
+          </Provider>
+        )
+
+        const assertion = shouldRenderTag ? 'exist' : 'not.exist'
+        cy.get('[data-test="collection-item-tags"]').should(assertion)
+        if (assertion === 'exist') {
+          cy.get('[data-test="collection-item-tag"]').should('have.text', role)
+        }
+      }
+    )
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { WinsRejectedList } from '../../../../../src/client/modules/ExportWins/Status/WinsRejectedList'
-import { exportWinsListData } from './export-wins-list-data'
+import { exportWinsData } from './export-wins-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
@@ -60,20 +60,20 @@ describe('WinsRejectedList', () => {
     cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
   })
   it('should conditionally render tags', () => {
-    const createProvider = (exportWinsList) =>
+    const createProvider = (exportWins) =>
       createTestProvider({
-        'Export Wins': () => Promise.resolve(exportWinsList),
+        'Export Wins': () => Promise.resolve(exportWins),
         Company: () => Promise.resolve({ id: 123 }),
         TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
       })
 
-    exportWinsListData.forEach(
-      ({ exportWinsList, currentAdviserId, shouldRenderTag, role }) => {
-        const Provider = createProvider(exportWinsList)
+    exportWinsData.forEach(
+      ({ exportWins, currentAdviserId, shouldRenderTag, role }) => {
+        const Provider = createProvider(exportWins)
         cy.mount(
           <Provider>
             <WinsRejectedList
-              exportWins={exportWinsList}
+              exportWins={exportWins}
               currentAdviserId={currentAdviserId}
             />
           </Provider>

--- a/test/component/cypress/specs/ExportWins/export-wins-data.js
+++ b/test/component/cypress/specs/ExportWins/export-wins-data.js
@@ -1,0 +1,129 @@
+import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
+
+export const exportWinsData = [
+  // The lead_officer id doesn't match the currentAdviserId
+  {
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        lead_officer: {
+          id: '2',
+        },
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: false,
+  },
+  {
+    // The lead_officer id matches the currentAdviserId
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        lead_officer: {
+          id: '1',
+        },
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: lead officer',
+  },
+  // The team_members array doesn't include the currentAdviserId
+  {
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        team_members: [
+          {
+            id: '1',
+          },
+          {
+            id: '2',
+          },
+          {
+            id: '3',
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '4',
+    shouldRenderTag: false,
+  },
+  {
+    // The team_members array includes the currentAdviserId
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        team_members: [
+          {
+            id: '1',
+          },
+          {
+            id: '2',
+          },
+          {
+            id: '3',
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: team member',
+  },
+  // The contributing_advisers array doesn't include the currentAdviserId
+  {
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        contributing_advisers: [
+          {
+            adviser: {
+              id: '1',
+            },
+          },
+          {
+            adviser: {
+              id: '2',
+            },
+          },
+          {
+            adviser: {
+              id: '3',
+            },
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '4',
+    shouldRenderTag: false,
+  },
+  {
+    // The contributing_advisers array includes the currentAdviserId
+    exportWins: [
+      {
+        ...exportWinsFaker(),
+        contributing_advisers: [
+          {
+            adviser: {
+              id: '1',
+            },
+          },
+          {
+            adviser: {
+              id: '2',
+            },
+          },
+          {
+            adviser: {
+              id: '3',
+            },
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: contributing officer',
+  },
+]

--- a/test/component/cypress/specs/ExportWins/export-wins-list-data.js
+++ b/test/component/cypress/specs/ExportWins/export-wins-list-data.js
@@ -1,0 +1,152 @@
+const exportWin = {
+  id: '111',
+  company: {
+    id: '222',
+    name: 'Foo Ltd',
+  },
+  name_of_export: 'Rolls Reese',
+  company_contacts: [
+    {
+      name: 'David Test',
+      id: '333',
+    },
+  ],
+  country: {
+    name: 'USA',
+  },
+  date: '2023-05-01',
+  customer_response: {
+    responded_on: '2024-04-18T12:15:49.361611Z',
+  },
+  total_expected_export_value: 1000,
+  total_expected_non_export_value: 2000,
+  total_expected_odi_value: 3000,
+}
+
+export const exportWinsListData = [
+  // The lead_officer id doesn't match the currentAdviserId
+  {
+    exportWinsList: [
+      {
+        ...exportWin,
+        lead_officer: {
+          id: '2',
+        },
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: false,
+  },
+  {
+    // The lead_officer id matches the currentAdviserId
+    exportWinsList: [
+      {
+        ...exportWin,
+        lead_officer: {
+          id: '1',
+        },
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: lead officer',
+  },
+  // The team_members array doesn't include the currentAdviserId
+  {
+    exportWinsList: [
+      {
+        ...exportWin,
+        team_members: [
+          {
+            id: '1',
+          },
+          {
+            id: '2',
+          },
+          {
+            id: '3',
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '4',
+    shouldRenderTag: false,
+  },
+  {
+    // The team_members array includes the currentAdviserId
+    exportWinsList: [
+      {
+        ...exportWin,
+        team_members: [
+          {
+            id: '1',
+          },
+          {
+            id: '2',
+          },
+          {
+            id: '3',
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: team member',
+  },
+  // The contributing_advisers array doesn't include the currentAdviserId
+  {
+    exportWinsList: [
+      {
+        ...exportWin,
+        contributing_advisers: [
+          {
+            adviser: {
+              id: '1',
+            },
+          },
+          {
+            adviser: {
+              id: '2',
+            },
+          },
+          {
+            adviser: {
+              id: '3',
+            },
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '4',
+    shouldRenderTag: false,
+  },
+  {
+    // The contributing_advisers array includes the currentAdviserId
+    exportWinsList: [
+      {
+        ...exportWin,
+        contributing_advisers: [
+          {
+            adviser: {
+              id: '1',
+            },
+          },
+          {
+            adviser: {
+              id: '2',
+            },
+          },
+          {
+            adviser: {
+              id: '3',
+            },
+          },
+        ],
+      },
+    ],
+    currentAdviserId: '1',
+    shouldRenderTag: true,
+    role: 'Role: contributing officer',
+  },
+]


### PR DESCRIPTION
## Description of change
This PR adds role tags to the following export win list items:
- Pending export wins
- Confirmed export wins
- Rejected export wins

When a user views any of these lists, they can now clearly see their role within each export win. If the user has not been involved in the win then no tag is displayed.

## Test instructions
Each list can be viewed here:
- `/exportwins/pending`
- `/exportwins/confirmed`
- `/exportwins/rejected`
 
**Lead officer tag**
To view the lead officer tag you need to create an export win and set yourself as the lead officer. Lead officers cannot be edited in the UI once an export win has been created. However, this can be done in Django Admin.

**Team member tag**
To view the team member tag you can edit a win (quicker then creating an export win) and add yourself as a team member via the **officer details** section.

**Contributing officer tag**
To view the contributing officer tag you can edit a win (again, quicker than creating a win) and add yourself as a team member via the **credit for this win** section.

To edit a win: `companies/<company-uuid>/exportwins/<export-win-uuid>/edit?step=summary`

## Screenshots

### Lead officer
<img width="977" alt="Screenshot 2024-10-11 at 12 27 40" src="https://github.com/user-attachments/assets/638acaf6-4643-48d5-a3ad-226595b06809">

### Team member
<img width="973" alt="Screenshot 2024-10-11 at 12 35 08" src="https://github.com/user-attachments/assets/083c4b92-105f-4b07-97eb-0750b728400e">

### Contributing officer
<img width="973" alt="Screenshot 2024-10-11 at 12 32 01" src="https://github.com/user-attachments/assets/d1538278-04ca-4e69-9027-9d22a01a800d">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
