### PR TITLE
CLS2-1015: Conditionally hide/show "Add Investment Project" button from EYB Lead

### DIFF
--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -122,24 +122,24 @@ const EYBLeadLayout = ({ id, children }) => {
                     </GridCol>
                     <GridCol setWith="one-third">
                       <StyledButtonContainer>
-                        {eybLead.company && !eybLead.investment_projects.length && (
-                          
-                          <Button
-                            as={StyledButtonLink}
-                            data-test="button-add-investment-project"
-                            href={
-                              !eybLead.company
-                                ? `/investments/projects/create`
-                                : eybLead.company.archived ||
-                                    eybLead.company.ukBased
-                                  ? null
-                                  : `/investments/projects/create/${eybLead.company.id}?eyb-lead-id=${eybLead.id}`
-                            }
-                            aria-label={`Add investment project`}
-                          >
-                            Add investment project
-                          </Button>
-                        )}
+                        {eybLead.company &&
+                          !eybLead.investmentProjects.length && (
+                            <Button
+                              as={StyledButtonLink}
+                              data-test="button-add-investment-project"
+                              href={
+                                !eybLead.company
+                                  ? `/investments/projects/create`
+                                  : eybLead.company.archived ||
+                                      eybLead.company.ukBased
+                                    ? null
+                                    : `/investments/projects/create/${eybLead.company.id}?eyb-lead-id=${eybLead.id}`
+                              }
+                              aria-label={`Add investment project`}
+                            >
+                              Add investment project
+                            </Button>
+                          )}
                       </StyledButtonContainer>
                     </GridCol>
                   </GridRow>

--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -123,7 +123,7 @@ const EYBLeadLayout = ({ id, children }) => {
                     <GridCol setWith="one-third">
                       <StyledButtonContainer>
                         {eybLead.company &&
-                          !eybLead.investmentProjects.length && (
+                          !eybLead.investmentProjects?.length && (
                             <Button
                               as={StyledButtonLink}
                               data-test="button-add-investment-project"

--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -122,7 +122,8 @@ const EYBLeadLayout = ({ id, children }) => {
                     </GridCol>
                     <GridCol setWith="one-third">
                       <StyledButtonContainer>
-                        {eybLead.company && (
+                        {eybLead.company && !eybLead.investment_projects.length && (
+                          
                           <Button
                             as={StyledButtonLink}
                             data-test="button-add-investment-project"

--- a/test/functional/cypress/fakers/eyb-leads.js
+++ b/test/functional/cypress/fakers/eyb-leads.js
@@ -115,6 +115,11 @@ const eybLeadFaker = (overrides = {}) => ({
     area: ALBERTA,
     country: CANADA,
   },
+  investment_projects: [
+    {
+      id: faker.string.uuid(),
+    },
+  ],
   ...overrides,
 })
 

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -43,6 +43,7 @@ describe('EYB lead details', () => {
       telephone_number: '01234567890',
       landing_timeframe: 'In the next 6 months',
       company_website: 'fake.website.com',
+      investment_projects: [],
     })
     beforeEach(() => {
       setup(eybLeadWithValues)

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -208,4 +208,35 @@ describe('EYB lead details', () => {
       cy.get('[data-test="button-add-investment-project"]').should('not.exist')
     })
   })
+  context(
+    'When viewing an EYB lead with company and investment projects associated',
+    () => {
+      const eybLeadWithCompanyAndInvestmentProjects = eybLeadFaker({
+        company: {
+          name: 'Mars',
+          id: 'fc752802-e454-4c7c-bbfd-4bdd84759b84',
+        },
+        investment_projects: [
+          {
+            id: 'fc752802-e454-4c7c-bbfd-4bdd84759b84',
+          },
+        ],
+      })
+      beforeEach(() => {
+        setup(eybLeadWithCompanyAndInvestmentProjects)
+        cy.visit(
+          investments.eybLeads.details(
+            eybLeadWithCompanyAndInvestmentProjects.id
+          )
+        )
+        cy.wait('@getEYBLeadDetails')
+      })
+
+      it('should not render the `Add investment project` button', () => {
+        cy.get('[data-test="button-add-investment-project"]').should(
+          'not.exist'
+        )
+      })
+    }
+  )
 })


### PR DESCRIPTION
## Description of change

Addresses [CLS2-1015](https://uktrade.atlassian.net/browse/CLS2-1015)

API counterpart: https://github.com/uktrade/data-hub-api/pull/5744

This is the frontend part of a PR that seeks to conditionally hide or show the `Add Investment Project` button on an EYB Lead page based on whether the lead already has 1 or more Investment Project(s) associated to it.

## Test instructions

- Add a EYB Lead with a Company
- View the newly created EYB Lead details page
- It **should** show the "Add Investment Project" button
- Add an Investment Project to that EYB Lead
- Refresh the EYB Lead details page
- It **should not** show the "Add Investment Project" button any longer

## Screenshots

Without Investment Project:

<img width="765" alt="Screenshot 2024-10-30 at 15 23 15" src="https://github.com/user-attachments/assets/0eb34597-7645-44b4-bf7c-04b61a650220">

With Investment Project:

<img width="765" alt="Screenshot 2024-10-30 at 15 22 55" src="https://github.com/user-attachments/assets/7becae1f-5992-4f97-8de2-0c0d2575e558">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)


[CLS2-1015]: https://uktrade.atlassian.net/browse/CLS2-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ