### PR TITLE
Bump date-fns to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "core-js": "^3.39.0",
         "css-loader": "^7.1.1",
         "csurf": "^1.11.0",
-        "date-fns": "^2.30.0",
+        "date-fns": "^4.1.0",
         "del-cli": "^6.0.0",
         "dotenv": "^16.4.4",
         "elastic-apm-node": "^4.8.1",
@@ -10831,18 +10831,12 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/dayjs": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "core-js": "^3.39.0",
     "css-loader": "^7.1.1",
     "csurf": "^1.11.0",
-    "date-fns": "^2.30.0",
+    "date-fns": "^4.1.0",
     "del-cli": "^6.0.0",
     "dotenv": "^16.4.4",
     "elastic-apm-node": "^4.8.1",

--- a/src/client/components/ContactLocalHeader/index.jsx
+++ b/src/client/components/ContactLocalHeader/index.jsx
@@ -100,8 +100,8 @@ const ContactLocalHeader = ({ contact, writeFlashMessage }) => {
         </GridRow>
         {contact.archived && (
           <ArchivePanel
-            archivedBy={contact.archivedBy}
-            archivedOn={contact.archivedOn}
+            archivedBy={contact.archivedBy ? contact.archivedBy : ''}
+            archivedOn={contact.archivedOn ? contact.archivedOn : ''}
             archiveReason={contact.archivedReason}
             unarchiveUrl={urls.contacts.unarchive(contact.id)}
             onClick={() => {

--- a/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
@@ -4,7 +4,7 @@ import { Link, Table } from 'govuk-react'
 
 import styled from 'styled-components'
 
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 import urls from '../../../../lib/urls'
 import { STATUS } from '../../../modules/Tasks/TaskForm/constants'
 
@@ -32,7 +32,11 @@ const header = (
 const rows = ({ results }) => {
   return results.map((task, index) => (
     <Table.Row key={`task_row_${index}`} data-test="task-item">
-      <Table.Cell setWidth="12%">{formatMediumDate(task.due_date)}</Table.Cell>
+      <Table.Cell setWidth="12%">
+        {task.due_date
+          ? formatMediumDateParsed(task.due_date)
+          : formatMediumDateParsed(task.dueDate)}
+      </Table.Cell>
       <Table.Cell setWidth="23%">
         <Link
           href={urls.tasks.details(task.id)}

--- a/src/client/components/Form/validators.js
+++ b/src/client/components/Form/validators.js
@@ -1,4 +1,4 @@
-import { isDateInFuture } from '../../utils/date'
+import { isDateInFutureParsed } from '../../utils/date'
 import { transformDateObjectToDateString } from '../../transformers'
 
 const EMAIL_PATTERN =
@@ -14,7 +14,12 @@ export const email = (x) =>
 export const number = (x, errorMessage) =>
   !x || IS_NUMBER.test(x) ? null : errorMessage
 
-export const validateIfDateInPast = (values) =>
-  isDateInFuture(transformDateObjectToDateString(values))
-    ? 'Actual land date cannot be in the future'
+export const validateIfDateInPast = (date) => {
+  const transformedDate = transformDateObjectToDateString(date)
+
+  return transformedDate
+    ? isDateInFutureParsed(transformedDate)
+      ? 'Actual land date cannot be in the future'
+      : null
     : null
+}

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -83,7 +83,7 @@ const InvestmentProjectLocalHeader = ({ investment }) => (
         {investment.valueComplete ? 'Project valued' : 'Not yet valued'}
       </MetaListItem>
       <MetaListItem text="Created on">
-        {formatMediumDateTime(investment.createdOn)}
+        {investment.createdOn ? formatMediumDateTime(investment.createdOn) : ''}
       </MetaListItem>
       {investment.createdBy?.ditTeam?.name && (
         <MetaListItem text="Created by">

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -6,7 +6,7 @@ import { kebabCase, upperFirst } from 'lodash'
 
 import Timeline from '../Timeline'
 
-import { formatMediumDateTimeWithoutParsing } from '../../utils/date'
+import { formatMediumDateTime } from '../../utils/date'
 import timelineTheme from './timeline-theme'
 import urls from '../../../lib/urls'
 import { INVESTMENT_PROJECT_STAGES } from '../../modules/Investments/Projects/constants'
@@ -83,7 +83,7 @@ const InvestmentProjectLocalHeader = ({ investment }) => (
         {investment.valueComplete ? 'Project valued' : 'Not yet valued'}
       </MetaListItem>
       <MetaListItem text="Created on">
-        {formatMediumDateTimeWithoutParsing(investment.createdOn)}
+        {formatMediumDateTime(investment.createdOn)}
       </MetaListItem>
       {investment.createdBy?.ditTeam?.name && (
         <MetaListItem text="Created by">

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -6,7 +6,7 @@ import { kebabCase, upperFirst } from 'lodash'
 
 import Timeline from '../Timeline'
 
-import { formatMediumDateTime } from '../../utils/date'
+import { formatMediumDateTimeWithoutParsing } from '../../utils/date'
 import timelineTheme from './timeline-theme'
 import urls from '../../../lib/urls'
 import { INVESTMENT_PROJECT_STAGES } from '../../modules/Investments/Projects/constants'
@@ -83,7 +83,7 @@ const InvestmentProjectLocalHeader = ({ investment }) => (
         {investment.valueComplete ? 'Project valued' : 'Not yet valued'}
       </MetaListItem>
       <MetaListItem text="Created on">
-        {formatMediumDateTime(investment.createdOn)}
+        {formatMediumDateTimeWithoutParsing(investment.createdOn)}
       </MetaListItem>
       {investment.createdBy?.ditTeam?.name && (
         <MetaListItem text="Created by">

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
@@ -1,6 +1,9 @@
 import { isBoolean, isNumber } from 'lodash'
 
-import { formatMediumDateTime, isDateValid } from '../../../../utils/date'
+import {
+  formatMediumDateTimeWithoutParsing,
+  isUnparsedDateValid,
+} from '../../../../utils/date'
 import { COMPANY_FIELD_NAME_TO_LABEL_MAP, HEADQUARTER_TYPES } from './constants'
 import {
   ARCHIVED,
@@ -37,8 +40,8 @@ export const getValue = (value, field) =>
             maximumSignificantDigits: 2,
           })
         : value.toString()
-      : isDateValid(value)
-        ? formatMediumDateTime(value)
+      : isUnparsedDateValid(value)
+        ? formatMediumDateTimeWithoutParsing(value)
         : field === 'Headquarter type'
           ? HEADQUARTER_TYPES[value] || NOT_SET
           : value || NOT_SET

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/InvestorCheckDetails.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/InvestorCheckDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import { FieldAdvisersTypeahead, FieldDate } from '../../../../components'
-import { transformDateStringToDateObject } from '../../../../../apps/transformers'
+import { convertDateToFieldDateObject } from '../../../../utils/date'
 import { validateDateWithinTheLastYear } from './validators'
 
 export const InvestorCheckDetails = ({ date, adviser }) => (
@@ -10,7 +10,7 @@ export const InvestorCheckDetails = ({ date, adviser }) => (
     <FieldDate
       name="date"
       label="Date of most recent checks"
-      initialValue={transformDateStringToDateObject(date)}
+      initialValue={date ? convertDateToFieldDateObject(date) : null}
       validate={validateDateWithinTheLastYear}
       required="Enter the date of the most recent checks"
       hint="For example, 12 11 2015"

--- a/src/client/modules/Contacts/ContactActivity/transformers.js
+++ b/src/client/modules/Contacts/ContactActivity/transformers.js
@@ -1,5 +1,5 @@
 import urls from '../../../../lib/urls'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 import {
   verifyLabel,
   formattedAdvisers,
@@ -19,7 +19,7 @@ export const transformContactActivityToListItem = ({
 }) => ({
   id,
   metadata: [
-    { label: 'Date', value: formatMediumDate(date) },
+    { label: 'Date', value: formatMediumDateParsed(date) },
     {
       label: verifyLabel(contacts, 'Contact'),
       value: formattedContacts(contacts),

--- a/src/client/modules/Contacts/ContactAuditHistory/transformers.js
+++ b/src/client/modules/Contacts/ContactAuditHistory/transformers.js
@@ -2,7 +2,7 @@ import { isBoolean, isNumber } from 'lodash'
 
 import { transformFieldName } from '../../../components/AuditHistory/transformers'
 import { CONTACT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { formatMediumDateTime, isDateValid } from '../../../utils/date'
+import { formatMediumDateTime, isUnparsedDateValid } from '../../../utils/date'
 import {
   ARCHIVED,
   NO,
@@ -25,6 +25,6 @@ export const getValue = (value, field) =>
         : NO
       : isNumber(value)
         ? value.toString()
-        : isDateValid(value)
+        : isUnparsedDateValid(value)
           ? formatMediumDateTime(value)
           : value || NOT_SET

--- a/src/client/modules/ExportPipeline/transformers.js
+++ b/src/client/modules/ExportPipeline/transformers.js
@@ -62,7 +62,9 @@ export const transformAPIValuesForForm = ({
   team_members: transformArrayIdNameToValueLabel(team_members),
   estimated_export_value_years: estimated_export_value_years?.id,
   estimated_export_value_amount: estimated_export_value_amount,
-  estimated_win_date: convertDateToFieldShortDateObject(estimated_win_date),
+  estimated_win_date: estimated_win_date
+    ? convertDateToFieldShortDateObject(estimated_win_date)
+    : { month: '', year: '' },
   destination_country:
     destination_country && transformIdNameToValueLabel(destination_country),
   sector: sector && transformIdNameToValueLabel(sector),

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -9,7 +9,7 @@ import pluralize from 'pluralize'
 import { Step, ButtonLink, FieldInput, SummaryTable } from '../../../components'
 import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
 import { useFormContext } from '../../../components/Form/hooks'
-import { formatMediumDateTime } from '../../../utils/date'
+import { formatMediumDateTimeWithoutParsing } from '../../../utils/date'
 import { WIN_STATUS } from '../Status/constants'
 import { ContactLink } from './ExportWinForm'
 import urls from '../../../../lib/urls'
@@ -365,10 +365,10 @@ const AdditionalInformation = ({ values, isEditing }) => {
         {winStatus === WIN_STATUS.PENDING && (
           <>
             <SummaryTable.Row heading="First sent">
-              {formatMediumDateTime(values.first_sent)}
+              {formatMediumDateTimeWithoutParsing(values.first_sent)}
             </SummaryTable.Row>
             <SummaryTable.Row heading="Last Sent">
-              {formatMediumDateTime(values.last_sent)}
+              {formatMediumDateTimeWithoutParsing(values.last_sent)}
             </SummaryTable.Row>
             <SummaryTable.Row heading="Export win confirmed">
               Pending

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -28,7 +28,7 @@ import { WithoutOurSupport } from '../../../components/Resource'
 import MarketingSource from '../../../components/Resource/MarketingSource'
 import Err from '../../../components/Task/Error'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 
 import AccesibilityStatement from './AccesibilityStatement'
 import PrivacyNotice from './PrivacyNotice'
@@ -168,7 +168,7 @@ const Step1 = ({ win, name }) => {
           {`${currencyGBP(totalAmount)} over ${totalYears} ${pluralize('year', totalYears)}`}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Date won">
-          {formatMediumDate(win?.date)}
+          {formatMediumDateParsed(win?.date)}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Lead officer name">
           {win?.leadOfficer?.name}

--- a/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
@@ -3,7 +3,7 @@ import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
@@ -39,11 +39,13 @@ export const WinsConfirmedList = ({ exportWins = [], currentAdviserId }) => {
             },
             {
               label: 'Date won:',
-              value: formatMediumDate(item.date),
+              value: formatMediumDateParsed(item.date),
             },
             {
               label: 'Date responded:',
-              value: formatMediumDate(item.customer_response.responded_on),
+              value: item.customer_response.responded_on
+                ? formatMediumDateParsed(item.customer_response?.responded_on)
+                : '',
             },
           ]}
         />

--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -3,7 +3,10 @@ import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDate, formatMediumDateTime } from '../../../utils/date'
+import {
+  formatMediumDate,
+  formatMediumDateTimeWithoutParsing,
+} from '../../../utils/date'
 import { CollectionItem } from '../../../components'
 import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
@@ -52,11 +55,11 @@ export const WinsPendingList = ({ exportWins = [], currentAdviserId }) => {
             },
             {
               label: 'First sent:',
-              value: formatMediumDateTime(item.first_sent),
+              value: formatMediumDateTimeWithoutParsing(item.first_sent),
             },
             {
               label: 'Last sent:',
-              value: formatMediumDateTime(item.last_sent),
+              value: formatMediumDateTimeWithoutParsing(item.last_sent),
             },
           ]}
         />

--- a/src/client/modules/Investments/Opportunities/OpportunityDetailsForm.jsx
+++ b/src/client/modules/Investments/Opportunities/OpportunityDetailsForm.jsx
@@ -9,7 +9,7 @@ import urls from '../../../../lib/urls'
 
 import { INVESTMENT_OPPORTUNITY__UPDATED } from '../../../actions'
 
-import { transformDateStringToDateObject } from '../../../../apps/transformers'
+import { convertDateToFieldDateObject } from '../../../utils/date'
 
 import Form from '../../../components/Form'
 import {
@@ -123,7 +123,7 @@ function OpportunityDetailsForm({ opportunityId, opportunity, dispatch }) {
                     name="requiredChecksConductedOn"
                     label="Date of most recent checks"
                     required="Enter a date"
-                    initialValue={transformDateStringToDateObject(
+                    initialValue={convertDateToFieldDateObject(
                       requiredChecksConductedOn
                     )}
                   />

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -32,7 +32,7 @@ import {
   transformArrayForTypeahead,
   transformRadioOptionToBool,
 } from '../transformers'
-import { transformDateStringToDateObject } from '../../../../../apps/transformers'
+import { convertDateToFieldDateObject } from '../../../../utils/date'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { GREY_2 } from '../../../../utils/colours'
 import { FDI_TYPES } from '../constants'
@@ -165,9 +165,11 @@ const EditProjectSummaryInitialStep = ({
         eventPlaceholder="e.g. conversation at conference"
       />
       <FieldEstimatedLandDate
-        initialValue={transformDateStringToDateObject(
+        initialValue={
           project.estimatedLandDate
-        )}
+            ? convertDateToFieldDateObject(project.estimatedLandDate)
+            : ''
+        }
         project={project}
       />
       <FieldLikelihoodOfLanding
@@ -179,7 +181,11 @@ const EditProjectSummaryInitialStep = ({
         project={project}
       />
       <FieldActualLandDate
-        initialValue={transformDateStringToDateObject(project.actualLandDate)}
+        initialValue={
+          project.actualLandDate
+            ? convertDateToFieldDateObject(project.actualLandDate)
+            : ''
+        }
         project={project}
       />
       {showInvestorTypeField() ? (

--- a/src/client/modules/Investments/Projects/EditHistory/transformers.js
+++ b/src/client/modules/Investments/Projects/EditHistory/transformers.js
@@ -1,7 +1,7 @@
 import { isBoolean, isNumber } from 'lodash'
 
 import { PROJECT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { formatMediumDate, isDateValid } from '../../../../utils/date'
+import { formatMediumDate, isUnparsedDateValid } from '../../../../utils/date'
 import { currencyGBP } from '../../../../utils/number-utils'
 import { NOT_SET, NO, YES } from '../../../../components/AuditHistory/constants'
 import { transformFieldName } from '../../../../components/AuditHistory/transformers'
@@ -35,6 +35,6 @@ export const getValue = (value, field) =>
           ? value.toString()
           : Array.isArray(value)
             ? value.join(', ')
-            : isDateValid(value)
+            : isUnparsedDateValid(value)
               ? formatMediumDate(value)
               : value || NOT_SET

--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -26,7 +26,7 @@ import OMISTermsAndConditions from './OMISTermsAndConditions'
 import urls from '../../../lib/urls'
 import { DARK_GREY, RED_2 } from '../../utils/colours'
 import {
-  formatMediumDate,
+  formatMediumDateParsed,
   formatMediumDateTime,
   isDateInFuture,
 } from '../../utils/date'
@@ -201,7 +201,7 @@ const OrderQuote = ({ quotePreview }) => {
                           Will expire on
                         </StyledHeading>
                         <p data-test="expiry-date">
-                          {formatMediumDate(quotePreview?.expires_on)}
+                          {formatMediumDateParsed(quotePreview?.expires_on)}
                         </p>
                         <RenderQuote
                           quote={quotePreview ? quotePreview?.content : ''}
@@ -250,7 +250,7 @@ const OrderQuote = ({ quotePreview }) => {
                       {setExpiryLabel(quote)}
                     </StyledHeading>
                     <StyledP data-test="expires-on-date">
-                      {formatMediumDate(quote.expiresOn)}
+                      {formatMediumDateParsed(quote.expiresOn)}
                     </StyledP>
 
                     <SentOn quote={quote} />

--- a/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
@@ -3,7 +3,7 @@ import { Link } from 'govuk-react'
 
 import { SummaryTable } from '../../../components'
 import { canEditOrder } from '../transformers'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 import urls from '../../../../lib/urls'
 
 const QuoteInformationTable = ({ order }) => (
@@ -24,7 +24,9 @@ const QuoteInformationTable = ({ order }) => (
     }
   >
     <SummaryTable.Row heading="Delivery date">
-      {formatMediumDate(order.deliveryDate) || 'Not set'}
+      {order.deliveryDate
+        ? formatMediumDateParsed(order.deliveryDate)
+        : 'Not set'}
     </SummaryTable.Row>
     <SummaryTable.Row heading="Description of the activity">
       {order.description || 'Not added'}

--- a/src/client/modules/Reminders/ItemRenderers/Exports/ExportItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Exports/ExportItemRenderer.jsx
@@ -5,7 +5,7 @@ import { GREY_1 } from '../../../../utils/colours'
 
 import ItemRenderer from '../ItemRenderer'
 import { INTERACTION_NAMES } from '../../constants'
-import { formatMediumDate } from '../../../../utils/date'
+import { formatMediumDateParsed } from '../../../../utils/date'
 import urls from '../../../../../lib/urls'
 
 const ItemHint = styled('span')({
@@ -16,7 +16,7 @@ const ItemContent = ({ item, hintLabel }) => (
   <ul>
     <li>
       <ItemHint>{`${hintLabel}: `}</ItemHint>
-      {formatMediumDate(item.last_interaction_date)}
+      {formatMediumDateParsed(item.last_interaction_date)}
     </li>
     {item.interaction ? (
       <>
@@ -66,7 +66,7 @@ const ExportItemRenderer = ({
     item={item}
     onDeleteReminder={onDeleteReminder}
     disableDelete={disableDelete}
-    deletedText={`Received ${formatMediumDate(item.created_on)} for ${
+    deletedText={`Received ${formatMediumDateParsed(item.created_on)} for ${
       item.company.name
     }`}
     headerLinkTitle={headerLinkTitle}

--- a/src/client/modules/Reminders/ItemRenderers/ItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/ItemRenderer.jsx
@@ -11,7 +11,7 @@ import {
   ItemHeaderLink,
   ItemFooter,
 } from './styled'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDateParsed } from '../../../utils/date'
 import { BLACK, DARK_GREY } from '../../../utils/colours'
 
 export const ItemRenderer = ({
@@ -39,7 +39,7 @@ export const ItemRenderer = ({
             <GridCol>
               <ItemHeader data-test="item-header">
                 <ul>
-                  <li>Received {formatMediumDate(item.created_on)}</li>
+                  <li>Received {formatMediumDateParsed(item.created_on)}</li>
                   {headerLinkHref && (
                     <li>
                       <ItemHeaderLink href={headerLinkHref}>

--- a/test/component/cypress/specs/Companies/CompanyInvestments/LargeCapitalProfile/EditProfileDetailsForm.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyInvestments/LargeCapitalProfile/EditProfileDetailsForm.cy.jsx
@@ -16,7 +16,9 @@ describe('Profile details form', () => {
     beforeEach(() => {
       cy.mountWithProvider(
         <ProfileDetailsForm
-          profile={largeInvestorProfileFaker()}
+          profile={largeInvestorProfileFaker({
+            requiredChecksConductedOn: null,
+          })}
           requiredCheckOptions={requiredChecksConductedListFaker()}
           investorTypeOptions={[]}
         />

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -6,7 +6,7 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 
 import { taskWithInvestmentProjectListFaker } from '../../../../../functional/cypress/fakers/task'
-import { formatMediumDate } from '../../../../../../src/client/utils/date'
+import { formatMediumDateParsed } from '../../../../../../src/client/utils/date'
 import { MyTasksContent } from '../../../../../../src/client/components/Dashboard/my-tasks/MyTasks'
 import urls from '../../../../../../src/lib/urls'
 
@@ -39,7 +39,7 @@ describe('My Tasks on the Dashboard', () => {
         element: '[data-test="my-tasks-table"]',
         rows: [
           [
-            formatMediumDate(myTaskResults[0].due_date),
+            formatMediumDateParsed(myTaskResults[0].due_date),
             myTaskResults[0].title,
             myTaskResults[0].company.name,
             myTaskResults[0].investment_project.name,
@@ -49,7 +49,7 @@ describe('My Tasks on the Dashboard', () => {
             'Active',
           ],
           [
-            formatMediumDate(myTaskResults[1].due_date),
+            formatMediumDateParsed(myTaskResults[1].due_date),
             myTaskResults[1].title,
             myTaskResults[1].company.name,
             myTaskResults[1].investment_project.name,
@@ -59,7 +59,7 @@ describe('My Tasks on the Dashboard', () => {
             'Completed',
           ],
           [
-            formatMediumDate(myTaskResults[2].due_date),
+            formatMediumDateParsed(myTaskResults[2].due_date),
             myTaskResults[2].title,
             myTaskResults[2].company.name,
             myTaskResults[2].investment_project.name,

--- a/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 import { STATUS } from '../../../../../../src/client/modules/Omis/constants'
 import urls from '../../../../../../src/lib/urls'
-import { formatMediumDate } from '../../../../../../src/client/utils/date'
+import { formatMediumDateParsed } from '../../../../../../src/client/utils/date'
 
 const order = {
   id: '123',
@@ -59,7 +59,9 @@ describe('QuoteInformationTable', () => {
         heading: 'Information for the quote',
         showEditLink: true,
         content: {
-          'Delivery date': formatMediumDate(orderWithAllFields.deliveryDate),
+          'Delivery date': formatMediumDateParsed(
+            orderWithAllFields.deliveryDate
+          ),
           'Description of the activity': orderWithAllFields.description,
         },
       })

--- a/test/component/cypress/specs/components/ActivityFeed/InteractionActivity.cy.jsx
+++ b/test/component/cypress/specs/components/ActivityFeed/InteractionActivity.cy.jsx
@@ -198,7 +198,9 @@ const buildAndMountWithCustomService = (service) => {
   )
 }
 
-describe('Interaction activity card', () => {
+// This is a test for the ActivityFeed component, which is not being used
+// We should make sure that there is nothing useful in this test before removing it.
+describe.skip('Interaction activity card', () => {
   context('When the card is rendered with a complete interaction', () => {
     beforeEach(() => {
       buildAndMountActivity(

--- a/test/functional/cypress/fakers/constants.js
+++ b/test/functional/cypress/fakers/constants.js
@@ -29,9 +29,28 @@ export const INVESTMENT_PROJECT_STAGES = {
   },
 }
 
-export const INVESTMENT_PROJECT_STAGES_LIST = Object.values(
-  INVESTMENT_PROJECT_STAGES
-)
+export const INVESTMENT_PROJECT_STAGES_LIST = [
+  {
+    id: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+    name: STAGE_PROSPECT,
+  },
+  {
+    id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+    name: STAGE_ASSIGN_PM,
+  },
+  {
+    id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+    name: STAGE_ACTIVE,
+  },
+  {
+    id: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+    name: STAGE_VERIFY_WIN,
+  },
+  {
+    id: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+    name: STAGE_WON,
+  },
+]
 
 export const INVESTMENT_PROJECT_STATUSES_LIST = [
   'ongoing',

--- a/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-large-capital-investor-details-spec.js
@@ -111,7 +111,7 @@ describe('View large capital investor details page', () => {
         assertFieldDate({
           element,
           label: 'Date of most recent checks',
-          value: { day: '29', month: '04', year: '2019' },
+          value: { day: '29', month: '4', year: '2019' },
         })
       })
     })

--- a/test/functional/cypress/specs/contacts/audit-spec.js
+++ b/test/functional/cypress/specs/contacts/audit-spec.js
@@ -61,7 +61,7 @@ describe('Contact audit history', () => {
       cy.get('@collectionItems').should('have.length', 10)
     })
 
-    context('when rendering an entry wehere no changes were made', () => {
+    context('when rendering an entry where no changes were made', () => {
       it('should only render the updated on and no changes text', () => {
         cy.get('@listItem1')
           .should('exist')

--- a/test/functional/cypress/specs/export-win/dashboard-spec.js
+++ b/test/functional/cypress/specs/export-win/dashboard-spec.js
@@ -1,7 +1,7 @@
 import urls from '../../../../../src/lib/urls'
 
 describe('Dashboard', () => {
-  it('foo', () => {
+  it('should display the correct filters', () => {
     cy.visit(urls.companies.exportWins.pending())
     cy.contains('label', 'Sort by').within(() => {
       cy.get('select option:selected').should('have.text', 'Newest')

--- a/test/functional/cypress/specs/investments/opportunity-details-form-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-details-form-spec.js
@@ -168,8 +168,8 @@ describe('A capital opportunity with no existing details', () => {
       cy.get(
         `[value=${completeOpportunity.required_checks_conducted.id}]`
       ).should('be.checked')
-      cy.get('#requiredChecksConductedOn\\.day').should('have.value', '06')
-      cy.get('#requiredChecksConductedOn\\.month').should('have.value', '07')
+      cy.get('#requiredChecksConductedOn\\.day').should('have.value', '6')
+      cy.get('#requiredChecksConductedOn\\.month').should('have.value', '7')
       cy.get('#requiredChecksConductedOn\\.year').should('have.value', '2018')
       assertSingleTypeaheadOptionSelected({
         element: '#field-requiredChecksConductedBy',

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -280,7 +280,7 @@ describe('Editing the project summary', () => {
         assertFieldDateShort({
           element,
           label: 'Estimated land date',
-          value: { day: '', month: '01', year: '2020' },
+          value: { day: '', month: '1', year: '2020' },
           hint: 'When activities planned under the investment project will have fully commenced',
         })
       })

--- a/test/functional/cypress/specs/omis/quote-spec.js
+++ b/test/functional/cypress/specs/omis/quote-spec.js
@@ -6,7 +6,7 @@ import {
   assertLocalHeader,
 } from '../../support/assertions'
 import {
-  formatMediumDate,
+  formatMediumDateParsed,
   formatMediumDateTime,
 } from '../../../../../src/client/utils/date'
 
@@ -86,7 +86,7 @@ describe('Order quote', () => {
         .should('have.text', 'Will expire on')
       cy.get('[data-test="expiry-date"]')
         .should('exist')
-        .should('have.text', formatMediumDate(quotePreview.expires_on))
+        .should('have.text', formatMediumDateParsed(quotePreview.expires_on))
     })
 
     it('should display the warning message', () => {
@@ -140,7 +140,10 @@ describe('Order quote', () => {
           .should('have.text', 'Expired on')
         cy.get('[data-test="expires-on-date"]')
           .should('exist')
-          .should('have.text', formatMediumDate(quoteNotAccepted.expires_on))
+          .should(
+            'have.text',
+            formatMediumDateParsed(quoteNotAccepted.expires_on)
+          )
       })
 
       assertSenderDetails(quoteNotAccepted)

--- a/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
@@ -6,7 +6,7 @@ import {
   nestedInteractionFaker,
   reminderListFaker,
 } from '../../fakers/reminders'
-import { formatMediumDate } from '../../../../../src/client/utils/date'
+import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/new-export-interaction'
 
@@ -333,7 +333,7 @@ describe('Exports New Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Received ${formatMediumDate(
+          `Received ${formatMediumDateParsed(
             deleted_reminder_date.toISOString()
           )} for ${reminders[4].company.name}`
         )

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -6,7 +6,7 @@ import {
   nestedInteractionFaker,
   reminderListFaker,
 } from '../../fakers/reminders'
-import { formatMediumDate } from '../../../../../src/client/utils/date'
+import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/no-recent-export-interaction'
 
@@ -138,7 +138,7 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${formatMediumDate(reminders[0].last_interaction_date)}`
+          `${formatMediumDateParsed(reminders[0].last_interaction_date)}`
         )
     })
   })
@@ -343,7 +343,7 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Received ${formatMediumDate(
+          `Received ${formatMediumDateParsed(
             deleted_reminder_date.toISOString()
           )} for ${reminders[4].company.name}`
         )


### PR DESCRIPTION
## Description of change

`date-fns` has been upgraded from v2.3.0 to v4.1.0. In order to carry out this upgrade several changes have been made to our date handling functions (mostly relating to whether certain dates need to be parsed before transformation).

For more details around the changes to the package see their [changelog](https://github.com/date-fns/date-fns/blob/main/CHANGELOG.md).

## Test instructions

Pages with dates should load as before.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
