### PR TITLE
CLS2-1000: Handle EYB leads that have no company gracefully

### DIFF
--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -86,13 +86,11 @@ const EYBLeadLayout = ({ id, children }) => {
         <StyledHeader>
           <EYBLeadResource id={id}>
             {(eybLead) => {
-              const breadcrumbs = buildEYBLeadBreadcrumbs(
-                eybLead.company
-                  ? {
-                      text: eybLead.company.name,
-                    }
-                  : {}
-              )
+              const breadcrumbs = buildEYBLeadBreadcrumbs({
+                text: eybLead.company
+                  ? eybLead.company.name
+                  : eybLead.companyName,
+              })
               return (
                 <>
                   <BreadcrumbsWrapper data-test="breadcrumbs">

--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -86,9 +86,13 @@ const EYBLeadLayout = ({ id, children }) => {
         <StyledHeader>
           <EYBLeadResource id={id}>
             {(eybLead) => {
-              const breadcrumbs = buildEYBLeadBreadcrumbs({
-                text: eybLead.company.name,
-              })
+              const breadcrumbs = buildEYBLeadBreadcrumbs(
+                eybLead.company
+                  ? {
+                      text: eybLead.company.name,
+                    }
+                  : {}
+              )
               return (
                 <>
                   <BreadcrumbsWrapper data-test="breadcrumbs">
@@ -113,26 +117,28 @@ const EYBLeadLayout = ({ id, children }) => {
                         EYB lead
                       </StyledSuperheading>
                       <LocalHeaderHeading data-test="heading">
-                        {eybLead.company.name}
+                        {eybLead.company ? eybLead.company.name : 'Not set'}
                       </LocalHeaderHeading>
                     </GridCol>
                     <GridCol setWith="one-third">
                       <StyledButtonContainer>
-                        <Button
-                          as={StyledButtonLink}
-                          data-test="button-add-investment-project"
-                          href={
-                            !eybLead.company
-                              ? `/investments/projects/create`
-                              : eybLead.company.archived ||
-                                  eybLead.company.ukBased
-                                ? null
-                                : `/investments/projects/create/${eybLead.company.id}`
-                          }
-                          aria-label={`Add investment project`}
-                        >
-                          Add investment project
-                        </Button>
+                        {eybLead.company && (
+                          <Button
+                            as={StyledButtonLink}
+                            data-test="button-add-investment-project"
+                            href={
+                              !eybLead.company
+                                ? `/investments/projects/create`
+                                : eybLead.company.archived ||
+                                    eybLead.company.ukBased
+                                  ? null
+                                  : `/investments/projects/create/${eybLead.company.id}`
+                            }
+                            aria-label={`Add investment project`}
+                          >
+                            Add investment project
+                          </Button>
+                        )}
                       </StyledButtonContainer>
                     </GridCol>
                   </GridRow>

--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -117,7 +117,9 @@ const EYBLeadLayout = ({ id, children }) => {
                         EYB lead
                       </StyledSuperheading>
                       <LocalHeaderHeading data-test="heading">
-                        {eybLead.company ? eybLead.company.name : 'Not set'}
+                        {eybLead.company
+                          ? eybLead.company.name
+                          : eybLead.companyName}
                       </LocalHeaderHeading>
                     </GridCol>
                     <GridCol setWith="one-third">

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -7,6 +7,7 @@ import urls from '../../../../lib/urls'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
 import { HIGH_VALUE_LABEL, LOW_VALUE_LABEL } from './constants'
+import NOT_SET_TEXT from '../../../../apps/companies/constants'
 
 const EYBLeadDetails = () => {
   const { eybLeadId } = useParams()
@@ -42,14 +43,14 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="Sector or industry"
-                children={eybLead.sector ? eybLead.sector.name : 'Not set'}
+                children={eybLead.sector ? eybLead.sector.name : NOT_SET_TEXT}
               />
               <SummaryTable.Row
                 heading="Location of company headquarters"
                 children={
                   eybLead.companyLocation
                     ? eybLead.companyLocation.name
-                    : 'Not set'
+                    : NOT_SET_TEXT
                 }
               />
               <SummaryTable.Row
@@ -65,7 +66,7 @@ const EYBLeadDetails = () => {
                     {eybLead.companyWebsite}
                   </NewWindowLink>
                 ) : (
-                  'Not set'
+                  NOT_SET_TEXT
                 )}
               </SummaryTable.Row>
               <SummaryTable.Row

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -7,7 +7,7 @@ import urls from '../../../../lib/urls'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
 import { HIGH_VALUE_LABEL, LOW_VALUE_LABEL } from './constants'
-import NOT_SET_TEXT from '../../../../apps/companies/constants'
+import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
 const EYBLeadDetails = () => {
   const { eybLeadId } = useParams()

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -16,17 +16,24 @@ const EYBLeadDetails = () => {
         {(eybLead) => {
           return (
             <SummaryTable data-test="eyb-lead-details-table">
-              <SummaryTable.TextRow
-                heading="Company name"
-                value={
-                  <Link
-                    href={urls.companies.overview.index(eybLead.company?.id)}
-                    data-test="company-link"
-                  >
-                    {eybLead.company?.name}
-                  </Link>
-                }
-              />
+              {eybLead.company ? (
+                <SummaryTable.TextRow
+                  heading="Company name"
+                  value={
+                    <Link
+                      href={urls.companies.overview.index(eybLead.company?.id)}
+                      data-test="company-link"
+                    >
+                      {eybLead.company.name}
+                    </Link>
+                  }
+                />
+              ) : (
+                <SummaryTable.TextRow
+                  heading="Company name"
+                  value={'Not set'}
+                />
+              )}
               <SummaryTable.Row
                 heading="Value"
                 children={

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -31,7 +31,7 @@ const EYBLeadDetails = () => {
               ) : (
                 <SummaryTable.TextRow
                   heading="Company name"
-                  value={'Not set'}
+                  value={eybLead.companyName}
                 />
               )}
               <SummaryTable.Row

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -42,11 +42,15 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="Sector or industry"
-                children={eybLead.sector.name}
+                children={eybLead.sector ? eybLead.sector.name : 'Not set'}
               />
               <SummaryTable.Row
                 heading="Location of company headquarters"
-                children={eybLead.companyLocation.name}
+                children={
+                  eybLead.companyLocation
+                    ? eybLead.companyLocation.name
+                    : 'Not set'
+                }
               />
               <SummaryTable.Row
                 heading="Submitted to EYB"

--- a/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
@@ -4,7 +4,7 @@ import { EYBLeadResource } from '../../../components/Resource'
 
 const EYBLeadName = (props) => (
   <EYBLeadResource.Inline {...props}>
-    {(eybLead) => eybLead.company.name}
+    {(eybLead) => (eybLead.company ? eybLead.company.name : 'Not set')}
   </EYBLeadResource.Inline>
 )
 

--- a/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
 
 import { EYBLeadResource } from '../../../components/Resource'
+import NOT_SET_TEXT from '../../../../apps/companies/constants'
 
 const EYBLeadName = (props) => (
   <EYBLeadResource.Inline {...props}>
-    {(eybLead) => (eybLead.company ? eybLead.company.name : 'Not set')}
+    {(eybLead) => (eybLead.company ? eybLead.company.name : NOT_SET_TEXT)}
   </EYBLeadResource.Inline>
 )
 

--- a/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadName.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { EYBLeadResource } from '../../../components/Resource'
-import NOT_SET_TEXT from '../../../../apps/companies/constants'
+import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
 const EYBLeadName = (props) => (
   <EYBLeadResource.Inline {...props}>

--- a/src/client/modules/Investments/EYBLeads/tasks.js
+++ b/src/client/modules/Investments/EYBLeads/tasks.js
@@ -15,7 +15,7 @@ export const getEYBLeads = ({
   let params = new URLSearchParams({
     limit,
     offset: limit * (parseInt(page, 10) - 1) || 0,
-    ...(company && { company }),
+    ...(company ? { company } : null),
   })
   if (sector) sector.forEach((sectorId) => params.append('sector', sectorId))
   if (value) value.forEach((valueOfLead) => params.append('value', valueOfLead))

--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -33,7 +33,7 @@ export const transformLeadToListItem = ({
   return {
     id,
     headingUrl: urls.investments.eybLeads.details(id),
-    headingText: company.name,
+    headingText: company ? company.name : 'Not set',
     tags,
     metadata,
   }

--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -4,6 +4,7 @@ import { format } from '../../../utils/date'
 export const transformLeadToListItem = ({
   id,
   company,
+  company_name,
   triage_created,
   spend,
   sector,
@@ -33,7 +34,7 @@ export const transformLeadToListItem = ({
   return {
     id,
     headingUrl: urls.investments.eybLeads.details(id),
-    headingText: company ? company.name : 'Not set',
+    headingText: company ? company.name : company_name,
     tags,
     metadata,
   }

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -4,7 +4,7 @@ import {
 } from '../../support/assertions'
 import { investments } from '../../../../../src/lib/urls'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
-import NOT_SET_TEXT from '../../../../../src/apps/companies/constants'
+import { NOT_SET_TEXT } from '../../../../../src/apps/companies/constants'
 
 const urls = require('../../../../../src/lib/urls')
 

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -133,10 +133,7 @@ describe('EYB lead details', () => {
     const eybLeadWithValues = eybLeadFaker({
       company: null,
       value: true,
-      sector: {
-        name: 'Mining',
-        id: 'a622c9d2-5f95-e211-a939-e4115bead28a',
-      },
+      sector: null,
       triage_created: '2023-06-07T10:00:00Z',
       intent: [
         'Find people with specialist skills',
@@ -168,7 +165,7 @@ describe('EYB lead details', () => {
         content: {
           'Company name': eybLeadWithValues.company_name,
           'Value': 'High value',
-          'Sector or industry': eybLeadWithValues.sector.name,
+          'Sector or industry': 'Not set',
           'Location of company headquarters': 'Canada',
           'Submitted to EYB': '07 Jun 2023',
           'Company website address': 'Not set',
@@ -192,6 +189,7 @@ describe('EYB lead details', () => {
       cy.get('[data-test="company-link"]')
         .should('exist')
         .should('have.text', eybLeadWithValues.company_name)
+        .shouldNot('have.attribute', 'href')
     })
 
     it('should show "Not set" instead of the company website link within the table', () => {

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -4,6 +4,7 @@ import {
 } from '../../support/assertions'
 import { investments } from '../../../../../src/lib/urls'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
+import NOT_SET_TEXT from '../../../../../src/apps/companies/constants'
 
 const urls = require('../../../../../src/lib/urls')
 
@@ -130,7 +131,7 @@ describe('EYB lead details', () => {
     })
   })
   context('When viewing an EYB lead without a company associated to it', () => {
-    const eybLeadWithValues = eybLeadFaker({
+    const eybLeadWithoutCompany = eybLeadFaker({
       company: null,
       value: true,
       sector: null,
@@ -153,8 +154,8 @@ describe('EYB lead details', () => {
       company_name: 'Mars Temp',
     })
     beforeEach(() => {
-      setup(eybLeadWithValues)
-      cy.visit(investments.eybLeads.details(eybLeadWithValues.id))
+      setup(eybLeadWithoutCompany)
+      cy.visit(investments.eybLeads.details(eybLeadWithoutCompany.id))
       cy.wait('@getEYBLeadDetails')
     })
 
@@ -163,24 +164,24 @@ describe('EYB lead details', () => {
         dataTest: 'eyb-lead-details-table',
         // prettier-ignore
         content: {
-          'Company name': eybLeadWithValues.company_name,
+          'Company name': eybLeadWithoutCompany.company_name,
           'Value': 'High value',
-          'Sector or industry': 'Not set',
+          'Sector or industry': NOT_SET_TEXT,
           'Location of company headquarters': 'Canada',
           'Submitted to EYB': '07 Jun 2023',
-          'Company website address': 'Not set',
-          'When do you want to set up?': eybLeadWithValues.landing_timeframe,
+          'Company website address': NOT_SET_TEXT,
+          'When do you want to set up?': eybLeadWithoutCompany.landing_timeframe,
           'Do you know where you want to set up in the UK?': 'Yes',
           'Where do you want to set up in the UK?': 'Cardiff',
           'How do you plan to expand your business in the UK?':
-            eybLeadWithValues.intent.join(''),
+            eybLeadWithoutCompany.intent.join(''),
           'How many people do you want to hire in the UK in the first 3 years?':
-            eybLeadWithValues.hiring,
+            eybLeadWithoutCompany.hiring,
           'How much do you want to spend on setting up in the first 3 years?':
-            eybLeadWithValues.spend,
-          'Full name': eybLeadWithValues.full_name,
-          'Job title': eybLeadWithValues.role,
-          'Phone number': eybLeadWithValues.telephone_number,
+            eybLeadWithoutCompany.spend,
+          'Full name': eybLeadWithoutCompany.full_name,
+          'Job title': eybLeadWithoutCompany.role,
+          'Phone number': eybLeadWithoutCompany.telephone_number,
         },
       })
     })
@@ -192,14 +193,14 @@ describe('EYB lead details', () => {
     it('should use backup name om the heading', () => {
       cy.get('[data-test="heading"]')
         .should('exist')
-        .should('have.text', eybLeadWithValues.company_name)
+        .should('have.text', eybLeadWithoutCompany.company_name)
     })
 
     it('should render the breadcrumbs', () => {
       assertLeadBreadcrumbs({
         leadType: 'EYB leads',
         leadDetailsUrl: urls.investments.eybLeads.index(),
-        leadName: null,
+        leadName: eybLeadWithoutCompany.company_name,
       })
     })
 

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -190,7 +190,7 @@ describe('EYB lead details', () => {
       cy.get('[data-test="website-link"]').should('not.exist')
     })
 
-    it('should use backup name om the heading', () => {
+    it('should use backup name on the heading', () => {
       cy.get('[data-test="heading"]')
         .should('exist')
         .should('have.text', eybLeadWithoutCompany.company_name)

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -185,13 +185,6 @@ describe('EYB lead details', () => {
       })
     })
 
-    it('should use backup name as company overview in the table', () => {
-      cy.get('[data-test="company-link"]')
-        .should('exist')
-        .should('have.text', eybLeadWithValues.company_name)
-        .should('not.have.attribute', 'href')
-    })
-
     it('should not show the company website link within the table', () => {
       cy.get('[data-test="website-link"]').should('not.exist')
     })

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -189,13 +189,11 @@ describe('EYB lead details', () => {
       cy.get('[data-test="company-link"]')
         .should('exist')
         .should('have.text', eybLeadWithValues.company_name)
-        .shouldNot('have.attribute', 'href')
+        .should('not.have.attribute', 'href')
     })
 
-    it('should show "Not set" instead of the company website link within the table', () => {
-      cy.get('[data-test="website-link"]')
-        .should('exist')
-        .should('have.text', 'Not set')
+    it('should not show the company website link within the table', () => {
+      cy.get('[data-test="website-link"]').should('not.exist')
     })
 
     it('should use backup name om the heading', () => {
@@ -213,7 +211,7 @@ describe('EYB lead details', () => {
     })
 
     it('should not render the `Add investment project` button', () => {
-      cy.get('[data-test="button-add-investment-project"]').shouldNot('exist')
+      cy.get('[data-test="button-add-investment-project"]').should('not.exist')
     })
   })
 })

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -129,4 +129,93 @@ describe('EYB lead details', () => {
         )
     })
   })
+  context('When viewing an EYB lead without a company associated to it', () => {
+    const eybLeadWithValues = eybLeadFaker({
+      company: null,
+      value: true,
+      sector: {
+        name: 'Mining',
+        id: 'a622c9d2-5f95-e211-a939-e4115bead28a',
+      },
+      triage_created: '2023-06-07T10:00:00Z',
+      intent: [
+        'Find people with specialist skills',
+        'Set up a new distribution centre',
+        'Other',
+        'Onward sales and exports from the UK',
+      ],
+      hiring: '6-50',
+      spend: '500000-1000000',
+      is_high_value: true,
+      full_name: 'Joe Bloggs',
+      role: 'CEO',
+      email: 'email@example.com',
+      telephone_number: '01234567890',
+      landing_timeframe: 'In the next 6 months',
+      company_website: null,
+      company_name: 'Mars Temp',
+    })
+    beforeEach(() => {
+      setup(eybLeadWithValues)
+      cy.visit(investments.eybLeads.details(eybLeadWithValues.id))
+      cy.wait('@getEYBLeadDetails')
+    })
+
+    it('should render all the fields of the details table', () => {
+      assertSummaryTable({
+        dataTest: 'eyb-lead-details-table',
+        // prettier-ignore
+        content: {
+          'Company name': eybLeadWithValues.company_name,
+          'Value': 'High value',
+          'Sector or industry': eybLeadWithValues.sector.name,
+          'Location of company headquarters': 'Canada',
+          'Submitted to EYB': '07 Jun 2023',
+          'Company website address': 'Not set',
+          'When do you want to set up?': eybLeadWithValues.landing_timeframe,
+          'Do you know where you want to set up in the UK?': 'Yes',
+          'Where do you want to set up in the UK?': 'Cardiff',
+          'How do you plan to expand your business in the UK?':
+            eybLeadWithValues.intent.join(''),
+          'How many people do you want to hire in the UK in the first 3 years?':
+            eybLeadWithValues.hiring,
+          'How much do you want to spend on setting up in the first 3 years?':
+            eybLeadWithValues.spend,
+          'Full name': eybLeadWithValues.full_name,
+          'Job title': eybLeadWithValues.role,
+          'Phone number': eybLeadWithValues.telephone_number,
+        },
+      })
+    })
+
+    it('should use backup name as company overview in the table', () => {
+      cy.get('[data-test="company-link"]')
+        .should('exist')
+        .should('have.text', eybLeadWithValues.company_name)
+    })
+
+    it('should show "Not set" instead of the company website link within the table', () => {
+      cy.get('[data-test="website-link"]')
+        .should('exist')
+        .should('have.text', 'Not set')
+    })
+
+    it('should use backup name om the heading', () => {
+      cy.get('[data-test="heading"]')
+        .should('exist')
+        .should('have.text', eybLeadWithValues.company_name)
+    })
+
+    it('should render the breadcrumbs', () => {
+      assertLeadBreadcrumbs({
+        leadType: 'EYB leads',
+        leadDetailsUrl: urls.investments.eybLeads.index(),
+        leadName: null,
+      })
+    })
+
+    it('should not render the `Add investment project` button', () => {
+      cy.get('[data-test="button-add-investment-project"]').shouldNot('exist')
+    })
+  })
 })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -26,6 +26,7 @@ const FILTER_ELEMENTS = {
 
 const DATE_TIME_STRING = '2024-09-25T08:30:00.000000Z'
 const COMPANY_NAME = 'Frost'
+const COMPANY_NAME_DEFAULT = 'Mars'
 const SECTOR_NAME = 'Mining'
 const SECTOR_ID = 'a622c9d2-5f95-e211-a939-e4115bead28a'
 const HIGH_VALUE = 'high'
@@ -44,7 +45,13 @@ const EYB_LEAD_LIST = Array(
     sector: { name: SECTOR_NAME, id: SECTOR_ID },
     is_high_value: false,
   }),
-  eybLeadFaker({ triage_created: DATE_TIME_STRING, is_high_value: false })
+  eybLeadFaker({ triage_created: DATE_TIME_STRING, is_high_value: false }),
+  eybLeadFaker({
+    triage_created: DATE_TIME_STRING,
+    is_high_value: false,
+    company: null,
+    company_name: COMPANY_NAME_DEFAULT,
+  })
 )
 
 const PAYLOADS = {
@@ -151,6 +158,11 @@ describe('EYB leads collection page', () => {
         .should('contain', `Estimated land date ${eybLead.landing_timeframe}`)
         .should('contain', `Location ${eybLead.location.name}`)
         .should('contain', eybLead.is_high_value ? 'HIGH VALUE' : 'LOW VALUE')
+    })
+    it('should display the other name when company is null for a collection item', () => {
+      cy.get('[data-test="collection-item"]')
+        .eq(3)
+        .should('contain', COMPANY_NAME_DEFAULT)
     })
   })
 

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -69,11 +69,15 @@ const buildQueryString = (queryParams = {}) =>
   }).toString()
 
 const getEYBLeadsByCompanyName = (companyName) => {
-  return EYB_LEAD_LIST.filter((lead) => lead.company.name.includes(companyName))
+  return EYB_LEAD_LIST.filter(
+    (lead) => lead.company && lead.company.name.includes(companyName)
+  )
 }
 
 const getEYBLeadsBySectorId = (sectorId) => {
-  return EYB_LEAD_LIST.filter((lead) => lead.sector.id === sectorId)
+  return EYB_LEAD_LIST.filter(
+    (lead) => lead.sector && lead.sector.id === sectorId
+  )
 }
 
 const convertValueStringToBoolean = (value) => {
@@ -292,7 +296,7 @@ describe('EYB leads collection page', () => {
             ...PAYLOADS.lowValueFilter,
           },
           chipsLabel: LOW_VALUE_LABEL,
-          expectedNumberOfResults: 2,
+          expectedNumberOfResults: 3,
         },
       ]
 


### PR DESCRIPTION
## Description of change

Takes care of [CLS2-1000](https://uktrade.atlassian.net/browse/CLS2-1000)

This ticket ensures the frontend handles gracefully when a `eybLead.company` object does not exist (yet).

This is going to be temporary and just a workaround solution.

## Test instructions

- Instead of `eybLead.company.name` we'll instead use `eybLead.companyName` when `company` is not yet synced an available (in ListView and DetailView)

- When a `eybLead.company` is not available, any value for `eybLead.company.*` will be replaced by `Not set`

- When a `eybLead.company` is not available, the breadcrumbs will not use the company name; links will not be rendered; the `Create investment project` button will not be rendered

## Screenshots

### After

![Screenshot 2024-10-18 at 16 53 57](https://github.com/user-attachments/assets/074d2691-84f2-415f-8c6d-71f30fd85f8b)

![Screenshot 2024-10-18 at 16 53 47](https://github.com/user-attachments/assets/cc325e3f-5ada-4d19-b339-954835e19ac7)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)


[CLS2-1000]: https://uktrade.atlassian.net/browse/CLS2-1000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ