### PR TITLE
Add export project vertical tab navigation

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -24,6 +24,7 @@ const reactRoutes = [
   '/export/create',
   '/export/:exportId/edit',
   '/export/:exportId/details',
+  '/export/:exportId/interactions',
   '/export/:exportId/delete',
   '/exportwins',
   '/companies/:companyId/exportwins/create',

--- a/src/client/components/ContactForm/index.jsx
+++ b/src/client/components/ContactForm/index.jsx
@@ -5,7 +5,7 @@ import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 import Link from '@govuk-react/link'
-import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
+import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 import styled from 'styled-components'
 import Label from '@govuk-react/label'
 
@@ -72,6 +72,11 @@ const StyledLabel = styled(Label)`
   font-weight: ${FONT_WEIGHTS.bold};
 `
 
+const StyledLink = styled(Link)({
+  fontSize: FONT_SIZE.SIZE_20,
+  lineHeight: '32px',
+})
+
 const _ContactForm = ({
   update,
   contactId,
@@ -133,7 +138,9 @@ const _ContactForm = ({
           <LocalHeader
             superheading={
               update && (
-                <Link href={`/companies/${company.id}`}>{company.name}</Link>
+                <StyledLink href={`/companies/${company.id}`}>
+                  {company.name}
+                </StyledLink>
               )
             }
             heading={`${update ? 'Edit' : 'Add'} contact`}

--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -17,6 +17,7 @@ const GlobalStyles = createGlobalStyle`
 `
 
 const DefaultLayout = ({
+  preheading,
   heading,
   headingLink,
   subheading,
@@ -44,6 +45,7 @@ const DefaultLayout = ({
         onShowVerticalNav={setShowVerticalNav}
       />
       <LocalHeader
+        preheading={preheading}
         heading={heading}
         headingLink={headingLink}
         subheading={subheading}
@@ -66,6 +68,7 @@ const DefaultLayout = ({
 }
 
 DefaultLayout.propTypes = {
+  preheading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   headingLink: PropTypes.shape({
     url: PropTypes.string.isRequired,

--- a/src/client/components/Layout/DefaultLayout.jsx
+++ b/src/client/components/Layout/DefaultLayout.jsx
@@ -17,7 +17,7 @@ const GlobalStyles = createGlobalStyle`
 `
 
 const DefaultLayout = ({
-  preheading,
+  superheading,
   heading,
   headingLink,
   subheading,
@@ -45,7 +45,7 @@ const DefaultLayout = ({
         onShowVerticalNav={setShowVerticalNav}
       />
       <LocalHeader
-        preheading={preheading}
+        superheading={superheading}
         heading={heading}
         headingLink={headingLink}
         subheading={subheading}
@@ -68,7 +68,7 @@ const DefaultLayout = ({
 }
 
 DefaultLayout.propTypes = {
-  preheading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  superheading: PropTypes.node,
   heading: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   headingLink: PropTypes.shape({
     url: PropTypes.string.isRequired,

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -28,11 +28,6 @@ const BreadcrumbsWrapper = styled(Breadcrumbs)`
   margin-top: 0;
 `
 
-const StyledSuperheading = styled.div({
-  fontSize: 20,
-  lineHeight: '32px',
-})
-
 const StyledLink = styled('a')({
   fontSize: 20,
   display: 'inline-block',
@@ -85,7 +80,7 @@ const LocalHeader = ({
       </BreadcrumbsWrapper>
       <FlashMessages flashMessages={flashMessages} />
       {preheading && preheading}
-      {superheading && <StyledSuperheading>{superheading}</StyledSuperheading>}
+      {superheading}
       {headingLink && (
         <StyledLink data-test="heading-link" href={headingLink.url}>
           {headingLink.text}

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -47,6 +47,7 @@ const StyledLink = styled('a')({
 const LocalHeader = ({
   breadcrumbs,
   flashMessages,
+  preheading,
   heading,
   subheading,
   headingLink,
@@ -83,6 +84,7 @@ const LocalHeader = ({
         )}
       </BreadcrumbsWrapper>
       <FlashMessages flashMessages={flashMessages} />
+      {preheading && preheading}
       {superheading && <StyledSuperheading>{superheading}</StyledSuperheading>}
       {headingLink && (
         <StyledLink data-test="heading-link" href={headingLink.url}>

--- a/src/client/components/LocalHeader/LocalHeader.jsx
+++ b/src/client/components/LocalHeader/LocalHeader.jsx
@@ -42,11 +42,10 @@ const StyledLink = styled('a')({
 const LocalHeader = ({
   breadcrumbs,
   flashMessages,
-  preheading,
-  heading,
-  subheading,
-  headingLink,
   superheading,
+  heading,
+  headingLink,
+  subheading,
   children,
   useReactRouter = false,
 }) => (
@@ -79,7 +78,6 @@ const LocalHeader = ({
         )}
       </BreadcrumbsWrapper>
       <FlashMessages flashMessages={flashMessages} />
-      {preheading && preheading}
       {superheading}
       {headingLink && (
         <StyledLink data-test="heading-link" href={headingLink.url}>

--- a/src/client/components/LocalHeader/__stories__/LocalHeader.stories.jsx
+++ b/src/client/components/LocalHeader/__stories__/LocalHeader.stories.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import Link from '@govuk-react/link'
 
 import LocalHeader from '../LocalHeader'
 
@@ -35,8 +36,8 @@ WithLink.story = {
 export const WithSuperheading = () => (
   <LocalHeader
     breadcrumbs={breadcrumbs}
+    superheading={<Link href={`/companies`}>Company name</Link>}
     heading={exampleText}
-    superheading={exampleText}
   />
 )
 

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -274,6 +274,7 @@ export const VerticalTabNav = styled(SmallScreenTabNav)({
           '&::before': {
             display: 'none',
           },
+          textAlign: 'left',
           textDecoration: 'none',
           border: 'none',
           background: 'none',

--- a/src/client/modules/ExportPipeline/Export.jsx
+++ b/src/client/modules/ExportPipeline/Export.jsx
@@ -39,7 +39,7 @@ export const ExportProjectTitle = (props) => (
   </ExportResource.Inline>
 )
 
-const ExportTabNav = () => {
+const Export = () => {
   const location = useLocation()
   const matchId = location.pathname.match(EXPORT_ID_REGEX)
   const exportId = matchId ? matchId[1] : null
@@ -76,4 +76,4 @@ const ExportTabNav = () => {
   )
 }
 
-export default ExportTabNav
+export default Export

--- a/src/client/modules/ExportPipeline/Export.jsx
+++ b/src/client/modules/ExportPipeline/Export.jsx
@@ -48,7 +48,7 @@ const Export = () => {
 
   return (
     <DefaultLayout
-      preheading={<CompanyLink id={exportId} />}
+      superheading={<CompanyLink id={exportId} />}
       heading={<ExportProjectTitle id={exportId} />}
       pageTitle={`Export ${aspect}`}
       breadcrumbs={[

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -9,7 +9,7 @@ import { BREAKPOINTS } from '@govuk-react/constants'
 
 import urls from '../../../../lib/urls'
 import { EXPORT_LOADED } from '../../../actions'
-import { DefaultLayout, SummaryTable } from '../../../components'
+import { SummaryTable } from '../../../components'
 import Task from '../../../components/Task'
 import { ID, state2props, TASK_GET_EXPORT_DETAIL } from './state'
 import { format } from '../../../../client/utils/date'
@@ -23,6 +23,7 @@ const StyledSummaryTable = styled(SummaryTable)({
 
 const Container = styled('div')`
   display: flex;
+  gap: 20px;
   align-items: baseline;
   margin-bottom: 30px;
   ${Link} {
@@ -55,163 +56,135 @@ const EstimatedExport = ({
   return <span>Not set</span>
 }
 
-const getBreadcrumbs = (exportItem) => {
-  const defaultBreadcrumbs = [
-    {
-      link: urls.exportPipeline.index(),
-      text: 'Home',
-    },
-  ]
-
-  if (exportItem) {
-    return [...defaultBreadcrumbs, { text: exportItem.title }]
-  }
-
-  return defaultBreadcrumbs
-}
-
 const ExportDetailsForm = ({ exportItem }) => {
   const { exportId } = useParams()
 
   return (
-    <DefaultLayout
-      heading={exportItem ? exportItem.title : ''}
-      headingLink={
-        exportItem && {
-          url: `/companies/${exportItem.company.id}/overview`,
-          text: exportItem.company.name,
-        }
-      }
-      pageTitle="Export details"
-      breadcrumbs={getBreadcrumbs(exportItem)}
-      useReactRouter={false}
+    <Task.Status
+      name={TASK_GET_EXPORT_DETAIL}
+      id={ID}
+      progressMessage="loading export details"
+      startOnRender={{
+        payload: exportId,
+        onSuccessDispatch: EXPORT_LOADED,
+      }}
     >
-      <Task.Status
-        name={TASK_GET_EXPORT_DETAIL}
-        id={ID}
-        progressMessage="loading export details"
-        startOnRender={{
-          payload: exportId,
-          onSuccessDispatch: EXPORT_LOADED,
-        }}
-      >
-        {() => {
-          return (
-            exportItem && (
-              <>
-                <StyledSummaryTable>
-                  <SummaryTable.Row
-                    heading="Export title"
-                    children={exportItem.title}
+      {() => {
+        return (
+          exportItem && (
+            <>
+              <StyledSummaryTable>
+                <SummaryTable.Row
+                  heading="Export title"
+                  children={exportItem.title}
+                />
+                <SummaryTable.Row heading="Owner">
+                  {isEmpty(exportItem.owner)
+                    ? 'Not set'
+                    : exportItem?.owner.name}
+                </SummaryTable.Row>
+                <SummaryTable.ListRow
+                  heading="Team members"
+                  emptyValue="Not set"
+                  hideWhenEmpty={true}
+                  value={exportItem.team_members.map(
+                    transformIdNameToValueLabel
+                  )}
+                ></SummaryTable.ListRow>
+                <SummaryTable.Row
+                  heading="Total estimated export value"
+                  hideWhenEmpty={false}
+                >
+                  <EstimatedExport
+                    estimated_export_value_amount={
+                      exportItem.estimated_export_value_amount
+                    }
+                    estimated_export_value_years={
+                      exportItem.estimated_export_value_years
+                    }
                   />
-                  <SummaryTable.Row heading="Owner">
-                    {isEmpty(exportItem.owner)
-                      ? 'Not set'
-                      : exportItem?.owner.name}
-                  </SummaryTable.Row>
-                  <SummaryTable.ListRow
-                    heading="Team members"
-                    emptyValue="Not set"
-                    hideWhenEmpty={true}
-                    value={exportItem.team_members.map(
-                      transformIdNameToValueLabel
-                    )}
-                  ></SummaryTable.ListRow>
-                  <SummaryTable.Row
-                    heading="Total estimated export value"
-                    hideWhenEmpty={false}
-                  >
-                    <EstimatedExport
-                      estimated_export_value_amount={
-                        exportItem.estimated_export_value_amount
-                      }
-                      estimated_export_value_years={
-                        exportItem.estimated_export_value_years
-                      }
-                    />
-                  </SummaryTable.Row>
-                  <SummaryTable.Row
-                    heading="Estimated date for win"
-                    hideWhenEmpty={false}
-                  >
-                    {isEmpty(exportItem.estimated_win_date)
-                      ? 'Not set'
-                      : format(exportItem.estimated_win_date, 'MMMM yyyy')}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="Status" hideWhenEmpty={false}>
-                    {isEmpty(exportItem.status)
-                      ? 'Not set'
-                      : capitalize(exportItem.status)}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row
-                    heading="Export potential"
-                    hideWhenEmpty={false}
-                  >
-                    {isEmpty(exportItem.export_potential)
-                      ? 'Not set'
-                      : capitalize(exportItem.export_potential)}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="Destination" hideWhenEmpty={false}>
-                    {isEmpty(exportItem.destination_country)
-                      ? 'Not set'
-                      : exportItem.destination_country.name}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="Main sector" hideWhenEmpty={false}>
-                    {isEmpty(exportItem.sector)
-                      ? 'Not set'
-                      : exportItem.sector.name}
-                  </SummaryTable.Row>
-                  <SummaryTable.ListRow
-                    heading="Company contacts"
-                    value={exportItem.contacts.map(transformIdNameToValueLabel)}
-                    emptyValue="Not set"
-                    hideWhenEmpty={false}
-                  />
-                  <SummaryTable.Row
-                    heading="Exporter experience"
-                    hideWhenEmpty={false}
-                  >
-                    {isEmpty(exportItem.exporter_experience)
-                      ? 'Not set'
-                      : exportItem.exporter_experience.name}
-                  </SummaryTable.Row>
-                  <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
-                    {isEmpty(exportItem.notes) ? 'Not set' : exportItem.notes}
-                  </SummaryTable.Row>{' '}
-                </StyledSummaryTable>
-                <Container>
-                  <Button
-                    as={'a'}
-                    href={urls.exportPipeline.edit(exportId)}
-                    buttonColour={GREY_3}
-                    buttonTextColour={BLACK}
-                    data-test="edit-export-details-button"
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    as={'a'}
-                    href={urls.companies.exportWins.createFromExport(
-                      exportItem.company.id,
-                      exportId
-                    )}
-                    data-test="convert-to-export-win"
-                  >
-                    Convert to export win
-                  </Button>
-                  <Link
-                    href={urls.exportPipeline.delete(exportId)}
-                    data-test="delete-export-details-button"
-                  >
-                    Delete
-                  </Link>
-                </Container>
-              </>
-            )
+                </SummaryTable.Row>
+                <SummaryTable.Row
+                  heading="Estimated date for win"
+                  hideWhenEmpty={false}
+                >
+                  {isEmpty(exportItem.estimated_win_date)
+                    ? 'Not set'
+                    : format(exportItem.estimated_win_date, 'MMMM yyyy')}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="Status" hideWhenEmpty={false}>
+                  {isEmpty(exportItem.status)
+                    ? 'Not set'
+                    : capitalize(exportItem.status)}
+                </SummaryTable.Row>
+                <SummaryTable.Row
+                  heading="Export potential"
+                  hideWhenEmpty={false}
+                >
+                  {isEmpty(exportItem.export_potential)
+                    ? 'Not set'
+                    : capitalize(exportItem.export_potential)}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="Destination" hideWhenEmpty={false}>
+                  {isEmpty(exportItem.destination_country)
+                    ? 'Not set'
+                    : exportItem.destination_country.name}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="Main sector" hideWhenEmpty={false}>
+                  {isEmpty(exportItem.sector)
+                    ? 'Not set'
+                    : exportItem.sector.name}
+                </SummaryTable.Row>
+                <SummaryTable.ListRow
+                  heading="Company contacts"
+                  value={exportItem.contacts.map(transformIdNameToValueLabel)}
+                  emptyValue="Not set"
+                  hideWhenEmpty={false}
+                />
+                <SummaryTable.Row
+                  heading="Exporter experience"
+                  hideWhenEmpty={false}
+                >
+                  {isEmpty(exportItem.exporter_experience)
+                    ? 'Not set'
+                    : exportItem.exporter_experience.name}
+                </SummaryTable.Row>
+                <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
+                  {isEmpty(exportItem.notes) ? 'Not set' : exportItem.notes}
+                </SummaryTable.Row>{' '}
+              </StyledSummaryTable>
+              <Container>
+                <Button
+                  as={'a'}
+                  href={urls.exportPipeline.edit(exportId)}
+                  buttonColour={GREY_3}
+                  buttonTextColour={BLACK}
+                  data-test="edit-export-details-button"
+                >
+                  Edit
+                </Button>
+                <Button
+                  as={'a'}
+                  href={urls.companies.exportWins.createFromExport(
+                    exportItem.company.id,
+                    exportId
+                  )}
+                  data-test="convert-to-export-win"
+                >
+                  Convert to export win
+                </Button>
+                <Link
+                  href={urls.exportPipeline.delete(exportId)}
+                  data-test="delete-export-details-button"
+                >
+                  Delete
+                </Link>
+              </Container>
+            </>
           )
-        }}
-      </Task.Status>
-    </DefaultLayout>
+        )
+      }}
+    </Task.Status>
   )
 }
 

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { isEmpty, capitalize } from 'lodash'
 import Button from '@govuk-react/button'
 import Link from '@govuk-react/link'
-import { BREAKPOINTS } from '@govuk-react/constants'
+import { BREAKPOINTS, SPACING } from '@govuk-react/constants'
 
 import urls from '../../../../lib/urls'
 import { EXPORT_LOADED } from '../../../actions'
@@ -23,11 +23,11 @@ const StyledSummaryTable = styled(SummaryTable)({
 
 const Container = styled('div')`
   display: flex;
-  gap: 20px;
+  gap: ${SPACING.SCALE_4};
   align-items: baseline;
-  margin-bottom: 30px;
+  margin-bottom: ${SPACING.SCALE_5};
   ${Link} {
-    margin-right: 20px;
+    margin-right: ${SPACING.SCALE_4};
   }
   @media (max-width: ${BREAKPOINTS.TABLET}) {
     flex-direction: column;

--- a/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const ExportInteractions = () => <></>
+
+export default ExportInteractions

--- a/src/client/modules/ExportPipeline/ExportTabNav.jsx
+++ b/src/client/modules/ExportPipeline/ExportTabNav.jsx
@@ -1,0 +1,79 @@
+import React from 'react'
+import styled from 'styled-components'
+import { useLocation } from 'react-router-dom'
+
+import ExportInteractionsList from './ExportInteractionsList'
+import Export from '../../components/Resource/Export'
+import { DefaultLayout } from '../../components'
+import TabNav from '../../components/TabNav'
+import ExportDetails from './ExportDetails'
+import urls from '../../../lib/urls'
+
+const EXPORT_ID_REGEX = /\/export\/([^/]+)\//
+const EXPORT_ASPECT_REGEX = /\/([^/]+)$/
+
+const StyledLink = styled('a')({
+  fontSize: 20,
+  display: 'inline-block',
+  fontFamily: 'Arial, sans-serif',
+  marginTop: 8,
+  marginBottom: 8,
+})
+
+export const CompanyLink = (props) => (
+  <Export.Inline {...props}>
+    {(exportProject) => (
+      <StyledLink
+        data-test="export-company-link"
+        href={urls.companies.detail(exportProject.company.id)}
+      >
+        {exportProject.company.name.toUpperCase()}
+      </StyledLink>
+    )}
+  </Export.Inline>
+)
+
+export const ExportProjectTitle = (props) => (
+  <Export.Inline {...props}>
+    {(exportProject) => exportProject.title}
+  </Export.Inline>
+)
+
+const ExportTabNav = () => {
+  const location = useLocation()
+  const matchId = location.pathname.match(EXPORT_ID_REGEX)
+  const exportId = matchId ? matchId[1] : null
+  const matchAspect = location.pathname.match(EXPORT_ASPECT_REGEX)
+  const aspect = matchAspect ? matchAspect[1] : null // aspect will be either 'details' or 'interactions'
+
+  return (
+    <DefaultLayout
+      preheading={<CompanyLink id={exportId} />}
+      heading={<ExportProjectTitle id={exportId} />}
+      pageTitle={`Export ${aspect}`}
+      breadcrumbs={[
+        { link: urls.exportPipeline.index(), text: 'Home' },
+        { text: <ExportProjectTitle id={exportId} /> },
+      ]}
+    >
+      <TabNav
+        id="export-tab-nav"
+        label="Export tab nav"
+        layout="vertical"
+        routed={true}
+        tabs={{
+          [urls.exportPipeline.details(exportId)]: {
+            label: 'Project details',
+            content: <ExportDetails />,
+          },
+          [urls.exportPipeline.interactions(exportId)]: {
+            label: 'Interactions',
+            content: ExportInteractionsList,
+          },
+        }}
+      />
+    </DefaultLayout>
+  )
+}
+
+export default ExportTabNav

--- a/src/client/modules/ExportPipeline/ExportTabNav.jsx
+++ b/src/client/modules/ExportPipeline/ExportTabNav.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { useLocation } from 'react-router-dom'
 
 import ExportInteractionsList from './ExportInteractionsList'
-import Export from '../../components/Resource/Export'
+import ExportResource from '../../components/Resource/Export'
 import { DefaultLayout } from '../../components'
 import TabNav from '../../components/TabNav'
 import ExportDetails from './ExportDetails'
@@ -21,7 +21,7 @@ const StyledLink = styled('a')({
 })
 
 export const CompanyLink = (props) => (
-  <Export.Inline {...props}>
+  <ExportResource.Inline {...props}>
     {(exportProject) => (
       <StyledLink
         data-test="export-company-link"
@@ -30,13 +30,13 @@ export const CompanyLink = (props) => (
         {exportProject.company.name.toUpperCase()}
       </StyledLink>
     )}
-  </Export.Inline>
+  </ExportResource.Inline>
 )
 
 export const ExportProjectTitle = (props) => (
-  <Export.Inline {...props}>
+  <ExportResource.Inline {...props}>
     {(exportProject) => exportProject.title}
-  </Export.Inline>
+  </ExportResource.Inline>
 )
 
 const ExportTabNav = () => {

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -18,7 +18,7 @@ import {
   ExportFormEdit,
 } from './modules/ExportPipeline/ExportForm'
 import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
-import ExportDetails from './modules/ExportPipeline/ExportDetails'
+import ExportProjectTabNav from './modules/ExportPipeline/ExportTabNav'
 import ExportWinsTabNav from './modules/ExportWins/Status/ExportWinsTabNav'
 import { CreateExportWin, EditExportWin } from './modules/ExportWins/Form'
 import ExportWinsRedirect from './modules/ExportWins/Status/Redirect'
@@ -667,7 +667,15 @@ function Routes() {
       path: '/export/:exportId/details',
       element: (
         <ProtectedRoute module={'datahub:companies'}>
-          <ExportDetails />
+          <ExportProjectTabNav />
+        </ProtectedRoute>
+      ),
+    },
+    {
+      path: '/export/:exportId/interactions',
+      element: (
+        <ProtectedRoute module={'datahub:companies'}>
+          <ExportProjectTabNav />
         </ProtectedRoute>
       ),
     },

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -18,7 +18,7 @@ import {
   ExportFormEdit,
 } from './modules/ExportPipeline/ExportForm'
 import ExportFormDelete from './modules/ExportPipeline/ExportDelete'
-import ExportProjectTabNav from './modules/ExportPipeline/ExportTabNav'
+import Export from './modules/ExportPipeline/Export'
 import ExportWinsTabNav from './modules/ExportWins/Status/ExportWinsTabNav'
 import { CreateExportWin, EditExportWin } from './modules/ExportWins/Form'
 import ExportWinsRedirect from './modules/ExportWins/Status/Redirect'
@@ -667,7 +667,7 @@ function Routes() {
       path: '/export/:exportId/details',
       element: (
         <ProtectedRoute module={'datahub:companies'}>
-          <ExportProjectTabNav />
+          <Export />
         </ProtectedRoute>
       ),
     },
@@ -675,7 +675,7 @@ function Routes() {
       path: '/export/:exportId/interactions',
       element: (
         <ProtectedRoute module={'datahub:companies'}>
-          <ExportProjectTabNav />
+          <Export />
         </ProtectedRoute>
       ),
     },

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -767,6 +767,7 @@ module.exports = {
     index: url('/export'),
     create: url('/export/create?companyId=', ':companyId'),
     details: url('/export', '/:exportId/details'),
+    interactions: url('/export', '/:exportId/interactions'),
     edit: url('/export', '/:exportId/edit'),
     delete: url('/export', '/:exportId/delete'),
   },

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -54,6 +54,7 @@ export const urlTestExclusions = [
     url: '/investments/projects/:projectId/edit-associated/:associatedProjectId',
   },
   { url: '/export/:exportId/details' },
+  { url: '/export/:exportId/interactions' },
   { url: '/omis/:orderId/edit/lead-adviser/:adviserId' },
   { url: '/interactions/ess/:essInteractionId/details' },
   {

--- a/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import ExportTabNav from '../../../../../src/client/modules/ExportPipeline/ExportTabNav'
+import Export from '../../../../../src/client/modules/ExportPipeline/Export'
 import { assertBreadcrumbs } from '../../../../functional/cypress/support/assertions'
 import { assertLocalNav } from '../../../../end-to-end/cypress/support/assertions'
 import urls from '../../../../../src/lib/urls'
@@ -16,7 +16,7 @@ const exportProject = {
 
 describe('Export project tab navigation', () => {
   it('should render the breadcrumbs for details', () => {
-    cy.mountWithProvider(<ExportTabNav />, {
+    cy.mountWithProvider(<Export />, {
       initialPath: '/export/1/details',
       tasks: {
         Export: () => exportProject,
@@ -29,7 +29,7 @@ describe('Export project tab navigation', () => {
   })
 
   it('should render the same breadcrumbs for interactions', () => {
-    cy.mountWithProvider(<ExportTabNav />, {
+    cy.mountWithProvider(<Export />, {
       initialPath: '/export/1/interactions/',
       tasks: {
         Export: () => exportProject,
@@ -42,7 +42,7 @@ describe('Export project tab navigation', () => {
   })
 
   it('should render a company link and page heading', () => {
-    cy.mountWithProvider(<ExportTabNav />, {
+    cy.mountWithProvider(<Export />, {
       initialPath: '/export/1/details',
       tasks: {
         Export: () => exportProject,
@@ -57,7 +57,7 @@ describe('Export project tab navigation', () => {
   })
 
   it('should render two tabs: Project details and Interactions', () => {
-    cy.mountWithProvider(<ExportTabNav />)
+    cy.mountWithProvider(<Export />)
     cy.get('[role="tablist"]').should('exist')
     cy.get('[role="tab"]').as('tabItems')
     assertLocalNav('@tabItems', ['Project details', 'Interactions'])

--- a/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import Export from '../../../../../src/client/modules/ExportPipeline/Export'
 import { assertBreadcrumbs } from '../../../../functional/cypress/support/assertions'
-import { assertLocalNav } from '../../../../end-to-end/cypress/support/assertions'
+import { assertTabNav } from '../../../../end-to-end/cypress/support/assertions'
 import urls from '../../../../../src/lib/urls'
 
 const exportProject = {
@@ -12,6 +12,19 @@ const exportProject = {
     id: '2',
     name: 'Rolls Royce',
   },
+  team_members: [
+    {
+      name: 'David Jones',
+      id: '1',
+    },
+  ],
+  contacts: [
+    {
+      name: 'Johan Person',
+      email: 'johan@nederlands.com',
+      id: '1',
+    },
+  ],
 }
 
 describe('Export project tab navigation', () => {
@@ -57,9 +70,16 @@ describe('Export project tab navigation', () => {
   })
 
   it('should render two tabs: Project details and Interactions', () => {
-    cy.mountWithProvider(<Export />)
-    cy.get('[role="tablist"]').should('exist')
-    cy.get('[role="tab"]').as('tabItems')
-    assertLocalNav('@tabItems', ['Project details', 'Interactions'])
+    cy.mountWithProvider(<Export />, {
+      initialPath: '/export/1/details',
+      tasks: {
+        Export: () => Promise.resolve(exportProject),
+        TASK_GET_EXPORT_DETAIL: () => Promise.resolve(exportProject),
+      },
+    })
+    assertTabNav({
+      tabs: ['Project details', 'Interactions'],
+      selectedIndex: 0,
+    })
   })
 })

--- a/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+
+import ExportTabNav from '../../../../../src/client/modules/ExportPipeline/ExportTabNav'
+import { assertBreadcrumbs } from '../../../../functional/cypress/support/assertions'
+import { assertLocalNav } from '../../../../end-to-end/cypress/support/assertions'
+import urls from '../../../../../src/lib/urls'
+
+const exportProject = {
+  id: '1',
+  title: 'Rolls Royce to UAE',
+  company: {
+    id: '2',
+    name: 'Rolls Royce',
+  },
+}
+
+describe('Export project tab navigation', () => {
+  it('should render the breadcrumbs for details', () => {
+    cy.mountWithProvider(<ExportTabNav />, {
+      initialPath: '/export/1/details',
+      tasks: {
+        Export: () => exportProject,
+      },
+    })
+    assertBreadcrumbs({
+      Home: urls.exportPipeline.index(),
+      [exportProject.title]: null,
+    })
+  })
+
+  it('should render the same breadcrumbs for interactions', () => {
+    cy.mountWithProvider(<ExportTabNav />, {
+      initialPath: '/export/1/interactions/',
+      tasks: {
+        Export: () => exportProject,
+      },
+    })
+    assertBreadcrumbs({
+      Home: urls.exportPipeline.index(),
+      [exportProject.title]: null,
+    })
+  })
+
+  it('should render a company link and page heading', () => {
+    cy.mountWithProvider(<ExportTabNav />, {
+      initialPath: '/export/1/details',
+      tasks: {
+        Export: () => exportProject,
+      },
+    })
+
+    cy.get('[data-test=export-company-link]')
+      .should('have.text', exportProject.company.name.toUpperCase())
+      .should('have.attr', 'href', `/companies/${exportProject.company.id}`)
+
+    cy.get('[data-test="heading"]').should('have.text', 'Rolls Royce to UAE')
+  })
+
+  it('should render two tabs: Project details and Interactions', () => {
+    cy.mountWithProvider(<ExportTabNav />)
+    cy.get('[role="tablist"]').should('exist')
+    cy.get('[role="tab"]').as('tabItems')
+    assertLocalNav('@tabItems', ['Project details', 'Interactions'])
+  })
+})

--- a/test/end-to-end/cypress/support/assertions.js
+++ b/test/end-to-end/cypress/support/assertions.js
@@ -68,6 +68,30 @@ const assertLocalNav = (selector, navList) => {
   })
 }
 
+function assertTabNav({ tabs, selectedIndex }) {
+  cy.viewport(1024, 768)
+  cy.get('[data-test="tablist"]')
+    .should('exist')
+    .and('have.attr', 'role', 'tablist')
+
+  cy.get('[data-test="tablist"] [role="tab"]').should(
+    'have.length',
+    tabs.length
+  )
+
+  tabs.forEach((tabText, index) => {
+    cy.get('[data-test="tablist"] [role="tab"]')
+      .eq(index)
+      .should('have.text', tabText)
+      .and(
+        'have.attr',
+        'aria-selected',
+        index === selectedIndex ? 'true' : 'false'
+      )
+      .and('have.attr', 'tabindex', index === selectedIndex ? '0' : '-1')
+  })
+}
+
 const assertActivitytab = (selector) => {
   const navElement = cy.get(selector)
   navElement.should('be.checked')
@@ -90,6 +114,7 @@ module.exports = {
   assertError,
   assertCollection,
   assertLocalNav,
+  assertTabNav,
   assertKeyValueTable,
   assertLocalReactNav,
   assertActivitytab,

--- a/test/functional/cypress/specs/export-pipeline/export-details-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-details-spec.js
@@ -19,6 +19,7 @@ describe('Export Details summary ', () => {
         body: exportItem,
       }).as('getExportItemApiRequest')
       cy.visit(`/export/${exportItem.id}/details`)
+      cy.wait('@getExportItemApiRequest')
     })
 
     it('should render breadcrumbs', () => {


### PR DESCRIPTION
## Description of change
This PR introduces a vertical tabbed navigation component to the export project details page, enabling users to switch between the project's details and its interactions. Additionally, it adds spacing around the buttons at the bottom of the page. The implementation of interactions will follow in a future PR.

## Test instructions
Go to: `/export/<export-id>/details` and `/export/<export-id>/interactions`

## Screenshots

### Before
<img width="1016" alt="aafter" src="https://github.com/user-attachments/assets/7f658c5f-dd34-478d-b004-97c3bfeedd46">

### After
<img width="1016" alt="bbefore" src="https://github.com/user-attachments/assets/5bc7a273-177a-4f41-b8ad-2e6f089d51a9">

<img width="1007" alt="Screenshot 2024-11-28 at 13 31 01" src="https://github.com/user-attachments/assets/68812e7c-9967-4517-a53b-3c399b9c14af">


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
