### PR TITLE
Fix Export Win TypeError

### DIFF
--- a/src/client/modules/ExportWins/Status/utils.js
+++ b/src/client/modules/ExportWins/Status/utils.js
@@ -9,38 +9,76 @@ export const sumExportValues = ({
   total_expected_non_export_value +
   total_expected_odi_value
 
+/**
+ * Checks if the current adviser is among the team members for an export win.
+ *
+ * @param {Array} teamMembers - Array of team member objects.
+ * @param {string} currentAdviserId - The ID of the current adviser.
+ * @returns {boolean} True if the current adviser is found among the team members, otherwise false.
+ *
+ * Note:
+ * - For export wins migrated to Data Hub, the teamMembers array will always be empty.
+ * - If a team member was added directly to an export win on Data Hub, the array will be populated.
+ */
 const teamMembersContainCurrentAdvisor = (teamMembers = [], currentAdviserId) =>
   teamMembers.some(({ id }) => id === currentAdviserId)
 
+/**
+ * Checks if the current adviser is among the contributing officers for an export win.
+ *
+ * @param {Array} contributingOfficers - Array of contributing officer objects.
+ * @param {string} currentAdviserId - The ID of the current adviser.
+ * @returns {boolean} True if the current adviser is found among the contributing officers, otherwise false.
+ *
+ * Note:
+ * - In a contributing officer object, the adviser field will be null if the export win
+ *   was migrated to Data Hub and no matching Data Hub adviser is found. In this case,
+ *   the name field will still be populated.
+ * - If a contributing officer was added directly on Data Hub, the adviser field
+ *   will be defined.
+ */
 const contributingOfficersContainCurrentAdvisor = (
   contributingOfficers = [],
   currentAdviserId
-) => contributingOfficers.some(({ adviser }) => adviser.id === currentAdviserId)
+) =>
+  contributingOfficers.some(({ adviser }) => adviser?.id === currentAdviserId)
 
+/**
+ * Checks if the current adviser is the lead officer for an export win.
+ *
+ * @param {Object} exportWin - The export win object.
+ * @param {Object} exportWin.lead_officer - The lead officer object.
+ * @param {string} currentAdviserId - The ID of the current adviser.
+ * @returns {boolean} True if the current adviser is the lead officer, otherwise false.
+ *
+ * Note:
+ * - The lead_officer field will be null if the export win was migrated to Data Hub
+ *   and no matching Data Hub adviser is found. In this case, the name and email fields
+ *   will still be populated.
+ * - If the lead officer was added directly on Data Hub, the lead_officer field
+ *   will be populated.
+ */
 const isCurrentAdviserLeadOfficer = ({ lead_officer }, currentAdviserId) =>
-  // If an export win from the old service hasn't been matched
-  // to a Data Hub lead officer, there won't be a lead officer ID.
-  // However, there will be lead officer name and email.
   lead_officer?.id === currentAdviserId
 
-export const createRoleTags = (item, currentAdviserId) => {
+export const createRoleTags = (exportWin, currentAdviserId) => {
   const tag = { colour: 'blue', textTransform: 'none' }
   const tags = []
 
-  isCurrentAdviserLeadOfficer(item, currentAdviserId) &&
+  isCurrentAdviserLeadOfficer(exportWin, currentAdviserId) &&
     tags.push({
       ...tag,
       text: `Role: ${ADVISER_ROLES.LEAD_OFFICER}`,
     })
 
-  teamMembersContainCurrentAdvisor(item.team_members, currentAdviserId) &&
+  teamMembersContainCurrentAdvisor(exportWin.team_members, currentAdviserId) &&
     tags.push({
       ...tag,
       text: `Role: ${ADVISER_ROLES.TEAM_MEMBER}`,
     })
 
   contributingOfficersContainCurrentAdvisor(
-    item.contributing_advisers,
+    exportWin.contributing_advisers,
     currentAdviserId
   ) &&
     tags.push({

--- a/test/component/cypress/specs/Companies/Export/CompanyExportWins.cy.jsx
+++ b/test/component/cypress/specs/Companies/Export/CompanyExportWins.cy.jsx
@@ -43,6 +43,18 @@ describe('CompanyExportWins', () => {
         shouldRenderTag: true,
         role: 'Role: lead officer',
       },
+      {
+        // The lead_officer field will be null if the export win has been migrated to
+        // Data Hub and doesn't match a Data Hub adviser.
+        exportWins: [
+          {
+            ...companyExportWin,
+            lead_officer: null,
+          },
+        ],
+        currentAdviserId: '1',
+        shouldRenderTag: false,
+      },
       // The team_members array doesn't include the currentAdviserId
       {
         exportWins: [
@@ -85,6 +97,18 @@ describe('CompanyExportWins', () => {
         currentAdviserId: '1',
         shouldRenderTag: true,
         role: 'Role: team member',
+      },
+      {
+        // The teamMembers array will always be empty for export wins that have been
+        // migrated to Data Hub.
+        exportWins: [
+          {
+            ...companyExportWin,
+            team_members: [],
+          },
+        ],
+        currentAdviserId: '4',
+        shouldRenderTag: false,
       },
       // The contributing_advisers array doesn't include the currentAdviserId
       {
@@ -140,6 +164,29 @@ describe('CompanyExportWins', () => {
         currentAdviserId: '1',
         shouldRenderTag: true,
         role: 'Role: contributing officer',
+      },
+      {
+        // The adviser field within a contributing adviser object will always
+        // be null if the export win has been migrated to Data Hub and doesn't
+        // match a Data Hub adviser.
+        exportWins: [
+          {
+            ...companyExportWin,
+            contributing_advisers: [
+              {
+                adviser: null,
+              },
+              {
+                adviser: null,
+              },
+              {
+                adviser: null,
+              },
+            ],
+          },
+        ],
+        currentAdviserId: '1',
+        shouldRenderTag: false,
       },
     ].forEach(({ exportWins, currentAdviserId, shouldRenderTag, role }) => {
       const Provider = createProvider(exportWins)


### PR DESCRIPTION
## Description of change
Fixes a `TypeError` thrown in prod around migrated export wins where the `contributing_advisers[0].adviser` field was `null` because the adviser couldn't be matched to a Data Hub adviser.

## Screenshots
`/companies/5eab1b65-664d-e411-985c-e4115bead28a/exports`

<img width="1283" alt="Screenshot 2024-10-28 at 15 46 17" src="https://github.com/user-attachments/assets/d1a59812-9a53-46d9-babf-555336b5b874">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
