### PR TITLE
Add great data to company activity

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/constants.js
+++ b/src/client/modules/Companies/CompanyActivity/constants.js
@@ -1,3 +1,5 @@
+import { TAG_COLOURS } from '../../../components/Tag/index'
+
 export const LABELS = {
   activityType: 'Activity type',
   interaction: 'Interaction',
@@ -33,6 +35,11 @@ export const TAGS = {
       text: 'Outstanding referral',
       colour: 'blue',
     },
+  },
+  ACTIVITY_LABELS: {
+    KIND: TAG_COLOURS.GREY,
+    THEME: TAG_COLOURS.GOV_BLUE,
+    SERVICE: TAG_COLOURS.BLUE,
   },
 }
 

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -40,6 +40,11 @@ export const formattedContacts = (contacts) =>
     </span>
   ))
 
+export const truncateEnquiry = (enquiry, maxLength = 200) =>
+  enquiry.length < maxLength
+    ? enquiry
+    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'
+
 export const formattedAdvisers = (advisers) =>
   !!advisers.length &&
   advisers.map((item) => (
@@ -280,6 +285,10 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
       {
         label: 'Contact',
         value: formattedContacts([great.contact]),
+      },
+      {
+        label: 'Comment',
+        value: truncateEnquiry(great.data_enquiry),
       },
     ].filter(({ value }) => Boolean(value)),
     tags: [

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -66,17 +66,20 @@ export const transformActivities = (activities) => {
   const transformedActivites = activities.results.map((activity) => {
     const activity_source = activity.activity_source
 
-    if (activity_source === 'interaction')
-      return transformInteractionToListItem(activity.interaction)
-    else if (activity_source === 'referral')
-      return transformReferralToListItem(activity)
-    else if (activity_source === 'investment')
-      return transformInvestmentToListItem(activity)
-    else if (activity_source === 'order')
-      return transformOrderToListItem(activity)
-    else if (activity_source === 'great_export_enquiry')
-      return transformGreatExportEnquiryToListItem(activity)
-    else return
+    switch (activity_source) {
+      case 'interaction':
+        return transformInteractionToListItem(activity.interaction)
+      case 'referral':
+        return transformReferralToListItem(activity)
+      case 'investment':
+        return transformInvestmentToListItem(activity)
+      case 'order':
+        return transformOrderToListItem(activity)
+      case 'great_export_enquiry':
+        return transformGreatExportEnquiryToListItem(activity)
+      default:
+        return {}
+    }
   })
 
   return transformedActivites.filter(
@@ -313,7 +316,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
 }
 
 export const transformResponseToCollection = (activities) => ({
-  count: activities.count,
+  count: transformActivities(activities).length,
   results: transformActivities(activities),
 })
 

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -69,8 +69,8 @@ export const transformActivities = (activities) => {
       return transformInvestmentToListItem(activity)
     else if (activity_source === 'order')
       return transformOrderToListItem(activity)
-    else if (activity_source === 'great')
-      return transformGreatToListItem(activity)
+    else if (activity_source === 'great_export_enquiry')
+      return transformGreatExportEnquiryToListItem(activity)
     else return
   })
 
@@ -271,8 +271,8 @@ export const transformOrderToListItem = (activity) => {
   }
 }
 
-export const transformGreatToListItem = (activity) => {
-  const great = activity.great
+export const transformGreatExportEnquiryToListItem = (activity) => {
+  const great = activity.great_export_enquiry
   return {
     id: great.id,
     metadata: [

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -56,8 +56,8 @@ export const transformActivity = (activities) => {
       return transformInvestmentToListItem(activity)
     else if (activity_source === 'order')
       return transformOrderToListItem(activity)
-    else if (activity_source === 'great')
-      return transformGreatToListItem(activity)
+    else if (activity_source === 'great_export_enquiry')
+      return transformGreatExportEnquiryToListItem(activity)
     else return
   })
 
@@ -174,8 +174,8 @@ export const transformOrderToListItem = (activity) => {
   }
 }
 
-export const transformGreatToListItem = (activity) => {
-  const great = activity.great
+export const transformGreatExportEnquiryToListItem = (activity) => {
+  const great = activity.great_export_enquiry
   return {
     id: great.id,
     date: formatMediumDate(activity.date),

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -48,17 +48,20 @@ export const transformActivity = (activities) => {
   const transformedActivites = activities.results.map((activity) => {
     const activity_source = activity.activity_source
 
-    if (activity_source === 'interaction')
-      return transformInteractionToListItem(activity.interaction)
-    else if (activity_source === 'referral')
-      return transformReferralToListItem(activity)
-    else if (activity_source === 'investment')
-      return transformInvestmentToListItem(activity)
-    else if (activity_source === 'order')
-      return transformOrderToListItem(activity)
-    else if (activity_source === 'great_export_enquiry')
-      return transformGreatExportEnquiryToListItem(activity)
-    else return
+    switch (activity_source) {
+      case 'interaction':
+        return transformInteractionToListItem(activity.interaction)
+      case 'referral':
+        return transformReferralToListItem(activity)
+      case 'investment':
+        return transformInvestmentToListItem(activity)
+      case 'order':
+        return transformOrderToListItem(activity)
+      case 'great_export_enquiry':
+        return transformGreatExportEnquiryToListItem(activity)
+      default:
+        return {}
+    }
   })
 
   return transformedActivites.filter(
@@ -193,6 +196,6 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
 }
 
 export const transformResponseToCollection = (activities) => ({
-  count: activities.count,
+  count: transformActivity(activities).length,
   results: transformActivity(activities),
 })

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Link } from 'govuk-react'
+import { Link, H3 } from 'govuk-react'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
 
@@ -60,7 +60,7 @@ const StyledLinkHeader = styled('h3')`
 // e.g. the positional arguments should be passed as an object
 export const TitleRenderer = (title, url, margin = { bottom: 10 }) => (
   <StyledLinkHeader margin={margin}>
-    <Link href={url}>{title}</Link>
+    {url ? <Link href={url}>{title}</Link> : <H3>{title}</H3>}
   </StyledLinkHeader>
 )
 

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -91,7 +91,7 @@ const companyActivityOrderFaker = (overrides = {}, orderOverrides = {}) => ({
 
 const companyActivityGreatFaker = (overrides = {}, orderOverrides = {}) => ({
   ...companyActivityFaker(),
-  activity_source: 'great',
+  activity_source: 'great_export_enquiry',
   great: {
     id: faker.string.uuid(),
     created_on: relativeDateFaker({ minDays: -100, maxDays: 365 }),

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -89,6 +89,22 @@ const companyActivityOrderFaker = (overrides = {}, orderOverrides = {}) => ({
   ...overrides,
 })
 
+const companyActivityGreatFaker = (overrides = {}, orderOverrides = {}) => ({
+  ...companyActivityFaker(),
+  activity_source: 'great',
+  great: {
+    id: faker.string.uuid(),
+    created_on: relativeDateFaker({ minDays: -100, maxDays: 365 }),
+    meta_full_name: faker.person.fullName(),
+    meta_email_address: faker.internet.email(),
+    contact: userFaker({ job_title: faker.person.jobTitle() }),
+    meta_subject: faker.company.buzzPhrase(),
+    data_enquiry: faker.lorem.paragraph(),
+    ...orderOverrides,
+  },
+  ...overrides,
+})
+
 const companyActivityInteractionListFaker = (length = 1, overrides) =>
   listFaker({
     fakerFunction: companyActivityInteractionFaker,
@@ -103,6 +119,19 @@ const companyActivityOrderListFaker = (
 ) => {
   return listFakerAdditionalOverrides({
     fakerFunction: companyActivityOrderFaker,
+    length,
+    overrides,
+    additionalOverrides: orderOverrides,
+  })
+}
+
+const companyActivityGreatListFaker = (
+  length = 1,
+  overrides,
+  orderOverrides
+) => {
+  return listFakerAdditionalOverrides({
+    fakerFunction: companyActivityGreatFaker,
     length,
     overrides,
     additionalOverrides: orderOverrides,
@@ -128,6 +157,7 @@ export {
   companyActivityInteractionListFaker,
   companyActivityInvestmentListFaker,
   companyActivityOrderListFaker,
+  companyActivityGreatListFaker,
 }
 
 export default companyActivityInteractionListFaker

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -92,7 +92,7 @@ const companyActivityOrderFaker = (overrides = {}, orderOverrides = {}) => ({
 const companyActivityGreatFaker = (overrides = {}, orderOverrides = {}) => ({
   ...companyActivityFaker(),
   activity_source: 'great_export_enquiry',
-  great: {
+  great_export_enquiry: {
     id: faker.string.uuid(),
     created_on: relativeDateFaker({ minDays: -100, maxDays: 365 }),
     meta_full_name: faker.person.fullName(),

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -1,5 +1,8 @@
 import { collectionListRequest } from '../../support/actions'
-import { companyActivityOrderListFaker } from '../../fakers/company-activity'
+import {
+  companyActivityOrderListFaker,
+  companyActivityGreatListFaker,
+} from '../../fakers/company-activity'
 
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
@@ -52,6 +55,43 @@ describe('Company activity feed', () => {
       urls.companies.detail(company.id),
       'Activity Feed'
     )
+  })
+  context('Great Export Enquiry activity feed', () => {
+    const greatData = companyActivityGreatListFaker(1)
+    beforeEach(() => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        greatData,
+        urls.companies.activity.index(company.id)
+      )
+    })
+
+    const activity = greatData[0]
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="great-kind-label"]').contains(
+        'great.gov.uk Enquiry',
+        {
+          matchCase: false,
+        }
+      )
+    })
+
+    it('displays the correct topic label', () => {
+      cy.get('[data-test="great-theme-label"]').contains('great.gov.uk', {
+        matchCase: false,
+      })
+    })
+
+    it('displays the correct sub-topic label', () => {
+      cy.get('[data-test="great-service-label"]').contains('service', {
+        matchCase: false,
+      })
+    })
+    it('displays the Great export enquiry subject', () => {
+      cy.get('[data-test="collection-item"]').each(() =>
+        cy.get('h3').contains(`${activity.great.meta_subject}`)
+      )
+    })
   })
 
   context('Orders (OMIS)', () => {

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -92,6 +92,16 @@ describe('Company activity feed', () => {
         cy.get('h3').contains(`${activity.great_export_enquiry.meta_subject}`)
       )
     })
+    it('displays the Great export enquiry contact', () => {
+      cy.get('[data-test="metadata-item"]').contains(
+        `${activity.great_export_enquiry.contact.name}`
+      )
+    })
+    it('displays the Great export enquiry comment', () => {
+      cy.get('[data-test="metadata-item"]').contains(
+        `${activity.great_export_enquiry.data_enquiry}`
+      )
+    })
   })
 
   context('Orders (OMIS)', () => {

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -89,7 +89,7 @@ describe('Company activity feed', () => {
     })
     it('displays the Great export enquiry subject', () => {
       cy.get('[data-test="collection-item"]').each(() =>
-        cy.get('h3').contains(`${activity.great.meta_subject}`)
+        cy.get('h3').contains(`${activity.great_export_enquiry.meta_subject}`)
       )
     })
   })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -591,10 +591,10 @@ describe('Company overview page', () => {
       const activity = greatList[0]
       cy.get('[data-test="great-kind-label"]').contains('great.gov.uk')
       cy.get('[data-test="activity-subject"]').contains(
-        activity.great.meta_subject
+        activity.great_export_enquiry.meta_subject
       )
       cy.get('[data-test="activity-summary"]').contains(
-        `Enquirer ${activity.great.contact.first_name} ${activity.great.contact.last_name}`
+        `Enquirer ${activity.great_export_enquiry.contact.first_name} ${activity.great_export_enquiry.contact.last_name}`
       )
     })
   })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -6,6 +6,7 @@ import {
 import { getCollectionList } from '../../support/collection-list-assertions'
 import { collectionListRequest } from '../../support/actions'
 import companyActivityListFaker, {
+  companyActivityGreatListFaker,
   companyActivityInvestmentListFaker,
   companyActivityOrderListFaker,
 } from '../../fakers/company-activity'
@@ -401,6 +402,7 @@ describe('Company overview page', () => {
       {},
       { primary_market: null }
     )
+    const greatList = companyActivityGreatListFaker(1)
     beforeEach(() => {
       collectionListRequest(
         'v4/search/company-activity',
@@ -578,6 +580,22 @@ describe('Company overview page', () => {
         .parent()
         .next()
         .contains('Joe Bloggs organised Best service')
+    })
+
+    it('should display Data Hub great activity', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        greatList,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      const activity = greatList[0]
+      cy.get('[data-test="great-kind-label"]').contains('great.gov.uk')
+      cy.get('[data-test="activity-subject"]').contains(
+        activity.great.meta_subject
+      )
+      cy.get('[data-test="activity-summary"]').contains(
+        `Enquirer ${activity.great.contact.first_name} ${activity.great.contact.last_name}`
+      )
     })
   })
 

--- a/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
+++ b/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
@@ -1,5 +1,5 @@
 {
-  "count": 2,
+  "count": 5,
   "results": [
     {
       "id": "e25696d1-a54b-4e2e-b0bf-9657e9c4c55b",


### PR DESCRIPTION
## Description of change

- Add great data to company activity overview and feed 
- Add test for company activity overview and feed spec 
- Change TitleRenderer to display H3 if no URL is passed
- Activities count to match `transformActivities` size. This is because if we add a new activity in the API and have not included the FE changes, we would get the incorrect activities count 

## Test instructions

Great data feed on company overview and activity feed

## Screenshots

<img width="957" alt="image" src="https://github.com/user-attachments/assets/5758fc16-46b0-4fd7-93b0-79d92d0adcf4">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
