### PR TITLE
Retry tests up to 2 additional times upon failure

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -27,4 +27,8 @@ module.exports = defineConfig({
     baseUrl: 'http://localhost:3000',
     supportFile: 'test/cypress/support/index.js',
   },
+  retries: {
+    runMode: 2, // number of retries when running `cypress run`
+    openMode: 2, // number of retries when running `cypress open`
+  },
 })


### PR DESCRIPTION
## Description of change

This PR enables retries for any failing tests, up to an additional 2 times. 

The thinking was this will alleviate the challenges we are having with flakey tests while we work on longer term fixes for the offending tests. Rather than needing to re-run the entire test suite upon a failure, Cypress will automatically retry individual tests. 

Retries are recorded in the results, so we will be able to keep visibility of these flakey tests while simultaneously increasing the chance of passing test suites. If the tests continue to fail after 3 attempts, the test suite will fail in the usual fashion. 

For local testing, developers may wish to set this value to 0 while testing new changes.

See the [cypress docs](https://docs.cypress.io/app/guides/test-retries) for more information.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
