### PR TITLE
Fix/export wins analytics

### DIFF
--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -376,6 +376,7 @@ const ReviewForm = () => {
             analyticsFormName={FORM_ID}
             submissionTaskName="TASK_PATCH_EXPORT_WIN_REVIEW"
             redirectMode="soft"
+            showStepInUrl={true}
             redirectTo={(_, { agree_with_win }) =>
               `../thankyou?agree=${agree_with_win}`
             }

--- a/src/templates/_includes/google-tag-manager/consent-not-needed.njk
+++ b/src/templates/_includes/google-tag-manager/consent-not-needed.njk
@@ -6,13 +6,14 @@ Google Analytics cookies.
 {% if GOOGLE_TAG_MANAGER_KEY %}
 {% include "_includes/google-tag-manager/gtag-definition.njk" %}
 <script nonce='{{ cspNonce }}'>
-  window.gtag({
+  {# We can't use gtag for these, we must use dataLayer directly #}
+  dataLayer.push({
     userId: '{{user.id}}',
     userUserId: '{{user.sso_user_id}}',
   })
 
   if ('{{userFeatureGTMEvent}}') {
-    window.gtag({
+    dataLayer.push({
       name: '{{userFeatureGTMEvent.name}}',
       event: '{{userFeatureGTMEvent.event}}',
     })

--- a/src/templates/_includes/google-tag-manager/gtag-definition.njk
+++ b/src/templates/_includes/google-tag-manager/gtag-definition.njk
@@ -1,4 +1,5 @@
 <script nonce='{{ cspNonce }}'>
   window.dataLayer = window.dataLayer || []
   window.gtag = function() { dataLayer.push(arguments); }
+  gtag('js', new Date())
 </script>


### PR DESCRIPTION
## Description of change

This PR fixes these two Google Analytics issues:

* No data about user's progress through the export win review form
* The `userId` and `userUserId` were not sent to GA

## Test instructions

### No data about user's progress through the export win review form

1. Go to `/exportwins/review/<token>`
2. Step through the form
3. The current form step should appear in the `step=<step>` query string parameter of the url in the browser's address bar

### The `userId` and `userUserId` were not sent to GA

1. Connect the app to the Google Tag Assistant
2. Go to any Data Hub page except for `/exportwins/review/<token>`
3. You should see a _Message_ event in the left hand panel
4. Click on it
5. Click on the _Data Layer_ tab
6. The data layer values object should have the `userId: <user-id>` and `userUserId: <user-sso-id>` properties. The `userUserId` might be an empty string on localhost. <img width="843" alt="Screenshot 2024-10-17 at 14 18 50" src="https://github.com/user-attachments/assets/152f8eab-aea2-44ec-a55c-a35fd072e09a">

