### PR TITLE
Fix investment project required fields

### DIFF
--- a/src/apps/investments/client/projects/create/transformers.js
+++ b/src/apps/investments/client/projects/create/transformers.js
@@ -73,7 +73,7 @@ export const transformFormValuesToPayload = (values, csrfToken) => {
 
   if (Array.isArray(specific_programmes)) {
     payload.specific_programmes = specific_programmes.map((x) => x.value)
-  } else if (typeof specific_programmes === 'object') {
+  } else if (typeof specific_programmes === 'object' && specific_programmes) {
     payload.specific_programmes = [specific_programmes.value]
   } else {
     payload.specific_programmes = []

--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -15,6 +15,50 @@ export const PROJECT_STATUS_OPTIONS = [
   { name: 'Dormant', id: 'dormant' },
 ]
 
+export const INITIAL_ID = null
+
+export const STAGE = {
+  PROSPECT_ID: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+  ASSIGN_PM_ID: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+  ACTIVE_ID: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+  VERIFY_WIN_ID: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+  WON_ID: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+}
+
+export const STAGE_ID_TO_INDEX_MAP = {
+  [STAGE.INITIAL_ID]: 0,
+  [STAGE.PROSPECT_ID]: 1,
+  [STAGE.ASSIGN_PM_ID]: 2,
+  [STAGE.ACTIVE_ID]: 3,
+  [STAGE.VERIFY_WIN_ID]: 4,
+  [STAGE.WON_ID]: 5,
+}
+
+export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
+  ['client_cannot_provide_total_investment']: STAGE.ASSIGN_PM_ID,
+  ['strategic_drivers']: STAGE.ASSIGN_PM_ID,
+  ['client_requirements']: STAGE.ASSIGN_PM_ID,
+  ['client_considering_other_countries']: STAGE.ASSIGN_PM_ID,
+  ['client_cannot_provide_foreign_investment']: STAGE.VERIFY_WIN_ID,
+  ['government_assistance']: STAGE.VERIFY_WIN_ID,
+  ['number_new_jobs']: STAGE.VERIFY_WIN_ID,
+  ['average_salary']: STAGE.VERIFY_WIN_ID,
+  ['number_safeguarded_jobs']: STAGE.VERIFY_WIN_ID,
+  ['r_and_d_budget']: STAGE.VERIFY_WIN_ID,
+  ['non_fdi_r_and_d_budget']: STAGE.VERIFY_WIN_ID,
+  ['new_tech_to_uk']: STAGE.VERIFY_WIN_ID,
+  ['export_revenue']: STAGE.VERIFY_WIN_ID,
+  ['site_decided']: STAGE.VERIFY_WIN_ID,
+  ['actual_uk_regions']: STAGE.VERIFY_WIN_ID,
+  ['delivery_partners']: STAGE.VERIFY_WIN_ID,
+  ['actual_land_date']: STAGE.VERIFY_WIN_ID,
+  ['specific_programmes']: STAGE.VERIFY_WIN_ID,
+  ['investor_type']: STAGE.VERIFY_WIN_ID,
+  ['level_of_involvement']: STAGE.VERIFY_WIN_ID,
+  ['likelihood_to_land']: STAGE.ACTIVE_ID,
+  ['uk_region_locations']: STAGE.ASSIGN_PM_ID,
+}
+
 export const STAGE_OPTIONS = [
   {
     name: 'Show all',
@@ -22,23 +66,23 @@ export const STAGE_OPTIONS = [
   },
   {
     name: 'Prospect',
-    id: '8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+    id: STAGE.PROSPECT_ID,
   },
   {
     name: 'Assign PM',
-    id: 'c9864359-fb1a-4646-a4c1-97d10189fc03',
+    id: STAGE.ASSIGN_PM_ID,
   },
   {
     name: 'Active',
-    id: '7606cc19-20da-4b74-aba1-2cec0d753ad8',
+    id: STAGE.ACTIVE_ID,
   },
   {
     name: 'Verify win',
-    id: '49b8f6f3-0c50-4150-a965-2c974f3149e3',
+    id: STAGE.VERIFY_WIN_ID,
   },
   {
     name: 'Won',
-    id: '945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+    id: STAGE.WON_ID,
   },
 ]
 

--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -34,6 +34,11 @@ import {
 import { idNamesToValueLabels } from '../../../../utils'
 import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
+import {
+  isFieldOptionalForStageLabel,
+  validateFieldForStage,
+} from '../validators'
+import { siteDecidedValidator } from './validators'
 
 const ukObject = {
   name: 'United Kingdom',
@@ -78,7 +83,10 @@ const EditProjectRequirements = () => {
             >
               <ResourceOptionsField
                 name="strategic_drivers"
-                label="Strategic drivers behind this investment"
+                label={
+                  'Strategic drivers behind this investment' +
+                  isFieldOptionalForStageLabel('strategic_drivers', project)
+                }
                 resource={StrategicDriversResource}
                 field={FieldTypeahead}
                 initialValue={transformArrayForTypeahead(
@@ -86,16 +94,38 @@ const EditProjectRequirements = () => {
                 )}
                 placeholder="Select a strategic driver"
                 isMulti={true}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a strategic driver'
+                  )
+                }}
               />
               <FieldTextarea
                 type="text"
                 name="client_requirements"
-                label="Client requirements"
+                label={
+                  'Client requirements' +
+                  isFieldOptionalForStageLabel('client_requirements', project)
+                }
                 initialValue={project.clientRequirements || ''}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Enter client requirements'
+                  )
+                }}
               />
               <FieldRadios
                 name="client_considering_other_countries"
-                label="Is the client considering other countries?"
+                label={
+                  'Is the client considering other countries?' +
+                  isFieldOptionalForStageLabel(project)
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.clientConsideringOtherCountries
                 )}
@@ -117,15 +147,34 @@ const EditProjectRequirements = () => {
                     ),
                   }),
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select other countries considered'
+                  )
+                }}
               />
               <FieldUKRegionTypeahead
                 name="uk_region_locations"
-                label="Possible UK locations for this investment"
+                label={
+                  'Possible UK locations for this investment' +
+                  isFieldOptionalForStageLabel('uk_region_locations', project)
+                }
                 initialValue={transformArrayForTypeahead(
                   project.ukRegionLocations
                 )}
                 placeholder="Select a UK region"
                 isMulti={true}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a possible UK location'
+                  )
+                }}
               />
               <FieldRadios
                 name="site_decided"
@@ -153,21 +202,41 @@ const EditProjectRequirements = () => {
                         />
                         <FieldUKRegionTypeahead
                           name="actual_uk_regions"
-                          label="UK regions landed"
+                          label={
+                            'UK regions landed' +
+                            isFieldOptionalForStageLabel(
+                              'actual_uk_regions',
+                              project
+                            )
+                          }
                           initialValue={transformArrayForTypeahead(
                             project.actualUkRegions
                           )}
                           placeholder="Select a UK region"
                           isMulti={true}
+                          validate={(values, field, formFields) => {
+                            return validateFieldForStage(
+                              field,
+                              formFields,
+                              project,
+                              'Select a UK region'
+                            )
+                          }}
                         />
                       </>
                     ),
                   }),
                 }))}
+                validate={(values, field, formFields) => {
+                  return siteDecidedValidator(field, formFields, project)
+                }}
               />
               <ResourceOptionsField
                 name="delivery_partners"
-                label="Delivery partners"
+                label={
+                  'Delivery partners' +
+                  isFieldOptionalForStageLabel('investor_type', project)
+                }
                 resource={DeliveryPartnersResource}
                 field={FieldTypeahead}
                 initialValue={transformArrayForTypeahead(
@@ -180,6 +249,14 @@ const EditProjectRequirements = () => {
                     result.filter((option) => !option.disabledOn)
                   )
                 }
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a delivery partner'
+                  )
+                }}
               />
             </Form>
           </>

--- a/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectSummaryInitialStep.jsx
@@ -35,11 +35,7 @@ import {
 import { transformDateStringToDateObject } from '../../../../../apps/transformers'
 import { OPTION_NO, OPTION_YES } from '../../../../../common/constants'
 import { GREY_2 } from '../../../../utils/colours'
-import {
-  FDI_TYPES,
-  STAGE_PROSPECT,
-  INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM,
-} from '../constants'
+import { FDI_TYPES } from '../constants'
 
 const StyledFieldWrapper = styled(FieldWrapper)`
   border: 1px solid ${GREY_2};
@@ -172,38 +168,37 @@ const EditProjectSummaryInitialStep = ({
         initialValue={transformDateStringToDateObject(
           project.estimatedLandDate
         )}
+        project={project}
       />
       <FieldLikelihoodOfLanding
         autoScroll={!!autoScroll}
-        initialValue={transformObjectForTypeahead(project.likelihoodToLand)}
-        optionalText={STAGE_PROSPECT.includes(project.stage.name)}
+        initialValue={transformObjectForTypeahead(
+          project.likelihoodToLand,
+          null
+        )}
+        project={project}
       />
       <FieldActualLandDate
         initialValue={transformDateStringToDateObject(project.actualLandDate)}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
+        project={project}
       />
       {showInvestorTypeField() ? (
         <FieldInvestmentInvestorType
           label="New or existing investor"
           initialValue={project.investorType?.id}
-          optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-            project.stage.name
-          )}
+          project={project}
         />
       ) : null}
       <FieldLevelOfInvolvement
-        initialValue={transformObjectForTypeahead(project.levelOfInvolvement)}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
+        initialValue={transformObjectForTypeahead(
+          project.levelOfInvolvement,
+          null
         )}
+        project={project}
       />
       <FieldSpecificProgramme
         initialValue={transformArrayForTypeahead(project.specificProgrammes)}
-        optionalText={INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM.includes(
-          project.stage.name
-        )}
+        project={project}
       />
     </Step>
   )

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -33,6 +33,10 @@ import {
   capitalExpenditureValidator,
   totalInvestmentValidator,
 } from './validators'
+import {
+  isFieldOptionalForStageLabel,
+  validateFieldForStage,
+} from '../validators'
 
 // For projects landing after 01/04/2020, the FDI value field is not needed
 const showFDIValueField = (project) =>
@@ -79,27 +83,55 @@ const EditProjectValue = () => {
             >
               <FieldRadios
                 name="client_cannot_provide_total_investment"
-                label="Can client provide total investment value?"
+                label={
+                  'Can client provide total investment value?' +
+                  isFieldOptionalForStageLabel(
+                    'client_cannot_provide_total_investment',
+                    project
+                  )
+                }
                 hint="Includes capital, operational and R&D expenditure"
                 initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
                   project.clientCannotProvideTotalInvestment
                 )}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether client can provide total investment value'
+                  )
+                }}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                   ...(option.value === OPTION_YES && {
                     children: (
                       <FieldCurrency
                         name="total_investment"
-                        label="Total investment"
+                        label={
+                          'Total investment' +
+                          isFieldOptionalForStageLabel(
+                            'total_investment',
+                            project
+                          )
+                        }
                         hint="Enter the total number of GB pounds"
                         initialValue={project.totalInvestment}
                         type="text"
                         required="Enter the total investment"
-                        validate={(fieldValue, fieldObject, stateObject) => {
-                          return totalInvestmentValidator(
-                            fieldValue,
-                            stateObject.values.foreign_equity_investment
+                        validate={(value, field, formFields) => {
+                          const result = validateFieldForStage(
+                            field,
+                            formFields,
+                            project,
+                            'Value for number of new jobs is required'
                           )
+                          return result
+                            ? result
+                            : totalInvestmentValidator(
+                                value,
+                                formFields.values.foreign_equity_investment
+                              )
                         }}
                       />
                     ),
@@ -108,11 +140,25 @@ const EditProjectValue = () => {
               />
               <FieldRadios
                 name="client_cannot_provide_foreign_investment"
-                label="Can client provide capital expenditure value?"
+                label={
+                  'Can client provide capital expenditure value?' +
+                  isFieldOptionalForStageLabel(
+                    'client_cannot_provide_foreign_investment',
+                    project
+                  )
+                }
                 hint="Foreign equity only, excluding operational and R&D expenditure"
                 initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
                   project.clientCannotProvideForeignInvestment
                 )}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether client can provide capital expenditure value'
+                  )
+                }}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                   ...(option.value === OPTION_YES && {
@@ -154,7 +200,10 @@ const EditProjectValue = () => {
               {project.fdiType?.name === 'Capital only' ? null : (
                 <>
                   <FieldInput
-                    label="Number of new jobs"
+                    label={
+                      'Number of new jobs' +
+                      isFieldOptionalForStageLabel('number_new_jobs', project)
+                    }
                     name="number_new_jobs"
                     type="number"
                     required={
@@ -167,12 +216,18 @@ const EditProjectValue = () => {
                         'Expansion of existing site or activity' &&
                       'An expansion project must always have at least 1 new job'
                     }
-                    validate={(value) =>
-                      project.fdiType?.name ===
+                    validate={(value, field, formFields) => {
+                      let result = validateFieldForStage(
+                        field,
+                        formFields,
+                        project,
+                        'Value for number of new jobs is required'
+                      )
+                      return project.fdiType?.name ===
                         'Expansion of existing site or activity' && value < 1
                         ? 'Number of new jobs must be greater than 0'
-                        : null
-                    }
+                        : result
+                    }}
                     initialValue={project.numberNewJobs?.toString()}
                   />
                   {project.investmentType.name === 'FDI' &&
@@ -191,7 +246,10 @@ const EditProjectValue = () => {
                     )}
                   <ResourceOptionsField
                     name="average_salary"
-                    label="Average salary of new jobs"
+                    label={
+                      'Average salary of new jobs' +
+                      isFieldOptionalForStageLabel('average_salary', project)
+                    }
                     resource={SalaryRangeResource}
                     field={FieldRadios}
                     initialValue={project.averageSalary?.id}
@@ -205,12 +263,34 @@ const EditProjectValue = () => {
                         )
                       )
                     }
+                    validate={(values, field, formFields) => {
+                      return validateFieldForStage(
+                        field,
+                        formFields,
+                        project,
+                        'Value for average salary of new jobs is required'
+                      )
+                    }}
                   />
                   <FieldInput
-                    label="Number of safeguarded jobs"
                     name="number_safeguarded_jobs"
+                    label={
+                      'Number of safeguarded jobs' +
+                      isFieldOptionalForStageLabel(
+                        'number_safeguarded_jobs',
+                        project
+                      )
+                    }
                     type="number"
                     initialValue={project.numberSafeguardedJobs?.toString()}
+                    validate={(values, field, formFields) => {
+                      return validateFieldForStage(
+                        field,
+                        formFields,
+                        project,
+                        'Value for number of safeguarded jobs is required'
+                      )
+                    }}
                   />
                 </>
               )}
@@ -226,53 +306,111 @@ const EditProjectValue = () => {
                 )}
               <FieldRadios
                 name="government_assistance"
-                label="Is this project receiving government financial assistance?"
+                label={
+                  'Is this project receiving government financial assistance?' +
+                  isFieldOptionalForStageLabel('government_assistance', project)
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.governmentAssistance
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether project receives government financial assitance'
+                  )
+                }}
               />
               <FieldRadios
                 name="r_and_d_budget"
-                label="Does this project have budget for research and development?"
+                label={
+                  'Does this project have budget for research and development?' +
+                  isFieldOptionalForStageLabel('r_and_d_budget', project)
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.rAndDBudget
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether project has budget for research and development'
+                  )
+                }}
               />
               <FieldRadios
                 name="non_fdi_r_and_d_budget"
-                label="Is this project associated with a non-FDI R&D project?"
+                label={
+                  'Is this project associated with a non-FDI R&D project?' +
+                  isFieldOptionalForStageLabel(
+                    'non_fdi_r_and_d_budget',
+                    project
+                  )
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.nonFdiRAndDBudget
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether the project is associated with a non-FDI R&D project'
+                  )
+                }}
               />
               <FieldRadios
                 name="new_tech_to_uk"
-                label="Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?"
+                label={
+                  'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?' +
+                  isFieldOptionalForStageLabel('new_tech_to_uk', project)
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.newTechToUk
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select whether project brings new technology to the UK'
+                  )
+                }}
               />
               <FieldRadios
                 name="export_revenue"
-                label="Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?"
+                label={
+                  'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?' +
+                  isFieldOptionalForStageLabel('export_revenue', project)
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
                   project.exportRevenue
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                 }))}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select export revenue as a result of the FDI project'
+                  )
+                }}
               />
             </Form>
           </>

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -185,7 +185,7 @@ export const transformProjectSummaryForApi = ({
 
   if (Array.isArray(specific_programmes)) {
     summaryPayload.specific_programmes = specific_programmes.map((x) => x.value)
-  } else if (typeof specific_programmes === 'object') {
+  } else if (typeof specific_programmes === 'object' && specific_programmes) {
     summaryPayload.specific_programmes = [specific_programmes?.value]
   } else {
     summaryPayload.specific_programmes = []

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -118,10 +118,16 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
       client_considering_other_countries,
       competitor_countries
     ),
-    delivery_partners: delivery_partners.map((x) => x.value),
+    delivery_partners: delivery_partners
+      ? delivery_partners.map((x) => x.value)
+      : [],
     site_decided: transformRadioOptionToBoolWithNullCheck(site_decided),
-    strategic_drivers: strategic_drivers.map((x) => x.value),
-    uk_region_locations: uk_region_locations.map((x) => x.value),
+    strategic_drivers: strategic_drivers
+      ? strategic_drivers.map((x) => x.value)
+      : [],
+    uk_region_locations: uk_region_locations
+      ? uk_region_locations.map((x) => x.value)
+      : [],
   }
 
   return { ...siteDecidedObject, ...requirementsValues }

--- a/src/client/modules/Investments/Projects/Details/validators.js
+++ b/src/client/modules/Investments/Projects/Details/validators.js
@@ -1,3 +1,8 @@
+import { STAGE } from '../../../../components/MyInvestmentProjects/constants'
+import { isFieldRequiredForStage } from '../validators'
+
+const { OPTION_YES } = require('../../../../../common/constants')
+
 export const totalInvestmentValidator = (value, foreignEquityInvestment) => {
   if (parseInt(value) < parseInt(foreignEquityInvestment)) {
     return 'Total investment must be >= to capital expenditure'
@@ -11,4 +16,18 @@ export const capitalExpenditureValidator = (value) => {
     return 'Capital expenditure must be >= £15,000,000 for capital only project'
   }
   return null
+}
+
+export const siteDecidedValidator = (field, formFields, project) => {
+  if (project?.stage?.id == STAGE.ACTIVE_ID && !formFields.values[field.name]) {
+    return 'Select a value for UK location decision'
+  }
+  return isFieldRequiredForStage(field.name, project) &&
+    formFields.values[field.name] != OPTION_YES
+    ? 'A UK region is required'
+    : null
+}
+
+export const isUkRegionLocationsRequiredForStage = (project) => {
+  return project?.stage?.id == STAGE.VERIFY_WIN_ID
 }

--- a/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
+++ b/src/client/modules/Investments/Projects/InvestmentFormFields.jsx
@@ -38,6 +38,11 @@ import { OPTIONS_YES_NO, OPTION_NO } from '../../../../common/constants'
 import { idNamesToValueLabels } from '../../../utils'
 import { validateIfDateInPast } from '../../../components/Form/validators'
 import { FDI_TYPES } from './constants'
+import {
+  isFieldOptionalForStageLabel,
+  isFieldRequiredForStage,
+  validateFieldForStage,
+} from './validators'
 
 const StyledReferralSourceWrapper = styled.div`
   margin-bottom: ${SPACING_POINTS[6]}px;
@@ -284,72 +289,106 @@ export const FieldEstimatedLandDate = ({ initialValue = null }) => (
 export const FieldLikelihoodOfLanding = ({
   initialValue = null,
   autoScroll,
-  optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="likelihood_to_land"
-    label={'Likelihood of landing' + (optionalText ? ' (optional)' : '')}
+    label={
+      'Likelihood of landing' +
+      isFieldOptionalForStageLabel('likelihood_to_land', project)
+    }
     resource={LikelihoodToLandResource}
     field={FieldTypeahead}
     placeholder="Select a likelihood of landing value"
     initialValue={initialValue}
     autoScroll={autoScroll}
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a likelihood of landing value'
+      )
+    }}
   />
 )
 
-export const FieldActualLandDate = ({
-  initialValue = null,
-  optionalText = true,
-}) => (
+export const FieldActualLandDate = ({ initialValue = null, project }) => (
   <FieldDate
     name="actual_land_date"
-    label={'Actual land date' + (optionalText ? ' (optional)' : '')}
+    label={
+      'Actual land date' +
+      isFieldOptionalForStageLabel('actual_land_date', project)
+    }
     hint="The date investment project activities started"
     invalid="Enter a valid actual land date"
     initialValue={initialValue}
-    validate={validateIfDateInPast}
+    validate={(values, field, formFields) => {
+      let result = validateIfDateInPast(values)
+      if (!result) {
+        return (!formFields.values[field.name].day ||
+          !formFields.values[field.name].month ||
+          !formFields.values[field.name].year) &&
+          isFieldRequiredForStage(field.name, project)
+          ? 'Enter an actual land date'
+          : null
+      }
+      return result
+    }}
   />
 )
 
 export const FieldInvestmentInvestorType = ({
   label,
   initialValue = null,
-  optionalText = true,
+  project,
 }) => (
   <ResourceOptionsField
     name="investor_type"
-    label={label + (optionalText ? ' (optional)' : '')}
+    label={label + isFieldOptionalForStageLabel('investor_type', project)}
     resource={InvestmentInvestorTypesResource}
     field={FieldRadios}
     initialValue={initialValue}
     placeholder="Choose an investor type"
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select an investor type'
+      )
+    }}
   />
 )
 
-export const FieldLevelOfInvolvement = ({
-  initialValue = null,
-  optionalText = true,
-}) => (
+export const FieldLevelOfInvolvement = ({ initialValue = null, project }) => (
   <ResourceOptionsField
     name="level_of_involvement"
     label={
-      'Level of investor involvement' + (optionalText ? ' (optional)' : '')
+      'Level of investor involvement' +
+      isFieldOptionalForStageLabel('level_of_involvement', project)
     }
     resource={LevelOfInvolvementResource}
     field={FieldTypeahead}
     initialValue={initialValue}
     placeholder="Choose a level of involvement"
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a level of involvement'
+      )
+    }}
   />
 )
 
-export const FieldSpecificProgramme = ({
-  initialValue = [],
-  optionalText = true,
-}) => (
+export const FieldSpecificProgramme = ({ initialValue = null, project }) => (
   <ResourceOptionsField
     name="specific_programmes"
     label={
-      'Specific investment programme' + (optionalText ? ' (optional)' : '')
+      'Specific investment programme' +
+      isFieldOptionalForStageLabel('specific_programmes', project)
     }
     resource={SpecificInvestmentProgrammesResource}
     field={FieldTypeahead}
@@ -359,5 +398,13 @@ export const FieldSpecificProgramme = ({
     resultToOptions={(result) =>
       idNamesToValueLabels(result.filter((option) => !option.disabledOn))
     }
+    validate={(values, field, formFields) => {
+      return validateFieldForStage(
+        field,
+        formFields,
+        project,
+        'Select a specific programme'
+      )
+    }}
   />
 )

--- a/src/client/modules/Investments/Projects/constants.js
+++ b/src/client/modules/Investments/Projects/constants.js
@@ -13,11 +13,6 @@ export const INVESTMENT_PROJECT_STAGES = [
   STAGE_WON,
 ]
 
-export const INVESTMENT_PROJECT_STAGES_TO_ASSIGN_PM = [
-  STAGE_PROSPECT,
-  STAGE_ASSIGN_PM,
-]
-
 export const EXPORT_REVENUE_TRUE = 'Yes, will create significant export revenue'
 export const EXPORT_REVENUE_FALSE =
   'No, will not create significant export revenue'

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -27,7 +27,7 @@ import Tag, { TAG_COLOURS } from '../../../components/Tag'
 export const checkIfItemHasValue = (item) => (item ? item : null)
 
 export const transformArrayForTypeahead = (array) =>
-  array
+  array && array.length
     ? array.map((value) => ({
         label: value.name,
         value: value.id,
@@ -44,16 +44,16 @@ export const transformAndFilterArrayForTypeahead = (array) => {
   }))
 }
 
-export const transformObjectForTypeahead = (object) =>
+export const transformObjectForTypeahead = (
+  object,
+  emptyValue = { label: '', value: '' }
+) =>
   object
     ? {
         label: object.name,
         value: object.id,
       }
-    : {
-        label: '',
-        value: '',
-      }
+    : emptyValue
 
 export const transformBoolToRadioOption = (boolean) =>
   boolean ? OPTION_YES : OPTION_NO

--- a/src/client/modules/Investments/Projects/validators.js
+++ b/src/client/modules/Investments/Projects/validators.js
@@ -1,0 +1,34 @@
+import {
+  GET_REQUIRED_FIELDS_AFTER_STAGE,
+  STAGE_ID_TO_INDEX_MAP,
+} from '../../../components/MyInvestmentProjects/constants'
+
+export const isFieldRequiredForStage = (fieldName, project) => {
+  return (
+    STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[fieldName]] <=
+    STAGE_ID_TO_INDEX_MAP[project?.stage?.id]
+  )
+}
+
+export const isFieldRequiredForNextStage = (fieldName, project) => {
+  return (
+    STAGE_ID_TO_INDEX_MAP[GET_REQUIRED_FIELDS_AFTER_STAGE[fieldName]] ===
+    STAGE_ID_TO_INDEX_MAP[project?.stage?.id] + 1
+  )
+}
+
+export const isFieldOptionalForStageLabel = (fieldName, project) => {
+  return isFieldRequiredForStage(fieldName, project)
+    ? ' (required)'
+    : isFieldRequiredForNextStage(fieldName, project)
+      ? ' (required for next stage)'
+      : ' (optional)'
+}
+
+export const validateFieldForStage = (field, formFields, project, message) => {
+  return (!formFields.values[field.name] ||
+    formFields.values[field.name].length == 0) &&
+    isFieldRequiredForStage(field.name, project)
+    ? message
+    : null
+}

--- a/test/functional/cypress/fakers/investment-projects.js
+++ b/test/functional/cypress/fakers/investment-projects.js
@@ -4,6 +4,7 @@ import jsf from 'json-schema-faker'
 import apiSchema from '../../../api-schema.json'
 
 import {
+  INVESTMENT_PROJECT_STAGES,
   INVESTMENT_PROJECT_STAGES_LIST,
   INVESTMENT_PROJECT_STATUSES_LIST,
 } from './constants'
@@ -86,6 +87,55 @@ const investmentProjectFaker = (overrides = {}) => ({
 })
 
 /**
+ * Generate "empty" single investment project without data.
+ *
+ * Starts by generating data based on the json schema, adds some defaults and
+ * merges in overrides.
+ */
+const investmentProjectEmptyFaker = (overrides = {}) =>
+  investmentProjectFaker({
+    stage: INVESTMENT_PROJECT_STAGES.prospect,
+    uk_region_locations: null,
+    name: null,
+    description: null,
+    sector: null,
+    BUSINESS_ACTIVITIES: null,
+    client_contacts: null,
+    referral_source_adviser: null,
+    estimated_land_date: null,
+    referral_source_activity: null,
+    anonymous_description: null,
+    other_business_activity: null,
+    client_cannot_provide_total_investment: null,
+    strategic_drivers: null,
+    client_requirements: null,
+    client_considering_other_countries: null,
+    project_manager: null,
+    project_assurance_adviser: null,
+    client_cannot_provide_foreign_investment: null,
+    government_assistance: null,
+    number_new_jobs: null,
+    number_safeguarded_jobs: null,
+    r_and_d_budget: null,
+    non_fdi_r_and_d_budget: null,
+    new_tech_to_uk: null,
+    export_revenue: null,
+    site_decided: null,
+    address_1: null,
+    address_town: null,
+    address_postcode: null,
+    actual_uk_regions: null,
+    delivery_partners: null,
+    actual_land_date: null,
+    specific_programmes: null,
+    uk_company: null,
+    investor_type: null,
+    level_of_involvement: null,
+    likelihood_to_land: null,
+    ...overrides,
+  })
+
+/**
  * Generate fake data for a list of investment projects.
  *
  * The number of items is determined by the length (default is 1).
@@ -96,6 +146,7 @@ const investmentProjectListFaker = (length = 1, overrides) =>
 
 export {
   investmentProjectFaker,
+  investmentProjectEmptyFaker,
   investmentProjectListFaker,
   investmentProjectCodeFaker,
   investmentProjectStageFaker,

--- a/test/functional/cypress/specs/investments/constants.js
+++ b/test/functional/cypress/specs/investments/constants.js
@@ -1,0 +1,13 @@
+export const INVESTMENT_PROJECT_FORM_VALIDATION = {
+  PROJECT_NAME: 'Enter a project name',
+  PROJECT_DESCRIPTION: 'Enter a project description',
+  PRIMARY_SECTOR: 'Choose a primary sector',
+  BUSINESS_ACTIVITY: 'Choose a business activity',
+  CLIENT_CONTACT: 'Choose a client contact',
+  IS_RELATIONSHIP_MANAGER:
+    "Select yes if you're the client relationship manager for this project",
+  IS_REFERRAL_SOURCE:
+    "Select yes if you're the referral source for this project",
+  ESTIMATED_LANDDATE: 'Enter an estimated land date',
+  REFERRAL_SOURCE_ACTIVITY: 'Choose a referral source activity',
+}

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -14,6 +14,7 @@ const {
   assertFieldDateShort,
 } = require('../../support/assertions')
 const { clearTypeahead } = require('../../support/form-fillers')
+const { INVESTMENT_PROJECT_FORM_VALIDATION } = require('./constants')
 
 const { usCompany } = company
 
@@ -292,7 +293,7 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldTypeahead({
         element,
         label: 'Business activities',
-        placeholder: 'Choose a business activity',
+        placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
         hint: 'You can select more than one activity',
       })
     })
@@ -324,7 +325,7 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldTypeahead({
         element,
         label: 'Client contact details',
-        placeholder: 'Choose a client contact',
+        placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
       })
     })
   })
@@ -368,7 +369,8 @@ describe('Investment Detail Step Form Content', () => {
       assertFieldSelect({
         element,
         label: 'Referral source activity',
-        placeholder: 'Choose a referral source activity',
+        placeholder:
+          INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
         optionsCount: 53,
       })
     })
@@ -431,15 +433,15 @@ describe('Investment Detail Step Form Content', () => {
 
 describe('Validation error messages', () => {
   const validationErrorMessages = [
-    'Enter a project name',
-    'Enter a project description',
-    'Choose a primary sector',
-    'Choose a business activity',
-    'Choose a client contact',
-    "Select yes if you're the client relationship manager for this project",
-    "Select yes if you're the referral source for this project",
-    'Enter an estimated land date',
-    'Choose a referral source activity',
+    INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_NAME,
+    INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_DESCRIPTION,
+    INVESTMENT_PROJECT_FORM_VALIDATION.PRIMARY_SECTOR,
+    INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
+    INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
+    INVESTMENT_PROJECT_FORM_VALIDATION.IS_RELATIONSHIP_MANAGER,
+    INVESTMENT_PROJECT_FORM_VALIDATION.IS_REFERRAL_SOURCE,
+    INVESTMENT_PROJECT_FORM_VALIDATION.ESTIMATED_LANDDATE,
+    INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
   ]
 
   const validationErrorMessageOtherBusinessActivities =

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -5,6 +5,7 @@ import {
 import { INVESTMENT_PROJECT_STAGES } from '../../fakers/constants'
 import { investmentProjectFaker } from '../../fakers/investment-projects'
 import { clickButton } from '../../support/actions'
+import { INVESTMENT_PROJECT_FORM_VALIDATION } from './constants'
 
 const urls = require('../../../../../src/lib/urls')
 
@@ -16,9 +17,9 @@ const {
   assertFieldSelect,
   assertFieldDateShort,
   assertFieldRadios,
-  assertErrorSummary,
   assertFieldTypeaheadWithExactText,
   assertFieldDateWithExactText,
+  assertErrorSummaryContains,
 } = require('../../support/assertions')
 
 const setupProjectFaker = (overrides) =>
@@ -28,6 +29,10 @@ const setupProjectFaker = (overrides) =>
     investment_type: {
       name: 'Commitment to invest',
       id: '031269ab-b7ec-40e9-8a4e-7371404f0622',
+    },
+    investor_type: {
+      name: 'Existing Investor',
+      id: '40e33f91-f565-4b89-8e18-cfefae192245',
     },
     anonymous_description: '',
     client_contacts: [
@@ -138,7 +143,7 @@ describe('Editing the project summary', () => {
         assertFieldTypeahead({
           element,
           label: 'Business activities',
-          placeholder: 'Choose a business activity',
+          placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
         })
       })
     })
@@ -158,7 +163,7 @@ describe('Editing the project summary', () => {
         assertFieldTypeahead({
           element,
           label: 'Client contact details',
-          placeholder: 'Choose a client contact',
+          placeholder: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
           value: 'Dean Cox',
         })
       })
@@ -195,7 +200,8 @@ describe('Editing the project summary', () => {
         assertFieldSelect({
           element,
           label: 'Referral source activity',
-          placeholder: 'Choose a referral source activity',
+          placeholder:
+            INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
           value: 'None',
           optionsCount: 53,
         })
@@ -340,7 +346,7 @@ describe('Editing the project summary', () => {
       cy.get('[data-test="actual_land_date-month"]').type('02')
       cy.get('[data-test="actual_land_date-year"]').type('2350')
       clickButton('Submit')
-      assertErrorSummary(['Actual land date cannot be in the future'])
+      assertErrorSummaryContains(['Actual land date cannot be in the future'])
     })
   })
 
@@ -353,41 +359,41 @@ describe('Editing the project summary', () => {
       )
     })
 
-    it('should display the investor type field label without the (optional) text', () => {
+    it('should display the investor type field label with the required for next stage text', () => {
       cy.get('[data-test="field-investor_type"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'New or existing investor',
+          label: 'New or existing investor (required for next stage)',
           optionsCount: 2,
         })
       })
     })
 
-    it('should render the actual land date field label without the word optional', () => {
+    it('should render the actual land date field label with the required for next stage text', () => {
       cy.get('[data-test="field-actual_land_date"]').then((element) => {
         assertFieldDateWithExactText({
           element,
-          label: 'Actual land date',
+          label: 'Actual land date (required for next stage)',
           hint: 'When activities under the investment project fully commenced',
         })
       })
     })
 
-    it('should render the level of investor involvement field label without the word optional', () => {
+    it('should render the level of investor involvement field label with the required for next stage text', () => {
       cy.get('[data-test="field-level_of_involvement"]').then((element) => {
         assertFieldTypeaheadWithExactText({
           element,
-          label: 'Level of investor involvement',
+          label: 'Level of investor involvement (required for next stage)',
           placeholder: 'Choose a level of involvement',
         })
       })
     })
 
-    it('should render the specific programme field label without the word optional', () => {
+    it('should render the specific programme field label with the required for next stage text', () => {
       cy.get('[data-test="field-specific_programmes"]').then((element) => {
         assertFieldTypeaheadWithExactText({
           element,
-          label: 'Specific investment programme',
+          label: 'Specific investment programme (required for next stage)',
           placeholder: 'Choose a specific programme',
         })
       })

--- a/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
@@ -68,7 +68,7 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
       (element) => {
         assertFieldRadios({
           element,
-          label: 'Is the client considering other countries?',
+          label: 'Is the client considering other countries? (required)',
           optionsCount: checkIfClientConsidering(
             project.client_considering_other_countries
           ),

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -1,0 +1,184 @@
+import { INVESTMENT_PROJECT_FORM_VALIDATION } from './constants'
+
+const urls = require('../../../../../src/lib/urls')
+const {
+  investmentProjectEmptyFaker,
+} = require('../../fakers/investment-projects')
+const { INVESTMENT_PROJECT_STAGES } = require('../../fakers/constants')
+
+export const FIELDS = {
+  // Update investment project summary
+  NAME: {
+    name: 'name',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_NAME,
+  },
+  DESCRIPTION: {
+    name: 'description',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PROJECT_DESCRIPTION,
+  },
+  SECTOR: {
+    name: 'sector',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.PRIMARY_SECTOR,
+  },
+  BUSINESS_ACTIVITIES: {
+    name: 'business_activities',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.BUSINESS_ACTIVITY,
+  },
+  CLIENT_CONTACTS: {
+    name: 'client_contacts',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.CLIENT_CONTACT,
+  },
+  IS_REFERRAL_SOURCE: {
+    name: 'is_referral_source',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.IS_REFERRAL_SOURCE,
+  },
+  ESTIMATED_LAND_DATE: {
+    name: 'estimated_land_date',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.ESTIMATED_LANDDATE,
+  },
+  REFERRAL_SOURCE_ACTIVITY: {
+    name: 'referral_source_activity',
+    message: INVESTMENT_PROJECT_FORM_VALIDATION.REFERRAL_SOURCE_ACTIVITY,
+  },
+  INVESTOR_TYPE: {
+    name: 'investor_type',
+    message: 'Select an investor type',
+  },
+  LEVEL_OF_INVOLVEMENT: {
+    name: 'level_of_involvement',
+    message: 'Select a level of involvement',
+  },
+  SPECIFIC_PROGRAMMES: {
+    name: 'specific_programmes',
+    message: 'Select a specific programme',
+  },
+  LIKELIHOOD_TO_LAND: {
+    name: 'likelihood_to_land',
+    message: 'Select a likelihood of landing value',
+  },
+  ACTUAL_LAND_DATE: {
+    name: 'actual_land_date',
+    message: 'Enter an actual land date',
+  },
+}
+
+function assertValidationMessage(elementName, message) {
+  cy.get('[id="form-errors"]').contains(message)
+  cy.get(`[id="field-${elementName}"]`).contains(message)
+}
+
+function assertValidationMessages(fields) {
+  fields.forEach((field) => {
+    assertValidationMessage(field.name, field.message)
+  })
+}
+
+describe('Field validation for each stage', () => {
+  describe('Update investment project summary', () => {
+    const stageRequiredFields = [
+      [
+        INVESTMENT_PROJECT_STAGES.prospect,
+        [
+          // Sector and investment_type can't be null, but should always be set at this stage.
+          // Cypress doesn't pick up null value for the above.
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.assignPm,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.active,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+          FIELDS.LIKELIHOOD_TO_LAND, // Required in API at active stage
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.verifyWin,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.INVESTOR_TYPE,
+          FIELDS.LEVEL_OF_INVOLVEMENT,
+          FIELDS.SPECIFIC_PROGRAMMES,
+          FIELDS.LIKELIHOOD_TO_LAND,
+          FIELDS.ACTUAL_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.won,
+        [
+          FIELDS.NAME,
+          FIELDS.DESCRIPTION,
+          FIELDS.BUSINESS_ACTIVITIES,
+          FIELDS.CLIENT_CONTACTS,
+          FIELDS.IS_REFERRAL_SOURCE,
+          FIELDS.ESTIMATED_LAND_DATE,
+          FIELDS.INVESTOR_TYPE,
+          FIELDS.LEVEL_OF_INVOLVEMENT,
+          FIELDS.SPECIFIC_PROGRAMMES,
+          FIELDS.LIKELIHOOD_TO_LAND,
+          FIELDS.ACTUAL_LAND_DATE,
+          FIELDS.REFERRAL_SOURCE_ACTIVITY,
+        ],
+      ],
+    ]
+    stageRequiredFields.forEach((stageRequiredField) => {
+      const [stage, requiredFields] = stageRequiredField
+
+      context(`In the ${stage.name} stage `, () => {
+        beforeEach(() => {
+          const projectEmptyFields = investmentProjectEmptyFaker({
+            stage: stage,
+          })
+          cy.intercept(
+            'GET',
+            `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+            projectEmptyFields
+          ).as('apiCall')
+          cy.visit(urls.investments.projects.editDetails(projectEmptyFields.id))
+          cy.wait('@apiCall')
+        })
+
+        it(`submitting an empty form should show validation errors`, () => {
+          cy.get('[data-test="submit"]').click()
+
+          assertValidationMessages(requiredFields)
+          // Ensure only the expected errors are shown.
+          cy.get('[data-test="summary-form-errors"] li').should(
+            'have.length',
+            requiredFields.length
+          )
+        })
+      })
+    })
+  })
+})

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -87,6 +87,53 @@ export const FIELDS = {
   ADDRESS1: { name: 'address1', message: 'Enter an address' },
   CITY: { name: 'city', message: 'Enter a town or city' },
   POSTCODE: { name: 'postcode', message: 'Enter a postcode' },
+
+  // Edit value
+  CLIENT_CANNOT_PROVIDE_FOREIGN_INVESTMENT: {
+    name: 'client_cannot_provide_foreign_investment',
+    message: 'Select whether client can provide capital expenditure value',
+  },
+  CLIENT_CANNOT_PROVIDE_TOTAL_INVESTMENT: {
+    name: 'client_cannot_provide_total_investment',
+    message: 'Select whether client can provide total investment value',
+  },
+  EXPORT_REVENUE: {
+    name: 'export_revenue',
+    message: 'Select export revenue as a result of the FDI project',
+  },
+  GOVERNMENT_ASSISTANCE: {
+    name: 'government_assistance',
+    message: 'Select whether project receives government financial assitance',
+  },
+  NEW_TECH_TO_UK: {
+    name: 'new_tech_to_uk',
+    message: 'Select whether project brings new technology to the UK',
+  },
+  NON_FDI_R_AND_D_BUDGET: {
+    name: 'non_fdi_r_and_d_budget',
+    message:
+      'Select whether the project is associated with a non-FDI R&D project',
+  },
+  NUMBER_NEW_JOBS: {
+    name: 'number_new_jobs',
+    message: 'Value for number of new jobs is required',
+  },
+  AVERAGE_SALARY: {
+    name: 'average_salary',
+    message: 'Value for average salary of new jobs is required',
+  },
+  NUMBER_SAFEGUARDED_JOBS: {
+    name: 'number_safeguarded_jobs',
+    message: 'Value for number of safeguarded jobs is required',
+  },
+  R_AND_D_BUDGET: {
+    name: 'r_and_d_budget',
+    message: 'Select whether project has budget for research and development',
+  },
+  TOTAL_INVESTMENT: {
+    name: 'total_investment',
+    message: '-total_investment',
+  },
 }
 
 function assertValidationMessage(elementName, message) {
@@ -303,6 +350,79 @@ describe('Field validation for each stage', () => {
             ])
           })
         }
+      })
+    })
+  })
+
+  describe('Edit value', () => {
+    const stageRequiredFields = [
+      [INVESTMENT_PROJECT_STAGES.prospect, []],
+      [
+        INVESTMENT_PROJECT_STAGES.assignPm,
+        [FIELDS.CLIENT_CANNOT_PROVIDE_TOTAL_INVESTMENT],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.active,
+        [FIELDS.CLIENT_CANNOT_PROVIDE_TOTAL_INVESTMENT],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.verifyWin,
+        [
+          FIELDS.CLIENT_CANNOT_PROVIDE_TOTAL_INVESTMENT,
+          FIELDS.CLIENT_CANNOT_PROVIDE_FOREIGN_INVESTMENT,
+          FIELDS.EXPORT_REVENUE,
+          FIELDS.GOVERNMENT_ASSISTANCE,
+          FIELDS.NEW_TECH_TO_UK,
+          FIELDS.NON_FDI_R_AND_D_BUDGET,
+          FIELDS.NUMBER_NEW_JOBS,
+          FIELDS.AVERAGE_SALARY,
+          FIELDS.NUMBER_SAFEGUARDED_JOBS,
+          FIELDS.R_AND_D_BUDGET,
+        ],
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.won,
+        [
+          FIELDS.CLIENT_CANNOT_PROVIDE_FOREIGN_INVESTMENT,
+          FIELDS.CLIENT_CANNOT_PROVIDE_TOTAL_INVESTMENT,
+          FIELDS.EXPORT_REVENUE,
+          FIELDS.GOVERNMENT_ASSISTANCE,
+          FIELDS.NEW_TECH_TO_UK,
+          FIELDS.NON_FDI_R_AND_D_BUDGET,
+          FIELDS.NUMBER_NEW_JOBS,
+          FIELDS.AVERAGE_SALARY,
+          FIELDS.NUMBER_SAFEGUARDED_JOBS,
+          FIELDS.R_AND_D_BUDGET,
+        ],
+      ],
+    ]
+    stageRequiredFields.forEach((stageRequiredField) => {
+      const [stage, requiredFields] = stageRequiredField
+
+      context(`In the ${stage.name} stage `, () => {
+        beforeEach(() => {
+          const projectEmptyFields = investmentProjectEmptyFaker({
+            stage: stage,
+          })
+          cy.intercept(
+            'GET',
+            `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+            projectEmptyFields
+          ).as('apiCall')
+          cy.visit(urls.investments.projects.editValue(projectEmptyFields.id))
+          cy.wait('@apiCall')
+        })
+
+        it(`submitting an empty form should show validation errors`, () => {
+          cy.get('[data-test="submit-button"]').click()
+
+          assertValidationMessages(requiredFields)
+          // Ensure only the expected errors are shown.
+          cy.get('[data-test="summary-form-errors"] li').should(
+            'have.length',
+            requiredFields.length
+          )
+        })
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -60,6 +60,33 @@ export const FIELDS = {
     name: 'actual_land_date',
     message: 'Enter an actual land date',
   },
+
+  // Edit requirements and location
+  STRATEGIC_DRIVERS: {
+    name: 'strategic_drivers',
+    message: 'Select a strategic driver',
+  },
+  CLIENT_REQUIREMENTS: {
+    name: 'client_requirements',
+    message: 'Enter client requirements',
+  },
+  CLIENT_CONSIDERING_OTHER_COUNTRIES: {
+    name: 'client_considering_other_countries',
+    message: 'Select other countries considered',
+  },
+  SITE_DECIDED: { name: 'site_decided', message: 'Select a UK region' },
+  DELIVERY_PARTNERS: {
+    name: 'delivery_partners',
+    message: 'Select a delivery partner',
+  },
+  UK_REGION_LOCATIONS: {
+    name: 'uk_region_locations',
+    message: 'Select a possible UK location',
+  },
+
+  ADDRESS1: { name: 'address1', message: 'Enter an address' },
+  CITY: { name: 'city', message: 'Enter a town or city' },
+  POSTCODE: { name: 'postcode', message: 'Enter a postcode' },
 }
 
 function assertValidationMessage(elementName, message) {
@@ -178,6 +205,104 @@ describe('Field validation for each stage', () => {
             requiredFields.length
           )
         })
+      })
+    })
+  })
+  describe('Edit requirements and location', () => {
+    const stageRequiredFields = [
+      [INVESTMENT_PROJECT_STAGES.prospect, [], false],
+      [
+        INVESTMENT_PROJECT_STAGES.assignPm,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        false,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.active,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          {
+            name: 'site_decided',
+            message: 'Select a value for UK location decision',
+          },
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        false,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.verifyWin,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          { name: 'site_decided', message: 'A UK region is required' },
+          FIELDS.DELIVERY_PARTNERS,
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        true,
+      ],
+      [
+        INVESTMENT_PROJECT_STAGES.won,
+        [
+          FIELDS.STRATEGIC_DRIVERS,
+          FIELDS.CLIENT_REQUIREMENTS,
+          { name: 'site_decided', message: 'A UK region is required' },
+          FIELDS.CLIENT_CONSIDERING_OTHER_COUNTRIES,
+          FIELDS.DELIVERY_PARTNERS,
+          FIELDS.UK_REGION_LOCATIONS,
+        ],
+        true,
+      ],
+    ]
+    stageRequiredFields.forEach((stageRequiredField) => {
+      const [stage, requiredFields, ukLocationRequired] = stageRequiredField
+
+      context(`In the ${stage.name} stage `, () => {
+        beforeEach(() => {
+          const projectEmptyFields = investmentProjectEmptyFaker({
+            stage: stage,
+          })
+          cy.intercept(
+            'GET',
+            `/api-proxy/v3/investment/${projectEmptyFields.id}`,
+            projectEmptyFields
+          ).as('apiCall')
+          cy.visit(
+            urls.investments.projects.editRequirements(projectEmptyFields.id)
+          )
+          cy.wait('@apiCall')
+        })
+
+        it(`submitting an empty form should show validation errors`, () => {
+          cy.get('[data-test="submit-button"]').click()
+
+          assertValidationMessages(requiredFields)
+          // Ensure only the expected errors are shown.
+          cy.get('[data-test="summary-form-errors"] li').should(
+            'have.length',
+            requiredFields.length
+          )
+        })
+
+        if (ukLocationRequired) {
+          it('submitting an empty form with site_decide set to Yes should show address validation errors', () => {
+            cy.get('[data-test="site-decided-yes"]').click()
+            cy.get('[data-test="submit-button"]').click()
+
+            assertValidationMessages([
+              FIELDS.SITE_DECIDED,
+              FIELDS.ADDRESS1,
+              FIELDS.CITY,
+              FIELDS.POSTCODE,
+            ])
+          })
+        }
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -1,3 +1,4 @@
+import { INVESTMENT_PROJECT_STAGES } from '../../fakers/constants'
 import { clickButton } from '../../support/actions'
 
 const {
@@ -31,6 +32,7 @@ const setup = (project) => {
 
 const setupProjectFaker = (overrides) =>
   investmentProjectFaker({
+    stage: INVESTMENT_PROJECT_STAGES.verifyWin,
     created_on: '2020-06-07T10:00:00Z',
     actual_land_date: null,
     estimated_land_date: null,
@@ -87,7 +89,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide total investment value?',
+            label: 'Can client provide total investment value? (required)',
             hint: 'Includes capital, operational and R&D expenditure',
             optionsCount: 2,
           })
@@ -106,7 +108,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-total_investment"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Total investment',
+            label: 'Total investment (required)',
             hint: 'Enter the total number of GB pounds',
           })
         })
@@ -118,7 +120,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide capital expenditure value?',
+            label: 'Can client provide capital expenditure value? (required)',
             hint: 'Foreign equity only, excluding operational and R&D expenditure',
             optionsCount: 2,
           })
@@ -159,7 +161,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-number_new_jobs"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Number of new jobs',
+            label: 'Number of new jobs (required)',
           })
         })
       })
@@ -174,7 +176,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 3,
           })
         })
@@ -185,7 +187,7 @@ describe('Edit the value details of a project', () => {
           (element) => {
             assertFieldInput({
               element,
-              label: 'Number of safeguarded jobs',
+              label: 'Number of safeguarded jobs (required)',
             })
           }
         )
@@ -199,7 +201,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-government_assistance"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project receiving government financial assistance?',
+            label:
+              'Is this project receiving government financial assistance? (required)',
             optionsCount: 2,
           })
         })
@@ -210,7 +213,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does this project have budget for research and development?',
+              'Does this project have budget for research and development? (required)',
             optionsCount: 2,
           })
         })
@@ -220,7 +223,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-non_fdi_r_and_d_budget"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project associated with a non-FDI R&D project?',
+            label:
+              'Is this project associated with a non-FDI R&D project? (required)',
             optionsCount: 2,
           })
         })
@@ -231,7 +235,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
+              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site? (required)',
             optionsCount: 2,
           })
         })
@@ -242,7 +246,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project? (required)',
             optionsCount: 2,
           })
         })
@@ -258,6 +262,9 @@ describe('Edit the value details of a project', () => {
 
         cy.get('[data-test="submit-button"]').click()
         assertErrorSummary([
+          'Value for number of new jobs is required',
+          'Value for average salary of new jobs is required',
+          'Value for number of safeguarded jobs is required',
           'Enter the total investment',
           'Enter the capital expenditure',
         ])
@@ -294,7 +301,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide total investment value?',
+            label: 'Can client provide total investment value? (required)',
             hint: 'Includes capital, operational and R&D expenditure',
             optionsCount: 3,
             value: convertBoolToInvertedYesNo(
@@ -305,7 +312,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-total_investment"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Total investment',
+            label: 'Total investment (required)',
             hint: 'Enter the total number of GB pounds',
             value: '1,000,000',
           })
@@ -318,7 +325,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide capital expenditure value?',
+            label: 'Can client provide capital expenditure value? (required)',
             hint: 'Foreign equity only, excluding operational and R&D expenditure',
             optionsCount: 3,
             value: convertBoolToInvertedYesNo(
@@ -353,7 +360,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-number_new_jobs"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Number of new jobs',
+            label: 'Number of new jobs (required)',
             value: capitalIntensiveProjectWithValue.number_new_jobs,
           })
         })
@@ -369,7 +376,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 3,
             value: capitalIntensiveProjectWithValue.average_salary.name,
           })
@@ -381,7 +388,7 @@ describe('Edit the value details of a project', () => {
           (element) => {
             assertFieldInput({
               element,
-              label: 'Number of safeguarded jobs',
+              label: 'Number of safeguarded jobs (required)',
               value: capitalIntensiveProjectWithValue.number_safeguarded_jobs,
             })
           }
@@ -396,7 +403,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-government_assistance"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project receiving government financial assistance?',
+            label:
+              'Is this project receiving government financial assistance? (required)',
             optionsCount: 2,
             value: convertBoolToYesNo(
               capitalIntensiveProjectWithValue.government_assistance
@@ -410,7 +418,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does this project have budget for research and development?',
+              'Does this project have budget for research and development? (required)',
             optionsCount: 2,
             value: convertBoolToYesNo(
               capitalIntensiveProjectWithValue.r_and_d_budget
@@ -423,7 +431,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-non_fdi_r_and_d_budget"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project associated with a non-FDI R&D project?',
+            label:
+              'Is this project associated with a non-FDI R&D project? (required)',
             optionsCount: 2,
             value: convertBoolToYesNo(
               capitalIntensiveProjectWithValue.non_fdi_r_and_d_budget
@@ -437,7 +446,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
+              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site? (required)',
             optionsCount: 2,
             value: convertBoolToYesNo(
               capitalIntensiveProjectWithValue.new_tech_to_uk
@@ -451,7 +460,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project? (required)',
             optionsCount: 2,
             value: convertBoolToYesNo(
               capitalIntensiveProjectWithValue.export_revenue
@@ -733,7 +742,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide total investment value?',
+            label: 'Can client provide total investment value? (required)',
             hint: 'Includes capital, operational and R&D expenditure',
             optionsCount: 2,
           })
@@ -752,7 +761,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-total_investment"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Total investment',
+            label: 'Total investment (required)',
             hint: 'Enter the total number of GB pounds',
           })
         })
@@ -764,7 +773,7 @@ describe('Edit the value details of a project', () => {
         ).then((element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide capital expenditure value?',
+            label: 'Can client provide capital expenditure value? (required)',
             hint: 'Foreign equity only, excluding operational and R&D expenditure',
             optionsCount: 2,
           })
@@ -801,7 +810,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-number_new_jobs"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Number of new jobs',
+            label: 'Number of new jobs (required)',
           })
         })
       })
@@ -822,7 +831,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 3,
           })
         })
@@ -833,7 +842,7 @@ describe('Edit the value details of a project', () => {
           (element) => {
             assertFieldInput({
               element,
-              label: 'Number of safeguarded jobs',
+              label: 'Number of safeguarded jobs (required)',
             })
           }
         )
@@ -847,7 +856,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-government_assistance"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project receiving government financial assistance?',
+            label:
+              'Is this project receiving government financial assistance? (required)',
             optionsCount: 2,
           })
         })
@@ -858,7 +868,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does this project have budget for research and development?',
+              'Does this project have budget for research and development? (required)',
             optionsCount: 2,
           })
         })
@@ -868,7 +878,8 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-non_fdi_r_and_d_budget"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Is this project associated with a non-FDI R&D project?',
+            label:
+              'Is this project associated with a non-FDI R&D project? (required)',
             optionsCount: 2,
           })
         })
@@ -879,7 +890,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
+              'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site? (required)',
             optionsCount: 2,
           })
         })
@@ -890,7 +901,7 @@ describe('Edit the value details of a project', () => {
           assertFieldRadios({
             element,
             label:
-              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+              'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project? (required)',
             optionsCount: 2,
           })
         })
@@ -906,6 +917,9 @@ describe('Edit the value details of a project', () => {
 
         cy.get('[data-test="submit-button"]').click()
         assertErrorSummary([
+          'Value for number of new jobs is required',
+          'Value for average salary of new jobs is required',
+          'Value for number of safeguarded jobs is required',
           'Enter the total investment',
           'Enter the capital expenditure',
         ])
@@ -943,7 +957,7 @@ describe('Edit the value details of a project', () => {
         (element) => {
           assertFieldRadios({
             element,
-            label: 'Can client provide total investment value?',
+            label: 'Can client provide total investment value? (required)',
             hint: 'Includes capital, operational and R&D expenditure',
             optionsCount: 3,
             value: convertBoolToInvertedYesNo(
@@ -955,7 +969,7 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-total_investment"]').then((element) => {
         assertFieldInput({
           element,
-          label: 'Total investment',
+          label: 'Total investment (required)',
           hint: 'Enter the total number of GB pounds',
           value: '1,000,000',
         })
@@ -968,7 +982,7 @@ describe('Edit the value details of a project', () => {
       ).then((element) => {
         assertFieldRadios({
           element,
-          label: 'Can client provide capital expenditure value?',
+          label: 'Can client provide capital expenditure value? (required)',
           hint: 'Foreign equity only, excluding operational and R&D expenditure',
           optionsCount: 3,
           value: convertBoolToInvertedYesNo(
@@ -999,7 +1013,7 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-number_new_jobs"]').then((element) => {
         assertFieldInput({
           element,
-          label: 'Number of new jobs',
+          label: 'Number of new jobs (required)',
           value: labourIntensiveProjectWithValue.number_new_jobs,
         })
       })
@@ -1019,7 +1033,7 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-average_salary"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'Average salary of new jobs',
+          label: 'Average salary of new jobs (required)',
           optionsCount: 3,
           value: labourIntensiveProjectWithValue.average_salary.name,
         })
@@ -1030,7 +1044,7 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-number_safeguarded_jobs"]').then((element) => {
         assertFieldInput({
           element,
-          label: 'Number of safeguarded jobs',
+          label: 'Number of safeguarded jobs (required)',
           value: labourIntensiveProjectWithValue.number_safeguarded_jobs,
         })
       })
@@ -1044,7 +1058,8 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-government_assistance"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'Is this project receiving government financial assistance?',
+          label:
+            'Is this project receiving government financial assistance? (required)',
           optionsCount: 2,
           value: convertBoolToYesNo(
             labourIntensiveProjectWithValue.government_assistance
@@ -1057,7 +1072,8 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-r_and_d_budget"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'Does this project have budget for research and development?',
+          label:
+            'Does this project have budget for research and development? (required)',
           optionsCount: 2,
           value: convertBoolToYesNo(
             labourIntensiveProjectWithValue.r_and_d_budget
@@ -1070,7 +1086,8 @@ describe('Edit the value details of a project', () => {
       cy.get('[data-test="field-non_fdi_r_and_d_budget"]').then((element) => {
         assertFieldRadios({
           element,
-          label: 'Is this project associated with a non-FDI R&D project?',
+          label:
+            'Is this project associated with a non-FDI R&D project? (required)',
           optionsCount: 2,
           value: convertBoolToYesNo(
             labourIntensiveProjectWithValue.non_fdi_r_and_d_budget
@@ -1084,7 +1101,7 @@ describe('Edit the value details of a project', () => {
         assertFieldRadios({
           element,
           label:
-            'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
+            'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site? (required)',
           optionsCount: 2,
           value: convertBoolToYesNo(
             labourIntensiveProjectWithValue.new_tech_to_uk
@@ -1098,7 +1115,7 @@ describe('Edit the value details of a project', () => {
         assertFieldRadios({
           element,
           label:
-            'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+            'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project? (required)',
           optionsCount: 2,
           value: convertBoolToYesNo(
             labourIntensiveProjectWithValue.export_revenue
@@ -1349,7 +1366,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 4,
           })
         })
@@ -1368,7 +1385,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 3,
           })
         })
@@ -1385,7 +1402,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-average_salary"]').then((element) => {
           assertFieldRadios({
             element,
-            label: 'Average salary of new jobs',
+            label: 'Average salary of new jobs (required)',
             optionsCount: 3,
           })
         })
@@ -1396,6 +1413,7 @@ describe('Edit the value details of a project', () => {
   context('Number of jobs error handling', () => {
     context('When editing an expansion project', () => {
       const expansionProject = setupProjectFaker({
+        stage: INVESTMENT_PROJECT_STAGES.active,
         fdi_type: {
           name: 'Expansion of existing site or activity',
           id: '8dc41652-12bc-4ecf-8e60-bdb6dfd5eab1',
@@ -1409,7 +1427,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="field-number_new_jobs"]').then((element) => {
           assertFieldInput({
             element,
-            label: 'Number of new jobs',
+            label: 'Number of new jobs (required for next stage)',
             hint: 'An expansion project must always have at least 1 new job',
           })
         })
@@ -1433,6 +1451,7 @@ describe('Edit the value details of a project', () => {
     context('When editing an non expansion project', () => {
       it('should not show an error or hint text if number of new jobs is empty and it is a non FDI project', () => {
         const nonFdiProject = setupProjectFaker({
+          stage: INVESTMENT_PROJECT_STAGES.active,
           investment_type: {
             name: 'non-FDI',
             id: '3d2c94e4-7871-465c-a7f7-45651eeffc64',
@@ -1449,7 +1468,9 @@ describe('Edit the value details of a project', () => {
         assertNotExists('[data-test="summary-form-errors"]')
       })
       it('should not show an error or hint text if number of new jobs is empty and it is not an expansion FDI project', () => {
-        const nonExpansionFdiProject = setupProjectFaker()
+        const nonExpansionFdiProject = setupProjectFaker({
+          stage: INVESTMENT_PROJECT_STAGES.active,
+        })
         setup(nonExpansionFdiProject)
         cy.get('[data-test="field-number_new_jobs"]').should(
           'not.contain',

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -945,6 +945,15 @@ const assertErrorSummary = (errors) => {
 }
 
 /**
+ * Assert error summary passing in a list of errors as as an array
+ */
+const assertErrorSummaryContains = (errors) => {
+  cy.contains('h2', 'There is a problem')
+    .next()
+    .should('contains.text', errors.join(''))
+}
+
+/**
  * Assert by selector if it is visible
  */
 const assertVisible = (selector) => {
@@ -1136,6 +1145,7 @@ module.exports = {
   assertDateInput,
   assertDateInputWithHint,
   assertErrorSummary,
+  assertErrorSummaryContains,
   assertVisible,
   assertNotExists,
   assertTextVisible,


### PR DESCRIPTION
## Description of change

Not all fields for investment projects that are required by the API were marked as required by the front end. This caused a cryptic message `"Could not load TASK_EDIT_INVESTMENT_PROJECT_REQUIREMENTS [Retry] [Dismiss]"` to be displayed to the user when the API required a field for which no value was provided.

This PR adds frontend field-level validation for the three investment project forms:

- Edit summary
- Edit requirements and locations
- Edit value

## Test instructions

When editing any part of an investment project (summary, requirements, or value), depending on the project's current stage and the stage a specific field is required, users should see one of:

1. The text `(optional)` added to fields that are optional at the current and next stage. These fields can be empty when saving the form.
2. The text `(required at next stage)` added to fields that are required at the next stage, and thus need a value before the project can move to the next stage. These fields can be empty when saving the form. These fields should also be listed in the blue info box when viewing a project.
3. The text `(required)` added to fields that are required at the current stage. If these fields don't have values at this stage, when attempting to save the form, these should raise a validation error and have red warning boxes appear. This is instead of the error `"Could not load TASK_EDIT_INVESTMENT_PROJECT_REQUIREMENTS [Retry] [Dismiss]"`.

Stages that individual fields are required at are specified in the `GET_REQUIRED_FIELDS_AFTER_STAGE` constant. These should match the API's `get_required_fields_after_stage` list.

> [!NOTE]
> Part of this work was already reviewed in #7269. However, this PR addresses bugs that were introduced in that PR.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/59a72a36-aa06-4da5-8915-a7ee59c03adb)

### After

<img width="823" alt="image" src="https://github.com/user-attachments/assets/ddb86526-d424-4fdb-a56b-72ee3a61117d">
<img width="855" alt="image" src="https://github.com/user-attachments/assets/6854ce75-b86d-4810-9ef5-35b1e97cbb15">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
