### PR TITLE
Use correct date format function for activity dates

### DIFF
--- a/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
@@ -35,7 +35,9 @@ const rows = ({ results }) => {
       <Table.Cell setWidth="12%">
         {task.due_date
           ? formatMediumDateParsed(task.due_date)
-          : formatMediumDateParsed(task.dueDate)}
+          : task.dueDate
+            ? formatMediumDateParsed(task.dueDate)
+            : ''}
       </Table.Cell>
       <Table.Cell setWidth="23%">
         <Link

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -3,7 +3,7 @@ import Link from '@govuk-react/link'
 
 import { TAGS } from './constants'
 import urls from '../../../../lib/urls'
-import { formatMediumDate } from '../../../utils/date'
+import { formatMediumDate, formatMediumDateParsed } from '../../../utils/date'
 import { AdviserResource } from '../../../components/Resource'
 import { INTERACTION_NAMES } from '../../../../apps/interactions/constants'
 
@@ -68,7 +68,7 @@ export const transformActivities = (activities) => {
 
     switch (activity_source) {
       case 'interaction':
-        return transformInteractionToListItem(activity.interaction)
+        return transformInteractionToListItem(activity)
       case 'referral':
         return transformReferralToListItem(activity)
       case 'investment':
@@ -87,58 +87,63 @@ export const transformActivities = (activities) => {
   )
 }
 
-export const transformInteractionToListItem = ({
-  date,
-  subject,
-  dit_participants,
-  service,
-  id,
-  contacts,
-  kind,
-  communication_channel,
-}) => ({
-  id,
-  metadata: [
-    { label: 'Date', value: formatMediumDate(date) },
-    {
-      label: verifyLabel(contacts, 'Contact'),
-      value: formattedContacts(contacts),
-    },
-    { label: 'Communication channel', value: communication_channel?.name },
-    {
-      label: verifyLabel(dit_participants, 'Adviser'),
-      value: formattedAdvisers(dit_participants),
-    },
-    { label: 'Service', value: service?.name },
-  ].filter(({ value }) => Boolean(value)),
-  tags: [
-    {
-      text: INTERACTION_NAMES[kind],
-      colour: 'grey',
-      dataTest: 'activity-kind-label',
-    },
-    {
-      text:
-        service && service.name.includes(' : ')
-          ? service.name.split(' : ')[0]
-          : service?.name,
-      colour: 'blue',
-      dataTest: 'activity-service-label',
-    },
-  ].filter(({ text }) => Boolean(text)),
-  headingUrl: urls.interactions.detail(id),
-  headingText: subject,
-})
+export const transformInteractionToListItem = (activity) => {
+  const interaction = activity.interaction
+  return {
+    id: interaction.id,
+    metadata: [
+      {
+        label: 'Date',
+        value: formatMediumDateParsed(interaction.date),
+      },
+      {
+        label: verifyLabel(interaction.contacts, 'Contact'),
+        value: formattedContacts(interaction.contacts),
+      },
+      {
+        label: 'Communication channel',
+        value: interaction.communication_channel?.name,
+      },
+      {
+        label: verifyLabel(interaction.dit_participants, 'Adviser'),
+        value: formattedAdvisers(interaction.dit_participants),
+      },
+      { label: 'Service', value: interaction.service?.name },
+    ].filter(({ value }) => Boolean(value)),
+    tags: [
+      {
+        text: INTERACTION_NAMES[interaction.kind],
+        colour: 'grey',
+        dataTest: 'activity-kind-label',
+      },
+      {
+        text:
+          interaction.service && interaction.service.name.includes(' : ')
+            ? interaction.service.name.split(' : ')[0]
+            : interaction.service?.name,
+        colour: 'blue',
+        dataTest: 'activity-service-label',
+      },
+    ].filter(({ text }) => Boolean(text)),
+    headingUrl: urls.interactions.detail(interaction.id),
+    headingText: interaction.subject,
+  }
+}
 
 export const transformReferralToListItem = (activity) => {
   const referral = activity.referral
   return {
     id: referral.id,
     metadata: [
-      { label: 'Created Date', value: formatMediumDate(referral.created_on) },
+      {
+        label: 'Created Date',
+        value: formatMediumDateParsed(referral.created_on),
+      },
       {
         label: 'Completed Date',
-        value: formatMediumDate(referral.completed_on),
+        value: referral.completed_on
+          ? formatMediumDate(referral.completed_on)
+          : '',
       },
       {
         label: 'Sending adviser',
@@ -174,7 +179,7 @@ export const transformInvestmentToListItem = (activity) => {
   return {
     id: activity.investment.id,
     metadata: [
-      { label: 'Created Date', value: formatMediumDate(activity.date) },
+      { label: 'Created Date', value: formatMediumDateParsed(activity.date) },
       {
         label: 'Investment Type',
         value: activity.investment.investment_type.name,
@@ -231,7 +236,7 @@ export const transformOrderToListItem = (activity) => {
   return {
     id: activity.order.id,
     metadata: [
-      { label: 'Date', value: formatMediumDate(activity.date) },
+      { label: 'Date', value: formatMediumDateParsed(activity.date) },
       {
         label: 'Country',
         value: activity.order.primary_market.name,
@@ -284,7 +289,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
   return {
     id: great.id,
     metadata: [
-      { label: 'Date', value: formatMediumDate(great.created_on) },
+      { label: 'Date', value: formatMediumDateParsed(great.created_on) },
       {
         label: 'Contact',
         value: formattedContacts([great.contact]),

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -1,5 +1,8 @@
 import { TAGS } from '../../../CompanyActivity/constants'
-import { formatMediumDate, isDateInFuture } from '../../../../../utils/date'
+import {
+  formatMediumDateParsed,
+  isDateInFuture,
+} from '../../../../../utils/date'
 import { INTERACTION_NAMES } from '../../../../../../apps/interactions/constants'
 import urls from '../../../../../../lib/urls'
 
@@ -76,7 +79,8 @@ export const transformReferralToListItem = (activity) => {
     receiving adviser ${referral.recipient.name}
   `
 
-  const date = !referral.completedOn && formatMediumDate(referral.created_on)
+  const date =
+    !referral.completedOn && formatMediumDateParsed(referral.created_on)
 
   return {
     id: referral.id,
@@ -107,7 +111,7 @@ export const transformInteractionToListItem = ({
   contacts,
 }) => ({
   id,
-  date: formatMediumDate(date),
+  date: formatMediumDateParsed(date),
   tags: [
     {
       text: INTERACTION_NAMES[kind],
@@ -130,7 +134,7 @@ export const transformInvestmentToListItem = (activity) => {
 
   return {
     id: investment.id,
-    date: formatMediumDate(activity.date),
+    date: formatMediumDateParsed(activity.date),
     tags: [
       {
         text: 'New Investment Project',
@@ -163,7 +167,7 @@ export const transformOrderToListItem = (activity) => {
     : summary.push('')
   return {
     id: order.id,
-    date: formatMediumDate(activity.date),
+    date: formatMediumDateParsed(activity.date),
     tags: [
       {
         text: 'New Order',
@@ -181,7 +185,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
   const great = activity.great_export_enquiry
   return {
     id: great.id,
-    date: formatMediumDate(activity.date),
+    date: formatMediumDateParsed(activity.date),
 
     tags: [
       {

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -53,7 +53,7 @@ export const transformActivity = (activities) => {
 
     switch (activity_source) {
       case 'interaction':
-        return transformInteractionToListItem(activity.interaction)
+        return transformInteractionToListItem(activity)
       case 'referral':
         return transformReferralToListItem(activity)
       case 'investment':
@@ -101,31 +101,23 @@ export const transformReferralToListItem = (activity) => {
   }
 }
 
-export const transformInteractionToListItem = ({
-  date,
-  subject,
-  id,
-  kind,
-  communication_channel,
-  dit_participants,
-  contacts,
-}) => ({
-  id,
-  date: formatMediumDateParsed(date),
+export const transformInteractionToListItem = (activity) => ({
+  id: activity.id,
+  date: formatMediumDateParsed(activity.date),
   tags: [
     {
-      text: INTERACTION_NAMES[kind],
+      text: INTERACTION_NAMES[activity.interaction.kind],
       colour: 'grey',
       dataTest: 'activity-kind-label',
     },
   ],
-  headingUrl: urls.interactions.detail(id),
-  headingText: subject,
+  headingUrl: urls.interactions.detail(activity.id),
+  headingText: activity.interaction.subject,
   summary: buildSummary(
-    dit_participants,
-    communication_channel?.name,
-    contacts,
-    date
+    activity.interaction.dit_participants,
+    activity.interaction.communication_channel?.name,
+    activity.interaction.contacts,
+    activity.date
   ),
 })
 

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -14,27 +14,28 @@ import { keysToSnakeCase } from '../../../../../functional/cypress/fakers/utils'
 import { STATUS } from '../../../../../../src/client/modules/Tasks/TaskForm/constants'
 
 describe('My Tasks on the Dashboard', () => {
-  // Create 3 tasks of which one is Archived
-  const myTasksList = taskWithInvestmentProjectListFaker()
+  // Create 4 tasks of which one is Archived and one has no due date
+  const myTasksList = taskWithInvestmentProjectListFaker((length = 4))
   myTasksList[1].status = STATUS.COMPLETED
+  myTasksList[3].dueDate = null
 
   const myTaskResults = myTasksList.map((task) => keysToSnakeCase(task))
   const myTasks = {
-    count: 3,
+    count: 4,
     results: myTaskResults,
   }
 
-  context('When the logged in adviser has three tasks', () => {
+  context('When the logged in adviser has four tasks', () => {
     beforeEach(() => {
       cy.viewport(1024, 768)
       cy.mountWithProvider(<MyTasksContent myTasks={myTasks} />)
     })
 
-    it('should display the heading 3 tasks', () => {
-      cy.get('h2').should('contain', '3 tasks')
+    it('should display the heading 4 tasks', () => {
+      cy.get('h2').should('contain', '4 tasks')
     })
 
-    it('should render three table rows in due date in default ascending order', () => {
+    it('should render four table rows in due date in default ascending order', () => {
       assertGovReactTable({
         element: '[data-test="my-tasks-table"]',
         rows: [
@@ -66,6 +67,16 @@ describe('My Tasks on the Dashboard', () => {
             myTaskResults[2].advisers[0].name +
               myTaskResults[2].advisers[1].name +
               myTaskResults[2].advisers[2].name,
+            'Active',
+          ],
+          [
+            '',
+            myTaskResults[3].title,
+            myTaskResults[3].company.name,
+            myTaskResults[3].investment_project.name,
+            myTaskResults[3].advisers[0].name +
+              myTaskResults[3].advisers[1].name +
+              myTaskResults[3].advisers[2].name,
             'Active',
           ],
         ],

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -61,6 +61,7 @@ describe('Company activity feed', () => {
       'Activity Feed'
     )
   })
+
   context('Great Export Enquiry activity feed', () => {
     const greatData = companyActivityGreatListFaker(1)
     beforeEach(() => {
@@ -169,67 +170,64 @@ describe('Company activity feed', () => {
         cy.get('span').contains('UK region').should('not.exist')
       )
     })
+  })
 
-    context('Investment project', () => {
-      beforeEach(() => {
-        cy.visit(urls.companies.activity.index(company.id))
-      })
+  context('Investment project', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.activity.index(company.id))
+    })
 
-      it('displays the correct activity type label', () => {
-        cy.get('[data-test="investment-service-label"]').contains(
-          'New Investment Project',
-          {
-            matchCase: false,
-          }
-        )
-      })
-
-      it('displays the correct topic label', () => {
-        cy.get('[data-test="investment-theme-label"]').contains('Investment', {
+    it('displays the correct activity type label', () => {
+      cy.get('[data-test="investment-service-label"]').contains(
+        'New Investment Project',
+        {
           matchCase: false,
-        })
+        }
+      )
+    })
+
+    it('displays the correct topic label', () => {
+      cy.get('[data-test="investment-theme-label"]').contains('Investment', {
+        matchCase: false,
       })
-      it('displays the investment project name with link', () => {
-        cy.get('[data-test="collection-item"]').each(() =>
-          cy
-            .get('a')
-            .contains('Bo Oh O Wa er')
-            .should(
-              'have.attr',
-              'href',
-              '/investments/projects/9a824ef8-207e-4f6b-9205-91a42c1c77ef/details'
-            )
-        )
+    })
+    it('displays the investment project name with link', () => {
+      cy.get('[data-test="collection-item"]').each(() =>
+        cy
+          .get('a')
+          .contains('Bo Oh O Wa er')
+          .should(
+            'have.attr',
+            'href',
+            '/investments/projects/9a824ef8-207e-4f6b-9205-91a42c1c77ef/details'
+          )
+      )
+    })
+  })
+
+  context('Referrals project', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.activity.index(company.id))
+    })
+
+    it('displays the correct referral type label', () => {
+      cy.get('[data-test="referral-label"]').contains('Outstanding Referral', {
+        matchCase: false,
       })
     })
 
-    context('Referrals project', () => {
-      beforeEach(() => {
-        cy.visit(urls.companies.activity.index(company.id))
-      })
-
-      it('displays the correct referral type label', () => {
-        cy.get('[data-test="referral-label"]').contains(
-          'Outstanding Referral',
-          {
-            matchCase: false,
-          }
-        )
-      })
-
-      it('displays the referral name with link', () => {
-        const activity = company_activities.results[2]
-        cy.get('[data-test="collection-item"]').each(() =>
-          cy
-            .get('a')
-            .contains(activity.referral.subject)
-            .should(
-              'have.attr',
-              'href',
-              `/companies/${activity.company.id}/referrals/${activity.referral.id}`
-            )
-        )
-      })
+    it('displays the referral name with link', () => {
+      const activity = company_activities.results[2]
+      cy.get('[data-test="collection-item"]').each(() =>
+        cy
+          .get('a')
+          .contains(activity.referral.subject)
+          .should(
+            'have.attr',
+            'href',
+            `/companies/${activity.company.id}/referrals/${activity.referral.id}`
+          )
+      )
     })
   })
 })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -509,9 +509,6 @@ describe('Company overview page', () => {
         'a',
         activity.interaction.subject
       )
-      cy.get('[data-test="activity-summary"]').contains(
-        `${activity.interaction.dit_participants[0].adviser.name} had ${activity.interaction.communication_channel.name} contact with ${activity.interaction.contacts[0].name}`
-      )
     })
     it('should display Data Hub investment activity', () => {
       collectionListRequest(


### PR DESCRIPTION
## Description of change

The dates for activities were not showing since the `date-fns` upgrade. It seems that there are no component tests (or any tests) for the content of these new cards meaning that this was not detected in the original PR.

An issue that caused tasks without due dates to crash the tasks table has also been fixed.

## Test instructions

Go to a company with activities (any company with interactions/investments/omis orders). They should have dates visible.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
