### PR TITLE
Use correct ID for interactions overview card

### DIFF
--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -102,7 +102,7 @@ export const transformReferralToListItem = (activity) => {
 }
 
 export const transformInteractionToListItem = (activity) => ({
-  id: activity.id,
+  id: activity.interaction.id,
   date: formatMediumDateParsed(activity.date),
   tags: [
     {
@@ -111,7 +111,7 @@ export const transformInteractionToListItem = (activity) => ({
       dataTest: 'activity-kind-label',
     },
   ],
-  headingUrl: urls.interactions.detail(activity.id),
+  headingUrl: urls.interactions.detail(activity.interaction.id),
   headingText: activity.interaction.subject,
   summary: buildSummary(
     activity.interaction.dit_participants,


### PR DESCRIPTION
## Description of change

In my PR from yesterday I used the wrong ID for the interaction items (instead of using the correct interaction ID I foolishly used the activity object ID). I've fixed this.

## Test instructions

Go to the company overview tab for a company with interactions. You should be able to open the interaction from that tab.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
