### PR TITLE
Fix investment project test flakiness

### DIFF
--- a/test/functional/cypress/fakers/investment-projects.js
+++ b/test/functional/cypress/fakers/investment-projects.js
@@ -65,6 +65,7 @@ const investmentProjectCodeFaker = () => `DHP-${numberStringFaker(8)}`
 const investmentProjectFaker = (overrides = {}) => ({
   ...jsf.generate(apiSchema.components.schemas.IProject),
   id: faker.string.uuid(),
+  name: 'Test Project',
   stage: investmentProjectStageFaker(),
   estimated_land_date: relativeDateFaker({ minDays: -100, maxDays: 365 }),
   investor_company: {

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -66,6 +66,7 @@ const setup = (project) => {
   }).as('getProjectDetails')
   cy.visit(urls.investments.projects.editDetails(project.id))
   cy.wait('@getProjectDetails')
+  cy.get('[data-test="submit"]').should('be.visible')
 }
 
 describe('Editing the project summary', () => {
@@ -414,6 +415,7 @@ describe('Editing the project summary', () => {
       )
       cy.get('[data-test="continue"]').should('exist')
       clickButton('Continue')
+      cy.get('[data-test="submit"]').should('exist')
     })
 
     it('should take the user to a confirmation step and display the warning', () => {
@@ -580,7 +582,9 @@ describe('Editing the project summary', () => {
     })
 
     it('should submit the request with investor type set to the user selection', () => {
-      cy.get('[data-test="investor-type-new-investor"]').click()
+      cy.get('[data-test="investor-type-new-investor"]')
+        .click()
+        .should('be.checked')
       clickButton('Submit')
       cy.wait('@editDetailsRequest')
         .its('request.body')


### PR DESCRIPTION
## Description of change

Several investment project tests were identified as flaky and this PR attempts to fix them.

### project-edit-details-spec

```
- When changing the project FDI type to Capital only
  - should take the user to a confirmation step and display the warning
    - AssertionError: Timed out retrying after 5000ms: Expected <div#field-fdi_type.src__FormGroup-sc-1m4431t-0.sc-bBeLUv.gMksRW.cFOgVy> not to exist in the DOM, but it was continuously found.
  - should submit the request with zero new and safeguarded jobs, and null for average salary
    - AssertionError: Timed out retrying after 5000ms: Expected to find content: 'Submit' within the selector: 'button' but never did.
- When changing the project FDI type from Expansion to other
  - should submit the request with investor type set to the user selection:
    - CypressError: Timed out retrying after 5000ms: `cy.wait()` timed out waiting `5000ms` for the 1st request to the route: `editDetailsRequest`. No request ever occurred.
```
These have been fixed by adding assertions after button actions to ensure the DOM has loaded before the Cypress command resolves and moves onto the next.

### project-edit-value-spec

```
- When viewing a capital intensive project with no value fields set
  - should render the header
    - CypressError: `cy.contains()` cannot be passed an empty string.
- When viewing a capital intensive project with no value fields set
  - should render the header
    - CypressError: `cy.contains()` cannot be passed an empty string.
- When viewing a capital intensive project with no value fields set
  - should render breadcrumbs:
    - CypressError: `cy.contains()` cannot be passed an empty string.
```

These have been fixed by setting the `name` property to a non-empty string in the `investmentProjectFaker`. Previously, the schema was occasionally generating an empty string causing `cy.contains(project.name)` to raise an error.

## Test instructions

The following specs should now consistently pass.
- project-edit-details-spec
- project-edit-value-spec

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
