### PR TITLE
Refine messaging for users with no export projects

### DIFF
--- a/src/client/components/DataHubFeed/index.jsx
+++ b/src/client/components/DataHubFeed/index.jsx
@@ -23,7 +23,7 @@ const Date = styled('div')({
 
 const DataHubFeed = ({ items, feedLimit = 5 }) => (
   <FeedContainer>
-    <H3>"What's new"</H3>
+    <H3>What's new?</H3>
     {!!items.length && (
       <>
         <UnorderedList listStyleType="none">

--- a/src/client/modules/ExportPipeline/ExportList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/index.jsx
@@ -1,13 +1,12 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import { HEADING_SIZES, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
+import { HEADING_SIZES, MEDIA_QUERIES } from '@govuk-react/constants'
 import { UnorderedList, ListItem, H2, Button } from 'govuk-react'
 import styled from 'styled-components'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import qs from 'qs'
 
-import ContentWithHeading from '../../../components/ContentWithHeading'
 import { ButtonLink, Pagination } from '../../../components'
 import { MID_GREY } from '../../../utils/colours'
 import { SHOW_ALL_OPTION } from '../constants.js'
@@ -37,10 +36,8 @@ const StyledResultCount = styled('span')({
   lineHeight: 1,
 })
 
-const StyledContent = styled.div({
-  display: 'flex',
-  flexDirection: 'column',
-  rowGap: FONT_SIZE.SIZE_20,
+const StyledParagraph = styled.p({
+  marginTop: 15,
 })
 
 const FiltersContainer = styled('div')({
@@ -213,26 +210,17 @@ const ExportList = ({
           <>
             {hasZeroExports ? (
               <div data-test="no-export-items">
-                <ContentWithHeading
-                  data-test="no-export-items"
-                  heading="You have no exports"
-                >
-                  <StyledContent>
-                    <div>
-                      Here you can create an export project to track a company's
-                      export progress. These will appear on your home page, so
-                      you keep track of your exports in one place.
-                    </div>
-                    <span>To add an export:</span>
-                    <div>
-                      <UnorderedList listStyleType="bullet">
-                        <ListItem>go to the company page</ListItem>
-                        <ListItem>select 'Add export project' button</ListItem>
-                      </UnorderedList>
-                    </div>
-                  </StyledContent>
-                  <ExportWinsLink />
-                </ContentWithHeading>
+                <StyledParagraph>
+                  Here you can create an export project to track a company's
+                  export progress. These will appear on your home page, so you
+                  keep track of your exports in one place.
+                </StyledParagraph>
+                <p>To add an export:</p>
+                <UnorderedList listStyleType="bullet">
+                  <ListItem>go to the company page</ListItem>
+                  <ListItem>select 'Add export project' button</ListItem>
+                </UnorderedList>
+                <ExportWinsLink />
               </div>
             ) : (
               <ListContainer>

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -26,7 +26,7 @@ describe('Dashboard', () => {
     })
 
     it('should display the correct heading', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', '"What\'s new"')
+      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
     })
 
     it('should display the info feed list', () => {

--- a/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
+++ b/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
@@ -14,7 +14,7 @@ describe('Dashboard - Data Hub feed', () => {
     })
 
     it('Should contain a header and no updates available text', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', '"What\'s new"')
+      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
 
       cy.get('@dataHubFeed')
         .find('p')
@@ -45,7 +45,7 @@ describe('Dashboard - Data Hub feed', () => {
     })
 
     it('should display only one feed item', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', '"What\'s new"')
+      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
 
       cy.get('@dataHubFeed')
         .find('[data-test="data-hub-feed-link-0"]')

--- a/test/functional/cypress/specs/export-pipeline/list-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/list-export-spec.js
@@ -67,7 +67,6 @@ describe('Export pipeline list', () => {
     })
 
     it('should display the empty results message', () => {
-      cy.get('[data-test=no-export-items]').should('exist')
       cy.get('[data-test=export-export]').should('not.exist')
     })
   })


### PR DESCRIPTION
## Description of change
This PR improves the messaging displayed when a user has no export projects and includes some content tweaks.

## Test instructions
Go to: `/export`

## Screenshots

### Before
<img width="1193" alt="Screenshot 2024-10-30 at 12 22 15" src="https://github.com/user-attachments/assets/8be88a2f-3116-4ad9-9290-7396b2ad6ea1">

<img width="1189" alt="Screenshot 2024-11-08 at 10 38 04" src="https://github.com/user-attachments/assets/df1753f0-29bf-4145-9d1d-9d7a4748eb94">

### After
<img width="1193" alt="Screenshot 2024-10-30 at 12 20 00" src="https://github.com/user-attachments/assets/c28bde7c-c169-4bf4-85b4-fcf3060008c4">

<img width="1189" alt="Screenshot 2024-11-08 at 10 31 58" src="https://github.com/user-attachments/assets/4d9b6aee-a651-40b6-849e-966c51881e23">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
