### PR TITLE
CLS2-1016: Company website is not a relative link

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -57,7 +57,7 @@ const EYBLeadDetails = () => {
                 {eybLead.companyWebsite ? (
                   <NewWindowLink
                     data-test="website-link"
-                    href={eybLead.companyWebsite}
+                    href={'//' + eybLead.companyWebsite}
                   >
                     {eybLead.companyWebsite}
                   </NewWindowLink>

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -96,7 +96,7 @@ describe('EYB lead details', () => {
           'have.text',
           eybLeadWithValues.company_website + ' (opens in new tab)'
         )
-        .should('have.attr', 'href', eybLeadWithValues.company_website)
+        .should('have.attr', 'href', '//' + eybLeadWithValues.company_website)
     })
 
     it('should render the superheading', () => {


### PR DESCRIPTION
## Description of change

Currently, when viewing a `Company`'s website via the `EYBLead` details page, the link is broken, as it's considered a relative path:

- current: https://datahub.trade.gov.uk/investments/eyb-leads/.../kontrolist.com
- desired: https://kontrolist.com

## Test instructions

- Ensure that the `EYBLead` has a company website url set
- Visit the `EYBLead` details page
- The company website doesn't link to an internal / relative url

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
