### PR TITLE
Fix a bug when export wins dashboard crashed when there were no company_contacts

### DIFF
--- a/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
+++ b/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
@@ -25,7 +25,7 @@ const getAddress = (contact, companyAddress) => {
         town: companyAddress.town,
         region: companyAddress.county || null,
         postcode: companyAddress.postcode,
-        country: companyAddress.country.name,
+        country: companyAddress.country?.name,
       }
     : {
         line1: contact.address1,

--- a/src/client/modules/ExportWins/Status/Contact.jsx
+++ b/src/client/modules/ExportWins/Status/Contact.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import Link from '@govuk-react/link'
+
+import urls from '../../../../lib/urls'
+
+const ContactLink = ({ name, id }) => (
+  <Link href={urls.contacts.details(id)}>{name}</Link>
+)
+
+const Contact = ({
+  win: { company_contacts: [contact] = [], customer_name },
+}) => (contact ? <ContactLink {...contact} /> : customer_name || 'Not set')
+
+export default Contact

--- a/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -9,6 +8,7 @@ import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
 import State from '../../../components/State'
 import urls from '../../../../lib/urls'
+import Contact from './Contact'
 
 export const WinsConfirmedList = ({ exportWins = [], currentAdviserId }) => {
   return exportWins.length === 0 ? null : (
@@ -27,11 +27,7 @@ export const WinsConfirmedList = ({ exportWins = [], currentAdviserId }) => {
           metadata={[
             {
               label: 'Contact name:',
-              value: (
-                <Link href={urls.contacts.details(item.company_contacts[0].id)}>
-                  {item.company_contacts[0].name}
-                </Link>
-              ),
+              value: <Contact win={item} />,
             },
             {
               label: 'Total value:',

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Link from '@govuk-react/link'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
@@ -9,6 +8,7 @@ import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
 import State from '../../../components/State'
 import urls from '../../../../lib/urls'
+import Contact from './Contact'
 
 export const WinsRejectedList = ({ exportWins, currentAdviserId }) => {
   return exportWins.length === 0 ? null : (
@@ -27,11 +27,7 @@ export const WinsRejectedList = ({ exportWins, currentAdviserId }) => {
           metadata={[
             {
               label: 'Contact name:',
-              value: (
-                <Link href={urls.contacts.details(item.company_contacts[0].id)}>
-                  {item.company_contacts[0].name}
-                </Link>
-              ),
+              value: <Contact win={item} />,
             },
             {
               label: 'Total value:',

--- a/test/component/cypress/specs/ExportWins/Contact.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Contact.cy.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import Contact from '../../../../../src/client/modules/ExportWins/Status/Contact'
+
+describe('Contact', () => {
+  ;['John Doe', 'Andy Pipkin', 'Lou Todd'].forEach((name) => {
+    it('should render a link to ${name} if company_contacts is not empty', () => {
+      const id = `id-of-${name}`
+
+      cy.mount(<Contact win={{ company_contacts: [{ name, id }] }} />)
+
+      cy.get('a')
+        .should('have.text', name)
+        .and('have.attr', 'href', `/contacts/${id}/details`)
+    })
+
+    it('should render customer_name if company_contacts empty', () => {
+      cy.mount(<Contact win={{ customer_name: name }} />)
+
+      cy.get('a').should('not.exist')
+      cy.contains(RegExp(`^${name}$`))
+    })
+  })
+
+  it("should render 'Not set' by default", () => {
+    cy.mount(<Contact win={{}} />)
+
+    cy.get('a').should('not.exist')
+    cy.contains(RegExp(`^Not set$`))
+  })
+})


### PR DESCRIPTION
## Description of change

Fixes a bug when export wins dashboard crashed if there was an export win with empty `company_contacts`. This is a valid state of some legacy export wins. The solution is to fall back to the value of the win's `customer_name` property or render `"Not set"`.

This PR also fixes a similar issue when `companyAddress.country.name` crashed the contact details page when `companyAddress.country` was `null`.

## Test instructions

1. By whatever means get the app to a state where the `/api-proxy/v4/export-win` responds with at least one item in its `results` with empty `company_contacts` array (the easiest way is to comment out [these lines](https://github.com/uktrade/data-hub-frontend/blob/main/test/sandbox/routes/v4/export-win/export-win.js#L42-L46))
2. Go to `/exportwins/confirmed`
3. The _Contact name_ field of those items in the list which have empty `company_contacts` should render the value of the export win's `customer_name` field, or fall back to `"Not set"` if that is empty too
4. Repeat steps 2 and 3 but this time go to `/exportwins/rejected`

