### PR TITLE
Remove banner from Eyb

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -11,7 +11,6 @@ import {
   CollectionFilters,
   FilteredCollectionList,
   Filters,
-  StatusMessage,
 } from '../../../components'
 import {
   INVESTMENT_EYB_LEADS_ID,
@@ -90,14 +89,6 @@ const EYBLeadCollection = ({ filterOptions, payload, ...props }) => {
   }
   return (
     <>
-      <StatusMessage>
-        <strong>Work in progress</strong>
-        <p>
-          {' '}
-          We are working to add Expand Your Business (EYB) data to Data Hub. It
-          will be available here soon.
-        </p>
-      </StatusMessage>
       <FilteredCollectionList
         {...props}
         collectionName="EYB Lead"

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -130,12 +130,6 @@ describe('EYB leads collection page', () => {
       assertTabbedLocalNav('UK opportunities')
     })
 
-    it('should render the status message', () => {
-      cy.get('[data-test=status-message]')
-        .should('exist')
-        .should('contain', 'Work in progress')
-    })
-
     it('should render the filters', () => {
       cy.get('[data-test="company-name-filter"]').should('be.visible')
       cy.get('[data-test="sector-filter"]').should('be.visible')


### PR DESCRIPTION
## Description of change

This PR addresses to remove the banner from the EYB for launch

## Test instructions

Banner should not be on the Investments/ eyb leads Page 

## Screenshots

### Before

<img width="1425" alt="image" src="https://github.com/user-attachments/assets/3268ffa8-5758-42c7-aaf5-d2188983320e">

### After

<img width="1286" alt="image" src="https://github.com/user-attachments/assets/66133a0d-2e0d-4f39-97cb-3e9b841b0c94">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
