### PR TITLE
Company name can be an empty string when generating fake data

### DIFF
--- a/test/functional/cypress/specs/tasks/add-task-spec.js
+++ b/test/functional/cypress/specs/tasks/add-task-spec.js
@@ -154,11 +154,18 @@ describe('Add company task', () => {
       cy.get('h1').should('have.text', `Add task`)
     })
 
-    it('add task button should send expected values to the api', () => {
+    it('add task button should send expected values with company to the api', () => {
+      company.name = 'a company name'
       cy.intercept(`/api-proxy/v4/company?*`, { results: [company] })
       cy.get('[data-test=assigned-to-me]').click()
       fillTypeahead('[data-test=field-company]', company.name)
       assertTaskForm(null, [myAdviserId], company.id, dashboard.myTasks())
+    })
+
+    it('add task button should send expected values without company to the api', () => {
+      cy.intercept(`/api-proxy/v4/company?*`, { results: [company] })
+      cy.get('[data-test=assigned-to-me]').click()
+      assertTaskForm(null, [myAdviserId], null, dashboard.myTasks())
     })
   })
 })

--- a/test/functional/cypress/specs/tasks/add-task-spec.js
+++ b/test/functional/cypress/specs/tasks/add-task-spec.js
@@ -155,11 +155,16 @@ describe('Add company task', () => {
     })
 
     it('add task button should send expected values with company to the api', () => {
-      company.name = 'a company name'
-      cy.intercept(`/api-proxy/v4/company?*`, { results: [company] })
+      const companyWithName = { ...companyFaker(), name: 'a company name' }
+      cy.intercept(`/api-proxy/v4/company?*`, { results: [companyWithName] })
       cy.get('[data-test=assigned-to-me]').click()
-      fillTypeahead('[data-test=field-company]', company.name)
-      assertTaskForm(null, [myAdviserId], company.id, dashboard.myTasks())
+      fillTypeahead('[data-test=field-company]', companyWithName.name)
+      assertTaskForm(
+        null,
+        [myAdviserId],
+        companyWithName.id,
+        dashboard.myTasks()
+      )
     })
 
     it('add task button should send expected values without company to the api', () => {


### PR DESCRIPTION
## Description of change

The type function expects a value and with the fake json data generator the company name could be an empty string. This change specifies the company name for the test and creates a new test for adding a task without a company name (it's optional).

Example use with the type function (line 118). For the add-task-spec, it tried to type in a company name which was an empty string.
https://github.com/uktrade/data-hub-frontend/blob/91040d6681918e81d93949e540a714df84bc0cf4/test/cypress/support/commands.js#L114-L123

Original Error:
```
Add company task
       When visiting the create a task page
         add task button should send expected values to the api:
     CypressError: `cy.type()` cannot accept an empty string. You need to actually type something.
```

## Checklist

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
