### PR TITLE
Fix flaky test when checking inner text

### DIFF
--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -98,16 +98,16 @@ describe('Company activity feed', () => {
     })
     it('displays the Great export enquiry subject', () => {
       cy.get('[data-test="collection-item"]').each(() =>
-        cy.get('h4').contains(`Enquiry ${great_subject}`)
+        cy.get('h4').should('have.text', `Enquiry ${great_subject}`)
       )
     })
     it('displays the Great export enquiry contact', () => {
       cy.get('[data-test="metadata-item"]').contains(
-        `${activity.great_export_enquiry.contact.name}`
+        activity.great_export_enquiry.contact.name
       )
     })
     it('displays the Great export enquiry comment', () => {
-      cy.get('[data-test="metadata-item"]').contains(`${great_comment}`)
+      cy.get('[data-test="metadata-item"]').contains(great_comment)
     })
   })
 


### PR DESCRIPTION
## Description of change

The test would fail when checking the text of a `h4` element. I was able to reproduce this locally by making the text a certain length. The element did contain the text but the `contain` errored, using `should('have.text', ...` resolved this. 

I could not reproduce the other flaky test in the ticket description and looking back through the CircleCI test runs I only found 1 occurrence of that test failing which was related to the PR that person was changing.

Also removed some superfluous string formatting.
