### PR TITLE
CLS2-1054 and CLS2-1055 Fixes for investment project header

### DIFF
--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -13,7 +13,11 @@ import { INVESTMENT_PROJECT_STAGES } from '../../modules/Investments/Projects/co
 import StatusMessage from '../StatusMessage'
 import { DARK_GREY, WHITE } from '../../utils/colours'
 
-const MetaList = styled('ul')({})
+const MetaList = styled('ul')({
+  display: 'flex',
+  flexWrap: 'wrap',
+  rowGap: SPACING.SCALE_5,
+})
 
 const StyledListItem = styled('li')({
   marginRight: SPACING.SCALE_5,
@@ -90,7 +94,7 @@ const InvestmentProjectLocalHeader = ({ investment }) => (
           {investment.createdBy.ditTeam.name}
         </MetaListItem>
       )}
-      {investment.eybLeads?.length && (
+      {investment.eybLeads?.length > 0 && (
         <MetaListItem text="Generated from">EYB lead</MetaListItem>
       )}
     </MetaList>


### PR DESCRIPTION
## Description of change

Fixes for Investment project header:
Include gaps between data rows in responsive fashion (CLS2-1054)
Remove stray 0 displayed when no leads (CLS2-1055)

## Test instructions

When viewing an Investment project there should be a space between rows when there are more entries in the Investment project header than fit in a single row.
When there are no EYB Leads associated with the investment project it should be blank and not display 0. 

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/4670af6f-cf2e-421d-bcbe-4089954ebd67)

### After

![image](https://github.com/user-attachments/assets/813e6dd9-1ae5-4f27-88d8-d3a93022513c)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
