### PR TITLE
update company overview

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -4,6 +4,7 @@ import Link from '@govuk-react/link'
 import { TAGS } from './constants'
 import urls from '../../../../lib/urls'
 import { formatMediumDate, formatMediumDateParsed } from '../../../utils/date'
+import { truncateData } from '../utils'
 import { AdviserResource } from '../../../components/Resource'
 import { INTERACTION_NAMES } from '../../../../apps/interactions/constants'
 
@@ -39,11 +40,6 @@ export const formattedContacts = (contacts) =>
       </Link>
     </span>
   ))
-
-export const truncateData = (enquiry, maxLength = 200) =>
-  enquiry.length < maxLength
-    ? enquiry
-    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'
 
 export const formattedAdvisers = (advisers) =>
   !!advisers.length &&

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -3,6 +3,7 @@ import {
   formatMediumDateParsed,
   isDateInFuture,
 } from '../../../../../utils/date'
+import { truncateData } from '../../../utils'
 import { INTERACTION_NAMES } from '../../../../../../apps/interactions/constants'
 import urls from '../../../../../../lib/urls'
 
@@ -186,7 +187,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
         dataTest: 'great-kind-label',
       },
     ].filter(({ text }) => Boolean(text)),
-    headingText: great.meta_subject,
+    headingText: truncateData(great.meta_subject, 35),
     summary: `Enquirer ${great.contact.first_name} ${great.contact.last_name}`,
   }
 }

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -3,7 +3,7 @@ import {
   formatMediumDateParsed,
   isDateInFuture,
 } from '../../../../../utils/date'
-import { truncateData } from '../../../utils'
+import { truncateData } from '../../../../../utils/truncate'
 import { INTERACTION_NAMES } from '../../../../../../apps/interactions/constants'
 import urls from '../../../../../../lib/urls'
 

--- a/src/client/modules/Companies/utils.js
+++ b/src/client/modules/Companies/utils.js
@@ -78,3 +78,8 @@ export const companyCollectionListMetadataTask = (ID) => {
     },
   }
 }
+
+export const truncateData = (enquiry, maxLength = 200) =>
+  enquiry.length < maxLength
+    ? enquiry
+    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Link, H3 } from 'govuk-react'
+import { Link, H4 } from 'govuk-react'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
 
@@ -60,7 +60,7 @@ const StyledLinkHeader = styled('h3')`
 // e.g. the positional arguments should be passed as an object
 export const TitleRenderer = (title, url, margin = { bottom: 10 }) => (
   <StyledLinkHeader margin={margin}>
-    {url ? <Link href={url}>{title}</Link> : <H3>{title}</H3>}
+    {url ? <Link href={url}>{title}</Link> : <H4>{title}</H4>}
   </StyledLinkHeader>
 )
 

--- a/src/client/utils/truncate.js
+++ b/src/client/utils/truncate.js
@@ -1,0 +1,4 @@
+export const truncateData = (enquiry, maxLength = 200) =>
+  enquiry.length < maxLength
+    ? enquiry
+    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -3,6 +3,7 @@ import {
   companyActivityOrderListFaker,
   companyActivityGreatListFaker,
 } from '../../fakers/company-activity'
+import { truncateData } from '../../../../../src/client/utils/truncate'
 
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
@@ -10,11 +11,6 @@ const { assertCompanyBreadcrumbs } = require('../../support/assertions')
 
 const company = fixtures.company.allActivitiesCompany
 const company_activities = fixtures.company.activities
-
-const truncateData = (enquiry, maxLength = 200) =>
-  enquiry.length < maxLength
-    ? enquiry
-    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'
 
 /*
  * Parts of this test are being skipped as we aren't pulling in this data from ActivityStream any more

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -102,7 +102,7 @@ describe('Company activity feed', () => {
     })
     it('displays the Great export enquiry subject', () => {
       cy.get('[data-test="collection-item"]').each(() =>
-        cy.get('h3').contains(`Enquiry ${great_subject}`)
+        cy.get('h4').contains(`Enquiry ${great_subject}`)
       )
     })
     it('displays the Great export enquiry contact', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -10,16 +10,12 @@ import companyActivityListFaker, {
   companyActivityInvestmentListFaker,
   companyActivityOrderListFaker,
 } from '../../fakers/company-activity'
+import { truncateData } from '../../../../../src/client/utils/truncate'
 
 const fixtures = require('../../fixtures')
 const urls = require('../../../../../src/lib/urls')
 
 const { usCompany } = company
-
-const truncateData = (enquiry, maxLength = 200) =>
-  enquiry.length < maxLength
-    ? enquiry
-    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'
 
 describe('Company overview page', () => {
   const interactionUrlAllOverview = urls.companies.interactions.index(

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -16,6 +16,11 @@ const urls = require('../../../../../src/lib/urls')
 
 const { usCompany } = company
 
+const truncateData = (enquiry, maxLength = 200) =>
+  enquiry.length < maxLength
+    ? enquiry
+    : enquiry.slice(0, maxLength).split(' ').slice(0, -1).join(' ') + ' ...'
+
 describe('Company overview page', () => {
   const interactionUrlAllOverview = urls.companies.interactions.index(
     fixtures.company.allOverviewDetails.id
@@ -586,10 +591,12 @@ describe('Company overview page', () => {
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
       const activity = greatList[0]
-      cy.get('[data-test="great-kind-label"]').contains('great.gov.uk')
-      cy.get('[data-test="activity-subject"]').contains(
-        activity.great_export_enquiry.meta_subject
+      const subject = truncateData(
+        activity.great_export_enquiry.meta_subject,
+        35
       )
+      cy.get('[data-test="great-kind-label"]').contains('great.gov.uk')
+      cy.get('[data-test="activity-subject"]').contains(subject)
       cy.get('[data-test="activity-summary"]').contains(
         `Enquirer ${activity.great_export_enquiry.contact.first_name} ${activity.great_export_enquiry.contact.last_name}`
       )


### PR DESCRIPTION
## Description of change

On the overview page for company we truncate great export enquiry title

Change non link titles to H4

## Screenshots

### Before

<img width="960" alt="image" src="https://github.com/user-attachments/assets/693df676-0ec8-42ef-b917-cf3d8737eba5">

### After

<img width="960" alt="image" src="https://github.com/user-attachments/assets/e27571ac-fdae-4dfb-a1cd-125bdc547edd">
_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
