### PR TITLE
Add null check for one list tier

### DIFF
--- a/src/client/modules/Companies/CompanyBusinessDetails/SectionOneList.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/SectionOneList.jsx
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import React from 'react'
 import PropTypes from 'prop-types'
 import Link from '@govuk-react/link'
@@ -7,6 +6,7 @@ import { SPACING_POINTS } from '@govuk-react/constants'
 
 import { SummaryTable } from '../../../components'
 import urls from '../../../../lib/urls'
+import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
 const StyledSummaryFooterLink = styled(Link)`
   margin-top: -${SPACING_POINTS[7]}px;
@@ -15,14 +15,14 @@ const StyledSummaryFooterLink = styled(Link)`
 
 const getLocation = (manager) => {
   if (!manager || !manager.ditTeam) {
-    return '-'
+    return ''
   }
 
   return manager.ditTeam.ukRegion
     ? manager.ditTeam.ukRegion.name
     : manager.ditTeam.country
-    ? manager.ditTeam.country.name
-    : '-'
+      ? manager.ditTeam.country.name
+      : ''
 }
 
 const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
@@ -41,14 +41,16 @@ const SectionOneList = ({ company, isArchived, isDnbCompany }) =>
         }
       >
         <SummaryTable.Row heading="One List tier">
-          {company.oneListGroupTier.name}
+          {company.oneListGroupTier
+            ? company.oneListGroupTier.name
+            : NOT_SET_TEXT}
         </SummaryTable.Row>
 
         <SummaryTable.Row heading="Global Account Manager">
           {company.oneListGroupGlobalAccountManager.name}
           {company.oneListGroupGlobalAccountManager.ditTeam
             ? company.oneListGroupGlobalAccountManager.ditTeam.name
-            : '-'}
+            : ''}
           {getLocation(company.oneListGroupGlobalAccountManager)}
         </SummaryTable.Row>
       </SummaryTable>


### PR DESCRIPTION
## Description of change

An issue has been identified in Sentry where the business details page does not load at all for account managed companies without a one list tier. This has now been fixed.

I've also updated the account manager table to not show anything where the manager's team or location are missing (currently this shows a `-` character).

## Test instructions

In dev, navigate to `/companies/0433587e-f4e1-455f-8249-7a69203121ec/business-details`. You will not be able to access the page due to an error.

Access the same company within this branch and it should work.

## Screenshots

### Before

<img width="514" alt="Screenshot 2024-11-18 at 15 23 14" src="https://github.com/user-attachments/assets/9969d66e-2385-4373-ab28-1c52879c6894">

<img width="999" alt="Screenshot 2024-11-18 at 15 26 36" src="https://github.com/user-attachments/assets/168f94c5-7bbc-420c-8771-6eebc234701c">


### After

<img width="658" alt="Screenshot 2024-11-18 at 15 22 41" src="https://github.com/user-attachments/assets/3768430b-55a0-4d25-9b63-b671c3f9d490">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
