### PR TITLE
companyFaker now always returns a company with archived = false

### DIFF
--- a/test/functional/cypress/fakers/companies.js
+++ b/test/functional/cypress/fakers/companies.js
@@ -26,6 +26,7 @@ const companyFaker = (overrides = {}) => ({
     name: faker.word.adjective(),
   },
   uk_region: ukRegionFaker(),
+  archived: false,
   ...overrides,
 })
 


### PR DESCRIPTION
## Description of change

Fixes a [flaky test] in [`test/functional/cypress/specs/export-pipeline/add-export-spec.js`](https://github.com/uktrade/data-hub-frontend/blob/main/test/functional/cypress/specs/export-pipeline/add-export-spec.js#L135-L138) when company page would crash when [`companyFaker`](https://github.com/uktrade/data-hub-frontend/blob/main/test/functional/cypress/fakers/companies.js#L18-L30) generated a company with `archived: true` and `archived_on: null` at the same time. This crashes the page because if `company.archived === true` the page renders a banner informing about the company being archived, which renders the date it was archived on, so it passes `company.archived_on` to a formatting function, which is expecting a string and the whole thing blows up when it gets `null` instead of a string.

## Test instructions

1. The [flaky test] should consistently pass

[flaky test]: https://github.com/uktrade/data-hub-frontend/blob/main/test/functional/cypress/specs/export-pipeline/add-export-spec.js#L135-L138
