### PR TITLE
Fix export win dates

### DIFF
--- a/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsConfirmedList.jsx
@@ -2,7 +2,11 @@ import React from 'react'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDateParsed } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MONTH_ABBR_YEAR,
+} from '../../../utils/date-utils'
 import { CollectionItem } from '../../../components'
 import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
@@ -35,13 +39,14 @@ export const WinsConfirmedList = ({ exportWins = [], currentAdviserId }) => {
             },
             {
               label: 'Date won:',
-              value: formatMediumDateParsed(item.date),
+              value: formatDate(item.date, DATE_FORMAT_MONTH_ABBR_YEAR), // Dec 2024
             },
             {
               label: 'Date responded:',
-              value: item.customer_response.responded_on
-                ? formatMediumDateParsed(item.customer_response?.responded_on)
-                : '',
+              value: formatDate(
+                item.customer_response?.responded_on,
+                DATE_FORMAT_MEDIUM // 4 Dec 2024
+              ),
             },
           ]}
         />

--- a/src/client/modules/ExportWins/Status/WinsPendingList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsPendingList.jsx
@@ -4,9 +4,12 @@ import Link from '@govuk-react/link'
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
 import {
-  formatMediumDate,
-  formatMediumDateTimeWithoutParsing,
-} from '../../../utils/date'
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MONTH_ABBR_YEAR,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils'
+
 import { CollectionItem } from '../../../components'
 import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
@@ -48,18 +51,21 @@ export const WinsPendingList = ({ exportWins = [], currentAdviserId }) => {
               label: 'Total value:',
               value: currencyGBP(sumExportValues(item)),
             },
-            { label: 'Date won:', value: formatMediumDate(item.date) },
+            {
+              label: 'Date won:',
+              value: formatDate(item.date, DATE_FORMAT_MONTH_ABBR_YEAR), // Dec 2024
+            },
             {
               label: 'Date modified:',
-              value: formatMediumDate(item.modified_on),
+              value: formatDate(item.modified_on, DATE_FORMAT_MEDIUM), // 4 Dec 2024
             },
             {
               label: 'First sent:',
-              value: formatMediumDateTimeWithoutParsing(item.first_sent),
+              value: formatDate(item.first_sent, DATE_FORMAT_MEDIUM_WITH_TIME), // 4 Dec 2024, 3:30PM
             },
             {
               label: 'Last sent:',
-              value: formatMediumDateTimeWithoutParsing(item.last_sent),
+              value: formatDate(item.last_sent, DATE_FORMAT_MEDIUM_WITH_TIME), // 4 Dec 2024, 3:30PM
             },
           ]}
         />

--- a/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
+++ b/src/client/modules/ExportWins/Status/WinsRejectedList.jsx
@@ -2,7 +2,11 @@ import React from 'react'
 
 import ExportWinsResource from '../../../components/Resource/ExportWins'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDate } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MONTH_ABBR_YEAR,
+} from '../../../utils/date-utils'
 import { CollectionItem } from '../../../components'
 import { sumExportValues, createRoleTags } from './utils'
 import { SORT_OPTIONS, WIN_STATUS } from './constants'
@@ -33,10 +37,13 @@ export const WinsRejectedList = ({ exportWins, currentAdviserId }) => {
               label: 'Total value:',
               value: currencyGBP(sumExportValues(item)),
             },
-            { label: 'Date won:', value: formatMediumDate(item.date) },
+            {
+              label: 'Date won:',
+              value: formatDate(item.date, DATE_FORMAT_MONTH_ABBR_YEAR), // Dec 2024
+            },
             {
               label: 'Date modified:',
-              value: formatMediumDate(item.modified_on),
+              value: formatDate(item.modified_on, DATE_FORMAT_MEDIUM), // 4 Dec 2024
             },
           ]}
         />

--- a/src/client/utils/__test__/date-utils.test.js
+++ b/src/client/utils/__test__/date-utils.test.js
@@ -1,0 +1,72 @@
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_FULL_DAY,
+  DATE_FORMAT_COMPACT,
+  DATE_FORMAT_ISO,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+  DATE_FORMAT_YEAR_MONTH,
+  DATE_FORMAT_MONTH_YEAR,
+  DATE_FORMAT_MONTH_ABBR_YEAR,
+  DATE_FORMAT_DAY_MONTH,
+  DATE_FORMAT_INTERACTION_TIMESTAMP,
+} from '../date-utils'
+
+describe('formatDate', () => {
+  const date = '2024-12-04'
+  const time = 'T10:41:45.425717Z'
+  const dateAndTime = `${date}${time}`
+
+  it("should render '04 Dec 2024' (default format)", () => {
+    expect(formatDate(date)).to.equal('04 Dec 2024') // the default
+  })
+
+  it("should render '04 Dec 2024' (DATE_FORMAT_COMPACT)", () => {
+    expect(formatDate(date, DATE_FORMAT_COMPACT)).to.equal('04 Dec 2024')
+  })
+
+  it("should render '4 Dec 2024' (DATE_FORMAT_MEDIUM)", () => {
+    expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM)).to.equal('4 Dec 2024')
+  })
+
+  it("should render '4 Dec 2024, 10:41am' (DATE_FORMAT_MEDIUM_WITH_TIME)", () => {
+    expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM_WITH_TIME)).to.equal(
+      '4 Dec 2024, 10:41am'
+    )
+  })
+
+  it("should render '4 December 2024' (DATE_FORMAT_FULL)", () => {
+    expect(formatDate(date, DATE_FORMAT_FULL)).to.equal('4 December 2024')
+  })
+
+  it("should render 'Wed, 04 Dec 2024' (DATE_FORMAT_FULL_DAY)", () => {
+    expect(formatDate(date, DATE_FORMAT_FULL_DAY)).to.equal('Wed, 04 Dec 2024')
+  })
+
+  it("should render '2024-12-04' (DATE_FORMAT_ISO)", () => {
+    expect(formatDate(date, DATE_FORMAT_ISO)).to.equal('2024-12-04')
+  })
+
+  it("should render '2024-12' (DATE_FORMAT_YEAR_MONTH)", () => {
+    expect(formatDate(date, DATE_FORMAT_YEAR_MONTH)).to.equal('2024-12')
+  })
+
+  it("should render 'December 2024' (DATE_FORMAT_MONTH_YEAR)", () => {
+    expect(formatDate(date, DATE_FORMAT_MONTH_YEAR)).to.equal('December 2024')
+  })
+
+  it("should render 'Dec 2024' (DATE_FORMAT_MONTH_ABBR_YEAR)", () => {
+    expect(formatDate(date, DATE_FORMAT_MONTH_ABBR_YEAR)).to.equal('Dec 2024')
+  })
+
+  it("should render '04 Dec' (DATE_FORMAT_DAY_MONTH)", () => {
+    expect(formatDate(date, DATE_FORMAT_DAY_MONTH)).to.equal('04 Dec')
+  })
+
+  it("should render '2024-12-4' (DATE_FORMAT_INTERACTION_TIMESTAMP)", () => {
+    expect(formatDate(date, DATE_FORMAT_INTERACTION_TIMESTAMP)).to.equal(
+      '2024-12-4'
+    )
+  })
+})

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -1,0 +1,120 @@
+const { format, parseISO } = require('date-fns')
+
+/**
+ * Full date format with day and full month name.
+ * Example: 4 December 2024
+ */
+const DATE_FORMAT_FULL = 'd MMMM yyyy'
+
+/**
+ * Full date format including the weekday.
+ * Example: Wed, 04 Dec 2024
+ */
+const DATE_FORMAT_FULL_DAY = 'E, dd MMM yyyy'
+
+/**
+ * Compact date format with two-digit day and abbreviated month name.
+ * Example: 04 Dec 2024
+ */
+const DATE_FORMAT_COMPACT = 'dd MMM yyyy'
+
+/**
+ * ISO standard date format.
+ * Example: 2024-12-04
+ */
+const DATE_FORMAT_ISO = 'yyyy-MM-dd'
+
+/**
+ * Medium date format with single-digit day and abbreviated month name.
+ * Example: 4 Dec 2024
+ */
+const DATE_FORMAT_MEDIUM = 'd MMM yyyy'
+
+/**
+ * Medium date format with time included in 12-hour format.
+ * Example: 4 Dec 2024, 3:30PM
+ */
+const DATE_FORMAT_MEDIUM_WITH_TIME = 'd MMM yyyy, h:mmaaa'
+
+/**
+ * Year and month format for compact representations.
+ * Example: 2024-12
+ */
+const DATE_FORMAT_YEAR_MONTH = 'yyyy-MM'
+
+/**
+ * Month and year format with full month name.
+ * Example: December 2024
+ */
+const DATE_FORMAT_MONTH_YEAR = 'MMMM yyyy'
+
+/**
+ * Abbreviated month and year format.
+ * Example: Dec 2024
+ */
+const DATE_FORMAT_MONTH_ABBR_YEAR = 'MMM yyyy'
+
+/**
+ * Day and month format with abbreviated month name.
+ * Example: 04 Dec
+ */
+const DATE_FORMAT_DAY_MONTH = 'dd MMM'
+
+/**
+ * Interaction timestamp format with single-digit day and month.
+ * Example: 2024-12-4
+ */
+const DATE_FORMAT_INTERACTION_TIMESTAMP = 'y-MM-d'
+
+/**
+ * Formats a given date string into a specified format using `date-fns`.
+ *
+ * @param {string} dateISO - The date string in ISO format (e.g., '2024-12-04').
+ * @param {string} [dateISOFormat=DATE_FORMAT_COMPACT] - The format to use for formatting the date.
+ *    Available format constants include:
+ *    - `DATE_FORMAT_FULL`: Full date with day and full month name (e.g., '4 December 2024').
+ *    - `DATE_FORMAT_FULL_DAY`: Full date with weekday included (e.g., 'Wed, 04 Dec 2024').
+ *    - `DATE_FORMAT_COMPACT`: Compact date with abbreviated month name (e.g., '04 Dec 2024').
+ *    - `DATE_FORMAT_ISO`: ISO standard format (e.g., '2024-12-04').
+ *    - `DATE_FORMAT_MEDIUM`: Medium date format with single-digit day (e.g., '4 Dec 2024').
+ *    - `DATE_FORMAT_MEDIUM_WITH_TIME`: Medium date with 12-hour time (e.g., '4 Dec 2024, 3:30PM').
+ *    - `DATE_FORMAT_YEAR_MONTH`: Year and month format (e.g., '2024-12').
+ *    - `DATE_FORMAT_MONTH_YEAR`: Full month and year (e.g., 'December 2024').
+ *    - `DATE_FORMAT_MONTH_ABBR_YEAR`: Abbreviated month and year (e.g., 'Dec 2024').
+ *    - `DATE_FORMAT_DAY_MONTH`: Day and abbreviated month (e.g., '04 Dec').
+ *    - `DATE_FORMAT_INTERACTION_TIMESTAMP`: Interaction timestamp format (e.g., '2024-12-4').
+ * @returns {string} - The formatted date string.
+ *
+ * @example
+ * // Format a date to the default compact format
+ * formatDate('2024-12-04')
+ * // Returns: '04 Dec 2024'
+ *
+ * @example
+ * // Format a date to a full format
+ * formatDate('2024-12-04', DATE_FORMAT_FULL)
+ * // Returns: '4 December 2024'
+ *
+ * @example
+ * // Format a date with abbreviated month and year
+ * formatDate('2024-12-04', DATE_FORMAT_MONTH_ABBR_YEAR)
+ * // Returns: 'Dec 2024'
+ */
+function formatDate(dateISO, dateISOFormat = DATE_FORMAT_COMPACT) {
+  return format(parseISO(dateISO), dateISOFormat)
+}
+
+module.exports = {
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_FULL_DAY,
+  DATE_FORMAT_COMPACT,
+  DATE_FORMAT_ISO,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+  DATE_FORMAT_YEAR_MONTH,
+  DATE_FORMAT_MONTH_YEAR,
+  DATE_FORMAT_MONTH_ABBR_YEAR,
+  DATE_FORMAT_DAY_MONTH,
+  DATE_FORMAT_INTERACTION_TIMESTAMP,
+  formatDate,
+}

--- a/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
@@ -5,37 +5,14 @@ import { WinsConfirmedList } from '../../../../../src/client/modules/ExportWins/
 import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
 import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
 import { currencyGBP } from '../../../../../src/client/utils/number-utils'
+import { formatDate } from '../../../../../src/client/utils/date-utils'
 import { exportWinsData } from './export-wins-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
 describe('WinsConfirmedList', () => {
-  const exportWin = {
-    id: '111',
-    company: {
-      id: '222',
-      name: 'Foo Ltd',
-    },
-    name_of_export: 'Rolls Reese',
-    company_contacts: [
-      {
-        name: 'David Test',
-        id: '333',
-      },
-    ],
-    country: {
-      name: 'USA',
-    },
-    date: '2023-05-01',
-    customer_response: {
-      responded_on: '2024-04-18T12:15:49.361611Z',
-    },
-    total_expected_export_value: 1000,
-    total_expected_non_export_value: 2000,
-    total_expected_odi_value: 3000,
-  }
-
   it('should render a list of confirmed export wins', () => {
+    const exportWin = exportWinsFaker()
     const exportWinsList = [exportWin, exportWinsFaker(), exportWinsFaker()]
 
     const Provider = createTestProvider({
@@ -57,7 +34,10 @@ describe('WinsConfirmedList', () => {
 
     cy.get('@firstItem').within(() => {
       cy.get('h3 a')
-        .should('have.text', 'Rolls Reese to USA')
+        .should(
+          'have.text',
+          `${exportWin.name_of_export} to ${exportWin.country.name}`
+        )
         .and(
           'have.attr',
           'href',
@@ -68,7 +48,7 @@ describe('WinsConfirmedList', () => {
         )
 
       cy.get('h4 a')
-        .should('have.text', 'Foo Ltd')
+        .should('have.text', exportWin.company.name)
         .and(
           'have.attr',
           'href',
@@ -77,7 +57,12 @@ describe('WinsConfirmedList', () => {
 
       const items = '[data-test="metadata-item"]'
       cy.get(items).should('have.length', 4)
-      cy.get(items).eq(0).should('have.text', 'Contact name: David Test')
+      cy.get(items)
+        .eq(0)
+        .should(
+          'have.text',
+          `Contact name: ${exportWin.company_contacts[0].name}`
+        )
       cy.get(items)
         .eq(1)
         .should(
@@ -92,8 +77,13 @@ describe('WinsConfirmedList', () => {
             )
           )}`
         )
-      cy.get(items).eq(2).should('have.text', 'Date won: 1 May 2023')
-      cy.get(items).eq(3).should('have.text', 'Date responded: 18 Apr 2024')
+      cy.get(items).eq(2).should('have.text', 'Date won: May 2023')
+      cy.get(items)
+        .eq(3)
+        .should(
+          'have.text',
+          `Date responded: ${formatDate(exportWin.customer_response.responded_on)}`
+        )
     })
   })
 

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -1,63 +1,110 @@
 import React from 'react'
+import { pick } from 'lodash'
 
 import { WinsPendingList } from '../../../../../src/client/modules/ExportWins/Status/WinsPendingList'
+import { sumExportValues } from '../../../../../src/client/modules/ExportWins/Status/utils'
+import { exportWinsFaker } from '../../../../functional/cypress/fakers/export-wins'
+import { currencyGBP } from '../../../../../src/client/utils/number-utils'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../src/client/utils/date-utils'
 import { exportWinsData } from './export-wins-data'
 import { createTestProvider } from '../provider'
 import urls from '../../../../../src/lib/urls'
 
 describe('WinsPendingList', () => {
   it('should render Export wins list', () => {
-    const wins = [
-      {
-        id: '123',
-        company: {
-          id: '456',
-          name: 'Foo Ltd',
-        },
-        name_of_export: 'Rolls Reese',
-        company_contacts: [
-          {
-            name: 'David Test',
-            id: 123,
-          },
-        ],
-        country: {
-          name: 'USA',
-        },
-        date: '2023-05-01',
-        customer_response: {
-          responded_on: '2024-04-18T12:15:49.361611Z',
-        },
-        total_expected_export_value: 1000,
-        total_expected_non_export_value: 2000,
-        total_expected_odi_value: 3000,
-      },
-    ]
+    const exportWin = exportWinsFaker()
+    const exportWinsList = [exportWin, exportWinsFaker(), exportWinsFaker()]
+
     const Provider = createTestProvider({
-      'Export Wins': () => Promise.resolve(wins),
+      'Export Wins': () => Promise.resolve(exportWinsList),
       Company: () => Promise.resolve({ id: 123 }),
       TASK_GET_REMINDER_SUMMARY: () => Promise.resolve(),
     })
 
     cy.mount(
       <Provider>
-        <WinsPendingList exportWins={wins} />
+        <WinsPendingList exportWins={exportWinsList} />
       </Provider>
     )
 
-    cy.get('[data-test="metadata-item"]').as('metadataItems')
+    cy.get('[data-test="collection-item"]').as('collectionItems')
+    cy.get('@collectionItems').eq(0).as('firstItem')
 
-    cy.get('@metadataItems')
-      .eq(0)
-      .should('have.text', 'Contact name: David Test')
-      .find('a')
-      .should(
-        'have.attr',
-        'href',
-        urls.contacts.details(wins[0].company_contacts[0].id)
-      )
+    cy.get('@collectionItems').should('have.length', 3)
 
-    cy.get('@metadataItems').eq(1).should('have.text', 'Total value: £6,000')
+    cy.get('@firstItem').within(() => {
+      cy.get('h3 a')
+        .should(
+          'have.text',
+          `${exportWin.name_of_export} to ${exportWin.country.name}`
+        )
+        .and(
+          'have.attr',
+          'href',
+          urls.companies.exportWins.editSummary(
+            exportWinsList[0].company.id,
+            exportWinsList[0].id
+          )
+        )
+
+      cy.get('h4 a')
+        .should('have.text', exportWin.company.name)
+        .and(
+          'have.attr',
+          'href',
+          urls.companies.overview.index(exportWinsList[0].company.id)
+        )
+
+      const items = '[data-test="metadata-item"]'
+      cy.get(items).should('have.length', 6)
+
+      cy.get(items)
+        .eq(0)
+        .should(
+          'have.text',
+          `Contact name: ${exportWin.company_contacts[0].name}`
+        )
+
+      cy.get(items)
+        .eq(1)
+        .should(
+          'have.text',
+          `Total value: ${currencyGBP(
+            sumExportValues(
+              pick(exportWin, [
+                'total_expected_export_value',
+                'total_expected_non_export_value',
+                'total_expected_odi_value',
+              ])
+            )
+          )}`
+        )
+
+      cy.get(items).eq(2).should('have.text', 'Date won: May 2023')
+
+      cy.get(items)
+        .eq(3)
+        .should(
+          'have.text',
+          `Date modified: ${formatDate(exportWin.modified_on)}`
+        )
+      cy.get(items)
+        .eq(4)
+        .should(
+          'have.text',
+          `First sent: ${formatDate(exportWin.first_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
+        )
+
+      cy.get(items)
+        .eq(5)
+        .should(
+          'have.text',
+          `Last sent: ${formatDate(exportWin.last_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
+        )
+    })
   })
 
   it('should conditionally render tags', () => {

--- a/test/functional/cypress/fakers/export-wins.js
+++ b/test/functional/cypress/fakers/export-wins.js
@@ -121,10 +121,13 @@ export const exportWinsFaker = () => ({
     min: 10_000,
     max: 10_000_000,
   }),
-  date: faker.date.anytime().toISOString(),
+  date: '2023-05-01',
+  modified_on: faker.date.past().toISOString(),
+  first_sent: faker.date.past().toISOString(),
+  last_sent: faker.date.past().toISOString(),
   customer_response: {
     agree_with_win: null, // Pending
-    responded_on: faker.date.anytime().toISOString(),
+    responded_on: faker.date.past().toISOString(),
     expected_portion_without_help: {
       name: '40%',
     },

--- a/test/functional/cypress/specs/export-win/dashboard-spec.js
+++ b/test/functional/cypress/specs/export-win/dashboard-spec.js
@@ -1,8 +1,14 @@
+import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
 
 describe('Dashboard', () => {
   it('should display the correct filters', () => {
+    cy.intercept('GET', '/api-proxy/v4/export-win?*', {
+      count: 2,
+      results: [exportWinsFaker(), exportWinsFaker()],
+    }).as('apiRequest')
     cy.visit(urls.companies.exportWins.pending())
+    cy.wait('@apiRequest')
     cy.contains('label', 'Sort by').within(() => {
       cy.get('select option:selected').should('have.text', 'Newest')
       cy.get('select').select('Oldest')

--- a/test/sandbox/routes/v4/export-win/export-win.js
+++ b/test/sandbox/routes/v4/export-win/export-win.js
@@ -54,6 +54,9 @@ const fakeExportWin = () => ({
     max: 10_000_000,
   }),
   date: faker.date.anytime(),
+  modified_on: faker.date.past().toISOString(),
+  first_sent: faker.date.past().toISOString(),
+  last_sent: faker.date.past().toISOString(),
   goods_vs_services: {
     id: faker.string.uuid(),
     name: faker.helpers.arrayElement(['Goods', 'Services']),
@@ -118,16 +121,27 @@ const fakeExportWin = () => ({
       id: faker.string.uuid(),
     },
     other_marketing_source: '',
-    responded_on: null,
+    responded_on: faker.date.recent(),
   },
 })
 
-const WON_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
-const SENT_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
+export const WIN_STATUS = {
+  PENDING: 'null',
+  CONFIRMED: 'true',
+  REJECTED: 'false',
+}
+
+const PENDING_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
+const CONFIRMED_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
+const REJECTED_EXPORT_WINS = Array(123).fill().map(fakeExportWin)
 
 export const getExportWinCollection = (req, res) => {
   const exportWins =
-    req.query.filter === 'sent' ? SENT_EXPORT_WINS : WON_EXPORT_WINS
+    req.query.confirmed === WIN_STATUS.CONFIRMED
+      ? CONFIRMED_EXPORT_WINS
+      : req.query.confirmed === WIN_STATUS.REJECTED
+        ? REJECTED_EXPORT_WINS
+        : PENDING_EXPORT_WINS
 
   const limit = parseInt(req.query.limit, 10)
   const offset = parseInt(req.query.offset, 10)


### PR DESCRIPTION
## Description of change
This PR fixes the dates on export wins following the `date-fns` [upgrade](https://github.com/uktrade/data-hub-frontend/pull/7300).

A new utility file `date-utils.js` has been created containing a single function `formatDate(dateISO, dateISOFormat)`. This function takes a date in either ISO standard format (`2024-12-04`) or a date-time format (`2024-12-04T10:41:45.425717Z`), and a format constant, to return the desired date format. For example:

```js
import { formatDate, DATE_FORMAT_MEDIUM_WITH_TIME,  DATE_FORMAT_COMPACT } from './date-utils'

formatDate('2024-12-04T10:41:45.425717Z', DATE_FORMAT_MEDIUM_WITH_TIME) // 4 Dec 2024, 10:41am
formatDate('2024-12-04', DATE_FORMAT_COMPACT) // 04 Dec 2024
```

This approach improves both readability (each constant has docstrings) and maintainability compared to the previous implementation. I plan to refactor the rest of the codebase to adopt this new method. Specifically, I’ll clean up `dates.js` by removing the outdated formatting functions and replacing them with calls to formatDate. The current state of `dates.js` is convoluted, and this change should make the codebase more manageable going forward. Eventually, we aim to consolidate all date-related functionality into a single, well-organised file.

## Test instructions
Go to: `/exportwins/pending`, `/exportwins/confirmed` and `/exportwins/rejected`.

## Screenshots

### Before
<img width="1007" alt="pending" src="https://github.com/user-attachments/assets/4de3acd1-11e8-4b32-a7b3-b97b1408a0b0">

<img width="1008" alt="rejected" src="https://github.com/user-attachments/assets/da42d351-1228-4802-b81e-5c055c39ba19">

### After (Pending)
<img width="1013" alt="pending-after" src="https://github.com/user-attachments/assets/98b99aa4-13cc-4e5d-9d7b-3274dfa55d64">

### After (Rejected)
<img width="1013" alt="rejected-after" src="https://github.com/user-attachments/assets/32d8a4e3-01d9-4765-a128-892c3909f53a">

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
