### PR TITLE
Refactor/event details page

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -28,7 +28,6 @@ module.exports = defineConfig({
     supportFile: 'test/cypress/support/index.js',
   },
   retries: {
-    runMode: 2, // number of retries when running `cypress run`
-    openMode: 2, // number of retries when running `cypress open`
+    runMode: 2,
   },
 })

--- a/src/apps/events/__test__/repos.test.js
+++ b/src/apps/events/__test__/repos.test.js
@@ -50,26 +50,12 @@ describe('Event Service', () => {
     })
   })
 
-  context('fetchEvent', () => {
-    it('should fetch single event by id', async () => {
-      const id = '123'
-      await fetchEvent(mockReq, id)
-      expect(authorisedRequestStub).to.have.been.calledWith(
-        mockReq,
-        `${config.apiRoot}/v3/event/${id}`
-      )
-    })
-  })
-
-  context('getAllEvents', () => {
-    it('should fetch all events with limit and offset', async () => {
-      await getAllEvents(mockReq)
-      expect(authorisedRequestStub).to.have.been.calledWith(
-        mockReq,
-        `${config.apiRoot}/v3/event?limit=100000&offset=0`
-      )
-    })
-  })
+  describe('#getActiveEvents', () => {
+    context(
+      'When there is a mix of active and inactive events on the server',
+      () => {
+        beforeEach(() => {
+          this.currentId = '3'
 
   context('getActiveEvents', () => {
     let clock

--- a/src/apps/events/__test__/repos.test.js
+++ b/src/apps/events/__test__/repos.test.js
@@ -5,15 +5,12 @@ const proxyquire = require('proxyquire')
 const authorisedRequestStub = sinon.stub()
 const searchStub = sinon.stub()
 
-const { saveEvent, fetchEvent, getAllEvents, getActiveEvents } = proxyquire(
-  '../repos',
-  {
-    '../../lib/authorised-request': {
-      authorisedRequest: authorisedRequestStub,
-    },
-    '../../modules/search/services': { search: searchStub },
-  }
-)
+const { saveEvent, getActiveEvents } = proxyquire('../repos', {
+  '../../lib/authorised-request': {
+    authorisedRequest: authorisedRequestStub,
+  },
+  '../../modules/search/services': { search: searchStub },
+})
 
 const config = require('../../../config')
 
@@ -49,13 +46,6 @@ describe('Event Service', () => {
       })
     })
   })
-
-  describe('#getActiveEvents', () => {
-    context(
-      'When there is a mix of active and inactive events on the server',
-      () => {
-        beforeEach(() => {
-          this.currentId = '3'
 
   context('getActiveEvents', () => {
     let clock

--- a/src/apps/events/attendees/controllers/list.js
+++ b/src/apps/events/attendees/controllers/list.js
@@ -48,6 +48,7 @@ async function renderAttendees(req, res, next) {
       children: [{ value: sortby }],
     })
 
+    // TODO: Can we remove this?
     res.breadcrumb(name).render('events/attendees/views/list', {
       incompleteEvent,
       attendees: attendeesCollection,

--- a/src/apps/events/attendees/router.js
+++ b/src/apps/events/attendees/router.js
@@ -1,8 +1,9 @@
+// TODO: Remove this whole module and the whole parent folder ../
 const router = require('express').Router()
 
 const { createAttendee, renderAttendees } = require('./controllers')
 
-router.get('/', renderAttendees)
+router.get('/*', renderAttendees)
 
 router.get('/create/:contactId', createAttendee)
 

--- a/src/apps/events/middleware/details.js
+++ b/src/apps/events/middleware/details.js
@@ -1,3 +1,4 @@
+// TODO: Get rid of this whole module
 const { assign } = require('lodash')
 
 const { transformEventFormBodyToApiRequest } = require('../transformers')
@@ -27,6 +28,7 @@ async function postDetails(req, res, next) {
   }
 }
 
+// TODO: Get rid of this
 async function getEventDetails(req, res, next, eventId) {
   try {
     res.locals.event = await fetchEvent(req, eventId)

--- a/src/apps/events/router.js
+++ b/src/apps/events/router.js
@@ -5,7 +5,7 @@ const { APP_PERMISSIONS, LOCAL_NAV } = require('./constants')
 const { handleRoutePermissions, setLocalNav } = require('../middleware')
 const { getEventDetails } = require('./middleware/details')
 const { renderEventsView } = require('./controllers/events')
-const attendeesRouter = require('./attendees/router')
+const { createAttendee } = require('./attendees/controllers/create')
 
 router.get('/create', renderEventsView)
 router.use(handleRoutePermissions(APP_PERMISSIONS))
@@ -19,12 +19,9 @@ router.use(
   setLocalNav(LOCAL_NAV)
 )
 
-router.use('/:eventId/attendees', attendeesRouter)
+// TODO: Get rid of this and fetch the event on the client
 router.param('eventId', getEventDetails)
-// TODO: When everything in the events space is converted to react
-// router.get('/*', renderEventsView)
-router.get('/:eventId/edit', renderEventsView)
-router.get('/:eventId', renderEventsView)
-router.get('/:eventId/details', renderEventsView)
+router.get('/:eventId/attendees/create/:contactId', createAttendee)
+router.get('/:eventId*', renderEventsView)
 
 module.exports = router

--- a/src/client/components/Resource/InteractionsV3.js
+++ b/src/client/components/Resource/InteractionsV3.js
@@ -1,0 +1,3 @@
+import { createCollectionResource } from './Resource'
+
+export default createCollectionResource('InteractionsV3', 'v3/interaction')

--- a/src/client/components/Resource/Paginated.js
+++ b/src/client/components/Resource/Paginated.js
@@ -53,6 +53,9 @@ const StyledCollectionSort = styled(CollectionSort)`
  * Forwarded to {qsParamName} prop of {StyledCollectionSort}.
  * @param {number} [props.defaultSortOptionIndex = 0] - The index of the sort option
  * that should be selected when there's nothing set in the query string.
+ * @param {string} [props.addItemUrl =] - If set, an "Add <item-name>" button
+ * will be displayed on the top-right corner of the header behaving as a link
+ * to the value of this prop. This is just forwarded to CollectionHeader.
  * @example
  * <PaginatedResource name="My task name" id="foo">
  *   {currentPage =>
@@ -100,6 +103,7 @@ const PaginatedResource = multiInstance({
     result,
     shouldPluralize,
     noResults = "You don't have any results",
+    addItemUrl,
   }) => {
     // We know better than ESLint that we are in deed in a React component
     // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -150,6 +154,7 @@ const PaginatedResource = multiInstance({
                     totalItems={result.count}
                     collectionName={heading || name}
                     shouldPluralize={shouldPluralize}
+                    addItemUrl={addItemUrl}
                   />
                   {totalPages > 0 && (
                     <StyledCollectionSort

--- a/src/client/components/Resource/tasks.js
+++ b/src/client/components/Resource/tasks.js
@@ -6,6 +6,7 @@ import Company from './Company'
 import CompanyContacts from './CompanyContacts'
 import Countries from './Countries'
 import Interactions from './Interactions'
+import InteractionsV3 from './InteractionsV3'
 import Opportunity from './Opportunity'
 import OpportunityStatuses from './OpportunityStatuses'
 import UKRegions from './UKRegions'
@@ -110,6 +111,7 @@ export default {
   ...ContactAuditHistory.tasks,
   ...Countries.tasks,
   ...Interactions.tasks,
+  ...InteractionsV3.tasks,
   ...Opportunity.tasks,
   ...OpportunityStatuses.tasks,
   ...CapitalInvestmentRequiredChecksConducted.tasks,

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
-import { MEDIA_QUERIES } from '@govuk-react/constants'
+import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
 import {
   BLACK,
@@ -288,6 +288,28 @@ export const VerticalTabNav = styled(SmallScreenTabNav)({
             background: DARK_BLUE_LEGACY,
             fontWeight: '600',
           },
+        },
+      },
+    },
+  },
+})
+
+export const DashboardTabNav = styled(HorizontalTabNav)({
+  '& > [role="tabpanel"]': {
+    border: `2px solid ${BLUE}`,
+    padding: SPACING.SCALE_3,
+    margin: 0,
+  },
+  '& > [role="tablist"]': {
+    border: 'none',
+    fontWeight: 'bold',
+    '& > [role="tab"]': {
+      [MEDIA_QUERIES.TABLET]: {
+        textDecoration: 'underline',
+        '&[aria-selected="true"]': {
+          background: BLUE,
+          borderColor: BLUE,
+          color: WHITE,
         },
       },
     },

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React, { useEffect, useRef } from 'react'
 import { useLocation, useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
-import { MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import { MEDIA_QUERIES } from '@govuk-react/constants'
 
 import {
   BLACK,
@@ -288,28 +288,6 @@ export const VerticalTabNav = styled(SmallScreenTabNav)({
             background: DARK_BLUE_LEGACY,
             fontWeight: '600',
           },
-        },
-      },
-    },
-  },
-})
-
-export const DashboardTabNav = styled(HorizontalTabNav)({
-  '& > [role="tabpanel"]': {
-    border: `2px solid ${BLUE}`,
-    padding: SPACING.SCALE_3,
-    margin: 0,
-  },
-  '& > [role="tablist"]': {
-    border: 'none',
-    fontWeight: 'bold',
-    '& > [role="tab"]': {
-      [MEDIA_QUERIES.TABLET]: {
-        textDecoration: 'underline',
-        '&[aria-selected="true"]': {
-          background: BLUE,
-          borderColor: BLUE,
-          color: WHITE,
         },
       },
     },

--- a/src/client/modules/Events/CollectionList/index.jsx
+++ b/src/client/modules/Events/CollectionList/index.jsx
@@ -69,7 +69,7 @@ const EventTemplate = (item) => {
     <StyledCollectionItem
       dataTest="data-hub-event"
       headingText={item.headingText}
-      headingUrl={item.headingUrl}
+      headingUrl={`/events/${item.id}/details`}
       metadata={item.metadata}
       tags={item.tags}
       titleRenderer={TitleRenderer}

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -3,33 +3,97 @@ import { connect } from 'react-redux'
 import { isEmpty } from 'lodash'
 import { useParams } from 'react-router-dom'
 
-import GridRow from '@govuk-react/grid-row'
-import GridCol from '@govuk-react/grid-col'
 import Button from '@govuk-react/button'
 import styled from 'styled-components'
+
+import { H3, Link } from 'govuk-react'
 
 import urls from '../../../../lib/urls'
 import { TASK_GET_EVENT_DETAILS, ID, state2props } from './state'
 import { EVENTS__DETAILS_LOADED } from '../../../actions'
 import Task from '../../../components/Task'
-import {
-  LocalNav,
-  LocalNavLink,
-  SummaryTable,
-  FormActions,
-  DefaultLayout,
-} from '../../../components'
+import { SummaryTable, FormActions, DefaultLayout } from '../../../components'
+import CollectionItem from '../../../components/CollectionList/CollectionItem'
+import State from '../../../components/State'
+
+import { VerticalTabNav } from '../../../components/TabNav'
+import InteractionsV3 from '../../../components/Resource/InteractionsV3'
+import { formatMediumDate } from '../../../utils/date'
 
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
 })
 
-const EventDetails = ({
-  name = 'Event',
+const Attendees = ({ eventId }) => (
+  <div>
+    <H3 as="h2">Event Attendees</H3>
+    <InteractionsV3.Paginated
+      id="???"
+      heading="attendee"
+      addItemUrl={`/events/${eventId}/attendees/find-new`}
+      sortOptions={[
+        { name: 'Last name: A-Z', value: 'last_name_of_first_contact' },
+        { name: 'Last name: Z-A', value: '-last_name_of_first_contact' },
+        { name: 'First name: A-Z', value: 'first_name_of_first_contact' },
+        { name: 'First name: Z-A', value: '-first_name_of_first_contact' },
+        { name: 'Company name: A-Z', value: 'company__name' },
+        { name: 'Company name: Z-A', value: '-company__name' },
+        { name: 'Recently added', value: '-created_on' },
+        { name: 'Least recently added', value: 'created_on' },
+      ]}
+      payload={{
+        event_id: eventId,
+      }}
+    >
+      {(page) => (
+        <ul>
+          {page.map((interaction) => (
+            <CollectionItem
+              headingText={interaction.contact.name}
+              headingUrl={`/contacts/${interaction.contact.id}`}
+              metadata={[
+                {
+                  label: 'Company',
+                  value: (
+                    <Link href={`/companies/${interaction.companies[0].id}`}>
+                      {interaction.companies[0].name}
+                    </Link>
+                  ),
+                },
+                ...(interaction.contact.job_title
+                  ? [
+                      {
+                        label: 'Job title',
+                        value: interaction.contact.job_title,
+                      },
+                    ]
+                  : []),
+                {
+                  label: 'Date attended',
+                  value: formatMediumDate(interaction.date),
+                },
+                {
+                  label: 'Service delivery',
+                  value: (
+                    <Link href={`/companies/${interaction.service.id}`}>
+                      {interaction.service.name}
+                    </Link>
+                  ),
+                },
+              ]}
+            />
+          ))}
+        </ul>
+      )}
+    </InteractionsV3.Paginated>
+  </div>
+)
+
+const Details = ({
   eventType,
+  eventDays,
   startDate,
   endDate,
-  eventDays,
   locationType,
   fullAddress,
   ukRegion,
@@ -39,130 +103,125 @@ const EventDetails = ({
   otherTeams,
   relatedProgrammes,
   relatedTradeAgreements,
-  service,
   disabledOn,
-}) => {
-  const { id } = useParams()
-  const breadcrumbs = [
-    {
-      link: urls.dashboard.index(),
-      text: 'Home',
-    },
-    {
-      link: urls.events.index(),
-      text: 'Events',
-    },
-    {
-      text: name || '',
-    },
-  ]
+  service,
+  id,
+}) => (
+  <>
+    <StyledSummaryTable>
+      <SummaryTable.Row heading="Type of event" children={eventType} />
+      <SummaryTable.Row
+        heading={eventDays == 1 ? 'Event date' : 'Event start date'}
+        children={startDate}
+      />
+      {eventDays > 1 ? (
+        <SummaryTable.Row heading="Event end date" children={endDate} />
+      ) : null}
+      <SummaryTable.Row heading="Event location type">
+        {isEmpty(locationType) ? 'Not set' : locationType}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Address">{fullAddress}</SummaryTable.Row>
+      <SummaryTable.Row heading="Region" hideWhenEmpty={false}>
+        {isEmpty(ukRegion) ? 'Not set' : ukRegion}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
+        {isEmpty(notes) ? 'Not set' : notes}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Lead team">
+        {isEmpty(leadTeam) ? 'Not set' : leadTeam}
+      </SummaryTable.Row>
+      <SummaryTable.Row heading="Organiser">
+        {isEmpty(organiser) ? 'Not set' : organiser}
+      </SummaryTable.Row>
+      <SummaryTable.ListRow
+        heading="Other teams"
+        value={otherTeams}
+        emptyValue="Not set"
+        hideWhenEmpty={false}
+      />
+      <SummaryTable.ListRow
+        heading="Related programmes"
+        value={relatedProgrammes}
+        emptyValue="Not set"
+        hideWhenEmpty={false}
+      />
+      <SummaryTable.ListRow
+        heading="Related Trade Agreements"
+        value={relatedTradeAgreements}
+        emptyValue="Not set"
+        hideWhenEmpty={false}
+      />
+      <SummaryTable.Row heading="Service" children={service} />
+    </StyledSummaryTable>
+    {!disabledOn && (
+      <FormActions>
+        <Button as={'a'} href={urls.events.edit(id)}>
+          Edit event
+        </Button>
+      </FormActions>
+    )}
+  </>
+)
+
+const EventDetails = ({ name, ...props }) => {
+  const { id, ['*']: path } = useParams()
 
   return (
-    <DefaultLayout
-      heading="Events"
-      pageTitle="Events"
-      breadcrumbs={breadcrumbs}
-      useReactRouter={true}
-    >
-      <Task.Status
-        name={TASK_GET_EVENT_DETAILS}
-        id={ID}
-        progressMessage="loading event details"
-        startOnRender={{
-          payload: id,
-          onSuccessDispatch: EVENTS__DETAILS_LOADED,
-        }}
-      >
-        {() => {
-          return (
-            name && (
-              <GridRow data-test="eventDetails">
-                <GridCol setWidth="one-quarter">
-                  <LocalNav data-test="event-details-nav">
-                    <LocalNavLink
-                      data-test="event-details-nav-link"
-                      href={urls.events.details(id)}
-                    >
-                      Details
-                    </LocalNavLink>
-                    <LocalNavLink
-                      data-test="event-details-nav-link"
-                      href={urls.events.attendees(id)}
-                    >
-                      Attendees
-                    </LocalNavLink>
-                  </LocalNav>
-                </GridCol>
-                <GridCol setWidth="three-quarters">
-                  <StyledSummaryTable>
-                    <SummaryTable.Row
-                      heading="Type of event"
-                      children={eventType}
-                    />
-                    <SummaryTable.Row
-                      heading={
-                        eventDays == 1 ? 'Event date' : 'Event start date'
-                      }
-                      children={startDate}
-                    />
-                    {eventDays > 1 ? (
-                      <SummaryTable.Row
-                        heading="Event end date"
-                        children={endDate}
-                      />
-                    ) : null}
-                    <SummaryTable.Row heading="Event location type">
-                      {isEmpty(locationType) ? 'Not set' : locationType}
-                    </SummaryTable.Row>
-                    <SummaryTable.Row heading="Address">
-                      {fullAddress}
-                    </SummaryTable.Row>
-                    <SummaryTable.Row heading="Region" hideWhenEmpty={false}>
-                      {isEmpty(ukRegion) ? 'Not set' : ukRegion}
-                    </SummaryTable.Row>
-                    <SummaryTable.Row heading="Notes" hideWhenEmpty={false}>
-                      {isEmpty(notes) ? 'Not set' : notes}
-                    </SummaryTable.Row>
-                    <SummaryTable.Row heading="Lead team">
-                      {isEmpty(leadTeam) ? 'Not set' : leadTeam}
-                    </SummaryTable.Row>
-                    <SummaryTable.Row heading="Organiser">
-                      {isEmpty(organiser) ? 'Not set' : organiser}
-                    </SummaryTable.Row>
-                    <SummaryTable.ListRow
-                      heading="Other teams"
-                      value={otherTeams}
-                      emptyValue="Not set"
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.ListRow
-                      heading="Related programmes"
-                      value={relatedProgrammes}
-                      emptyValue="Not set"
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.ListRow
-                      heading="Related Trade Agreements"
-                      value={relatedTradeAgreements}
-                      emptyValue="Not set"
-                      hideWhenEmpty={false}
-                    />
-                    <SummaryTable.Row heading="Service" children={service} />
-                  </StyledSummaryTable>
-                  {!disabledOn && (
-                    <FormActions>
-                      <Button as={'a'} href={urls.events.edit(id)}>
-                        Edit event
-                      </Button>
-                    </FormActions>
-                  )}
-                </GridCol>
-              </GridRow>
-            )
-          )
-        }}
-      </Task.Status>
-    </DefaultLayout>
+    <State>
+      {({ flashMessages }) => (
+        <DefaultLayout
+          heading={name}
+          pageTitle="Events"
+          flashMessages={flashMessages}
+          breadcrumbs={[
+            {
+              link: urls.dashboard.index(),
+              text: 'Home',
+            },
+            {
+              link: urls.events.index(),
+              text: 'Events',
+            },
+            {
+              text: name,
+            },
+            {
+              text: { details: 'Details', attendees: 'Attendees' }[path],
+            },
+          ]}
+          useReactRouter={true}
+        >
+          <Task.Status
+            name={TASK_GET_EVENT_DETAILS}
+            id={ID}
+            progressMessage="loading event details"
+            startOnRender={{
+              payload: id,
+              onSuccessDispatch: EVENTS__DETAILS_LOADED,
+            }}
+          >
+            {() => (
+              <VerticalTabNav
+                routed={true}
+                id="event-details-tab-nav"
+                label="Event tab navigation"
+                selectedIndex="attendees"
+                tabs={{
+                  [`/events/${id}/details`]: {
+                    label: 'Details',
+                    content: <Details {...props} />,
+                  },
+                  [`/events/${id}/attendees`]: {
+                    label: 'Attendes',
+                    content: <Attendees eventId={id} />,
+                  },
+                }}
+              />
+            )}
+          </Task.Status>
+        </DefaultLayout>
+      )}
+    </State>
   )
 }
 

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -21,6 +21,17 @@ import InteractionsV3 from '../../../components/Resource/InteractionsV3'
 import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import StatusMessage from '../../../components/StatusMessage'
 
+const ATTENDEE_SORT_OPTIONS = [
+  { name: 'Last name: A-Z', value: 'last_name_of_first_contact' },
+  { name: 'Last name: Z-A', value: '-last_name_of_first_contact' },
+  { name: 'First name: A-Z', value: 'first_name_of_first_contact' },
+  { name: 'First name: Z-A', value: '-first_name_of_first_contact' },
+  { name: 'Company name: A-Z', value: 'company__name' },
+  { name: 'Company name: Z-A', value: '-company__name' },
+  { name: 'Recently added', value: '-created_on' },
+  { name: 'Least recently added', value: 'created_on' },
+]
+
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
 })
@@ -37,16 +48,7 @@ const Attendees = ({ eventId, isDisabled }) => (
       id="???"
       heading="attendee"
       addItemUrl={!isDisabled && `/events/${eventId}/attendees/find-new`}
-      sortOptions={[
-        { name: 'Last name: A-Z', value: 'last_name_of_first_contact' },
-        { name: 'Last name: Z-A', value: '-last_name_of_first_contact' },
-        { name: 'First name: A-Z', value: 'first_name_of_first_contact' },
-        { name: 'First name: Z-A', value: '-first_name_of_first_contact' },
-        { name: 'Company name: A-Z', value: 'company__name' },
-        { name: 'Company name: Z-A', value: '-company__name' },
-        { name: 'Recently added', value: '-created_on' },
-        { name: 'Least recently added', value: 'created_on' },
-      ]}
+      sortOptions={ATTENDEE_SORT_OPTIONS}
       payload={{
         event_id: eventId,
       }}

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -226,7 +226,7 @@ const EventDetails = ({ name, ...props }) => {
                     content: <Details {...props} />,
                   },
                   [`/events/${id}/attendees`]: {
-                    label: 'Attendes',
+                    label: 'Attendees',
                     content: (
                       <Attendees eventId={id} isDisabled={props.disabledOn} />
                     ),

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -18,7 +18,7 @@ import State from '../../../components/State'
 
 import { VerticalTabNav } from '../../../components/TabNav'
 import InteractionsV3 from '../../../components/Resource/InteractionsV3'
-import { formatLongDate } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import StatusMessage from '../../../components/StatusMessage'
 
 const StyledSummaryTable = styled(SummaryTable)({
@@ -73,7 +73,7 @@ const Attendees = ({ eventId, isDisabled }) => (
                   },
                   {
                     label: 'Date attended',
-                    value: formatLongDate(date),
+                    value: formatDate(date, DATE_FORMAT_FULL),
                   },
                   {
                     label: 'Service delivery',
@@ -182,7 +182,7 @@ const EventDetails = ({ name, ...props }) => {
               ...(flashMessages.info || []),
               ...(props.disabledOn
                 ? [
-                    `This event was disabled on ${formatLongDate(props.disabledOn)} and can no longer be edited.`,
+                    `This event was disabled on ${formatDate(props.disabledOn, DATE_FORMAT_FULL)} and can no longer be edited.`,
                   ]
                 : []),
             ],

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -19,18 +19,24 @@ import State from '../../../components/State'
 import { VerticalTabNav } from '../../../components/TabNav'
 import InteractionsV3 from '../../../components/Resource/InteractionsV3'
 import { formatLongDate } from '../../../utils/date'
+import StatusMessage from '../../../components/StatusMessage'
 
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
 })
 
-const Attendees = ({ eventId }) => (
+const Attendees = ({ eventId, isDisabled }) => (
   <div>
     <H3 as="h2">Event Attendees</H3>
+    {isDisabled && (
+      <StatusMessage>
+        You cannot add an event attendee because the event has been disabled.
+      </StatusMessage>
+    )}
     <InteractionsV3.Paginated
       id="???"
       heading="attendee"
-      addItemUrl={`/events/${eventId}/attendees/find-new`}
+      addItemUrl={!isDisabled && `/events/${eventId}/attendees/find-new`}
       sortOptions={[
         { name: 'Last name: A-Z', value: 'last_name_of_first_contact' },
         { name: 'Last name: Z-A', value: '-last_name_of_first_contact' },
@@ -170,7 +176,17 @@ const EventDetails = ({ name, ...props }) => {
         <DefaultLayout
           heading={name}
           pageTitle="Events"
-          flashMessages={flashMessages}
+          flashMessages={{
+            ...flashMessages,
+            info: [
+              ...(flashMessages.info || []),
+              ...(props.disabledOn
+                ? [
+                    `This event was disabled on ${formatLongDate(props.disabledOn)} and can no longer be edited.`,
+                  ]
+                : []),
+            ],
+          }}
           breadcrumbs={[
             {
               link: urls.dashboard.index(),
@@ -211,7 +227,9 @@ const EventDetails = ({ name, ...props }) => {
                   },
                   [`/events/${id}/attendees`]: {
                     label: 'Attendes',
-                    content: <Attendees eventId={id} />,
+                    content: (
+                      <Attendees eventId={id} isDisabled={props.disabledOn} />
+                    ),
                   },
                 }}
               />
@@ -223,4 +241,5 @@ const EventDetails = ({ name, ...props }) => {
   )
 }
 
+// TODO: Get rid of this
 export default connect(state2props)(EventDetails)

--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -18,7 +18,7 @@ import State from '../../../components/State'
 
 import { VerticalTabNav } from '../../../components/TabNav'
 import InteractionsV3 from '../../../components/Resource/InteractionsV3'
-import { formatMediumDate } from '../../../utils/date'
+import { formatLongDate } from '../../../utils/date'
 
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
@@ -47,42 +47,40 @@ const Attendees = ({ eventId }) => (
     >
       {(page) => (
         <ul>
-          {page.map((interaction) => (
-            <CollectionItem
-              headingText={interaction.contact.name}
-              headingUrl={`/contacts/${interaction.contact.id}`}
-              metadata={[
-                {
-                  label: 'Company',
-                  value: (
-                    <Link href={`/companies/${interaction.companies[0].id}`}>
-                      {interaction.companies[0].name}
-                    </Link>
-                  ),
-                },
-                ...(interaction.contact.job_title
-                  ? [
-                      {
-                        label: 'Job title',
-                        value: interaction.contact.job_title,
-                      },
-                    ]
-                  : []),
-                {
-                  label: 'Date attended',
-                  value: formatMediumDate(interaction.date),
-                },
-                {
-                  label: 'Service delivery',
-                  value: (
-                    <Link href={`/companies/${interaction.service.id}`}>
-                      {interaction.service.name}
-                    </Link>
-                  ),
-                },
-              ]}
-            />
-          ))}
+          {page.map(
+            ({ contacts: [contact], companies: [company], date, service }) => (
+              <CollectionItem
+                headingText={contact?.name || 'Not available'}
+                headingUrl={contact && `/contacts/${contact?.id}`}
+                metadata={[
+                  {
+                    label: 'Company',
+                    value: (
+                      <Link href={`/companies/${company?.id}`}>
+                        {company?.name}
+                      </Link>
+                    ),
+                  },
+                  {
+                    label: 'Job title',
+                    value: contact?.job_title || 'Not available',
+                  },
+                  {
+                    label: 'Date attended',
+                    value: formatLongDate(date),
+                  },
+                  {
+                    label: 'Service delivery',
+                    value: (
+                      <Link href={`/companies/${service.id}`}>
+                        {service.name}
+                      </Link>
+                    ),
+                  },
+                ]}
+              />
+            )
+          )}
         </ul>
       )}
     </InteractionsV3.Paginated>

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -418,7 +418,7 @@ function Routes() {
       ),
     },
     {
-      path: '/events/:id/details',
+      path: '/events/:id/*',
       element: (
         <ProtectedRoute module={'datahub:events'}>
           <EventDetails />

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -9,7 +9,7 @@ const transformModulePermissions = (modules) =>
 module.exports = () => {
   return function reactGlobalProps(req, res, next) {
     res.locals.globalProps = {
-      flashMessages: res.locals.flashMessages,
+      flashMessages: res.locals.getMessages(),
       sentryDsn: config.sentryDsn,
       sentryEnvironment: config.sentryEnvironment,
       csrfToken: req.csrfToken(),

--- a/src/middleware/react-global-props.js
+++ b/src/middleware/react-global-props.js
@@ -9,7 +9,7 @@ const transformModulePermissions = (modules) =>
 module.exports = () => {
   return function reactGlobalProps(req, res, next) {
     res.locals.globalProps = {
-      flashMessages: res.locals.getMessages(),
+      flashMessages: res.locals.flashMessages,
       sentryDsn: config.sentryDsn,
       sentryEnvironment: config.sentryEnvironment,
       csrfToken: req.csrfToken(),

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -128,22 +128,15 @@ describe('Event', () => {
       cy.visit(urls.events.index())
       cy.contains(eventName).click()
       cy.contains('Attendees').click()
-      cy.get(selectors.entityCollection.addAttendee).click()
+      cy.contains('Add attendee').click()
 
-      cy.get('[data-test="contact-name-filter"]')
-        .type('dean cox')
-        .type('{enter}')
+      cy.get('input[name="name"]').type('dean cox').type('{enter}')
       cy.contains('Dean Cox').click()
 
-      cy.get(selectors.message.flashMessages)
-        .should(
-          'contain',
-          'Event attendee added - This has created a service delivery record.'
-        )
-        .and(
-          'contain',
+      cy.contains(
+        'Event attendee added - This has created a service delivery record. ' +
           'If required, you can view or edit the service delivery directly from the attendee record.'
-        )
+      )
     })
   })
 
@@ -187,9 +180,7 @@ describe('Event', () => {
       cy.visit(urls.events.details(event.pk))
       cy.contains('a', 'Attendees').click()
       cy.contains('Add attendee').click()
-      cy.get('[data-test="contact-name-filter"]')
-        .type('Attendee')
-        .type('{enter}')
+      cy.get('input[name="name"]').type('Attendee').type('{enter}')
       cy.contains('Joe Attendee').click()
       cy.contains('Event attendee added')
     })
@@ -198,17 +189,12 @@ describe('Event', () => {
       cy.visit(urls.events.details(event.pk))
       cy.contains('a', 'Attendees').click()
       cy.contains('Add attendee').click()
-      cy.get('[data-test="contact-name-filter"]')
-        .type('Attendee')
-        .type('{enter}')
+      cy.get('input[name="name"]').type('Attendee').type('{enter}')
       cy.contains('Joe Attendee').click()
       cy.contains('Add attendee').click()
-      cy.get('[data-test="contact-name-filter"]')
-        .type('Attendee')
-        .type('{enter}')
+      cy.get('input[name="name"]').type('Attendee').type('{enter}')
       cy.contains('Joe Attendee').click()
-      cy.get(selectors.message.flashMessages).should(
-        'contain',
+      cy.contains(
         'Event attendee not added - This contact has already been added as an event attendee'
       )
     })

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -178,7 +178,7 @@ describe('Event', () => {
 
     it('Should add an interaction with the attendee', () => {
       cy.visit(urls.events.details(event.pk))
-      cy.contains('a', 'Attendees').click()
+      cy.contains('button', 'Attendees').click()
       cy.contains('Add attendee').click()
       cy.get('input[name="name"]').type('Attendee').type('{enter}')
       cy.contains('Joe Attendee').click()
@@ -187,7 +187,7 @@ describe('Event', () => {
 
     it('Should not be able to add a duplicate attendee', () => {
       cy.visit(urls.events.details(event.pk))
-      cy.contains('a', 'Attendees').click()
+      cy.contains('button', 'Attendees').click()
       cy.contains('Add attendee').click()
       cy.get('input[name="name"]').type('Attendee').type('{enter}')
       cy.contains('Joe Attendee').click()

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -164,7 +164,7 @@ describe('Event', () => {
         .invoke('text')
         .should('contain', 'Account management')
       cy.contains(eventName).click()
-      cy.get(selectors.entityCollection.editEvent).click()
+      cy.contains('a', 'Edit event')
       fillEventType('Exhibition')
       clickSaveAndReturnButton()
 

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -108,17 +108,4 @@ describe('DBT Permission', () => {
       ])
     })
   })
-
-  describe('event', () => {
-    beforeEach(() => {
-      const event = fixtures.event.create.defaultEvent()
-      cy.loadFixture([event])
-      cy.visit(urls.events.details(event.pk))
-    })
-
-    it('should display DBT only side navs', () => {
-      const navSelector = '[data-test="event-details-nav-link"]'
-      assertLocalNav(navSelector, ['Details', 'Attendee'])
-    })
-  })
 })

--- a/test/functional/cypress/specs/events/attendees-search-spec.js
+++ b/test/functional/cypress/specs/events/attendees-search-spec.js
@@ -174,12 +174,9 @@ describe('Event attendee search', () => {
     it('should add an attendee to the event', () => {
       cy.contains('Hanna Reinger').click()
 
-      cy.get('.c-message')
-        .should('exist')
-        .should(
-          'have.text',
-          'Event attendee added - This has created a service delivery record. If required, you can view or edit the service delivery directly from the attendee record.Dismiss'
-        )
+      cy.contains(
+        'Event attendee added - This has created a service delivery record. If required, you can view or edit the service delivery directly from the attendee record.'
+      )
     })
   })
 })

--- a/test/functional/cypress/specs/events/attendees-spec.js
+++ b/test/functional/cypress/specs/events/attendees-spec.js
@@ -1,5 +1,4 @@
 const fixtures = require('../../fixtures')
-const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
 
 const {
@@ -8,101 +7,35 @@ const {
 } = require('../../support/assertions')
 
 describe('Event Attendees', () => {
-  context('Enabled events', () => {
-    beforeEach(() => {
-      cy.visit(`/events/${fixtures.event.oneDayExhibition.id}/attendees`)
-      cy.get('.c-collection').as('collectionList')
+  it('Enabled events', () => {
+    cy.visit(`/events/${fixtures.event.oneDayExhibition.id}/attendees`)
+    assertBreadcrumbs({
+      Home: urls.dashboard.index(),
+      Events: urls.events.index(),
+      'One-day exhibition': null,
+      Attendees: null,
     })
-
-    it('should render breadcrumbs', () => {
-      assertBreadcrumbs({
-        Home: urls.dashboard.index(),
-        Events: urls.events.index(),
-        'One-day exhibition': null,
-      })
-    })
-
-    it('should render the header', () => {
-      assertLocalHeader('One-day exhibition')
-    })
-
-    it('should display a collection header', () => {
-      cy.get('main article h2').should('contain', 'Event Attendees')
-    })
-
-    it('should display attendee collection list', () => {
-      cy.get(selectors.entityCollection.collection)
-        .find('header')
-        .should('contain', '1,233')
-        .parent()
-        .find('span')
-        .should('contain', 'Page 1 of 13')
-        .parents('header')
-        .next()
-        .find('li')
-        .should('have.length', 100)
-    })
-
-    it('should be able to use the pagination', () => {
-      cy.get(selectors.entityCollection.collection)
-        .find('nav ul li')
-        .as('pageLinks')
-        .eq(1)
-        .click()
-
-      cy.get(selectors.entityCollection.collection)
-        .find('header')
-        .should('contain', 'Page 2 of 13')
-
-      cy.get('@pageLinks').eq(0).click()
-
-      cy.get(selectors.entityCollection.collection)
-        .find('header')
-        .should('contain', 'Page 1 of 13')
-    })
+    assertLocalHeader('One-day exhibition')
+    cy.contains('h2', 'Event Attendees')
+    cy.contains('h2', '1,233 attendees')
+    cy.contains('Page 1 of 124')
   })
-  context('Disabled events', () => {
-    beforeEach(() => {
-      cy.visit(`/events/${fixtures.event.teddyBearExpo.id}/attendees`)
-    })
 
-    it('should render breadcrumbs', () => {
-      assertBreadcrumbs({
-        Home: urls.dashboard.index(),
-        Events: urls.events.index(),
-        'Teddy bear expo': null,
-      })
+  it('Disabled events', () => {
+    cy.visit(`/events/${fixtures.event.teddyBearExpo.id}/attendees`)
+    assertBreadcrumbs({
+      Home: urls.dashboard.index(),
+      Events: urls.events.index(),
+      'Teddy bear expo': null,
+      Attendees: null,
     })
-
-    it('should render the header', () => {
-      assertLocalHeader('Teddy bear expo')
-    })
-
-    it('should display a message indicating when the event was disabled', () => {
-      assertLocalHeader(
-        'This event was disabled on 5 September 2017 and can no longer be edited'
-      )
-    })
-
-    it('should not display add attendees button for disabled events', () => {
-      cy.get(selectors.entityCollection.addAttendee).should('not.exist')
-    })
-
-    it('should display a message indicating that you cannot add an event attendee', () => {
-      cy.get('main article h2')
-        .next()
-        .should(
-          'contain',
-          'You cannot add an event attendee because the event has been disabled.'
-        )
-    })
-
-    it('should display a collection header', () => {
-      cy.get('main article h2').should('contain', 'Event Attendees')
-    })
-
-    it('should display attendee collection list', () => {
-      cy.get(selectors.collection.headerCount).should('contain', '1,233')
-    })
+    assertLocalHeader('Teddy bear expo')
+    assertLocalHeader(
+      'This event was disabled on 5 September 2017 and can no longer be edited'
+    )
+    cy.contains(
+      'You cannot add an event attendee because the event has been disabled.'
+    )
+    cy.contains('Add attendee').should('not.exist')
   })
 })

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -1,141 +1,120 @@
 import urls from '../../../../../src/lib/urls'
 
 const {
-  assertKeyValueTable,
   assertBreadcrumbs,
+  assertSummaryTableStrict,
 } = require('../../support/assertions')
 
 const fixtures = require('../../fixtures')
 const event = require('../../../../sandbox/fixtures/v3/event/single-event-missing-teams.json')
-const selectors = require('../../../../selectors')
+
+const EVENT_DETAILS_ROWS = {
+  'Type of event': 'Exhibition',
+  'Event date': '1 January 2021',
+  'Event location type': 'HQ',
+  Address: 'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
+  Region: 'Not set',
+  Notes: 'This is a dummy event for testing.',
+  'Lead team': 'CBBC Hangzhou',
+  Organiser: 'John Rogers',
+  'Other teams': 'CBBC HangzhouCBBC North West',
+  'Related programmes': 'Grown in Britain',
+  'Related Trade Agreements': 'UK - Japan',
+  Service: 'Events : UK based',
+}
 
 describe('Event Details', () => {
   it('should display one day event details', () => {
     cy.visit(urls.events.details(fixtures.event.oneDayExhibition.id))
 
-    cy.get(selectors.entityCollection.editEvent).should('be.visible')
-
     assertBreadcrumbs({
       Home: urls.dashboard.index.route,
       Events: urls.events.index(),
       'One-day exhibition': null,
+      Details: null,
     })
 
-    assertKeyValueTable('eventDetails', {
-      'Type of event': 'Exhibition',
-      'Event date': '1 January 2021',
-      'Event location type': 'HQ',
-      Address:
-        'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
-      Region: 'Not set',
-      Notes: 'This is a dummy event for testing.',
-      'Lead team': 'CBBC Hangzhou',
-      Organiser: 'John Rogers',
-      'Other teams': 'CBBC HangzhouCBBC North West',
-      'Related programmes': 'Grown in Britain',
-      'Related Trade Agreements': 'UK - Japan',
-      Service: 'Events : UK based',
+    assertSummaryTableStrict({
+      rows: EVENT_DETAILS_ROWS,
     })
+
+    cy.contains('a', 'Edit event')
   })
 
   it('should display one day event details with no teams', () => {
     cy.visit(urls.events.details(event.id))
 
-    cy.get(selectors.entityCollection.editEvent).should('be.visible')
-
-    assertKeyValueTable('eventDetails', {
-      'Type of event': 'Exhibition',
-      'Event date': '1 January 2021',
-      'Event location type': 'HQ',
-      Address:
-        'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
-      Region: 'Not set',
-      Notes: 'This is a dummy event for testing.',
-      'Lead team': 'Not set',
-      Organiser: 'John Rogers',
-      'Other teams': 'Not set',
-      'Related programmes': 'Grown in Britain',
-      'Related Trade Agreements': 'UK - Japan',
-      Service: 'Events : UK based',
+    assertSummaryTableStrict({
+      rows: {
+        ...EVENT_DETAILS_ROWS,
+        'Lead team': 'Not set',
+        'Other teams': 'Not set',
+      },
     })
+
+    cy.contains('a', 'Edit event')
   })
 
-  describe('Disabled event with no document', () => {
-    beforeEach(() => {
-      cy.visit(urls.events.details(fixtures.event.teddyBearExpo.id))
+  it('should display no document link details', () => {
+    cy.visit(urls.events.details(fixtures.event.teddyBearExpo.id))
+
+    assertBreadcrumbs({
+      Home: urls.dashboard.index.route,
+      Events: urls.events.index(),
+      'Teddy bear expo': null,
+      Details: null,
     })
 
-    it('should display no document link details', () => {
-      assertBreadcrumbs({
-        Home: urls.dashboard.index.route,
-        Events: urls.events.index(),
-        'Teddy bear expo': null,
-      })
-
-      assertKeyValueTable('eventDetails', {
-        'Type of event': 'Exhibition',
-        'Event date': '1 January 2021',
-        'Event location type': 'HQ',
-        Address:
-          'Day Court Exhibition Centre, Day Court Lane, China, SW9 9AB, China',
-        Region: 'Not set',
-        Notes: 'This is a dummy event for testing.',
-        'Lead team': 'CBBC Hangzhou',
-        Organiser: 'John Rogers',
-        'Other teams': 'CBBC HangzhouCBBC North West',
-        'Related programmes': 'Grown in Britain',
+    assertSummaryTableStrict({
+      rows: {
+        ...EVENT_DETAILS_ROWS,
         'Related Trade Agreements': 'Not set',
-        Service: 'Events : UK based',
-      })
+      },
     })
 
-    it('should hide edit event button for disabled events', () => {
-      cy.get(selectors.entityCollection.editEvent).should('not.exist')
-    })
+    cy.contains('a', 'Edit event').should('not.exist')
   })
 
-  describe('Certain fields that are null', () => {
-    before(() => {
-      cy.intercept(
-        'GET',
-        `/api-proxy/v4/event/${fixtures.event.teddyBearExpo.id}`,
-        {
-          address_1: '16 Grande Parade',
-          address_2: '',
-          address_country: {
-            name: 'China',
-            id: '63af72a6-5d95-e211-a939-e4115bead28a',
-          },
-          address_county: '',
-          address_postcode: '',
-          address_town: 'Shanghai',
-          end_date: '2016-03-16',
-          event_type: {
-            name: 'Exhibition',
-            id: '2fade471-e868-4ea9-b125-945eb90ae5d4',
-          },
-          lead_team: {
-            name: 'UK Fashion and Textile Association Ltd (UKFT)',
-            id: '23f12898-9698-e211-a939-e4115bead28a',
-          },
-          name: 'Shanghai Fashion Week including The Hub, Chic-Pure-Intertextile March 2016',
-          notes: null,
-          organiser: null,
-          start_date: '2016-03-16',
-          service: {
-            name: 'DBT export service or funding : UK Tradeshow Programme (UKTP) – exhibitor',
-            id: '380bba2b-3499-e211-a939-e4115bead28a',
-          },
-          uk_region: null,
-        }
-      ).as('apiRequest')
-      cy.visit(urls.events.details(fixtures.event.teddyBearExpo.id))
-      cy.wait('@apiRequest')
-    })
+  it('should set fields that are null to "Not set"', () => {
+    cy.intercept(
+      'GET',
+      `/api-proxy/v4/event/${fixtures.event.teddyBearExpo.id}`,
+      {
+        address_1: '16 Grande Parade',
+        address_2: '',
+        address_country: {
+          name: 'China',
+          id: '63af72a6-5d95-e211-a939-e4115bead28a',
+        },
+        address_county: '',
+        address_postcode: '',
+        address_town: 'Shanghai',
+        end_date: '2016-03-16',
+        event_type: {
+          name: 'Exhibition',
+          id: '2fade471-e868-4ea9-b125-945eb90ae5d4',
+        },
+        lead_team: {
+          name: 'UK Fashion and Textile Association Ltd (UKFT)',
+          id: '23f12898-9698-e211-a939-e4115bead28a',
+        },
+        name: 'Shanghai Fashion Week including The Hub, Chic-Pure-Intertextile March 2016',
+        notes: null,
+        organiser: null,
+        start_date: '2016-03-16',
+        service: {
+          name: 'DBT export service or funding : UK Tradeshow Programme (UKTP) – exhibitor',
+          id: '380bba2b-3499-e211-a939-e4115bead28a',
+        },
+        uk_region: null,
+      }
+    )
 
-    it('should set fields that are null to "Not set"', () => {
-      assertKeyValueTable('eventDetails', {
-        'Type of event': 'Exhibition',
+    cy.visit(urls.events.details(fixtures.event.teddyBearExpo.id))
+
+    assertSummaryTableStrict({
+      rows: {
+        ...EVENT_DETAILS_ROWS,
         'Event date': '16 March 2016',
         'Event location type': 'Not set',
         Address: '16 Grande Parade, Shanghai, China',
@@ -148,7 +127,7 @@ describe('Event Details', () => {
         'Related Trade Agreements': 'Not set',
         Service:
           'DBT export service or funding : UK Tradeshow Programme (UKTP) – exhibitor',
-      })
+      },
     })
   })
 })

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -76,13 +76,15 @@ const assertSummaryTable = ({
 }
 
 /**
- * @param {{rows: [string, string | number][], caption?: string}} options
+ * @param {{rows: [string, string | number][] | Record<string, string>, caption?: string}} options
  */
 const assertSummaryTableStrict = ({ caption, rows }) => {
-  const assertRows = (el) => {
-    cy.wrap(el).find('tr').as('rows').should('have.length', rows.length)
+  const _rows = Array.isArray(rows) ? rows : Object.entries(rows)
 
-    rows.forEach(([key, val], i) => {
+  const assertRows = (el) => {
+    cy.wrap(el).find('tr').as('rows').should('have.length', _rows.length)
+
+    _rows.forEach(([key, val], i) => {
       cy.get('@rows')
         .eq(i)
         .within(() => {

--- a/test/functional/cypress/support/utils.js
+++ b/test/functional/cypress/support/utils.js
@@ -1,6 +1,0 @@
-// TODO: Remove this module
-module.exports = {
-  randomString: () => {
-    return Math.random().toString(36).substring(7)
-  },
-}

--- a/test/functional/cypress/support/utils.js
+++ b/test/functional/cypress/support/utils.js
@@ -1,3 +1,4 @@
+// TODO: Remove this module
 module.exports = {
   randomString: () => {
     return Math.random().toString(36).substring(7)

--- a/test/selectors/entity-collection.js
+++ b/test/selectors/entity-collection.js
@@ -1,5 +1,4 @@
 module.exports = {
-  addAttendee: '[data-test="Add attendee"]',
   addProposition: '[data-test="add-collection-item-button"]',
   collection: '.c-collection',
   sortBy: '[name="sortBy"] > select',

--- a/test/selectors/entity-collection.js
+++ b/test/selectors/entity-collection.js
@@ -1,6 +1,5 @@
 module.exports = {
   addAttendee: '[data-test="Add attendee"]',
-  editEvent: 'a:contains("Edit event")',
   addProposition: '[data-test="add-collection-item-button"]',
   collection: '.c-collection',
   sortBy: '[name="sortBy"] > select',


### PR DESCRIPTION
## Description of change

This PR refactors the `/events/{id}/details` and `/events/{id}/attendees` paths to React. It also fixes:

* Missing trailing segments in breadcrumbs
* The title in the header is now always the `{event-name}` (previously it was "Events" when on the `/events/{id}/details`} page

## Test instructions

1. Go to `/events`
2. Click on one of the events
3. You should land on `/events/{id}/details`
4. Click on the _Attendees_ item on the left hand side navigation
5. You should see
   * The _Attendees_ side bar navigation item highlighted as selected
   * Path in the address bar to have changed to `/events/{id}/attendees`, without page reloading
   * A list of attendees to the right of the sidebar
   * The breadcrumbs should be _Home > Events > {event-title} > Attendees_
6. Click on the _Details_ nav item
7. You should see
    * The _Details_ side bar navigation item highlighted as selected
   * Path in the address bar to have changed to `/events/{id}/details`, without page reloading
   * The event details table to the right of the sidebar
   * The breadcrumbs should be _Home > Events > {event-name} > Details_

## Screenshots

### Before

<img width="1022" alt="Screenshot 2024-12-06 at 10 49 09" src="https://github.com/user-attachments/assets/e7f13c9f-14f7-41ad-a0ee-00e039e684d0">

### After

<img width="1023" alt="Screenshot 2024-12-06 at 10 48 38" src="https://github.com/user-attachments/assets/81d110f9-a5c8-4a8f-bdfe-c00b307cbc9f">
