### PR TITLE
Implement EW migration alert banner messages

### DIFF
--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -26,6 +26,7 @@ import {
 } from '../../modules/Companies/utils'
 import { RelatedCompaniesCountResource } from '../Resource'
 import { companyState2Props } from './state'
+import { WINS_HISTORIC_ALERT_BANNER } from '../../modules/ExportWins/Status/ExportWinsTabNav'
 
 const LocalHeaderTradingNames = styled(H4)`
   font-weight: normal;
@@ -121,7 +122,7 @@ const hasManagedAccountDetails = (company) =>
 
 const CompanyLocalHeader = ({
   breadcrumbs,
-  flashMessages,
+  flashMessages = [],
   company,
   csrfToken,
 }) =>
@@ -133,7 +134,11 @@ const CompanyLocalHeader = ({
           company.id,
           company.name
         )}
-        flashMessages={flashMessages}
+        flashMessages={
+          breadcrumbs[0]?.text === 'Exports'
+            ? [[WINS_HISTORIC_ALERT_BANNER, ...flashMessages]]
+            : flashMessages
+        }
       >
         <GridRow>
           <GridCol setWidth="two-thirds">

--- a/src/client/components/CompanyLocalHeader/index.jsx
+++ b/src/client/components/CompanyLocalHeader/index.jsx
@@ -26,7 +26,6 @@ import {
 } from '../../modules/Companies/utils'
 import { RelatedCompaniesCountResource } from '../Resource'
 import { companyState2Props } from './state'
-import { WINS_HISTORIC_ALERT_BANNER } from '../../modules/ExportWins/Status/ExportWinsTabNav'
 
 const LocalHeaderTradingNames = styled(H4)`
   font-weight: normal;
@@ -122,7 +121,7 @@ const hasManagedAccountDetails = (company) =>
 
 const CompanyLocalHeader = ({
   breadcrumbs,
-  flashMessages = [],
+  flashMessages,
   company,
   csrfToken,
 }) =>
@@ -134,11 +133,7 @@ const CompanyLocalHeader = ({
           company.id,
           company.name
         )}
-        flashMessages={
-          breadcrumbs[0]?.text === 'Exports'
-            ? [[WINS_HISTORIC_ALERT_BANNER, ...flashMessages]]
-            : flashMessages
-        }
+        flashMessages={flashMessages}
       >
         <GridRow>
           <GridCol setWidth="two-thirds">

--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -21,6 +21,7 @@ import {
   transformExportCountries,
 } from './transformers'
 import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
+import { HistoricWinsAlertBanner } from '../../ExportWins/Status/ExportWinsTabNav'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin-top: 0;
@@ -41,6 +42,7 @@ const ExportsIndex = () => {
             company={company}
             breadcrumbs={[{ text: 'Exports' }]}
             pageTitle="Export"
+            flashMessages={[[HistoricWinsAlertBanner]]}
           >
             <SummaryTable
               caption="Exports"

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -22,7 +22,7 @@ import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 import SummaryStep from './SummaryStep'
 import { Form, FormLayout, DefaultLayout } from '../../../components'
-import { WINS_HISTORIC_ALERT_BANNER } from '../Status/ExportWinsTabNav'
+import { HistoricWinsAlertBanner } from '../Status/ExportWinsTabNav'
 
 const FORM_ID = 'export-win-form'
 
@@ -86,7 +86,7 @@ const ExportWinForm = ({
                   isEditing ? (
                     <>
                       <StyledParagraph>
-                        {WINS_HISTORIC_ALERT_BANNER}
+                        {HistoricWinsAlertBanner}
                       </StyledParagraph>
                       {currentStepName === steps.SUMMARY ? (
                         <>

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -4,7 +4,6 @@ import { Link } from 'govuk-react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
-import { FONT_SIZE } from '@govuk-react/constants'
 
 import FlashMessages from '../../../components/LocalHeader/FlashMessages'
 import { steps, EMAIL, STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
@@ -22,21 +21,10 @@ import { ExportWinSuccess } from './Success'
 import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 import SummaryStep from './SummaryStep'
-import {
-  Form,
-  FormLayout,
-  DefaultLayout,
-  StatusMessage,
-} from '../../../components'
+import { Form, FormLayout, DefaultLayout } from '../../../components'
+import { WINS_HISTORIC_ALERT_BANNER } from '../Status/ExportWinsTabNav'
 
 const FORM_ID = 'export-win-form'
-
-const StyledStatusMessage = styled(StatusMessage)({
-  fontSize: FONT_SIZE.SIZE_20,
-  fontWeight: 700,
-  marginTop: 25,
-  marginBottom: 5,
-})
 
 const StyledParagraph = styled('p')({
   fontWeight: 'bold',
@@ -93,6 +81,28 @@ const ExportWinForm = ({
               heading={heading}
               subheading={subheading}
               breadcrumbs={breadcrumbs}
+              flashMessages={[
+                [
+                  isEditing ? (
+                    <>
+                      <StyledParagraph>
+                        {WINS_HISTORIC_ALERT_BANNER}
+                      </StyledParagraph>
+                      {currentStepName === steps.SUMMARY ? (
+                        <>
+                          <StyledParagraph>
+                            To edit an export win: edit each section that needs
+                            changing then return to the summary page. When you
+                            are happy with all the changes save the page.
+                          </StyledParagraph>
+                        </>
+                      ) : excludedStepFields ? (
+                        <ContactLink sections={excludedStepFields} />
+                      ) : null}
+                    </>
+                  ) : null,
+                ],
+              ]}
               localHeaderChildren={
                 isEditing ? (
                   currentStepName === steps.SUMMARY ? (
@@ -104,24 +114,12 @@ const ExportWinForm = ({
                           }}
                         />
                       )}
-                      <StyledStatusMessage>
-                        <StyledParagraph>To edit an export win</StyledParagraph>
-                        <StyledParagraph>
-                          Edit each section that needs changing then return to
-                          the summary page. When you are happy with all the
-                          changes save the page.
-                        </StyledParagraph>
-                      </StyledStatusMessage>
                       {winStatus === WIN_STATUS.PENDING && (
                         <ResentExportWinContainer>
                           <ResendExportWin id={exportWinId} />
                         </ResentExportWinContainer>
                       )}
                     </>
-                  ) : excludedStepFields ? (
-                    <StyledStatusMessage>
-                      <ContactLink sections={excludedStepFields} />
-                    </StyledStatusMessage>
                   ) : null
                 ) : null
               }

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -53,6 +53,7 @@ export const bothGoodsAndServices = {
 }
 
 export const STEP_TO_EXCLUDED_FIELDS_MAP = {
+  [steps.OFFICER_DETAILS]: ['lead officer name.'],
   [steps.CUSTOMER_DETAILS]: ['export experience.'],
   [steps.WIN_DETAILS]: [
     'summary of the support given',

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -53,13 +53,12 @@ export const bothGoodsAndServices = {
 }
 
 export const STEP_TO_EXCLUDED_FIELDS_MAP = {
-  [steps.OFFICER_DETAILS]: ['Lead officer name'],
-  [steps.CUSTOMER_DETAILS]: ['Export experience'],
+  [steps.CUSTOMER_DETAILS]: ['export experience.'],
   [steps.WIN_DETAILS]: [
-    'Summary of the support given',
-    'Destination country',
-    'Date won',
-    'Type of win and Value',
+    'summary of the support given',
+    'destination country',
+    'date won',
+    'type of win and value.',
   ],
 }
 

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -9,21 +9,21 @@ import WinsRejectedList from './WinsRejectedList'
 import WinsPendingList from './WinsPendingList'
 import WinsConfirmedList from './WinsConfirmedList'
 import urls from '../../../../lib/urls'
-import { HISTORIC_ALERT_MESSAGE } from './constants'
+import { HISTORIC_WINS_ALERT_MESSAGE } from './constants'
 
 const LAST_WORD = /([^\/]+)$/
 
-export const WINS_HISTORIC_ALERT_BANNER = (
+export const HistoricWinsAlertBanner = (
   <>
-    {[HISTORIC_ALERT_MESSAGE.ELEMENT].concat(' ')}
+    {[HISTORIC_WINS_ALERT_MESSAGE.ELEMENT].concat(' ')}
     {[
       <Link
-        href={HISTORIC_ALERT_MESSAGE.URI_LINK}
+        href={HISTORIC_WINS_ALERT_MESSAGE.URI_LINK}
         target="_blank"
         rel="noopener noreferrer"
         aria-label="Find out more about historic wins moved to Data Hub"
       >
-        {HISTORIC_ALERT_MESSAGE.URI_ELEMENT}
+        {HISTORIC_WINS_ALERT_MESSAGE.URI_ELEMENT}
       </Link>,
     ].concat('.')}
   </>
@@ -46,7 +46,7 @@ const ExportWinsTabNav = () => {
         },
         { text: capitalize(title) },
       ]}
-      flashMessages={[[WINS_HISTORIC_ALERT_BANNER]]}
+      flashMessages={[[HistoricWinsAlertBanner]]}
     >
       <TabNav
         id="exportwins-tab-nav"

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { capitalize } from 'lodash'
+import { Link } from 'govuk-react'
 
 import { DefaultLayout } from '../../../components'
 import TabNav from '../../../components/TabNav'
@@ -8,8 +9,25 @@ import WinsRejectedList from './WinsRejectedList'
 import WinsPendingList from './WinsPendingList'
 import WinsConfirmedList from './WinsConfirmedList'
 import urls from '../../../../lib/urls'
+import { HISTORIC_ALERT_MESSAGE } from './constants'
 
 const LAST_WORD = /([^\/]+)$/
+
+export const WINS_HISTORIC_ALERT_BANNER = (
+  <>
+    {[HISTORIC_ALERT_MESSAGE.ELEMENT].concat(' ')}
+    {[
+      <Link
+        href={HISTORIC_ALERT_MESSAGE.URI_LINK}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Find out more about historic wins moved to Data Hub"
+      >
+        {HISTORIC_ALERT_MESSAGE.URI_ELEMENT}
+      </Link>,
+    ].concat('.')}
+  </>
+)
 
 const ExportWinsTabNav = () => {
   const location = useLocation()
@@ -28,6 +46,7 @@ const ExportWinsTabNav = () => {
         },
         { text: capitalize(title) },
       ]}
+      flashMessages={[[WINS_HISTORIC_ALERT_BANNER]]}
     >
       <TabNav
         id="exportwins-tab-nav"

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -22,3 +22,10 @@ export const ADVISER_ROLES = {
   TEAM_MEMBER: 'team member',
   CONTRIBUTING_OFFICER: 'contributing officer',
 }
+
+export const HISTORIC_ALERT_MESSAGE = {
+  ELEMENT: 'Historic export wins have now moved to Data Hub,',
+  URI_ELEMENT: 'see the export wins announcement',
+  URI_LINK:
+    'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/historic-export-wins-are-now-on-data-hub/',
+}

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -23,7 +23,7 @@ export const ADVISER_ROLES = {
   CONTRIBUTING_OFFICER: 'contributing officer',
 }
 
-export const HISTORIC_ALERT_MESSAGE = {
+export const HISTORIC_WINS_ALERT_MESSAGE = {
   ELEMENT: 'Historic export wins have now moved to Data Hub,',
   URI_ELEMENT: 'see the export wins announcement',
   URI_LINK:

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -1,6 +1,9 @@
 const { company } = require('../../../fixtures')
 const { assertBreadcrumbs } = require('../../../support/assertions')
 const urls = require('../../../../../../src/lib/urls')
+const {
+  assertHistoricExportWinsMessage,
+} = require('../../export-win/edit-export-win-pending-spec.js')
 
 describe('Company Export tab', () => {
   function assertTable({ rows, caption, action }) {
@@ -65,6 +68,10 @@ describe('Company Export tab', () => {
           [company.dnbCorp.name]: urls.companies.detail(company.dnbCorp.id),
           Exports: null,
         })
+      })
+
+      it('should render historic export win banner message', () => {
+        assertHistoricExportWinsMessage()
       })
 
       it('should render the "Exports" table', () => {
@@ -190,4 +197,28 @@ describe('Company Export tab', () => {
         .should('not.exist')
     })
   })
+})
+
+describe("Other Company tabs - should't be shown banner message in the other tabs", () => {
+  ;[
+    'overview',
+    'activity',
+    'business-details',
+    'contacts',
+    'account-management',
+    'investments/projects',
+    'orders',
+  ].forEach((slug) =>
+    it(slug, () => {
+      cy.visit(`/companies/${company.dnbCorp.id}/${slug}`)
+
+      // We need to wait for company name appear...
+      cy.contains(company.dnbCorp.name)
+
+      // ...so that this waits for whent the data has been loaded and rendered
+      cy.contains('Historic export wins have now moved to Data Hub').should(
+        'not.exist'
+      )
+    })
+  )
 })

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -198,27 +198,3 @@ describe('Company Export tab', () => {
     })
   })
 })
-
-describe("Other Company tabs - should't be shown banner message in the other tabs", () => {
-  ;[
-    'overview',
-    'activity',
-    'business-details',
-    'contacts',
-    'account-management',
-    'investments/projects',
-    'orders',
-  ].forEach((slug) =>
-    it(slug, () => {
-      cy.visit(`/companies/${company.dnbCorp.id}/${slug}`)
-
-      // We need to wait for company name appear...
-      cy.contains(company.dnbCorp.name)
-
-      // ...so that this waits for whent the data has been loaded and rendered
-      cy.contains('Historic export wins have now moved to Data Hub').should(
-        'not.exist'
-      )
-    })
-  )
-})

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -1,8 +1,40 @@
 import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
 import { company, formFields } from './constants'
+import { HISTORIC_ALERT_MESSAGE } from '../../../../../src/client/modules/ExportWins/Status/constants'
 
 const exportWin = exportWinsFaker()
+
+export const assertHistoricExportWinsMessage = () => {
+  cy.get('[data-test="status-message"]')
+    .should('contain', HISTORIC_ALERT_MESSAGE.ELEMENT)
+    .should('contain.text', HISTORIC_ALERT_MESSAGE.URI_ELEMENT)
+    .find('a')
+    .should('have.attr', 'href', HISTORIC_ALERT_MESSAGE.URI_LINK)
+}
+
+const assertCustomerDetailsMessage = () => {
+  cy.get('[data-test="status-message"]').should(
+    'contain.text',
+    'Contact exportwins@businessandtrade.gov.uk if you need to update the section: export experience.'
+  )
+}
+
+const assertWinDetailsMessage = () => {
+  cy.get('[data-test="status-message"]').should(
+    'contain.text',
+    'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
+      'summary of the support given, destination country, date won, type of win and value.'
+  )
+}
+
+const assertSummaryMessage = () => {
+  cy.get('[data-test="status-message"]').should(
+    'contain.text',
+    'To edit an export win: edit each section that needs changing then return to the summary page. ' +
+      'When you are happy with all the changes save the page.'
+  )
+}
 
 describe('Editing a pending export win', () => {
   beforeEach(() => {
@@ -41,10 +73,7 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editOfficerDetails(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
-      cy.get('[data-test="status-message"]').should(
-        'have.text',
-        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: Lead officer name'
-      )
+      assertHistoricExportWinsMessage()
     })
   })
 
@@ -54,7 +83,7 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editCreditForThisWin(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
-      cy.get('[data-test="status-message"]').should('not.exist')
+      assertHistoricExportWinsMessage()
     })
   })
 
@@ -67,12 +96,8 @@ describe('Editing a pending export win', () => {
     })
 
     it('should render an edit status message', () => {
-      cy.get('[data-test="status-message"]')
-        .should('exist')
-        .should(
-          'have.text',
-          'Contact exportwins@businessandtrade.gov.uk if you need to update the section: Export experience'
-        )
+      assertHistoricExportWinsMessage()
+      assertCustomerDetailsMessage()
     })
 
     it('should not render Export experience', () => {
@@ -91,13 +116,8 @@ describe('Editing a pending export win', () => {
     })
 
     it('should render an edit status message', () => {
-      cy.get('[data-test="status-message"]')
-        .should('exist')
-        .should(
-          'have.text',
-          'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-            'Summary of the support given, Destination country, Date won, Type of win and Value'
-        )
+      assertHistoricExportWinsMessage()
+      assertWinDetailsMessage()
     })
 
     it('should not render a hint', () => {
@@ -137,7 +157,8 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editSupportProvided(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin'])
-      cy.get('[data-test="status-message"]').should('not.exist')
+      cy.get('[data-test="status-message"]')
+      assertHistoricExportWinsMessage()
     })
   })
 
@@ -145,12 +166,8 @@ describe('Editing a pending export win', () => {
     it('should render an edit status message', () => {
       cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
-      cy.get('[data-test="status-message"]').should(
-        'contain',
-        'To edit an export win' +
-          'Edit each section that needs changing then return to the summary page. ' +
-          'When you are happy with all the changes save the page.'
-      )
+      assertHistoricExportWinsMessage()
+      assertSummaryMessage()
     })
 
     it('should render a lead officer name contact link', () => {
@@ -249,7 +266,7 @@ describe('Editing a pending export win', () => {
       cy.get('[data-test="resend-export-win"]').click()
       cy.wait('@apiResendExportWin')
       cy.get('[data-test="flash"]').should(
-        'have.text',
+        'contain.text',
         `The export win ${exportWin.name_of_export} to ${exportWin.country.name} has been sent to ${exportWin.company_contacts[0].email} for review and confirmation.`
       )
     })

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -20,6 +20,13 @@ const assertCustomerDetailsMessage = () => {
   )
 }
 
+const assertLeadOfficerDetailsMessage = () => {
+  cy.get('[data-test="status-message"]').should(
+    'contain.text',
+    'Contact exportwins@businessandtrade.gov.uk if you need to update the section: lead officer name.'
+  )
+}
+
 const assertWinDetailsMessage = () => {
   cy.get('[data-test="status-message"]').should(
     'contain.text',
@@ -74,6 +81,7 @@ describe('Editing a pending export win', () => {
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
       assertHistoricExportWinsMessage()
+      assertLeadOfficerDetailsMessage()
     })
   })
 

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -1,16 +1,16 @@
 import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
 import { company, formFields } from './constants'
-import { HISTORIC_ALERT_MESSAGE } from '../../../../../src/client/modules/ExportWins/Status/constants'
+import { HISTORIC_WINS_ALERT_MESSAGE } from '../../../../../src/client/modules/ExportWins/Status/constants'
 
 const exportWin = exportWinsFaker()
 
 export const assertHistoricExportWinsMessage = () => {
   cy.get('[data-test="status-message"]')
-    .should('contain', HISTORIC_ALERT_MESSAGE.ELEMENT)
-    .should('contain.text', HISTORIC_ALERT_MESSAGE.URI_ELEMENT)
+    .should('contain', HISTORIC_WINS_ALERT_MESSAGE.ELEMENT)
+    .should('contain.text', HISTORIC_WINS_ALERT_MESSAGE.URI_ELEMENT)
     .find('a')
-    .should('have.attr', 'href', HISTORIC_ALERT_MESSAGE.URI_LINK)
+    .should('have.attr', 'href', HISTORIC_WINS_ALERT_MESSAGE.URI_LINK)
 }
 
 const assertCustomerDetailsMessage = () => {


### PR DESCRIPTION
## Description of change

This PR is a consolidated implementation of Export wins migration alert banner message(see related tickets).
It will shown a flash messages on the top of local header for Pending, Confirmed and Rejected tab. Also, it tells the instruction to modify each sections of the form.

In addition, ticket https://uktrade.atlassian.net/browse/EGTB-1526 with PR https://github.com/uktrade/data-hub-frontend/pull/7184 also consolidated into this PR to unify in one implementation.

Mural design: https://app.mural.co/t/departmentforbusinessandtrad1574/m/departmentforbusinessandtrad1574/1719843845967/af61127b5d7ad8b8ef5587b9cd9ced47f3dedc90

Related tickets:
https://uktrade.atlassian.net/browse/EGTB-1526
https://uktrade.atlassian.net/browse/EGTB-1527
https://uktrade.atlassian.net/browse/EGTB-1528
https://uktrade.atlassian.net/browse/EGTB-1529



## Test instructions

- Navigate into `http:://localhost:3000/exportwins/` select `Pending`, `Confirmed` or `Rejected`.
- Choose any Wins on the list and shown an appropriate alert banner message for export win summary, edit officer details, edit credit for this win, edit customer details, win details and support given form section. 


## Screenshots

### Before
- **Export Wins main dashboard**
![image](https://github.com/user-attachments/assets/48db0848-fdb8-4534-a04d-3242779dc282)
- **Pending Export Win** 
![image](https://github.com/user-attachments/assets/26518383-2e03-47c1-9634-771a4f25f05a)


### After

- **Export Wins main dashboard**
![image](https://github.com/user-attachments/assets/48c97319-0564-4e44-9751-6859b0f697c7)

- **Pending Export Win - Summary**
![image](https://github.com/user-attachments/assets/56b99c97-ce9d-42e1-87c7-669b827459e2)

- **Pending Export Win - Officer details**
![image](https://github.com/user-attachments/assets/c3f281c3-e5e8-43dc-80bb-661b84361d77)

- **Pending Customer details**
![image](https://github.com/user-attachments/assets/779f933a-b68b-4895-b541-fc5e4c66fdb7)

- **Pending Win details**
![image](https://github.com/user-attachments/assets/0f8f3178-8e66-41cb-8bc3-0c056950c169)



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
