### PR TITLE
Fix/cls2 1007 validation fields in investment form stages

### DIFF
--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -73,7 +73,7 @@ export const transformFormValuesToPayload = (values, csrfToken) => {
 
   if (Array.isArray(specific_programmes)) {
     payload.specific_programmes = specific_programmes.map((x) => x.value)
-  } else if (typeof specific_programmes === 'object') {
+  } else if (typeof specific_programmes === 'object' && specific_programmes) {
     payload.specific_programmes = [specific_programmes.value]
   } else {
     payload.specific_programmes = []

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -28,7 +28,7 @@ export const STAGE = {
 }
 
 export const STAGE_ID_TO_INDEX_MAP = {
-  [STAGE.ACTIVE_ID]: 0,
+  [STAGE.PROSPECT_ID]: 0,
   [STAGE.ASSIGN_PM_ID]: 1,
   [STAGE.ACTIVE_ID]: 2,
   [STAGE.VERIFY_WIN_ID]: 3,
@@ -55,11 +55,11 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['address_postcode']: STAGE.VERIFY_WIN_ID,
   ['actual_uk_regions']: STAGE.VERIFY_WIN_ID,
   ['delivery_partners']: STAGE.VERIFY_WIN_ID,
-  ['actual_land_date']: STAGE.VERIFY_WIN_ID,
-  ['specific_programmes']: STAGE.VERIFY_WIN_ID,
+  ['actual_land_date']: STAGE.ASSIGN_PM_ID,
+  ['specific_programmes']: STAGE.ASSIGN_PM_ID,
   ['uk_company']: STAGE.VERIFY_WIN_ID,
-  ['investor_type']: STAGE.VERIFY_WIN_ID,
-  ['level_of_involvement']: STAGE.VERIFY_WIN_ID,
+  ['investor_type']: STAGE.ASSIGN_PM_ID,
+  ['level_of_involvement']: STAGE.ASSIGN_PM_ID,
   ['likelihood_to_land']: STAGE.ACTIVE_ID,
 }
 

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -14,18 +14,13 @@ export const PROJECT_STATUS_OPTIONS = [
 ]
 
 export const INITIAL_ID = null
-export const PROSPECT_ID = '8a320cc9-ae2e-443e-9d26-2f36452c2ced'
-export const ASSIGN_PM_ID = 'c9864359-fb1a-4646-a4c1-97d10189fc03'
-export const ACTIVE_ID = '7606cc19-20da-4b74-aba1-2cec0d753ad8'
-export const VERIFY_WIN_ID = '49b8f6f3-0c50-4150-a965-2c974f3149e3'
-export const WON_ID = '945ea6d1-eee3-4f5b-9144-84a75b71b8e6'
 
 export const STAGE = {
-  PROSPECT_ID,
-  ASSIGN_PM_ID,
-  ACTIVE_ID,
-  VERIFY_WIN_ID,
-  WON_ID,
+  PROSPECT_ID: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+  ASSIGN_PM_ID: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+  ACTIVE_ID: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+  VERIFY_WIN_ID: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+  WON_ID: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
 }
 
 export const STAGE_ID_TO_INDEX_MAP = {
@@ -38,6 +33,7 @@ export const STAGE_ID_TO_INDEX_MAP = {
 }
 
 export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
+  // TODO verify that all fields below have validation implemented if not remove
   ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
   ['strategic_drivers']: STAGE.PROSPECT_ID,
   ['client_requirements']: STAGE.PROSPECT_ID,

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -59,7 +59,7 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['address_postcode']: STAGE.VERIFY_WIN_ID,
   ['actual_uk_regions']: STAGE.ACTIVE_ID,
   ['delivery_partners']: STAGE.ACTIVE_ID,
-  ['actual_land_date']: STAGE.ACTIVE_ID,
+  ['actual_land_date']: STAGE.ASSIGN_PM_ID,
   ['specific_programmes']: STAGE.ASSIGN_PM_ID,
   ['uk_company']: STAGE.VERIFY_WIN_ID,
   ['investor_type']: STAGE.ASSIGN_PM_ID,

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -40,7 +40,7 @@ export const STAGE_ID_TO_INDEX_MAP = {
 export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
   ['strategic_drivers']: STAGE.PROSPECT_ID,
-  ['client_requirements']: STAGE.INITIAL_ID,
+  ['client_requirements']: STAGE.PROSPECT_ID,
   ['investment_type']: STAGE.INITIAL_ID,
   ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
   ['project_manager']: STAGE.ACTIVE_ID,

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -41,6 +41,7 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
   ['strategic_drivers']: STAGE.PROSPECT_ID,
   ['client_requirements']: STAGE.INITIAL_ID,
+  ['investment_type']: STAGE.INITIAL_ID,
   ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
   ['project_manager']: STAGE.ACTIVE_ID,
   ['project_assurance_adviser']: STAGE.ACTIVE_ID,
@@ -52,18 +53,18 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['non_fdi_r_and_d_budget']: STAGE.VERIFY_WIN_ID,
   ['new_tech_to_uk']: STAGE.VERIFY_WIN_ID,
   ['export_revenue']: STAGE.VERIFY_WIN_ID,
-  ['site_decided']: STAGE.ACTIVE_ID, // is required to be Yes from verify win.
+  ['site_decided']: STAGE.ACTIVE_ID,
   ['address_1']: STAGE.VERIFY_WIN_ID,
   ['address_town']: STAGE.VERIFY_WIN_ID,
   ['address_postcode']: STAGE.VERIFY_WIN_ID,
   ['actual_uk_regions']: STAGE.ACTIVE_ID,
   ['delivery_partners']: STAGE.ACTIVE_ID,
-  ['actual_land_date']: STAGE.ASSIGN_PM_ID,
+  ['actual_land_date']: STAGE.ACTIVE_ID,
   ['specific_programmes']: STAGE.ASSIGN_PM_ID,
   ['uk_company']: STAGE.VERIFY_WIN_ID,
   ['investor_type']: STAGE.ASSIGN_PM_ID,
   ['level_of_involvement']: STAGE.ASSIGN_PM_ID,
-  ['likelihood_to_land']: STAGE.ACTIVE_ID,
+  ['likelihood_to_land']: STAGE.ASSIGN_PM_ID,
 }
 
 export const STAGE_OPTIONS = [

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -42,7 +42,7 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['strategic_drivers']: STAGE.PROSPECT_ID,
   ['client_requirements']: STAGE.PROSPECT_ID,
   ['investment_type']: STAGE.INITIAL_ID,
-  ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
+  ['client_considering_other_countries']: STAGE.PROSPECT_ID,
   ['project_manager']: STAGE.ACTIVE_ID,
   ['project_assurance_adviser']: STAGE.ACTIVE_ID,
   ['client_cannot_provide_foreign_investment']: STAGE.VERIFY_WIN_ID,

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -13,6 +13,56 @@ export const PROJECT_STATUS_OPTIONS = [
   { name: 'Dormant', id: 'dormant' },
 ]
 
+export const PROSPECT_ID = '8a320cc9-ae2e-443e-9d26-2f36452c2ced'
+export const ASSIGN_PM_ID = 'c9864359-fb1a-4646-a4c1-97d10189fc03'
+export const ACTIVE_ID = '7606cc19-20da-4b74-aba1-2cec0d753ad8'
+export const VERIFY_WIN_ID = '49b8f6f3-0c50-4150-a965-2c974f3149e3'
+export const WON_ID = '945ea6d1-eee3-4f5b-9144-84a75b71b8e6'
+
+export const STAGE = {
+  PROSPECT_ID,
+  ASSIGN_PM_ID,
+  ACTIVE_ID,
+  VERIFY_WIN_ID,
+  WON_ID,
+}
+
+export const STAGE_ID_TO_INDEX_MAP = {
+  [STAGE.ACTIVE_ID]: 0,
+  [STAGE.ASSIGN_PM_ID]: 1,
+  [STAGE.ACTIVE_ID]: 2,
+  [STAGE.VERIFY_WIN_ID]: 3,
+  [STAGE.WON_ID]: 4,
+}
+
+export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
+  ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
+  ['strategic_drivers']: STAGE.ASSIGN_PM_ID,
+  ['client_requirements']: STAGE.ASSIGN_PM_ID,
+  ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
+  ['project_manager']: STAGE.ACTIVE_ID,
+  ['project_assurance_adviser']: STAGE.ACTIVE_ID,
+  ['client_cannot_provide_foreign_investment']: STAGE.VERIFY_WIN_ID,
+  ['government_assistance']: STAGE.VERIFY_WIN_ID,
+  ['number_new_jobs']: STAGE.VERIFY_WIN_ID,
+  ['number_safeguarded_jobs']: STAGE.VERIFY_WIN_ID,
+  ['r_and_d_budget']: STAGE.VERIFY_WIN_ID,
+  ['non_fdi_r_and_d_budget']: STAGE.VERIFY_WIN_ID,
+  ['new_tech_to_uk']: STAGE.VERIFY_WIN_ID,
+  ['export_revenue']: STAGE.VERIFY_WIN_ID,
+  ['address_1']: STAGE.VERIFY_WIN_ID,
+  ['address_town']: STAGE.VERIFY_WIN_ID,
+  ['address_postcode']: STAGE.VERIFY_WIN_ID,
+  ['actual_uk_regions']: STAGE.VERIFY_WIN_ID,
+  ['delivery_partners']: STAGE.VERIFY_WIN_ID,
+  ['actual_land_date']: STAGE.VERIFY_WIN_ID,
+  ['specific_programmes']: STAGE.VERIFY_WIN_ID,
+  ['uk_company']: STAGE.VERIFY_WIN_ID,
+  ['investor_type']: STAGE.VERIFY_WIN_ID,
+  ['level_of_involvement']: STAGE.VERIFY_WIN_ID,
+  ['likelihood_to_land']: STAGE.ACTIVE_ID,
+}
+
 export const STAGE_OPTIONS = [
   {
     name: 'Show all',
@@ -20,23 +70,23 @@ export const STAGE_OPTIONS = [
   },
   {
     name: 'Prospect',
-    id: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+    id: STAGE.PROSPECT_ID,
   },
   {
     name: 'Assign PM',
-    id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+    id: STAGE.ASSIGN_PM_ID,
   },
   {
     name: 'Active',
-    id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+    id: STAGE.ACTIVE_ID,
   },
   {
     name: 'Verify win',
-    id: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+    id: STAGE.VERIFY_WIN_ID,
   },
   {
     name: 'Won',
-    id: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+    id: STAGE.WON_ID,
   },
 ]
 

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -13,6 +13,7 @@ export const PROJECT_STATUS_OPTIONS = [
   { name: 'Dormant', id: 'dormant' },
 ]
 
+export const INITIAL_ID = null
 export const PROSPECT_ID = '8a320cc9-ae2e-443e-9d26-2f36452c2ced'
 export const ASSIGN_PM_ID = 'c9864359-fb1a-4646-a4c1-97d10189fc03'
 export const ACTIVE_ID = '7606cc19-20da-4b74-aba1-2cec0d753ad8'
@@ -28,17 +29,18 @@ export const STAGE = {
 }
 
 export const STAGE_ID_TO_INDEX_MAP = {
-  [STAGE.PROSPECT_ID]: 0,
-  [STAGE.ASSIGN_PM_ID]: 1,
-  [STAGE.ACTIVE_ID]: 2,
-  [STAGE.VERIFY_WIN_ID]: 3,
-  [STAGE.WON_ID]: 4,
+  [STAGE.INITIAL_ID]: 0,
+  [STAGE.PROSPECT_ID]: 1,
+  [STAGE.ASSIGN_PM_ID]: 2,
+  [STAGE.ACTIVE_ID]: 3,
+  [STAGE.VERIFY_WIN_ID]: 4,
+  [STAGE.WON_ID]: 5,
 }
 
 export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
-  ['strategic_drivers']: STAGE.ASSIGN_PM_ID,
-  ['client_requirements']: STAGE.ASSIGN_PM_ID,
+  ['strategic_drivers']: STAGE.PROSPECT_ID,
+  ['client_requirements']: STAGE.INITIAL_ID,
   ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
   ['project_manager']: STAGE.ACTIVE_ID,
   ['project_assurance_adviser']: STAGE.ACTIVE_ID,
@@ -50,11 +52,12 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['non_fdi_r_and_d_budget']: STAGE.VERIFY_WIN_ID,
   ['new_tech_to_uk']: STAGE.VERIFY_WIN_ID,
   ['export_revenue']: STAGE.VERIFY_WIN_ID,
+  ['site_decided']: STAGE.ACTIVE_ID, // is required to be Yes from verify win.
   ['address_1']: STAGE.VERIFY_WIN_ID,
   ['address_town']: STAGE.VERIFY_WIN_ID,
   ['address_postcode']: STAGE.VERIFY_WIN_ID,
-  ['actual_uk_regions']: STAGE.VERIFY_WIN_ID,
-  ['delivery_partners']: STAGE.VERIFY_WIN_ID,
+  ['actual_uk_regions']: STAGE.ACTIVE_ID,
+  ['delivery_partners']: STAGE.ACTIVE_ID,
   ['actual_land_date']: STAGE.ASSIGN_PM_ID,
   ['specific_programmes']: STAGE.ASSIGN_PM_ID,
   ['uk_company']: STAGE.VERIFY_WIN_ID,

--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -125,7 +125,12 @@ const EditProjectRequirements = () => {
               />
               <FieldRadios
                 name="client_considering_other_countries"
-                label="Is the client considering other countries?"
+                label={
+                  'Is the client considering other countries?' +
+                  (isUkRegionLocationsRequiredForStage(project)
+                    ? ''
+                    : ' (optional)')
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.clientConsideringOtherCountries
                 )}
@@ -147,6 +152,14 @@ const EditProjectRequirements = () => {
                     ),
                   }),
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select other countries considered'
+                  )
+                }}
               />
               <FieldUKRegionTypeahead
                 name="uk_region_locations"

--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -34,6 +34,14 @@ import {
 import { idNamesToValueLabels } from '../../../../utils'
 import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
+import {
+  isFieldOptionalForStageLabel,
+  validateFieldForStage,
+} from '../validators'
+import {
+  isUkRegionLocationsRequiredForStage,
+  siteDecidedValidator,
+} from './validators'
 
 const ukObject = {
   name: 'United Kingdom',
@@ -78,7 +86,10 @@ const EditProjectRequirements = () => {
             >
               <ResourceOptionsField
                 name="strategic_drivers"
-                label="Strategic drivers behind this investment"
+                label={
+                  'Strategic drivers behind this investment' +
+                  isFieldOptionalForStageLabel('strategic_drivers', project)
+                }
                 resource={StrategicDriversResource}
                 field={FieldTypeahead}
                 initialValue={transformArrayForTypeahead(
@@ -86,12 +97,31 @@ const EditProjectRequirements = () => {
                 )}
                 placeholder="Select a strategic driver"
                 isMulti={true}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a strategic driver'
+                  )
+                }}
               />
               <FieldTextarea
                 type="text"
                 name="client_requirements"
-                label="Client requirements"
+                label={
+                  'Client requirements' +
+                  isFieldOptionalForStageLabel('client_requirements', project)
+                }
                 initialValue={project.clientRequirements || ''}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Enter client requirements'
+                  )
+                }}
               />
               <FieldRadios
                 name="client_considering_other_countries"
@@ -120,12 +150,23 @@ const EditProjectRequirements = () => {
               />
               <FieldUKRegionTypeahead
                 name="uk_region_locations"
-                label="Possible UK locations for this investment"
+                label={
+                  'Possible UK locations for this investment' +
+                  (isUkRegionLocationsRequiredForStage(project)
+                    ? ''
+                    : ' (optional)')
+                }
                 initialValue={transformArrayForTypeahead(
                   project.ukRegionLocations
                 )}
                 placeholder="Select a UK region"
                 isMulti={true}
+                validate={(values, field, formFields) => {
+                  return isUkRegionLocationsRequiredForStage(project) &&
+                    !formFields.values[field.name]
+                    ? 'Select a possible UK location'
+                    : null
+                }}
               />
               <FieldRadios
                 name="site_decided"
@@ -153,21 +194,41 @@ const EditProjectRequirements = () => {
                         />
                         <FieldUKRegionTypeahead
                           name="actual_uk_regions"
-                          label="UK regions landed"
+                          label={
+                            'UK regions landed' +
+                            isFieldOptionalForStageLabel(
+                              'actual_uk_regions',
+                              project
+                            )
+                          }
                           initialValue={transformArrayForTypeahead(
                             project.actualUkRegions
                           )}
                           placeholder="Select a UK region"
                           isMulti={true}
+                          validate={(values, field, formFields) => {
+                            return validateFieldForStage(
+                              field,
+                              formFields,
+                              project,
+                              'Select a UK region'
+                            )
+                          }}
                         />
                       </>
                     ),
                   }),
                 }))}
+                validate={(values, field, formFields) => {
+                  return siteDecidedValidator(field, formFields, project)
+                }}
               />
               <ResourceOptionsField
                 name="delivery_partners"
-                label="Delivery partners"
+                label={
+                  'Delivery partners' +
+                  isFieldOptionalForStageLabel('investor_type', project)
+                }
                 resource={DeliveryPartnersResource}
                 field={FieldTypeahead}
                 initialValue={transformArrayForTypeahead(
@@ -180,6 +241,14 @@ const EditProjectRequirements = () => {
                     result.filter((option) => !option.disabledOn)
                   )
                 }
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a delivery partner'
+                  )
+                }}
               />
             </Form>
           </>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -173,6 +173,7 @@ const EditProjectSummaryInitialStep = ({
         initialValue={transformDateStringToDateObject(
           project.estimatedLandDate
         )}
+        project={project}
       />
       <FieldLikelihoodOfLanding
         autoScroll={!!autoScroll}
@@ -187,6 +188,7 @@ const EditProjectSummaryInitialStep = ({
         optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
           project.stage.name
         )}
+        project={project}
       />
       {showInvestorTypeField() ? (
         <FieldInvestmentInvestorType
@@ -195,6 +197,7 @@ const EditProjectSummaryInitialStep = ({
           optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
             project.stage.name
           )}
+          project={project}
         />
       ) : null}
       <FieldLevelOfInvolvement
@@ -211,6 +214,7 @@ const EditProjectSummaryInitialStep = ({
         optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
           project.stage.name
         )}
+        project={project}
       />
     </Step>
   )

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -31,6 +31,7 @@ import {
   transformObjectForTypeahead,
   transformArrayForTypeahead,
   transformRadioOptionToBool,
+  transformObjectForTypeaheadInitialValue,
 } from '../transformers'
 import { transformDateStringToDateObject } from '../../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
@@ -175,8 +176,11 @@ const EditProjectSummaryInitialStep = ({
       />
       <FieldLikelihoodOfLanding
         autoScroll={!!autoScroll}
-        initialValue={transformObjectForTypeahead(project.likelihoodToLand)}
+        initialValue={transformObjectForTypeaheadInitialValue(
+          project.likelihoodToLand
+        )}
         optionalText={STAGE_PROSPECT.includes(project.stage.name)}
+        project={project}
       />
       <FieldActualLandDate
         initialValue={transformDateStringToDateObject(project.actualLandDate)}
@@ -194,10 +198,13 @@ const EditProjectSummaryInitialStep = ({
         />
       ) : null}
       <FieldLevelOfInvolvement
-        initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}
+        initialValue={transformObjectForTypeaheadInitialValue(
+          project.levelOfInvolvement
+        )}
         optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
           project.stage.name
         )}
+        project={project}
       />
       <FieldSpecificProgramme
         initialValue={transformArrayForTypeahead(project.specificProgrammes)}

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -36,11 +36,7 @@ import {
 import { transformDateStringToDateObject } from '../../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { GREY_2 } from '../../../../utils/colours'
-import {
-  FDI_TYPES,
-  STAGE_PROSPECT,
-  INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM,
-} from '../constants'
+import { FDI_TYPES } from '../constants'
 
 const StyledFieldWrapper = styled(FieldWrapper)`
   border: 1px solid ${GREY_2};
@@ -180,23 +176,16 @@ const EditProjectSummaryInitialStep = ({
         initialValue={transformObjectForTypeaheadInitialValue(
           project.likelihoodToLand
         )}
-        optionalText={STAGE_PROSPECT.includes(project.stage.name)}
         project={project}
       />
       <FieldActualLandDate
         initialValue={transformDateStringToDateObject(project.actualLandDate)}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
         project={project}
       />
       {showInvestorTypeField() ? (
         <FieldInvestmentInvestorType
           label="New or existing investor"
           initialValue={project.investorType?.id}
-          optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-            project.stage.name
-          )}
           project={project}
         />
       ) : null}
@@ -204,16 +193,10 @@ const EditProjectSummaryInitialStep = ({
         initialValue={transformObjectForTypeaheadInitialValue(
           project.levelOfInvolvement
         )}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
         project={project}
       />
       <FieldSpecificProgramme
         initialValue={transformArrayForTypeahead(project.specificProgrammes)}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
         project={project}
       />
     </Step>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -31,7 +31,6 @@ import {
   transformObjectForTypeahead,
   transformArrayForTypeahead,
   transformRadioOptionToBool,
-  transformObjectForTypeaheadInitialValue,
 } from '../transformers'
 import { transformDateStringToDateObject } from '../../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
@@ -173,8 +172,9 @@ const EditProjectSummaryInitialStep = ({
       />
       <FieldLikelihoodOfLanding
         autoScroll={!!autoScroll}
-        initialValue={transformObjectForTypeaheadInitialValue(
-          project.likelihoodToLand
+        initialValue={transformObjectForTypeahead(
+          project.likelihoodToLand,
+          null
         )}
         project={project}
       />
@@ -190,8 +190,9 @@ const EditProjectSummaryInitialStep = ({
         />
       ) : null}
       <FieldLevelOfInvolvement
-        initialValue={transformObjectForTypeaheadInitialValue(
-          project.levelOfInvolvement
+        initialValue={transformObjectForTypeahead(
+          project.levelOfInvolvement,
+          null
         )}
         project={project}
       />

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -182,10 +182,10 @@ export const transformProjectSummaryForApi = ({
     referral_source_activity_event: setReferralSourceEvent(values),
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
   }
-
+  debugger
   if (Array.isArray(specific_programmes)) {
     summaryPayload.specific_programmes = specific_programmes.map((x) => x.value)
-  } else if (typeof specific_programmes === 'object') {
+  } else if (typeof specific_programmes === 'object' && specific_programmes) {
     summaryPayload.specific_programmes = [specific_programmes?.value]
   } else {
     summaryPayload.specific_programmes = []

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -182,7 +182,7 @@ export const transformProjectSummaryForApi = ({
     referral_source_activity_event: setReferralSourceEvent(values),
     referral_source_adviser: setReferralSourceAdviser(currentAdviser, values),
   }
-  debugger
+
   if (Array.isArray(specific_programmes)) {
     summaryPayload.specific_programmes = specific_programmes.map((x) => x.value)
   } else if (typeof specific_programmes === 'object' && specific_programmes) {

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -118,10 +118,16 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
       client_considering_other_countries,
       competitor_countries
     ),
-    delivery_partners: delivery_partners.map((x) => x.value),
+    delivery_partners: delivery_partners
+      ? delivery_partners.map((x) => x.value)
+      : [],
     site_decided: transformRadioOptionToBoolWithNullCheck(site_decided),
-    strategic_drivers: strategic_drivers.map((x) => x.value),
-    uk_region_locations: uk_region_locations.map((x) => x.value),
+    strategic_drivers: strategic_drivers
+      ? strategic_drivers.map((x) => x.value)
+      : [],
+    uk_region_locations: uk_region_locations
+      ? uk_region_locations.map((x) => x.value)
+      : [],
   }
 
   return { ...siteDecidedObject, ...requirementsValues }

--- a/src/client/modules/Investments/Projects/Details/validators.js
+++ b/src/client/modules/Investments/Projects/Details/validators.js
@@ -1,3 +1,8 @@
+import { STAGE } from '../../../../components/MyInvestmentProjects/constants'
+import { isFieldRequiredForStage } from '../validators'
+
+const { OPTION_YES } = require('../../../../../common/constants')
+
 export const totalInvestmentValidator = (value, foreignEquityInvestment) => {
   if (parseInt(value) < parseInt(foreignEquityInvestment)) {
     return 'Total investment must be >= to capital expenditure'
@@ -11,4 +16,21 @@ export const capitalExpenditureValidator = (value) => {
     return 'Capital expenditure must be >= £15,000,000 for capital only project'
   }
   return null
+}
+
+export const siteDecidedValidator = (field, formFields, project) => {
+  if (project?.stage?.id == STAGE.ACTIVE_ID && !formFields.values[field.name]) {
+    return 'Select a value for UK location decision'
+  }
+  return isFieldRequiredForStage(field.name, project) &&
+    formFields.values[field.name] != OPTION_YES
+    ? 'A UK region is required'
+    : null
+}
+
+export const isUkRegionLocationsRequiredForStage = (project) => {
+  return project?.stage?.id == STAGE.PROSPECT_ID ||
+    project?.stage?.id == STAGE.WON_ID
+    ? false
+    : true
 }

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -40,6 +40,7 @@ import { validateIfDateInPast } from '../../../components/Form/validators'
 import { FDI_TYPES } from './constants'
 import {
   isFieldOptionalForStageLabel,
+  isFieldRequiredForStage,
   validateFieldForStage,
 } from './validators'
 
@@ -325,12 +326,12 @@ export const FieldActualLandDate = ({ initialValue = null, project }) => (
     validate={(values, field, formFields) => {
       let result = validateIfDateInPast(values)
       if (!result) {
-        result = validateFieldForStage(
-          field,
-          formFields,
-          project,
-          'Select a likelihood of landing value'
-        )
+        return (!formFields.values[field.name].day ||
+          !formFields.values[field.name].month ||
+          !formFields.values[field.name].year) &&
+          isFieldRequiredForStage(field.name, project)
+          ? 'Enter an actual land date'
+          : null
       }
       return result
     }}

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -38,7 +38,10 @@ import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
 import { validateIfDateInPast } from '../../../components/Form/validators'
 import { FDI_TYPES } from './constants'
-import { investmentProjectValidateFieldForStage } from './validators'
+import {
+  isFieldOptionalForStageLabel,
+  validateFieldForStage,
+} from './validators'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -285,19 +288,21 @@ export const FieldEstimatedLandDate = ({ initialValue = null }) => (
 export const FieldLikelihoodOfLanding = ({
   initialValue = null,
   autoScroll,
-  optionalText = true,
   project,
 }) => (
   <ResourceOptionsField
     name="likelihood_to_land"
-    label={'Likelihood of landing' + (optionalText ? ' (optional)' : '')}
+    label={
+      'Likelihood of landing' +
+      isFieldOptionalForStageLabel('likelihood_to_land', project)
+    }
     resource={LikelihoodToLandResource}
     field={FieldTypeahead}
     placeholder="Select a likelihood of landing value"
     initialValue={initialValue}
     autoScroll={autoScroll}
-    validate={(a, field, formFields) => {
-      return investmentProjectValidateFieldForStage(
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
         field,
         formFields,
         project,
@@ -307,87 +312,82 @@ export const FieldLikelihoodOfLanding = ({
   />
 )
 
-export const FieldActualLandDate = ({
-  initialValue = null,
-  optionalText = true,
-  // project,
-}) => (
+export const FieldActualLandDate = ({ initialValue = null, project }) => (
   <FieldDate
     name="actual_land_date"
-    label={'Actual land date' + (optionalText ? ' (optional)' : '')}
+    label={
+      'Actual land date' +
+      isFieldOptionalForStageLabel('actual_land_date', project)
+    }
     hint="The date investment project activities started"
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
-    validate={validateIfDateInPast}
-    // TODO Combine validators.
-    // validate={(a, field, formFields) => {
-    //   return investmentProjectValidateFieldForStage(
-    //     field,
-    //     formFields,
-    //     project,
-    //     'Select a likelihood of landing value'
-    //   )
-    // }}
+    validate={(values, field, formFields) => {
+      let result = validateIfDateInPast(values)
+      if (!result) {
+        result = validateFieldForStage(
+          field,
+          formFields,
+          project,
+          'Select a likelihood of landing value'
+        )
+      }
+      return result
+    }}
   />
 )
 
 export const FieldInvestmentInvestorType = ({
   label,
   initialValue = null,
-  optionalText = true,
   project,
 }) => (
   <ResourceOptionsField
     name="investor_type"
-    label={label + (optionalText ? ' (optional)' : '')}
+    label={label + isFieldOptionalForStageLabel('investor_type', project)}
     resource={InvestmentInvestorTypesResource}
     field={FieldRadios}
     initialValue={initialValue}
     placeholder="Choose an investor type"
-    required="We need this"
-    validate={(a, field, formFields) => {
-      return investmentProjectValidateFieldForStage(
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
         field,
         formFields,
         project,
-        'Select a likelihood of landing value'
+        'Select an investor type'
       )
     }}
   />
 )
 
-export const FieldLevelOfInvolvement = ({
-  initialValue = [],
-  optionalText = true,
-  project,
-}) => (
+export const FieldLevelOfInvolvement = ({ initialValue = null, project }) => (
   <ResourceOptionsField
     name="level_of_involvement"
     label={
-      'Level of investor involvement' + (optionalText ? ' (optional)' : '')
+      'Level of investor involvement' +
+      isFieldOptionalForStageLabel('level_of_involvement', project)
     }
     resource={LevelOfInvolvementResource}
     field={FieldTypeahead}
     initialValue={initialValue}
     placeholder="Choose a level of involvement"
-    validate={(a, b, formFields) => {
-      return !formFields.values.level_of_involvement &&
-        project.stage.id == '49b8f6f3-0c50-4150-a965-2c974f3149e3'
-        ? 'We required level of investor involvment'
-        : null
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a level of involvement'
+      )
     }}
   />
 )
 
-export const FieldSpecificProgramme = ({
-  initialValue = [],
-  optionalText = true,
-  project,
-}) => (
+export const FieldSpecificProgramme = ({ initialValue = null, project }) => (
   <ResourceOptionsField
     name="specific_programmes"
     label={
-      'Specific investment programme' + (optionalText ? ' (optional)' : '')
+      'Specific investment programme' +
+      isFieldOptionalForStageLabel('specific_programmes', project)
     }
     resource={SpecificInvestmentProgrammesResource}
     field={FieldTypeahead}
@@ -397,12 +397,12 @@ export const FieldSpecificProgramme = ({
     resultToOptions={(result) =>
       idNamesToValueLabels(result.filter((option) => !option.disabledOn))
     }
-    validate={(a, field, formFields) => {
-      return investmentProjectValidateFieldForStage(
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
         field,
         formFields,
         project,
-        'Select a specific investment programme'
+        'Select a specific programme'
       )
     }}
   />

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -38,6 +38,10 @@ import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
 import { validateIfDateInPast } from '../../../components/Form/validators'
 import { FDI_TYPES } from './constants'
+import {
+  STAGE,
+  STAGE_ID_TO_INDEX_MAP,
+} from '../../../components/MyInvestmentProjects/constants'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -285,6 +289,7 @@ export const FieldLikelihoodOfLanding = ({
   initialValue = null,
   autoScroll,
   optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="likelihood_to_land"
@@ -294,6 +299,13 @@ export const FieldLikelihoodOfLanding = ({
     placeholder="Select a likelihood of landing value"
     initialValue={initialValue}
     autoScroll={autoScroll}
+    validate={(a, field, formFields) => {
+      return !formFields.values.likelihood_to_land &&
+        STAGE_ID_TO_INDEX_MAP[project.stage.id] <
+          STAGE_ID_TO_INDEX_MAP[STAGE.ACTIVE_ID]
+        ? 'We required likelihood of landing'
+        : null
+    }}
   />
 )
 
@@ -308,6 +320,7 @@ export const FieldActualLandDate = ({
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
     validate={validateIfDateInPast}
+    required="We need tis"
   />
 )
 
@@ -323,12 +336,14 @@ export const FieldInvestmentInvestorType = ({
     field={FieldRadios}
     initialValue={initialValue}
     placeholder="Choose an investor type"
+    required="We need this"
   />
 )
 
 export const FieldLevelOfInvolvement = ({
-  initialValue = null,
+  initialValue = [],
   optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="level_of_involvement"
@@ -339,6 +354,13 @@ export const FieldLevelOfInvolvement = ({
     field={FieldTypeahead}
     initialValue={initialValue}
     placeholder="Choose a level of involvement"
+    // resultToOptions={(result) => result}
+    validate={(a, b, formFields) => {
+      return !formFields.values.level_of_involvement &&
+        project.stage.id == '49b8f6f3-0c50-4150-a965-2c974f3149e3'
+        ? 'We required level of involvment'
+        : null
+    }}
   />
 )
 
@@ -359,5 +381,6 @@ export const FieldSpecificProgramme = ({
     resultToOptions={(result) =>
       idNamesToValueLabels(result.filter((option) => !option.disabledOn))
     }
+    required="We need specific programmes"
   />
 )

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -38,10 +38,7 @@ import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
 import { validateIfDateInPast } from '../../../components/Form/validators'
 import { FDI_TYPES } from './constants'
-import {
-  STAGE,
-  STAGE_ID_TO_INDEX_MAP,
-} from '../../../components/MyInvestmentProjects/constants'
+import { investmentProjectValidateFieldForStage } from './validators'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -300,11 +297,12 @@ export const FieldLikelihoodOfLanding = ({
     initialValue={initialValue}
     autoScroll={autoScroll}
     validate={(a, field, formFields) => {
-      return !formFields.values.likelihood_to_land &&
-        STAGE_ID_TO_INDEX_MAP[project.stage.id] <
-          STAGE_ID_TO_INDEX_MAP[STAGE.ACTIVE_ID]
-        ? 'We required likelihood of landing'
-        : null
+      return investmentProjectValidateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a likelihood of landing value'
+      )
     }}
   />
 )
@@ -312,6 +310,7 @@ export const FieldLikelihoodOfLanding = ({
 export const FieldActualLandDate = ({
   initialValue = null,
   optionalText = true,
+  // project,
 }) => (
   <FieldDate
     name="actual_land_date"
@@ -320,7 +319,15 @@ export const FieldActualLandDate = ({
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
     validate={validateIfDateInPast}
-    required="We need tis"
+    // TODO Combine validators.
+    // validate={(a, field, formFields) => {
+    //   return investmentProjectValidateFieldForStage(
+    //     field,
+    //     formFields,
+    //     project,
+    //     'Select a likelihood of landing value'
+    //   )
+    // }}
   />
 )
 
@@ -328,6 +335,7 @@ export const FieldInvestmentInvestorType = ({
   label,
   initialValue = null,
   optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="investor_type"
@@ -337,6 +345,14 @@ export const FieldInvestmentInvestorType = ({
     initialValue={initialValue}
     placeholder="Choose an investor type"
     required="We need this"
+    validate={(a, field, formFields) => {
+      return investmentProjectValidateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a likelihood of landing value'
+      )
+    }}
   />
 )
 
@@ -354,11 +370,10 @@ export const FieldLevelOfInvolvement = ({
     field={FieldTypeahead}
     initialValue={initialValue}
     placeholder="Choose a level of involvement"
-    // resultToOptions={(result) => result}
     validate={(a, b, formFields) => {
       return !formFields.values.level_of_involvement &&
         project.stage.id == '49b8f6f3-0c50-4150-a965-2c974f3149e3'
-        ? 'We required level of involvment'
+        ? 'We required level of investor involvment'
         : null
     }}
   />
@@ -367,6 +382,7 @@ export const FieldLevelOfInvolvement = ({
 export const FieldSpecificProgramme = ({
   initialValue = [],
   optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="specific_programmes"
@@ -381,6 +397,13 @@ export const FieldSpecificProgramme = ({
     resultToOptions={(result) =>
       idNamesToValueLabels(result.filter((option) => !option.disabledOn))
     }
-    required="We need specific programmes"
+    validate={(a, field, formFields) => {
+      return investmentProjectValidateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a specific investment programme'
+      )
+    }}
   />
 )

--- a/src/client/modules/Investments/Projects/constants.js
+++ b/src/client/modules/Investments/Projects/constants.js
@@ -13,11 +13,6 @@ export const INVESTMENT_PROJECT_STAGES = [
   STAGE_WON,
 ]
 
-export const INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM = [
-  STAGE_PROSPECT,
-  STAGE_ASSIGN_PM,
-]
-
 export const EXPORT_REVENUE_TRUE = 'Yes, will create significant export revenue'
 export const EXPORT_REVENUE_FALSE =
   'No, will not create significant export revenue'

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -27,7 +27,7 @@ import Tag from '../../../components/Tag'
 export const checkIfItemHasValue = (item) => (item ? item : null)
 
 export const transformArrayForTypeahead = (array) =>
-  array
+  array && array.length
     ? array.map((value) => ({
         label: value.name,
         value: value.id,

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -44,24 +44,16 @@ export const transformAndFilterArrayForTypeahead = (array) => {
   }))
 }
 
-export const transformObjectForTypeahead = (object) =>
+export const transformObjectForTypeahead = (
+  object,
+  emptyValue = { label: '', value: '' }
+) =>
   object
     ? {
         label: object.name,
         value: object.id,
       }
-    : {
-        label: '',
-        value: '',
-      }
-
-export const transformObjectForTypeaheadInitialValue = (object) =>
-  object
-    ? {
-        label: object.name,
-        value: object.id,
-      }
-    : null
+    : emptyValue
 
 export const transformBoolToRadioOption = (boolean) =>
   boolean ? OPTION_YES : OPTION_NO

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -55,6 +55,14 @@ export const transformObjectForTypeahead = (object) =>
         value: '',
       }
 
+export const transformObjectForTypeaheadInitialValue = (object) =>
+  object
+    ? {
+        label: object.name,
+        value: object.id,
+      }
+    : null
+
 export const transformBoolToRadioOption = (boolean) =>
   boolean ? OPTION_YES : OPTION_NO
 

--- a/src/client/modules/Investments/Projects/validators.js
+++ b/src/client/modules/Investments/Projects/validators.js
@@ -1,0 +1,20 @@
+import {
+  GET_REQUIRED_FIELDS_AFTER_STAGE,
+  STAGE_ID_TO_INDEX_MAP,
+} from '../../../components/MyInvestmentProjects/constants'
+
+export const investmentProjectValidateFieldForStage = (
+  field,
+  formFields,
+  project,
+  message
+) => {
+  if (
+    !formFields.values[field.name] &&
+    STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[field.name]] <=
+      STAGE_ID_TO_INDEX_MAP[project.stage.id]
+  ) {
+    return message
+  }
+  return null
+}

--- a/src/client/modules/Investments/Projects/validators.js
+++ b/src/client/modules/Investments/Projects/validators.js
@@ -3,18 +3,20 @@ import {
   STAGE_ID_TO_INDEX_MAP,
 } from '../../../components/MyInvestmentProjects/constants'
 
-export const investmentProjectValidateFieldForStage = (
-  field,
-  formFields,
-  project,
-  message
-) => {
-  if (
-    !formFields.values[field.name] &&
-    STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[field.name]] <=
-      STAGE_ID_TO_INDEX_MAP[project.stage.id]
-  ) {
-    return message
-  }
-  return null
+export const isFieldRequiredForStage = (fieldName, project) => {
+  return (
+    STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[fieldName]] <
+    STAGE_ID_TO_INDEX_MAP[project.stage.id]
+  )
+}
+
+export const isFieldOptionalForStageLabel = (fieldName, project) => {
+  return isFieldRequiredForStage(fieldName, project) ? '' : ' (optional)'
+}
+
+export const validateFieldForStage = (field, formFields, project, message) => {
+  return !formFields.values[field.name] &&
+    isFieldRequiredForStage(field.name, project)
+    ? message
+    : null
 }

--- a/src/client/modules/Investments/Projects/validators.js
+++ b/src/client/modules/Investments/Projects/validators.js
@@ -15,7 +15,8 @@ export const isFieldOptionalForStageLabel = (fieldName, project) => {
 }
 
 export const validateFieldForStage = (field, formFields, project, message) => {
-  return !formFields.values[field.name] &&
+  return (!formFields.values[field.name] ||
+    formFields.values[field.name].length == 0) &&
     isFieldRequiredForStage(field.name, project)
     ? message
     : null

--- a/src/client/modules/Investments/Projects/validators.js
+++ b/src/client/modules/Investments/Projects/validators.js
@@ -6,7 +6,7 @@ import {
 export const isFieldRequiredForStage = (fieldName, project) => {
   return (
     STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[fieldName]] <
-    STAGE_ID_TO_INDEX_MAP[project.stage.id]
+    STAGE_ID_TO_INDEX_MAP[project?.stage?.id]
   )
 }
 

--- a/test/functional/cypress/fakers/investment-projects.js
+++ b/test/functional/cypress/fakers/investment-projects.js
@@ -96,7 +96,16 @@ const investmentProjectEmptyFaker = (overrides = {}) =>
   investmentProjectFaker({
     stage: INVESTMENT_PROJECT_STAGES.prospect,
     uk_region_locations: null,
-
+    name: null,
+    description: null,
+    sector: null,
+    BUSINESS_ACTIVITIES: null,
+    client_contacts: null,
+    referral_source_adviser: null,
+    estimated_land_date: null,
+    referral_source_activity: null,
+    anonymous_description: null,
+    other_business_activity: null,
     client_cannot_provide_total_investment: null,
     strategic_drivers: null,
     client_requirements: null,

--- a/test/functional/cypress/fakers/investment-projects.js
+++ b/test/functional/cypress/fakers/investment-projects.js
@@ -4,6 +4,7 @@ import jsf from 'json-schema-faker'
 import apiSchema from '../../../api-schema.json'
 
 import {
+  INVESTMENT_PROJECT_STAGES,
   INVESTMENT_PROJECT_STAGES_LIST,
   INVESTMENT_PROJECT_STATUSES_LIST,
 } from './constants'
@@ -86,6 +87,46 @@ const investmentProjectFaker = (overrides = {}) => ({
 })
 
 /**
+ * Generate "empty" single investment project without data.
+ *
+ * Starts by generating data based on the json schema, adds some defaults and
+ * merges in overrides.
+ */
+const investmentProjectEmptyFaker = (overrides = {}) =>
+  investmentProjectFaker({
+    stage: INVESTMENT_PROJECT_STAGES.prospect,
+    uk_region_locations: null,
+
+    client_cannot_provide_total_investment: null,
+    strategic_drivers: null,
+    client_requirements: null,
+    client_considering_other_countries: null,
+    project_manager: null,
+    project_assurance_adviser: null,
+    client_cannot_provide_foreign_investment: null,
+    government_assistance: null,
+    number_new_jobs: null,
+    number_safeguarded_jobs: null,
+    r_and_d_budget: null,
+    non_fdi_r_and_d_budget: null,
+    new_tech_to_uk: null,
+    export_revenue: null,
+    site_decided: null,
+    address_1: null,
+    address_town: null,
+    address_postcode: null,
+    actual_uk_regions: null,
+    delivery_partners: null,
+    actual_land_date: null,
+    specific_programmes: null,
+    uk_company: null,
+    investor_type: null,
+    level_of_involvement: null,
+    likelihood_to_land: null,
+    ...overrides,
+  })
+
+/**
  * Generate fake data for a list of investment projects.
  *
  * The number of items is determined by the length (default is 1).
@@ -96,6 +137,7 @@ const investmentProjectListFaker = (length = 1, overrides) =>
 
 export {
   investmentProjectFaker,
+  investmentProjectEmptyFaker,
   investmentProjectListFaker,
   investmentProjectCodeFaker,
   investmentProjectStageFaker,

--- a/test/functional/cypress/specs/investments/constants.js
+++ b/test/functional/cypress/specs/investments/constants.js
@@ -1,0 +1,13 @@
+export const INVESTMENT_PROJECT_FORM_VALIDATION = {
+  PROJECT_NAME: 'Enter a project name',
+  PROJECT_DESCRIPTION: 'Enter a project description',
+  PRIMARY_SECTOR: 'Choose a primary sector',
+  BUSINESS_ACTIVITY: 'Choose a business activity',
+  CLIENT_CONTACT: 'Choose a client contact',
+  IS_RELATIONSHIP_MANAGER:
+    "Select yes if you're the client relationship manager for this project",
+  IS_REFERRAL_SOURCE:
+    "Select yes if you're the referral source for this project",
+  ESTIMATED_LANDDATE: 'Enter an estimated land date',
+  REFERRAL_SOURCE_ACTIVITY: 'Choose a referral source activity',
+}

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -14,6 +14,7 @@ const {
   assertFieldDateShort,
 } = require('../../support/assertions')
 const { clearTypeahead } = require('../../support/form-fillers')
+const { INVESTMENT_PROJECT_FORM_VALIDATION } = require('./constants')
 
 const { usCompany } = company
 
@@ -292,7 +293,7 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldTypeahead({
         element,
         label: 'Business activities',
-        placeholder: 'Choose a business activity',
+        placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
         hint: 'You can select more than one activity',
       })
     })
@@ -324,7 +325,7 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldTypeahead({
         element,
         label: 'Client contact details',
-        placeholder: 'Choose a client contact',
+        placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
       })
     })
   })
@@ -368,7 +369,8 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldSelect({
         element,
         label: 'Referral source activity',
-        placeholder: 'Choose a referral source activity',
+        placeholder:
+          INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
         optionsCount: 53,
       })
     })
@@ -431,15 +433,15 @@ describe('Investment Detail Step Form Content', () => {
 
 describe('Validation error messages', () => {
   const validationErrorMessages = [
-    'Enter a project name',
-    'Enter a project description',
-    'Choose a primary sector',
-    'Choose a business activity',
-    'Choose a client contact',
-    "Select yes if you're the client relationship manager for this project",
-    "Select yes if you're the referral source for this project",
-    'Enter an estimated land date',
-    'Choose a referral source activity',
+    INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_NAME,
+    INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_DESCRIPTION,
+    INVESTMENT_PROJECT_FORM_VALIDATION.PRIMARY_SECTOR,
+    INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
+    INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
+    INVESTMENT_PROJECT_FORM_VALIDATION.IS_RELATIONSHIP_MANAGER,
+    INVESTMENT_PROJECT_FORM_VALIDATION.IS_REFERRAL_SOURCE,
+    INVESTMENT_PROJECT_FORM_VALIDATION.ESTIMATED_LANDDATE,
+    INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
   ]
 
   const validationErrorMessageOtherBusinessActivities =

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -5,6 +5,7 @@ import {
 import { INVESTMENT_PROJECT_STAGES } from '../../fakers/constants'
 import { investmentProjectFaker } from '../../fakers/investment-projects'
 import { clickButton } from '../../support/actions'
+import { INVESTMENT_PROJECT_FORM_VALIDATION } from './constants'
 
 const urls = require('../../../../../src/lib/urls')
 
@@ -138,7 +139,7 @@ describe('Editing the project summary', () => {
         assertFieldTypeahead({
           element,
           label: 'Business activities',
-          placeholder: 'Choose a business activity',
+          placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
         })
       })
     })
@@ -158,7 +159,7 @@ describe('Editing the project summary', () => {
         assertFieldTypeahead({
           element,
           label: 'Client contact details',
-          placeholder: 'Choose a client contact',
+          placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
           value: 'Dean Cox',
         })
       })
@@ -195,7 +196,8 @@ describe('Editing the project summary', () => {
         assertFieldSelect({
           element,
           label: 'Referral source activity',
-          placeholder: 'Choose a referral source activity',
+          placeholder:
+            INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
           value: 'None',
           optionsCount: 53,
         })

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -1,3 +1,5 @@
+import { INVESTMENT_PROJECT_FORM_VALIDATION } from './constants'
+
 const urls = require('../../../../../src/lib/urls')
 const {
   investmentProjectEmptyFaker,
@@ -8,39 +10,35 @@ export const FIELDS = {
   // Update investment project summary
   NAME: {
     name: 'name',
-    message: 'Enter a project name',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_NAME,
   },
   DESCRIPTION: {
     name: 'description',
-    message: 'Enter a project description',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_DESCRIPTION,
   },
   SECTOR: {
     name: 'sector',
-    message: 'Choose a primary sector',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PRIMARY_SECTOR,
   },
   BUSINESS_ACTIVITIES: {
     name: 'business_activities',
-    message: 'Choose a business activity',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
   },
   CLIENT_CONTACTS: {
     name: 'client_contacts',
-    message: 'Choose a client contact',
-  },
-  REFERRAL_SOURCE_ADVISER: {
-    name: 'referral_source_adviser',
-    message: "Select yes if you're the referral source for this project",
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
   },
   IS_REFERRAL_SOURCE: {
     name: 'is_referral_source',
-    message: "Select yes if you're the referral source for this project",
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.IS_REFERRAL_SOURCE,
   },
   ESTIMATED_LAND_DATE: {
     name: 'estimated_land_date',
-    message: 'Enter an estimated land date',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.ESTIMATED_LANDDATE,
   },
   REFERRAL_SOURCE_ACTIVITY: {
     name: 'referral_source_activity',
-    message: 'Choose a referral source activity',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
   },
   INVESTOR_TYPE: {
     name: 'investor_type',
@@ -108,18 +106,15 @@ describe('Field validation for each stage', () => {
       [
         INVESTMENT_PROJECT_STAGES.prospect,
         [
+          // Sector and investment_type can't be null, but should always be set at this stage.
+          // Cypress doesn't pick up null value for the above.
           FIELDS.NAME,
           FIELDS.DESCRIPTION,
-          // FIELDS.SECTOR, // Cypress doesn't pick up null value.
-          // FIELDS.REFERRAL_SOURCE_ACTIVITY,
           FIELDS.BUSINESS_ACTIVITIES,
           FIELDS.CLIENT_CONTACTS,
           FIELDS.IS_REFERRAL_SOURCE,
           FIELDS.ESTIMATED_LAND_DATE,
-
-          // FIELDS.REFERRAL_SOURCE_ADVISER, // required when IS_REFERRAL_SOURCE = No
           FIELDS.REFERRAL_SOURCE_ACTIVITY,
-          // investment_type can't be null, but should always be set at this stage.
         ],
       ],
       [

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -5,6 +5,65 @@ const {
 const { INVESTMENT_PROJECT_STAGES } = require('../../fakers/constants')
 
 export const FIELDS = {
+  // Update investment project summary
+  NAME: {
+    name: 'name',
+    message: 'Enter a project name',
+  },
+  DESCRIPTION: {
+    name: 'description',
+    message: 'Enter a project description',
+  },
+  SECTOR: {
+    name: 'sector',
+    message: 'Choose a primary sector',
+  },
+  BUSINESS_ACTIVITIES: {
+    name: 'business_activities',
+    message: 'Choose a business activity',
+  },
+  CLIENT_CONTACTS: {
+    name: 'client_contacts',
+    message: 'Choose a client contact',
+  },
+  REFERRAL_SOURCE_ADVISER: {
+    name: 'referral_source_adviser',
+    message: "Select yes if you're the referral source for this project",
+  },
+  IS_REFERRAL_SOURCE: {
+    name: 'is_referral_source',
+    message: "Select yes if you're the referral source for this project",
+  },
+  ESTIMATED_LAND_DATE: {
+    name: 'estimated_land_date',
+    message: 'Enter an estimated land date',
+  },
+  REFERRAL_SOURCE_ACTIVITY: {
+    name: 'referral_source_activity',
+    message: 'Choose a referral source activity',
+  },
+  INVESTOR_TYPE: {
+    name: 'investor_type',
+    message: 'Select an investor type',
+  },
+  LEVEL_OF_INVOLVEMENT: {
+    name: 'level_of_involvement',
+    message: 'Select a level of involvement',
+  },
+  SPECIFIC_PROGRAMMES: {
+    name: 'specific_programmes',
+    message: 'Select a specific programme',
+  },
+  LIKELIHOOD_TO_LAND: {
+    name: 'likelihood_to_land',
+    message: 'Select a likelihood of landing value',
+  },
+  ACTUAL_LAND_DATE: {
+    name: 'actual_land_date',
+    message: 'Enter an actual land date',
+  },
+
+  // Edit requirements and location
   STRATEGIC_DRIVERS: {
     name: 'strategic_drivers',
     message: 'Select a strategic driver',
@@ -39,96 +98,211 @@ function assertValidationMessages(fields) {
   })
 }
 
-describe('Field validation stages project edit requirements', () => {
-  const stageRequiredFields = [
-    [INVESTMENT_PROJECT_STAGES.prospect, [FIELDS.CLIENT_REQUIREMENTS], false],
-    [
-      INVESTMENT_PROJECT_STAGES.assignPm,
+describe('Field validation for each stage', () => {
+  describe('Update investment project summary', () => {
+    const stageRequiredFields = [
       [
-        FIELDS.STRATEGIC_DRIVERS,
-        FIELDS.CLIENT_REQUIREMENTS,
-        FIELDS.UK_REGION_LOCATIONS,
-      ],
-      false,
-    ],
-    [
-      INVESTMENT_PROJECT_STAGES.active,
-      [
-        FIELDS.STRATEGIC_DRIVERS,
-        FIELDS.CLIENT_REQUIREMENTS,
-        {
-          name: 'site_decided',
-          message: 'Select a value for UK location decision',
-        },
-        FIELDS.UK_REGION_LOCATIONS,
-      ],
-      false,
-    ],
-    [
-      INVESTMENT_PROJECT_STAGES.verifyWin,
-      [
-        FIELDS.STRATEGIC_DRIVERS,
-        FIELDS.CLIENT_REQUIREMENTS,
-        { name: 'site_decided', message: 'A UK region is required' },
-        FIELDS.DELIVERY_PARTNERS,
-        FIELDS.UK_REGION_LOCATIONS,
-      ],
-      true,
-    ],
-    [
-      INVESTMENT_PROJECT_STAGES.won,
-      [
-        FIELDS.STRATEGIC_DRIVERS,
-        FIELDS.CLIENT_REQUIREMENTS,
-        { name: 'site_decided', message: 'A UK region is required' },
-        FIELDS.DELIVERY_PARTNERS,
-      ],
-      true,
-    ],
-  ]
-  stageRequiredFields.forEach((stageRequiredField) => {
-    const [stage, requiredFields, ukLocationRequired] = stageRequiredField
+        INVESTMENT_PROJECT_STAGES.prospect,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          // FIELDS.SECTOR, // Cypress doesn't pick up null value.
+          // FIELDS.REFERRAL_SOURCE_ACTIVITY,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
 
-    context(`In the ${stage.name} stage `, () => {
-      beforeEach(() => {
-        const projectEmptyFields = investmentProjectEmptyFaker({
-          stage: stage,
+          // FIELDS.REFERRAL_SOURCE_ADVISER, // required when IS_REFERRAL_SOURCE = No
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+          // investment_type can't be null, but should always be set at this stage.
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.assignPm,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.active,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.INVESTOR_TYPE,
+          FIELDS.LEVEL_OF_INVOLVEMENT,
+          FIELDS.SPECIFIC_PROGRAMMES,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+          FIELDS.LIKELIHOOD_TO_LAND, // Required in API at active stage
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.verifyWin,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.INVESTOR_TYPE,
+          FIELDS.LEVEL_OF_INVOLVEMENT,
+          FIELDS.SPECIFIC_PROGRAMMES,
+          FIELDS.LIKELIHOOD_TO_LAND,
+          FIELDS.ACTUAL_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.won,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.INVESTOR_TYPE,
+          FIELDS.LEVEL_OF_INVOLVEMENT,
+          FIELDS.SPECIFIC_PROGRAMMES,
+          FIELDS.LIKELIHOOD_TO_LAND,
+          FIELDS.ACTUAL_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+    ]
+    stageRequiredFields.forEach((stageRequiredField) => {
+      const [stage, requiredFields] = stageRequiredField
+
+      context(`In the ${stage.name} stage `, () => {
+        beforeEach(() => {
+          const projectEmptyFields = investmentProjectEmptyFaker({
+            stage: stage,
+          })
+          cy.intercept(
+            'GET',
+            `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+            projectEmptyFields
+          ).as('apiCall')
+          cy.visit(urls.investments.projects.editDetails(projectEmptyFields.id))
+          cy.wait('@apiCall')
         })
-        cy.intercept(
-          'GET',
-          `/api-proxy/v3/investment/${projectEmptyFields.id}`,
-          projectEmptyFields
-        ).as('apiCall')
-        cy.visit(
-          urls.investments.projects.editRequirements(projectEmptyFields.id)
-        )
-        cy.wait('@apiCall')
+
+        it(`submitting an empty form should show validation errors`, () => {
+          cy.get('[data-test="submit"]').click()
+
+          assertValidationMessages(requiredFields)
+          // Ensure only the expected errors are shown.
+          cy.get('[data-test="summary-form-errors"] li').should(
+            'have.length',
+            requiredFields.length
+          )
+        })
       })
+    })
+  })
 
-      it(`submitting an empty form should show validation errors`, () => {
-        cy.get('[data-test="submit-button"]').click()
+  describe('Edit requirements and location', () => {
+    const stageRequiredFields = [
+      [INVESTMENT_PROJECT_STAGES.prospect, [FIELDS.CLIENT_REQUIREMENTS], false],
+      [
+        INVESTMENT_PROJECT_STAGES.assignPm,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        false,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.active,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          {
+            name: 'site_decided',
+            message: 'Select a value for UK location decision',
+          },
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        false,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.verifyWin,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          { name: 'site_decided', message: 'A UK region is required' },
+          FIELDS.DELIVERY_PARTNERS,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        true,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.won,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          { name: 'site_decided', message: 'A UK region is required' },
+          FIELDS.DELIVERY_PARTNERS,
+        ],
+        true,
+      ],
+    ]
+    stageRequiredFields.forEach((stageRequiredField) => {
+      const [stage, requiredFields, ukLocationRequired] = stageRequiredField
 
-        assertValidationMessages(requiredFields)
-        // Ensure only the expected errors are shown.
-        cy.get('[data-test="summary-form-errors"] li').should(
-          'have.length',
-          requiredFields.length
-        )
-      })
+      context(`In the ${stage.name} stage `, () => {
+        beforeEach(() => {
+          const projectEmptyFields = investmentProjectEmptyFaker({
+            stage: stage,
+          })
+          cy.intercept(
+            'GET',
+            `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+            projectEmptyFields
+          ).as('apiCall')
+          cy.visit(
+            urls.investments.projects.editRequirements(projectEmptyFields.id)
+          )
+          cy.wait('@apiCall')
+        })
 
-      if (ukLocationRequired) {
-        it('submitting an empty form with site_decide set to Yes should show address validation errors', () => {
-          cy.get('[data-test="site-decided-yes"]').click()
+        it(`submitting an empty form should show validation errors`, () => {
           cy.get('[data-test="submit-button"]').click()
 
-          assertValidationMessages([
-            FIELDS.SITE_DECIDED,
-            FIELDS.ADDRESS1,
-            FIELDS.CITY,
-            FIELDS.POSTCODE,
-          ])
+          assertValidationMessages(requiredFields)
+          // Ensure only the expected errors are shown.
+          cy.get('[data-test="summary-form-errors"] li').should(
+            'have.length',
+            requiredFields.length
+          )
         })
-      }
+
+        if (ukLocationRequired) {
+          it('submitting an empty form with site_decide set to Yes should show address validation errors', () => {
+            cy.get('[data-test="site-decided-yes"]').click()
+            cy.get('[data-test="submit-button"]').click()
+
+            assertValidationMessages([
+              FIELDS.SITE_DECIDED,
+              FIELDS.ADDRESS1,
+              FIELDS.CITY,
+              FIELDS.POSTCODE,
+            ])
+          })
+        }
+      })
     })
   })
 })

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -144,6 +144,7 @@ describe('Field validation for each stage', () => {
           FIELDS.SPECIFIC_PROGRAMMES,
           FIELDS.REFERRAL_SOURCE_ACTIVITY,
           FIELDS.LIKELIHOOD_TO_LAND, // Required in API at active stage
+          FIELDS.ACTUAL_LAND_DATE,
         ],
       ],
       [

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -1,0 +1,134 @@
+const urls = require('../../../../../src/lib/urls')
+const {
+  investmentProjectEmptyFaker,
+} = require('../../fakers/investment-projects')
+const { INVESTMENT_PROJECT_STAGES } = require('../../fakers/constants')
+
+export const FIELDS = {
+  STRATEGIC_DRIVERS: {
+    name: 'strategic_drivers',
+    message: 'Select a strategic driver',
+  },
+  CLIENT_REQUIREMENTS: {
+    name: 'client_requirements',
+    message: 'Enter client requirements',
+  },
+  SITE_DECIDED: { name: 'site_decided', message: 'Select a UK region' },
+  DELIVERY_PARTNERS: {
+    name: 'delivery_partners',
+    message: 'Select a delivery partner',
+  },
+  UK_REGION_LOCATIONS: {
+    name: 'uk_region_locations',
+    message: 'Select a possible UK location',
+  },
+
+  ADDRESS1: { name: 'address1', message: 'Enter an address' },
+  CITY: { name: 'city', message: 'Enter a town or city' },
+  POSTCODE: { name: 'postcode', message: 'Enter a postcode' },
+}
+
+function assertValidationMessage(elementName, message) {
+  cy.get('[id="form-errors"]').contains(message)
+  cy.get(`[id="field-${elementName}"]`).contains(message)
+}
+
+function assertValidationMessages(fields) {
+  fields.forEach((field) => {
+    assertValidationMessage(field.name, field.message)
+  })
+}
+
+describe('Field validation stages project edit requirements', () => {
+  const stageRequiredFields = [
+    [INVESTMENT_PROJECT_STAGES.prospect, [FIELDS.CLIENT_REQUIREMENTS], false],
+    [
+      INVESTMENT_PROJECT_STAGES.assignPm,
+      [
+        FIELDS.STRATEGIC_DRIVERS,
+        FIELDS.CLIENT_REQUIREMENTS,
+        FIELDS.UK_REGION_LOCATIONS,
+      ],
+      false,
+    ],
+    [
+      INVESTMENT_PROJECT_STAGES.active,
+      [
+        FIELDS.STRATEGIC_DRIVERS,
+        FIELDS.CLIENT_REQUIREMENTS,
+        {
+          name: 'site_decided',
+          message: 'Select a value for UK location decision',
+        },
+        FIELDS.UK_REGION_LOCATIONS,
+      ],
+      false,
+    ],
+    [
+      INVESTMENT_PROJECT_STAGES.verifyWin,
+      [
+        FIELDS.STRATEGIC_DRIVERS,
+        FIELDS.CLIENT_REQUIREMENTS,
+        { name: 'site_decided', message: 'A UK region is required' },
+        FIELDS.DELIVERY_PARTNERS,
+        FIELDS.UK_REGION_LOCATIONS,
+      ],
+      true,
+    ],
+    [
+      INVESTMENT_PROJECT_STAGES.won,
+      [
+        FIELDS.STRATEGIC_DRIVERS,
+        FIELDS.CLIENT_REQUIREMENTS,
+        { name: 'site_decided', message: 'A UK region is required' },
+        FIELDS.DELIVERY_PARTNERS,
+      ],
+      true,
+    ],
+  ]
+  stageRequiredFields.forEach((stageRequiredField) => {
+    const [stage, requiredFields, ukLocationRequired] = stageRequiredField
+
+    context(`In the ${stage.name} stage `, () => {
+      beforeEach(() => {
+        const projectEmptyFields = investmentProjectEmptyFaker({
+          stage: stage,
+        })
+        cy.intercept(
+          'GET',
+          `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+          projectEmptyFields
+        ).as('apiCall')
+        cy.visit(
+          urls.investments.projects.editRequirements(projectEmptyFields.id)
+        )
+        cy.wait('@apiCall')
+      })
+
+      it(`submitting an empty form should show validation errors`, () => {
+        cy.get('[data-test="submit-button"]').click()
+
+        assertValidationMessages(requiredFields)
+        // Ensure only the expected errors are shown.
+        cy.get('[data-test="summary-form-errors"] li').should(
+          'have.length',
+          requiredFields.length
+        )
+      })
+
+      if (ukLocationRequired) {
+        it('submitting an empty form with site_decide set to Yes should show address validation errors', () => {
+          cy.get('[data-test="site-decided-yes"]').click()
+          cy.get('[data-test="submit-button"]').click()
+
+          assertValidationMessages([
+            FIELDS.SITE_DECIDED,
+            FIELDS.ADDRESS1,
+            FIELDS.CITY,
+            FIELDS.POSTCODE,
+          ])
+        })
+      }
+    })
+  })
+})

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -72,6 +72,10 @@ export const FIELDS = {
     name: 'client_requirements',
     message: 'Enter client requirements',
   },
+  CLIENT_CONSIDERING_OTHER_COUNTRIES: {
+    name: 'client_considering_other_countries',
+    message: 'Select other countries considered',
+  },
   SITE_DECIDED: { name: 'site_decided', message: 'Select a UK region' },
   DELIVERY_PARTNERS: {
     name: 'delivery_partners',
@@ -221,6 +225,7 @@ describe('Field validation for each stage', () => {
         [
           FIELDS.STRATEGIC_DRIVERS,
           FIELDS.CLIENT_REQUIREMENTS,
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
           FIELDS.UK_REGION_LOCATIONS,
         ],
         false,
@@ -234,6 +239,7 @@ describe('Field validation for each stage', () => {
             name: 'site_decided',
             message: 'Select a value for UK location decision',
           },
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
           FIELDS.UK_REGION_LOCATIONS,
         ],
         false,
@@ -245,6 +251,7 @@ describe('Field validation for each stage', () => {
           FIELDS.CLIENT_REQUIREMENTS,
           { name: 'site_decided', message: 'A UK region is required' },
           FIELDS.DELIVERY_PARTNERS,
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
           FIELDS.UK_REGION_LOCATIONS,
         ],
         true,
@@ -255,6 +262,7 @@ describe('Field validation for each stage', () => {
           FIELDS.STRATEGIC_DRIVERS,
           FIELDS.CLIENT_REQUIREMENTS,
           { name: 'site_decided', message: 'A UK region is required' },
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
           FIELDS.DELIVERY_PARTNERS,
         ],
         true,

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -215,7 +215,7 @@ describe('Field validation for each stage', () => {
 
   describe('Edit requirements and location', () => {
     const stageRequiredFields = [
-      [INVESTMENT_PROJECT_STAGES.prospect, [FIELDS.CLIENT_REQUIREMENTS], false],
+      [INVESTMENT_PROJECT_STAGES.prospect, [], false],
       [
         INVESTMENT_PROJECT_STAGES.assignPm,
         [


### PR DESCRIPTION
## Description of change

Not all fields for investment projects that are required by the API were marked as required by the front end. This caused a cryptic message "Could not load TASK_EDIT_INVESTMENT_PROJECT_REQUIREMENTS [Retry] [Dismiss]" to be displayed to the user when the API required a field for which no value was provided.

This PR adds front end field validation for the `Update investment project summary` and `Edit requirements and location` pages. Different fields are required depending on the stage of investment project.

## Test instructions

The different stages should show friendly error messages for the required fields. The table below show screenshots for containing the fields that are required for each of the stages. It also shows the fields for which the requirements changed.

Tip for testing create a bare investment project in the API and alter the Stage in the Django back end to test the different stages on the front end.

## Screenshots

### Update investment project summary

<details>

| Before | After |
| ----- | ----- |
| Stage | Prospect |
|  | + Client contact |
| ![image](https://github.com/user-attachments/assets/1d491c5f-9903-4fe3-b894-b7d02b23fb3f) | ![image](https://github.com/user-attachments/assets/eaef5baf-5484-4c4f-9379-b9a18f5c4da1) |
| Stage | Assign PM |
| No changes |  |
| Stage | Active |
|  | + Likelihood of landing, + Actual land date, + Investor Type, + Level of involvement, + Specific programme |
| ![image](https://github.com/user-attachments/assets/9b6cda6f-dd72-42c6-b9e2-b5ec6f54be79) | ![image](https://github.com/user-attachments/assets/05a9be68-7443-4e4b-a36b-7e72e8ae45d4) |
| Stage | Verify win |
|  | + Specific programme |
| ![image](https://github.com/user-attachments/assets/281658a7-715b-4be2-9a0e-20b89f92158b) | ![image](https://github.com/user-attachments/assets/05a9be68-7443-4e4b-a36b-7e72e8ae45d4) |
| Stage | Won |
|  | - ~~Estimated land date~~, + Likelihood of landing, + Actual land date, + Investor Type, + Level of involvement, + Specific programme |
| ![image](https://github.com/user-attachments/assets/9dfdf532-df52-4819-945b-16de2ba043b8) | ![image](https://github.com/user-attachments/assets/451e1464-41db-4602-a2f6-d14832a62598) |

</details>

### Edit requirements and location

<details>

| Before | After |
| ----- | ----- |
| Stage | Prospect |
| No changes |  |
| Stage | Assign PM |
|  | + Strategic driver, + Client requirements, + Other countries considered, + Possible UK location |
| ![image](https://github.com/user-attachments/assets/d37665f8-7d48-4a23-9324-bc76762e83a6) | ![image](https://github.com/user-attachments/assets/073bf41c-3d5b-43ac-bae7-3ae761f4a75a) |
| Stage | Active |
|  | + Strategic driver, + Client requirements, + Other countries considered, + Possible UK location, + Location decision |
| ![image](https://github.com/user-attachments/assets/0dd5a4dd-9de2-4fd2-825d-fb721eb0cd56) | ![image](https://github.com/user-attachments/assets/51e4b942-6b0d-4360-ab2c-42727f5effcf) |
| Stage | Verify win |
|  | + Strategic driver, + Client requirements, + Other countries considered, + Possible UK location, + Location decision, + Delivery partners |
| ![image](https://github.com/user-attachments/assets/77a94d3c-0fe1-4b1d-9e17-63fd2be05dfb) | ![image](https://github.com/user-attachments/assets/f5e36db1-9a91-48ab-a723-4ca7fdcb726c) |
| Stage | Won |
|  | + Strategic driver, + Client requirements, + Other countries considered, + Location decision, + Delivery partners |
| ![image](https://github.com/user-attachments/assets/78498be0-a43a-4996-af8c-43821cc4b87c) | ![image](https://github.com/user-attachments/assets/30a67d2c-adf9-41c8-834f-2695ec340ca6) |

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
