### PR TITLE
Replace references to 'Digital Workspace' with 'the Intranet'

### DIFF
--- a/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
@@ -82,7 +82,7 @@ const StepReferralDetails = ({
               This can be an adviser at post, a sector specialist or an{' '}
               international trade advisor. If you're not sure, you can{' '}
               <NewWindowLink href="https://people.trade.gov.uk/teams/department-for-international-trade">
-                find the right team and person on Digital Workspace
+                find the right team and person on the Intranet
               </NewWindowLink>
               .
             </>

--- a/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/send-referral/client/StepReferralDetails.jsx
@@ -81,7 +81,7 @@ const StepReferralDetails = ({
             <>
               This can be an adviser at post, a sector specialist or an{' '}
               international trade advisor. If you're not sure, you can{' '}
-              <NewWindowLink href="https://people.trade.gov.uk/teams/department-for-international-trade">
+              <NewWindowLink href={urls.external.intranet.teams}>
                 find the right team and person on the Intranet
               </NewWindowLink>
               .

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -50,7 +50,7 @@ const getFlashMessage = (interactionId, wasPolicyFeedbackProvided) => {
       const body = [
         'Thanks for submitting business intelligence (BI), which feeds into the Business Intelligence Unit’s reports. If they need more information, they will contact you.',
         '',
-        'For more on the value of BI, <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/business-intelligence-reports/" rel="noopener noreferrer" target="_blank">See the Digital Workspace article (opens in new tab)</a>',
+        'For more on the value of BI, <a href="https://workspace.trade.gov.uk/working-at-dit/policies-and-guidance/business-intelligence-reports/" rel="noopener noreferrer" target="_blank">See the Intranet article (opens in new tab)</a>',
       ].join('<br />')
       return ['Interaction created', body]
     } else {

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -293,9 +293,7 @@ const AccountManagement = ({ permissions }) => {
             >
               For more information, or if you need to change the One List tier
               or account management team for this company, go to the{' '}
-              <NewWindowLink
-                href={urls.external.digitalWorkspace.accountManagement}
-              >
+              <NewWindowLink href={urls.external.intranet.accountManagement}>
                 Intranet
               </NewWindowLink>{' '}
               or email{' '}

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -296,7 +296,7 @@ const AccountManagement = ({ permissions }) => {
               <NewWindowLink
                 href={urls.external.digitalWorkspace.accountManagement}
               >
-                Digital Workspace
+                Intranet
               </NewWindowLink>{' '}
               or email{' '}
               <Link href={`mailto:${ONE_LIST_EMAIL}`}>{ONE_LIST_EMAIL}</Link>

--- a/src/client/modules/Companies/Referrals/Help/ReferralHelp.jsx
+++ b/src/client/modules/Companies/Referrals/Help/ReferralHelp.jsx
@@ -75,7 +75,7 @@ export default connect(state2props)(({ company, sendingAdviser }) => {
             <p>
               Or{' '}
               <NewWindowLink href={urls.external.digitalWorkspace.teams}>
-                find their contact details on Digital Workspace
+                find their contact details on the Intranet
               </NewWindowLink>
             </p>
             <H2 size={LEVEL_SIZE[3]}>I'm not the right adviser for this</H2>

--- a/src/client/modules/Companies/Referrals/Help/ReferralHelp.jsx
+++ b/src/client/modules/Companies/Referrals/Help/ReferralHelp.jsx
@@ -74,7 +74,7 @@ export default connect(state2props)(({ company, sendingAdviser }) => {
             </p>
             <p>
               Or{' '}
-              <NewWindowLink href={urls.external.digitalWorkspace.teams}>
+              <NewWindowLink href={urls.external.intranet.teams}>
                 find their contact details on the Intranet
               </NewWindowLink>
             </p>

--- a/src/client/modules/Investments/Projects/Team/GlobalAccountManagerDetails.jsx
+++ b/src/client/modules/Investments/Projects/Team/GlobalAccountManagerDetails.jsx
@@ -32,7 +32,7 @@ const GlobalAccountManagerDetails = ({ oneListEmail, companyId }) => (
           <NewWindowLink
             href={urls.external.digitalWorkspace.accountManagement}
           >
-            Digital Workspace
+            Intranet
           </NewWindowLink>
           {' or '}
           {oneListEmail && (

--- a/src/client/modules/Investments/Projects/Team/GlobalAccountManagerDetails.jsx
+++ b/src/client/modules/Investments/Projects/Team/GlobalAccountManagerDetails.jsx
@@ -29,9 +29,7 @@ const GlobalAccountManagerDetails = ({ oneListEmail, companyId }) => (
         >
           If you need to change the Global Account Manager for this company, go
           to the{' '}
-          <NewWindowLink
-            href={urls.external.digitalWorkspace.accountManagement}
-          >
+          <NewWindowLink href={urls.external.intranet.accountManagement}>
             Intranet
           </NewWindowLink>
           {' or '}

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -100,7 +100,7 @@ module.exports = {
       privacyPolicy: 'https://www.great.gov.uk/uk/privacy-policy/',
     },
     govUkHomepage: 'https://www.gov.uk/',
-    digitalWorkspace: {
+    intranet: {
       teams:
         'https://people.trade.gov.uk/teams/department-for-international-trade',
       accountManagement:

--- a/test/component/cypress/specs/Referrals/StepReferralDetails.cy.jsx
+++ b/test/component/cypress/specs/Referrals/StepReferralDetails.cy.jsx
@@ -67,7 +67,7 @@ describe('StepReferralDetails component', () => {
             element,
             label: 'Adviser',
             placeholder: 'Search for an adviser',
-            hint: "This can be an adviser at post, a sector specialist or an international trade advisor. If you're not sure, you can find the right team and person on Digital Workspace (opens in new tab).",
+            hint: "This can be an adviser at post, a sector specialist or an international trade advisor. If you're not sure, you can find the right team and person on the Intranet (opens in new tab).",
           })
         })
 

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -323,7 +323,7 @@ describe('One List core team', () => {
         .click()
         .should('exist')
         .contains(
-          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in new tab) or email'
+          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Intranet (opens in new tab) or email'
         )
     })
   })

--- a/test/functional/cypress/specs/companies/core-team-spec.js
+++ b/test/functional/cypress/specs/companies/core-team-spec.js
@@ -83,7 +83,7 @@ describe('One List core team', () => {
         .click()
         .should('exist')
         .contains(
-          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Digital Workspace (opens in new tab) or email'
+          'Need to find out more, or edit the One List tier information?For more information, or if you need to change the One List tier or account management team for this company, go to the Intranet (opens in new tab) or email'
         )
     })
   })

--- a/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
@@ -41,7 +41,7 @@ describe('Referral help', () => {
         .next()
         .should(
           'contain',
-          'Or find their contact details on Digital Workspace (opens in new tab)'
+          'Or find their contact details on the Intranet (opens in new tab)'
         )
         .next()
         .should('have.prop', 'tagName', 'H2')
@@ -66,8 +66,8 @@ describe('Referral help', () => {
         .should('contain', 'Back to the referral')
     })
 
-    it("should link to digital workspace's people finder", () => {
-      cy.contains('Digital Workspace').should(
+    it('should link to people finder', () => {
+      cy.contains('Intranet').should(
         'have.attr',
         'href',
         urls.external.digitalWorkspace.teams

--- a/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
+++ b/test/functional/cypress/specs/companies/referrals/referral-help-spec.js
@@ -70,7 +70,7 @@ describe('Referral help', () => {
       cy.contains('Intranet').should(
         'have.attr',
         'href',
-        urls.external.digitalWorkspace.teams
+        urls.external.intranet.teams
       )
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
@@ -86,13 +86,13 @@ describe('Edit client relationship management page', () => {
     it('should render the hidden help text with visually hidden text for screen reader', () => {
       cy.get('[data-test="global-account-manager-links"]').click()
       cy.contains(
-        'If you need to change the Global Account Manager for this company, go to the Digital Workspace (opens in new tab) or opens email client for'
+        'If you need to change the Global Account Manager for this company, go to the Intranet (opens in new tab) or opens email client for'
       )
     })
 
-    it('should always have a Digital Workspace link', () => {
+    it('should always have an Intranet link', () => {
       cy.get('[data-test="newWindowLink"]')
-        .should('contain', 'Digital Workspace (opens in new tab)')
+        .should('contain', 'Intranet (opens in new tab)')
         .should(
           'have.attr',
           'href',

--- a/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-client-relationship-management-spec.js
@@ -93,11 +93,7 @@ describe('Edit client relationship management page', () => {
     it('should always have an Intranet link', () => {
       cy.get('[data-test="newWindowLink"]')
         .should('contain', 'Intranet (opens in new tab)')
-        .should(
-          'have.attr',
-          'href',
-          urls.external.digitalWorkspace.accountManagement
-        )
+        .should('have.attr', 'href', urls.external.intranet.accountManagement)
     })
   })
 


### PR DESCRIPTION
## Description of change

Now that Digital Workspace has been renamed to the Intranet, we need to update all references to use the new name. I've also renamed the URL object to avoid confusion (the URLs themselves have not changed).

## Test instructions

Pages referencing Digital Workspace should use the new name

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
