### PR TITLE
Filter out disabled export experience options 

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -38,6 +38,7 @@ import { validateTeamMembers } from './validation'
 import { STATUS_OPTIONS, EXPORT_POTENTIAL_OPTIONS } from '../constants'
 import { ERROR_MESSAGES, POSITIVE_INT_REGEX } from './constants'
 import { FORM_LAYOUT } from '../../../../common/constants'
+import { idNamesToValueLabels } from '../../../utils'
 
 export const isPositiveInteger = (value) => POSITIVE_INT_REGEX.test(value)
 
@@ -205,6 +206,11 @@ const ExportFormFields = ({
                   field={FieldRadios}
                   name="exporter_experience"
                   label="Exporter experience (optional)"
+                  resultToOptions={(result) =>
+                    idNamesToValueLabels(
+                      result.filter((option) => !option.disabledOn)
+                    )
+                  }
                 />
                 <FieldTextarea
                   name="notes"

--- a/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/CustomerDetailsStep.jsx
@@ -70,6 +70,9 @@ const CustomerDetailsStep = ({ companyId, isEditing }) => (
         label="Export experience"
         required="Select export experience"
         hint="Your customer will be asked to confirm this information."
+        resultToOptions={(result) =>
+          idNamesToValueLabels(result.filter((option) => !option.disabledOn))
+        }
       />
     )}
   </Step>

--- a/test/functional/cypress/fakers/constants.js
+++ b/test/functional/cypress/fakers/constants.js
@@ -94,6 +94,18 @@ export const EXPORTER_EXPERIENCE = [
     order: 40,
     name: 'An exporter that DBT are helping maintain and grow their exports',
   },
+  {
+    id: 'd23012c5-c1a6-459d-9e05-b3d1b8539025',
+    order: 1040,
+    disabled_on: '2018-06-20T10:19:43Z',
+    name: 'Is an exporter but exports currently account for less than 10% of its overall turnover',
+  },
+  {
+    id: '9390cc45-6ebb-4005-866c-c87fd6d6dec0',
+    order: 1080,
+    disabled_on: '2018-06-20T10:19:43Z',
+    name: 'Is an exporter but has only won export orders in three countries or fewer',
+  },
 ]
 
 export const HEADQUARTER_TYPE = [

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -26,6 +26,7 @@ const {
   assertTypeaheadValues,
   assertFieldDateShort,
   assertPayload,
+  assertFieldRadiosStrict,
   assertTypeaheadOptionSelected,
 } = require('../../support/assertions')
 const {
@@ -72,6 +73,11 @@ describe('Export pipeline edit', () => {
     const exportItem = exportFaker({
       sector: sectors[0],
       destination_country: countries[0],
+      exporter_experience: {
+        id: '8937c359-157e-41dd-8520-679383847ea0',
+        order: 20,
+        name: 'Exported in the last 12 months, but has not won an export order by having an export plan',
+      },
     })
     const editPageUrl = urls.exportPipeline.edit(exportItem.id)
 
@@ -200,13 +206,17 @@ describe('Export pipeline edit', () => {
           '[data-test="field-contacts"]',
           exportItem.contacts.map((t) => t.name)
         )
-        cy.get('[data-test="field-exporter_experience"]').then((element) => {
-          assertFieldRadios({
-            element,
-            label: 'Exporter experience (optional)',
-            optionsCount: 5,
-            value: exportItem.exporter_experience.name,
-          })
+        assertFieldRadiosStrict({
+          inputName: 'exporter_experience',
+          legend: 'Exporter experience (optional)',
+          options: [
+            'Never exported',
+            'Exported before, but no exports in the last 12 months',
+            'Exported in the last 12 months, but has not won an export order by having an export plan',
+            'An exporter with a new export win, but has not exported to this country within the last 3 years',
+            'An exporter that DBT are helping maintain and grow their exports',
+          ],
+          selectedIndex: 2,
         })
         cy.get('[data-test="field-notes"]').then((element) => {
           assertFieldTextarea({

--- a/test/sandbox/fixtures/v4/export/export-experience.json
+++ b/test/sandbox/fixtures/v4/export/export-experience.json
@@ -23,5 +23,17 @@
     "id": "02a063e3-dab8-40ca-92d3-8e9c2d9f812d",
     "order": 40,
     "name": "An exporter that DBT are helping maintain and grow their exports"
+  },
+  {
+    "id": "d23012c5-c1a6-459d-9e05-b3d1b8539025",
+    "order": 1040,
+    "disabled_on": "2018-06-20T10:19:43Z",
+    "name": "Is an exporter but exports currently account for less than 10% of its overall turnover"
+  },
+  {
+    "id": "9390cc45-6ebb-4005-866c-c87fd6d6dec0",
+    "order": 1080,
+    "disabled_on": "2018-06-20T10:19:43Z",
+    "name": "Is an exporter but has only won export orders in three countries or fewer"
   }
 ]


### PR DESCRIPTION
## Description of change
Filter out all export experience metadata options that have the `disabled_on` field set. This applies to both export projects and export wins.

The PR must be deployed to production in tandem with this [API PR](https://github.com/uktrade/data-hub-api/pull/5765), as both need to be live simultaneously.

## Test instructions
Both the FE commit and the BE commit have been deployed to UAT.

**Export projects**
Go to: `/export/create?companyId=<company-uuid>`  and scroll down to **Exporter experience**. Here you should only see 5 radio buttons, not 7.

**Export  wins**
Go to: `/companies/<company-uuid>/exportwins/create?step=customer_details`  and scroll down to **Exporter experience**. Again, you should only see 5 radio buttons.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
