### PR TITLE
Fix company activity count

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -316,6 +316,10 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
 }
 
 export const transformResponseToCollection = (activities) => ({
+  // activities.count comes from the backend because the frontend
+  // only collects the paginated amount on each request. If a new data
+  // source is added to the backend and not the frontend this count
+  // will show more activities than are displayed until the frontend is updated.
   count: activities.count,
   results: transformActivities(activities),
 })

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -316,7 +316,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
 }
 
 export const transformResponseToCollection = (activities) => ({
-  count: transformActivities(activities).length,
+  count: activities.count,
   results: transformActivities(activities),
 })
 

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -196,6 +196,6 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
 }
 
 export const transformResponseToCollection = (activities) => ({
-  count: transformActivity(activities).length,
+  count: activities.count,
   results: transformActivity(activities),
 })


### PR DESCRIPTION
## Description of change

Update the company activity count to be sourced from `activities.count` again. This is necessary because the frontend only retrieves the paginated data with each request. If a new data source is added to `company_activity` but not included in the frontend's `transformActivities`, the count will display more activities than are actually shown.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
