### PR TITLE
Remove jsonpath override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -139,7 +139,7 @@
         "js-cookie": "^3.0.5",
         "jsdom": "^20.0.3",
         "jsdom-global": "^3.0.2",
-        "json-schema-faker": "^0.5.5",
+        "json-schema-faker": "^0.5.8",
         "lint-staged": "^15.2.10",
         "mocha": "^10.8.2",
         "mocha-junit-reporter": "^2.2.1",
@@ -15743,13 +15743,13 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
     },
     "node_modules/json-schema-faker": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.6.tgz",
-      "integrity": "sha512-u/cFC26/GDxh2vPiAC8B8xVvpXAW+QYtG2mijEbKrimCk8IHtiwQBjCE8TwvowdhALWq9IcdIWZ+/8ocXvdL3Q==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/json-schema-faker/-/json-schema-faker-0.5.8.tgz",
+      "integrity": "sha512-sqzPEbEDlpiH8U1tfmJHScXHy52onvMxITPsHyhe/jhS83g8TX6ruvRqt/ot1bXUPRsh7Ps1sWqJiBxIXmW5Xw==",
       "dev": true,
       "dependencies": {
         "json-schema-ref-parser": "^6.1.0",
-        "jsonpath-plus": "^7.2.0"
+        "jsonpath-plus": "^10.1.0"
       },
       "bin": {
         "jsf": "bin/gen.cjs"
@@ -15828,9 +15828,9 @@
       }
     },
     "node_modules/jsonpath-plus": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.0.0.tgz",
-      "integrity": "sha512-v7j76HGp/ibKlXYeZ7UrfCLSNDaBWuJMA0GaMjA4sZJtCtY89qgPyToDDcl2zdeHh4B5q/B3g2pQdW76fOg/dA==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.1.0.tgz",
+      "integrity": "sha512-gHfV1IYqH8uJHYVTs8BJX1XKy2/rR93+f8QQi0xhx95aCiXn1ettYAd5T+7FU6wfqyDoX/wy0pm/fL3jOKJ9Lg==",
       "dev": true,
       "dependencies": {
         "@jsep-plugin/assignment": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "js-cookie": "^3.0.5",
     "jsdom": "^20.0.3",
     "jsdom-global": "^3.0.2",
-    "json-schema-faker": "^0.5.5",
+    "json-schema-faker": "^0.5.8",
     "lint-staged": "^15.2.10",
     "mocha": "^10.8.2",
     "mocha-junit-reporter": "^2.2.1",
@@ -223,7 +223,6 @@
   "overrides": {
     "yaml": "^2.2.2",
     "semver": "7.5.2",
-    "tough-cookie": "4.1.3",
-    "jsonpath-plus": "10.0.0"
+    "tough-cookie": "4.1.3"
   }
 }


### PR DESCRIPTION
## Description of change

We have a critical security alert for `jsonpath-plus`, I have fixed it by updating the dependency and removed the override for it.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
