### PR TITLE
Chore/Dependancies/CPS-639 Bump nivo/core to 0.88.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "MIT",
       "dependencies": {
         "@govuk-react/constants": "^0.10.7",
-        "@nivo/core": "^0.87.0",
+        "@nivo/core": "^0.88.0",
         "@nivo/pie": "^0.87.0",
         "@nivo/tooltip": "^0.87.0",
         "@redux-devtools/extension": "^3.3.0",
@@ -4841,27 +4841,7 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/colors": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.87.0.tgz",
-      "integrity": "sha512-S4pZzRGKK23t8XAjQMhML6wwsfKO9nH03xuyN4SvCodNA/Dmdys9xV+9Dg/VILTzvzsBTBGTX0dFBg65WoKfVg==",
-      "dependencies": {
-        "@nivo/core": "0.87.0",
-        "@types/d3-color": "^3.0.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-scale-chromatic": "^3.0.0",
-        "@types/prop-types": "^15.7.2",
-        "d3-color": "^3.1.0",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/core": {
+    "node_modules/@nivo/arcs/node_modules/@nivo/core": {
       "version": "0.87.0",
       "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
       "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
@@ -4887,6 +4867,90 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
+    "node_modules/@nivo/colors": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.87.0.tgz",
+      "integrity": "sha512-S4pZzRGKK23t8XAjQMhML6wwsfKO9nH03xuyN4SvCodNA/Dmdys9xV+9Dg/VILTzvzsBTBGTX0dFBg65WoKfVg==",
+      "dependencies": {
+        "@nivo/core": "0.87.0",
+        "@types/d3-color": "^3.0.0",
+        "@types/d3-scale": "^4.0.8",
+        "@types/d3-scale-chromatic": "^3.0.0",
+        "@types/prop-types": "^15.7.2",
+        "d3-color": "^3.1.0",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/colors/node_modules/@nivo/core": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
+      "dependencies": {
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/core": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.88.0.tgz",
+      "integrity": "sha512-XjUkA5MmwjLP38bdrJwn36Gj7T5SYMKD55LYQp/1nIJPdxqJ38dUfE4XyBDfIEgfP6yrHOihw3C63cUdnUBoiw==",
+      "dependencies": {
+        "@nivo/tooltip": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/core/node_modules/@nivo/tooltip": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
+      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
+      "dependencies": {
+        "@nivo/core": "0.88.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
     "node_modules/@nivo/legends": {
       "version": "0.87.0",
       "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.87.0.tgz",
@@ -4896,6 +4960,32 @@
         "@nivo/core": "0.87.0",
         "@types/d3-scale": "^4.0.8",
         "d3-scale": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/legends/node_modules/@nivo/core": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
+      "dependencies": {
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
@@ -4918,6 +5008,32 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
+    "node_modules/@nivo/pie/node_modules/@nivo/core": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
+      "dependencies": {
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
     "node_modules/@nivo/tooltip": {
       "version": "0.87.0",
       "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.87.0.tgz",
@@ -4925,6 +5041,32 @@
       "dependencies": {
         "@nivo/core": "0.87.0",
         "@react-spring/web": "9.4.5 || ^9.7.2"
+      },
+      "peerDependencies": {
+        "react": ">= 16.14.0 < 19.0.0"
+      }
+    },
+    "node_modules/@nivo/tooltip/node_modules/@nivo/core": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
+      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
+      "dependencies": {
+        "@nivo/tooltip": "0.87.0",
+        "@react-spring/web": "9.4.5 || ^9.7.2",
+        "@types/d3-shape": "^3.1.6",
+        "d3-color": "^3.1.0",
+        "d3-format": "^1.4.4",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-scale-chromatic": "^3.0.0",
+        "d3-shape": "^3.2.0",
+        "d3-time-format": "^3.0.0",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "dependencies": {
         "@govuk-react/constants": "^0.10.7",
         "@nivo/core": "^0.88.0",
-        "@nivo/pie": "^0.87.0",
-        "@nivo/tooltip": "^0.87.0",
+        "@nivo/pie": "^0.88.0",
+        "@nivo/tooltip": "^0.88.0",
         "@redux-devtools/extension": "^3.3.0",
         "@reduxjs/toolkit": "^2.3.0",
         "@sentry/browser": "^8.40.0",
@@ -4827,12 +4827,12 @@
       }
     },
     "node_modules/@nivo/arcs": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.87.0.tgz",
-      "integrity": "sha512-YWmIm0el0hgVbPI3C5AX6R59WNnuKjh2GdocaVDP5zupqAMhfqyoMx+IM+A+Cg+UzE4xakrL0mSzL+rpMUK90Q==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.88.0.tgz",
+      "integrity": "sha512-q7MHxT71s/KKlDDtSJS4L9+/JIa5HPZZrDr3ZFECLnvp0TC1qzyFMtVevN2CsXopSTj8poN4uFXPWxYVXOq8vg==",
       "dependencies": {
-        "@nivo/colors": "0.87.0",
-        "@nivo/core": "0.87.0",
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
         "@react-spring/web": "9.4.5 || ^9.7.2",
         "@types/d3-shape": "^3.1.6",
         "d3-shape": "^3.2.0"
@@ -4841,38 +4841,12 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/arcs/node_modules/@nivo/core": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
-      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
-      "dependencies": {
-        "@nivo/tooltip": "0.87.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
     "node_modules/@nivo/colors": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.87.0.tgz",
-      "integrity": "sha512-S4pZzRGKK23t8XAjQMhML6wwsfKO9nH03xuyN4SvCodNA/Dmdys9xV+9Dg/VILTzvzsBTBGTX0dFBg65WoKfVg==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.88.0.tgz",
+      "integrity": "sha512-IZ+leYIqAlo7dyLHmsQwujanfRgXyoQ5H7PU3RWLEn1PP0zxDKLgEjFEDADpDauuslh2Tx0L81GNkWR6QSP0Mw==",
       "dependencies": {
-        "@nivo/core": "0.87.0",
+        "@nivo/core": "0.88.0",
         "@types/d3-color": "^3.0.0",
         "@types/d3-scale": "^4.0.8",
         "@types/d3-scale-chromatic": "^3.0.0",
@@ -4882,32 +4856,6 @@
         "d3-scale-chromatic": "^3.0.0",
         "lodash": "^4.17.21",
         "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/colors/node_modules/@nivo/core": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
-      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
-      "dependencies": {
-        "@nivo/tooltip": "0.87.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
@@ -4939,25 +4887,13 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/core/node_modules/@nivo/tooltip": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
-      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
-      "dependencies": {
-        "@nivo/core": "0.88.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
     "node_modules/@nivo/legends": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.87.0.tgz",
-      "integrity": "sha512-bVJCeqEmK4qHrxNaPU/+hXUd/yaKlcQ0yrsR18ewoknVX+pgvbe/+tRKJ+835JXlvRijYIuqwK1sUJQIxyB7oA==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.88.0.tgz",
+      "integrity": "sha512-d4DF9pHbD8LmGJlp/Gp1cF4e8y2wfQTcw3jVhbZj9zkb7ZWB7JfeF60VHRfbXNux9bjQ9U78/SssQqueVDPEmg==",
       "dependencies": {
-        "@nivo/colors": "0.87.0",
-        "@nivo/core": "0.87.0",
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
         "@types/d3-scale": "^4.0.8",
         "d3-scale": "^4.0.2"
       },
@@ -4965,42 +4901,16 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/legends/node_modules/@nivo/core": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
-      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
-      "dependencies": {
-        "@nivo/tooltip": "0.87.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
     "node_modules/@nivo/pie": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.87.0.tgz",
-      "integrity": "sha512-kY6LAQhOITwg8waFoDYLPkwUj/5XavSm61c7dXXJgCtqoj6c5u9AgwOTnZqS6IhMVEc5KV7ZNxSEHlHLQinmrg==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.88.0.tgz",
+      "integrity": "sha512-BE6dFWlGne1SnaEkFHNbg0sZBiwtcIqBFwmMRJ0F11SiKOzVeJyq3KiyY1I2ySSCx5VR1V8/MNBXzXFu3vJMAQ==",
       "dependencies": {
-        "@nivo/arcs": "0.87.0",
-        "@nivo/colors": "0.87.0",
-        "@nivo/core": "0.87.0",
-        "@nivo/legends": "0.87.0",
-        "@nivo/tooltip": "0.87.0",
+        "@nivo/arcs": "0.88.0",
+        "@nivo/colors": "0.88.0",
+        "@nivo/core": "0.88.0",
+        "@nivo/legends": "0.88.0",
+        "@nivo/tooltip": "0.88.0",
         "@types/d3-shape": "^3.1.6",
         "d3-shape": "^3.2.0"
       },
@@ -5008,65 +4918,13 @@
         "react": ">= 16.14.0 < 19.0.0"
       }
     },
-    "node_modules/@nivo/pie/node_modules/@nivo/core": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
-      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
-      "dependencies": {
-        "@nivo/tooltip": "0.87.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
     "node_modules/@nivo/tooltip": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.87.0.tgz",
-      "integrity": "sha512-nZJWyRIt/45V/JBdJ9ksmNm1LFfj59G1Dy9wB63Icf2YwyBT+J+zCzOGXaY7gxCxgF1mnSL3dC7fttcEdXyN/g==",
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
+      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
       "dependencies": {
-        "@nivo/core": "0.87.0",
+        "@nivo/core": "0.88.0",
         "@react-spring/web": "9.4.5 || ^9.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/tooltip/node_modules/@nivo/core": {
-      "version": "0.87.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.87.0.tgz",
-      "integrity": "sha512-yEQWJn7QjWnbmCZccBCo4dligNyNyz3kgyV9vEtcaB1iGeKhg55RJEAlCOul+IDgSCSPFci2SxTmipE6LZEZCg==",
-      "dependencies": {
-        "@nivo/tooltip": "0.87.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
       },
       "peerDependencies": {
         "react": ">= 16.14.0 < 19.0.0"
@@ -7602,9 +7460,9 @@
       }
     },
     "node_modules/@types/d3-time": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.3.tgz",
-      "integrity": "sha512-2p6olUZ4w3s+07q3Tm2dbiMZy5pCDfYwtLXXHUnVzXgQlZ/OyPtUz6OL382BkOuGlLXqfT+wqv8Fw2v8/0geBw=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@govuk-react/constants": "^0.10.7",
-    "@nivo/core": "^0.87.0",
+    "@nivo/core": "^0.88.0",
     "@nivo/pie": "^0.87.0",
     "@nivo/tooltip": "^0.87.0",
     "@redux-devtools/extension": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "@govuk-react/constants": "^0.10.7",
     "@nivo/core": "^0.88.0",
-    "@nivo/pie": "^0.87.0",
-    "@nivo/tooltip": "^0.87.0",
+    "@nivo/pie": "^0.88.0",
+    "@nivo/tooltip": "^0.88.0",
     "@redux-devtools/extension": "^3.3.0",
     "@reduxjs/toolkit": "^2.3.0",
     "@sentry/browser": "^8.40.0",


### PR DESCRIPTION
## Description of change

Dependabot - bump nivo/core to 0.88.0

This is going out separately from the rest of this week's dependabots as it had failing tests. This was resolved by running the nivo bulk upgrade script

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
