### PR TITLE
TET-757: Remove chai-as-promised dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,6 @@
         "babel-loader": "^9.2.1",
         "babel-plugin-istanbul": "7.0.0",
         "chai": "^4.5.0",
-        "chai-as-promised": "^7.1.2",
         "chai-subset": "^1.6.0",
         "cypress": "^13.16.0",
         "cypress-axe": "^1.5.0",
@@ -9427,18 +9426,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.2.tgz",
-      "integrity": "sha512-aBDHZxRzYnUYuIAIPBH2s511DjlKPzXNlXSGFC8CwmroWQLfrW0LtE1nK3MAwwNhJPa9raEjNCmRoFpG0Hurdw==",
-      "dev": true,
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 6"
       }
     },
     "node_modules/chai-subset": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,6 @@
     "babel-loader": "^9.2.1",
     "babel-plugin-istanbul": "7.0.0",
     "chai": "^4.5.0",
-    "chai-as-promised": "^7.1.2",
     "chai-subset": "^1.6.0",
     "cypress": "^13.16.0",
     "cypress-axe": "^1.5.0",

--- a/src/apps/companies/apps/advisers/client/__test__/tasks.test.js
+++ b/src/apps/companies/apps/advisers/client/__test__/tasks.test.js
@@ -1,5 +1,7 @@
 import proxyquire from 'proxyquire'
 
+import { expectThrowsAsync } from '../../../../../../../test/unit/helpers/promise-assertions'
+
 describe('updateAdviser', () => {
   const adviserData = {
     dit_participants: { value: '123' },
@@ -48,7 +50,8 @@ describe('updateAdviser', () => {
     })
 
     it('returns an error message', async () => {
-      await expect(tasks.updateAdviser(adviserData)).to.be.rejectedWith(
+      await expectThrowsAsync(
+        () => tasks.updateAdviser(adviserData),
         "No global Lead ITAs were found for this company. Please note: it is not possible to add Lead ITAs to a subsidiary that are not attached to the company's Global Headquarters"
       )
     })

--- a/src/apps/companies/apps/advisers/client/tasks.js
+++ b/src/apps/companies/apps/advisers/client/tasks.js
@@ -14,7 +14,9 @@ export async function updateAdviser({ dit_participants, companyId }) {
     }
   } else {
     return Promise.reject(
-      "No global Lead ITAs were found for this company. Please note: it is not possible to add Lead ITAs to a subsidiary that are not attached to the company's Global Headquarters"
+      new Error(
+        "No global Lead ITAs were found for this company. Please note: it is not possible to add Lead ITAs to a subsidiary that are not attached to the company's Global Headquarters"
+      )
     )
   }
 }

--- a/src/apps/events/attendees/__test__/transformers.test.js
+++ b/src/apps/events/attendees/__test__/transformers.test.js
@@ -94,7 +94,7 @@ describe('#transformEventToAttendeeListItem', () => {
       })
 
       it('should return a transformed attendee with the company name and link', () => {
-        expect(this.transformedAttendee.meta).to.include.deep({
+        expect(this.transformedAttendee.meta).to.deep.include({
           label: 'Company',
           value: 'Test company',
           url: `/companies/2222`,
@@ -102,7 +102,7 @@ describe('#transformEventToAttendeeListItem', () => {
       })
 
       it('should return a transformed attendee with the attendance date', () => {
-        expect(this.transformedAttendee.meta).to.include.deep({
+        expect(this.transformedAttendee.meta).to.deep.include({
           label: 'Date attended',
           value: '2017-05-31T00:00:00',
           type: 'date',
@@ -110,7 +110,7 @@ describe('#transformEventToAttendeeListItem', () => {
       })
 
       it('should return a transformed attendee with a link to the associated service delivery', () => {
-        expect(this.transformedAttendee.meta).to.include.deep({
+        expect(this.transformedAttendee.meta).to.deep.include({
           label: 'Service delivery',
           value: 'View or edit service delivery',
           url: '/interactions/1234',
@@ -134,7 +134,7 @@ describe('#transformEventToAttendeeListItem', () => {
       })
 
       it('should return a transformed attendee with their job title', () => {
-        expect(this.transformedAttendee.meta).to.include.deep({
+        expect(this.transformedAttendee.meta).to.deep.include({
           label: 'Job title',
           value: 'Director',
         })

--- a/src/lib/__test__/hawk-request.test.js
+++ b/src/lib/__test__/hawk-request.test.js
@@ -5,6 +5,9 @@ const rewire = require('rewire')
 
 const config = require('../../config')
 const { StatusCodeError } = require('../errors')
+const {
+  expectThrowsAsync,
+} = require('../../../test/unit/helpers/promise-assertions')
 
 const modulePath = '../hawk-request'
 
@@ -93,7 +96,7 @@ describe('#hawkRequest: check sendHawkRequest', () => {
   })
 
   it('fails when no url provided', async () => {
-    await expect(this.hawkRequest()).to.be.rejectedWith(Error)
+    await expectThrowsAsync(() => this.hawkRequest())
   })
 
   it('calls hawkRequestPromise', async () => {
@@ -140,13 +143,13 @@ describe('#hawkRequest: check hawkRequestPromise', () => {
     )
     this.hawkRequestPromise = this.hawkRequest.__get__('hawkRequestPromise')
 
-    await expect(
+    await expectThrowsAsync(() =>
       this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
       )
-    ).to.be.rejectedWith(Error)
+    )
   })
 
   it('fails when response is not valid', async () => {
@@ -158,13 +161,13 @@ describe('#hawkRequest: check hawkRequestPromise', () => {
     const authenticateStub = sinon.stub().returns(true)
     this.hawkRequest.__set__('Hawk.client.authenticate', authenticateStub)
 
-    await expect(
+    await expectThrowsAsync(() =>
       this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
       )
-    ).to.be.rejectedWith(Error)
+    )
 
     expect(authenticateStub).to.be.calledOnceWith(
       { status: 401, data: {} },
@@ -181,13 +184,13 @@ describe('#hawkRequest: check hawkRequestPromise', () => {
     const authenticateStub = sinon.stub().throws(Error)
     this.hawkRequest.__set__('Hawk.client.authenticate', authenticateStub)
 
-    await expect(
+    await expectThrowsAsync(() =>
       this.hawkRequestPromise(
         testRequestOptions,
         testDataHubCredentials,
         testClientHeaderArtifacts
       )
-    ).to.be.rejectedWith(Error)
+    )
 
     expect(authenticateStub).to.be.calledOnceWith(
       { status: 200 },

--- a/test/unit/common.js
+++ b/test/unit/common.js
@@ -8,7 +8,6 @@ const reqres = require('reqres')
 const nock = require('nock')
 
 chai.use(require('sinon-chai'))
-chai.use(require('chai-as-promised'))
 chai.use(require('chai-subset'))
 
 // mocha globals

--- a/test/unit/helpers/promise-assertions.js
+++ b/test/unit/helpers/promise-assertions.js
@@ -1,0 +1,12 @@
+export const expectThrowsAsync = async (method, errorMessage) => {
+  let error = null
+  try {
+    await method()
+  } catch (err) {
+    error = err
+  }
+  expect(error).to.be.an('Error')
+  if (errorMessage) {
+    expect(error.message).to.equal(errorMessage)
+  }
+}


### PR DESCRIPTION
## Description of change

Remove `chai-as-promised` dev dependency as it now requires ESM which we're not currently using.

## Test instructions

_What should I see?_


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)

