### PR TITLE
Fix a bug when adding investment project failed when related company had no contacts.

### DIFF
--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -26,13 +26,11 @@ import Tag, { TAG_COLOURS } from '../../../components/Tag'
 
 export const checkIfItemHasValue = (item) => (item ? item : null)
 
-export const transformArrayForTypeahead = (array) =>
-  array && array.length
-    ? array.map((value) => ({
-        label: value.name,
-        value: value.id,
-      }))
-    : null
+export const transformArrayForTypeahead = (x) =>
+  x?.map((value) => ({
+    label: value.name,
+    value: value.id,
+  })) || []
 
 export const transformAndFilterArrayForTypeahead = (array) => {
   const filteredArray = idNamesToValueLabels(

--- a/test/functional/cypress/specs/investments/project-add-investment-spec.js
+++ b/test/functional/cypress/specs/investments/project-add-investment-spec.js
@@ -98,6 +98,18 @@ const investmentTypeTests = () => {
   })
 }
 
+it('Adding an investment related to company with no contacts should not fail', () => {
+  cy.intercept('GET', '/api-proxy/v4/contact*', {
+    count: 0,
+    next: null,
+    previous: null,
+    results: [],
+  })
+  cy.visit('/investments/projects/create/foo')
+  cy.contains('label', 'Non-FDI').click()
+  cy.contains('Continue').click()
+})
+
 describe('Adding an investment via "Companies"', () => {
   beforeEach(() => {
     cy.visit(urls.companies.investments.companyInvestmentProjects(usCompany.id))


### PR DESCRIPTION
## Description of change

Fixes a bug when adding investment project failed when related company had no contacts.

## Test instructions

1. Find a company with no contacts and grab its ID
2. Go to `/investments/projects/create/<id-of-company-with-no-contacts>`
3. Fill out the required fields of the form and click the _Continue_ button
4. You should get to the next step of the form without any errors.

## Screenshots

Nothing should have changed visually
