### PR TITLE
Rename `advisers` to `contributing_advisers` (Export wins)

### DIFF
--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -18,7 +18,7 @@ import {
 
 const CONFIDENTIAL = 'confidential'
 
-const transformContributingOfficersToAdvisers = (values) =>
+const transformContributingOfficers = (values) =>
   Object.keys(values)
     .filter((key) => key.startsWith('contributing_officer'))
     .map((k, index) => ({
@@ -37,8 +37,8 @@ const transformYearlyValuesToBreakdowns = (key, id, values) =>
       value: values[k],
     }))
 
-const transformAdvisersToContributingOfficers = (advisers = []) =>
-  advisers.reduce(
+const transformContributingAdvisers = (contributing_advisers = []) =>
+  contributing_advisers.reduce(
     (acc, val, index) => ({
       ...acc,
       [`contributing_officer_${index}`]: {
@@ -137,8 +137,10 @@ export const transformExportWinForForm = (exportWin) => ({
   hq_team: idNameToValueLabel(exportWin.hq_team),
   team_members: exportWin.team_members.map(idNameToValueLabel),
   // Credit for this win
-  credit_for_win: exportWin.advisers.length ? OPTION_YES : OPTION_NO,
-  ...transformAdvisersToContributingOfficers(exportWin.advisers),
+  credit_for_win: exportWin.contributing_advisers.length
+    ? OPTION_YES
+    : OPTION_NO,
+  ...transformContributingAdvisers(exportWin.contributing_advisers),
   // Customer details
   company_contacts: transformCompanyContact(exportWin.company_contacts[0]),
   customer_location: idNameToValueLabel(exportWin.customer_location),
@@ -187,7 +189,7 @@ export const transformFormValuesForAPI = (values) => ({
     ? values.team_members.map((member) => member.value)
     : [],
   // Credit for this win
-  advisers: transformContributingOfficersToAdvisers(values),
+  contributing_advisers: transformContributingOfficers(values),
   // Customer details
   company_contacts: [values.company_contacts.value],
   customer_location: values.customer_location.value,

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -41,7 +41,7 @@ export const exportWinsFaker = () => ({
     id: faker.string.uuid(),
     name: faker.person.fullName(),
   },
-  advisers: [],
+  contributing_advisers: [],
   company: {
     id: faker.string.uuid(),
     name: faker.company.name(),

--- a/test/functional/cypress/specs/export-win/add-export-win-spec.js
+++ b/test/functional/cypress/specs/export-win/add-export-win-spec.js
@@ -274,7 +274,7 @@ describe('Adding an export win', () => {
             team_type: '42bdaf2e-ae19-4589-9840-5dbb67b50add', // Investment (ITFG or IG)
             hq_team: '1e5aec69-c581-4356-b0ca-1f710d3d077d', // ITFG - E-Business Projects Team
             team_members: [],
-            advisers: [
+            contributing_advisers: [
               {
                 adviser: '101',
                 team_type: 'a4839e09-e30e-492c-93b5-8ab2ef90b891', // Trade (TD or ST)


### PR DESCRIPTION
## Description of change
Renamed `advisers` to `contributing_advisers` (export wins endpoint) to avoid confusion with the `adviser` field.

## Test instructions
No visual changes

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
