### PR TITLE
Replace the legacy format functions with formatDate

### DIFF
--- a/src/apps/investments/client/projects/transformers.js
+++ b/src/apps/investments/client/projects/transformers.js
@@ -1,4 +1,7 @@
-const { formatMediumDateTime } = require('../../../../client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../../client/utils/date-utils')
 
 const { addressToString } = require('../../../../client/utils/addresses')
 
@@ -9,7 +12,7 @@ const transformCompanyToListItem = (company) => ({
   meta: [
     {
       label: 'Updated on',
-      value: formatMediumDateTime(company.modified_on),
+      value: formatDate(company.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME),
     },
     {
       label: 'Company address',

--- a/src/apps/investments/middleware/shared.js
+++ b/src/apps/investments/middleware/shared.js
@@ -5,7 +5,10 @@ const { getDitCompany } = require('../../companies/repos')
 const { getAdviser } = require('../../adviser/repos')
 const { getInvestment } = require('../repos')
 const { companies, investments } = require('../../../lib/urls')
-const { formatMediumDateTime } = require('../../../client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../client/utils/date-utils')
 
 function getCompanyDetails(req, res, next) {
   getDitCompany(req, req.params.companyId)
@@ -82,7 +85,10 @@ async function getInvestmentDetails(req, res, next) {
         },
         {
           label: 'Created on',
-          value: formatMediumDateTime(investment.created_on),
+          value: formatDate(
+            investment.created_on,
+            DATE_FORMAT_MEDIUM_WITH_TIME
+          ),
         },
         ...(investment.created_by?.dit_team?.name
           ? [

--- a/src/client/components/AuditHistory/transformers.js
+++ b/src/client/components/AuditHistory/transformers.js
@@ -1,7 +1,10 @@
 import React from 'react'
 import { capitalize, isEmpty, lowerCase } from 'lodash'
 
-import { formatMediumDateTime } from '../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../utils/date-utils'
 import { AUTOMATIC_UPDATE } from './constants'
 
 export const transformFieldName = (fieldName) =>
@@ -24,7 +27,7 @@ const transformChanges = (changes, fieldMapper, excludedFields) =>
     }))
 
 const getUpdatedBy = (timestamp, user) => {
-  const formattedTime = formatMediumDateTime(timestamp)
+  const formattedTime = formatDate(timestamp, DATE_FORMAT_MEDIUM_WITH_TIME)
   const changedBy = user
     ? isEmpty(user?.name)
       ? user?.email

--- a/src/client/components/Dashboard/my-companies/MyCompaniesTable.jsx
+++ b/src/client/components/Dashboard/my-companies/MyCompaniesTable.jsx
@@ -14,7 +14,7 @@ import Filters from './MyCompaniesFilters'
 import { GREY_1, GREY_3, TEXT_COLOUR } from '../../../../client/utils/colours'
 import urls from '../../../../lib/urls'
 
-const { formatMediumDate } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_MEDIUM } = require('../../../utils/date-utils')
 
 const StyledCellHeader = styled(Table.CellHeader)(
   typography.font({ size: 14, weight: 'bold' }),
@@ -100,7 +100,7 @@ function MyCompaniesTable() {
         </Table.Cell>
         <StyledDateCell setWidth="15%">
           {latestInteraction.date
-            ? formatMediumDate(latestInteraction.date)
+            ? formatDate(latestInteraction.date, DATE_FORMAT_MEDIUM)
             : '-'}
         </StyledDateCell>
         <Table.Cell setWidth="50%">

--- a/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
+++ b/src/client/components/Dashboard/my-tasks/MyTasksTable.jsx
@@ -4,7 +4,7 @@ import { Link, Table } from 'govuk-react'
 
 import styled from 'styled-components'
 
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
 import { STATUS } from '../../../modules/Tasks/TaskForm/constants'
 
@@ -34,9 +34,9 @@ const rows = ({ results }) => {
     <Table.Row key={`task_row_${index}`} data-test="task-item">
       <Table.Cell setWidth="12%">
         {task.due_date
-          ? formatMediumDateParsed(task.due_date)
+          ? formatDate(task.due_date, DATE_FORMAT_MEDIUM)
           : task.dueDate
-            ? formatMediumDateParsed(task.dueDate)
+            ? formatDate(task.dueDate, DATE_FORMAT_MEDIUM)
             : ''}
       </Table.Cell>
       <Table.Cell setWidth="23%">

--- a/src/client/components/InvestmentProjectLocalHeader/index.jsx
+++ b/src/client/components/InvestmentProjectLocalHeader/index.jsx
@@ -6,7 +6,10 @@ import { kebabCase, upperFirst } from 'lodash'
 
 import Timeline from '../Timeline'
 
-import { formatMediumDateTime } from '../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../utils/date-utils'
 import timelineTheme from './timeline-theme'
 import urls from '../../../lib/urls'
 import { INVESTMENT_PROJECT_STAGES } from '../../modules/Investments/Projects/constants'
@@ -87,7 +90,9 @@ const InvestmentProjectLocalHeader = ({ investment }) => (
         {investment.valueComplete ? 'Project valued' : 'Not yet valued'}
       </MetaListItem>
       <MetaListItem text="Created on">
-        {investment.createdOn ? formatMediumDateTime(investment.createdOn) : ''}
+        {investment.createdOn
+          ? formatDate(investment.createdOn, DATE_FORMAT_MEDIUM_WITH_TIME)
+          : ''}
       </MetaListItem>
       {investment.createdBy?.ditTeam?.name && (
         <MetaListItem text="Created by">

--- a/src/client/filters.js
+++ b/src/client/filters.js
@@ -1,9 +1,13 @@
-const { formatShortDate } = require('./utils/date')
-const { formatDate, DATE_FORMAT_FULL } = require('./utils/date-utils')
+const {
+  formatDate,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_MONTH_YEAR,
+} = require('./utils/date-utils')
 
 const getDateLabel = (value) =>
   value ? formatDate(value, DATE_FORMAT_FULL) : ''
-const getShortDateLabel = (value) => (value ? formatShortDate(value) : '')
+const getShortDateLabel = (value) =>
+  value ? formatDate(value, DATE_FORMAT_MONTH_YEAR) : ''
 
 export const buildOptionsFilter = ({
   options = [],

--- a/src/client/filters.js
+++ b/src/client/filters.js
@@ -1,6 +1,8 @@
-const { formatLongDate, formatShortDate } = require('./utils/date')
+const { formatShortDate } = require('./utils/date')
+const { formatDate, DATE_FORMAT_FULL } = require('./utils/date-utils')
 
-const getDateLabel = (value) => (value ? formatLongDate(value) : '')
+const getDateLabel = (value) =>
+  value ? formatDate(value, DATE_FORMAT_FULL) : ''
 const getShortDateLabel = (value) => (value ? formatShortDate(value) : '')
 
 export const buildOptionsFilter = ({

--- a/src/client/modules/Companies/CollectionList/transformers.js
+++ b/src/client/modules/Companies/CollectionList/transformers.js
@@ -5,7 +5,11 @@ import urls from '../../../../lib/urls'
 
 import { addressToString } from '../../../utils/addresses'
 
-const { format, formatMediumDateTime } = require('../../../utils/date')
+const { format } = require('../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../utils/date-utils')
 
 export const transformArchivedToApi = (archivedParam) => {
   const archived = Array.isArray(archivedParam)
@@ -79,7 +83,7 @@ const transformCompanyToListItem = ({
   return {
     id,
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : undefined,
     headingText: name,
     headingUrl: urls.companies.detail(id),

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -93,9 +93,8 @@ export const transformInteractionToListItem = (activity) => {
     metadata: [
       {
         label: 'Date',
-        value: interaction.date
-          ? formatDate(interaction.date, DATE_FORMAT_MEDIUM)
-          : '',
+        value:
+          interaction.date && formatDate(interaction.date, DATE_FORMAT_MEDIUM),
       },
       {
         label: verifyLabel(interaction.contacts, 'Contact'),
@@ -118,9 +117,7 @@ export const transformInteractionToListItem = (activity) => {
         dataTest: 'activity-kind-label',
       },
       {
-        text: interaction.service
-          ? getServiceText(interaction.service?.name)
-          : '',
+        text: interaction.service && getServiceText(interaction.service?.name),
         colour: 'blue',
         dataTest: 'activity-service-label',
       },
@@ -141,9 +138,9 @@ export const transformReferralToListItem = (activity) => {
       },
       {
         label: 'Completed on',
-        value: referral.completed_on
-          ? formatDate(referral.completed_on, DATE_FORMAT_MEDIUM)
-          : '',
+        value:
+          referral.completed_on &&
+          formatDate(referral.completed_on, DATE_FORMAT_MEDIUM),
       },
       {
         label: 'Sending adviser',
@@ -189,12 +186,12 @@ export const transformInvestmentToListItem = (activity) => {
       },
       {
         label: 'Added by',
-        value: activity.investment.created_by
-          ? AdviserRenderer({
-              adviser: activity.investment.created_by,
-              team: activity.investment.created_by.dit_team,
-            })
-          : '',
+        value:
+          activity.investment.created_by &&
+          AdviserRenderer({
+            adviser: activity.investment.created_by,
+            team: activity.investment.created_by.dit_team,
+          }),
       },
       {
         label: 'Estimated land date',
@@ -244,20 +241,18 @@ export const transformOrderToListItem = (activity) => {
         label: 'Country',
         value: activity.order.primary_market.name,
       },
-      activity.order.uk_region
-        ? {
-            label: 'UK region',
-            value: activity.order.uk_region.name,
-          }
-        : '',
+      activity.order.uk_region && {
+        label: 'UK region',
+        value: activity.order.uk_region.name,
+      },
       {
         label: 'Added by',
-        value: activity.order.created_by
-          ? AdviserRenderer({
-              adviser: activity.order.created_by,
-              team: activity.order.created_by.dit_team,
-            })
-          : '',
+        value:
+          activity.order.created_by &&
+          AdviserRenderer({
+            adviser: activity.order.created_by,
+            team: activity.order.created_by.dit_team,
+          }),
       },
       {
         label: 'Company Contact',

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -3,7 +3,7 @@ import Link from '@govuk-react/link'
 
 import { TAGS } from './constants'
 import urls from '../../../../lib/urls'
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 import { truncateData } from '../utils'
 import { AdviserResource } from '../../../components/Resource'
 import { INTERACTION_NAMES } from '../../../../apps/interactions/constants'
@@ -93,7 +93,9 @@ export const transformInteractionToListItem = (activity) => {
     metadata: [
       {
         label: 'Date',
-        value: interaction.date ? formatMediumDateParsed(interaction.date) : '',
+        value: interaction.date
+          ? formatDate(interaction.date, DATE_FORMAT_MEDIUM)
+          : '',
       },
       {
         label: verifyLabel(interaction.contacts, 'Contact'),
@@ -135,12 +137,12 @@ export const transformReferralToListItem = (activity) => {
     metadata: [
       {
         label: 'Created on',
-        value: formatMediumDateParsed(referral.created_on),
+        value: formatDate(referral.created_on, DATE_FORMAT_MEDIUM),
       },
       {
         label: 'Completed on',
         value: referral.completed_on
-          ? formatMediumDateParsed(referral.completed_on)
+          ? formatDate(referral.completed_on, DATE_FORMAT_MEDIUM)
           : '',
       },
       {
@@ -177,7 +179,10 @@ export const transformInvestmentToListItem = (activity) => {
   return {
     id: activity.investment.id,
     metadata: [
-      { label: 'Created Date', value: formatMediumDateParsed(activity.date) },
+      {
+        label: 'Created Date',
+        value: formatDate(activity.date, DATE_FORMAT_MEDIUM),
+      },
       {
         label: 'Investment Type',
         value: activity.investment.investment_type.name,
@@ -234,7 +239,7 @@ export const transformOrderToListItem = (activity) => {
   return {
     id: activity.order.id,
     metadata: [
-      { label: 'Date', value: formatMediumDateParsed(activity.date) },
+      { label: 'Date', value: formatDate(activity.date, DATE_FORMAT_MEDIUM) },
       {
         label: 'Country',
         value: activity.order.primary_market.name,
@@ -287,7 +292,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
   return {
     id: great.id,
     metadata: [
-      { label: 'Date', value: formatMediumDateParsed(activity.date) },
+      { label: 'Date', value: formatDate(activity.date, DATE_FORMAT_MEDIUM) },
       {
         label: 'Contact',
         value: formattedContacts([great.contact]),

--- a/src/client/modules/Companies/CompanyActivity/transformers.js
+++ b/src/client/modules/Companies/CompanyActivity/transformers.js
@@ -259,7 +259,7 @@ export const transformOrderToListItem = (activity) => {
         value:
           activity.order.contact.name + ' ' + activity.order.contact.job_title,
       },
-    ].filter(({ value }) => Boolean(value)),
+    ].filter((entry) => entry && Boolean(entry.value)),
     tags: [
       {
         text: 'Orders (OMIS)',

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
@@ -1,10 +1,5 @@
 import { isBoolean, isNumber } from 'lodash'
 
-import {
-  formatDate,
-  normaliseToDate,
-  DATE_FORMAT_MEDIUM_WITH_TIME,
-} from '../../../../utils/date-utils'
 import { COMPANY_FIELD_NAME_TO_LABEL_MAP, HEADQUARTER_TYPES } from './constants'
 import {
   ARCHIVED,
@@ -33,8 +28,6 @@ const getValueFromBoolean = (value, field) => {
 }
 
 export const getValue = (value, field) => {
-  const date = normaliseToDate(value)
-
   if (isBoolean(value)) {
     return getValueFromBoolean(value, field)
   }
@@ -44,10 +37,6 @@ export const getValue = (value, field) => {
       return currencyGBP(value, { maximumSignificantDigits: 2 })
     }
     return value.toString()
-  }
-
-  if (date) {
-    return formatDate(date, DATE_FORMAT_MEDIUM_WITH_TIME)
   }
 
   if (field === 'Headquarter type') {

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyEditHistory/transformers.js
@@ -1,9 +1,10 @@
 import { isBoolean, isNumber } from 'lodash'
 
 import {
-  formatMediumDateTimeWithoutParsing,
-  isUnparsedDateValid,
-} from '../../../../utils/date'
+  formatDate,
+  normaliseToDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../utils/date-utils'
 import { COMPANY_FIELD_NAME_TO_LABEL_MAP, HEADQUARTER_TYPES } from './constants'
 import {
   ARCHIVED,
@@ -31,17 +32,27 @@ const getValueFromBoolean = (value, field) => {
   }
 }
 
-export const getValue = (value, field) =>
-  isBoolean(value)
-    ? getValueFromBoolean(value, field)
-    : isNumber(value)
-      ? field === 'Turnover'
-        ? currencyGBP(value, {
-            maximumSignificantDigits: 2,
-          })
-        : value.toString()
-      : isUnparsedDateValid(value)
-        ? formatMediumDateTimeWithoutParsing(value)
-        : field === 'Headquarter type'
-          ? HEADQUARTER_TYPES[value] || NOT_SET
-          : value || NOT_SET
+export const getValue = (value, field) => {
+  const date = normaliseToDate(value)
+
+  if (isBoolean(value)) {
+    return getValueFromBoolean(value, field)
+  }
+
+  if (isNumber(value)) {
+    if (field === 'Turnover') {
+      return currencyGBP(value, { maximumSignificantDigits: 2 })
+    }
+    return value.toString()
+  }
+
+  if (date) {
+    return formatDate(date, DATE_FORMAT_MEDIUM_WITH_TIME)
+  }
+
+  if (field === 'Headquarter type') {
+    return HEADQUARTER_TYPES[value] || NOT_SET
+  }
+
+  return value || NOT_SET
+}

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/transformers.js
@@ -5,7 +5,11 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format, formatMediumDateTime } = require('../../../../utils/date')
+const { format } = require('../../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../../utils/date-utils')
 
 const transformGlobalHQToListItem = (childCompanyId) => (company) => {
   const {
@@ -54,7 +58,7 @@ const transformGlobalHQToListItem = (childCompanyId) => (company) => {
   return {
     id,
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : undefined,
     headingText: name,
     headingUrl: urls.companies.hierarchies.ghq.add(childCompanyId, id),

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/transformers.js
@@ -5,7 +5,11 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format, formatMediumDateTime } = require('../../../../utils/date')
+const { format } = require('../../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../../utils/date-utils')
 
 const isGlobalHQ = (hqId) => hqId == '43281c5e-92a4-4794-867b-b4d5f801e6f3'
 
@@ -70,7 +74,7 @@ const transformSubsidiaryToListItem = (parentCompanyId) => (company) => {
   return {
     id,
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : undefined,
     headingText: name,
     headingUrl: buildUrl(id, parentCompanyId, headquarter_type),

--- a/src/client/modules/Companies/CompanyExports/ExportHistory/tasks.js
+++ b/src/client/modules/Companies/CompanyExports/ExportHistory/tasks.js
@@ -1,4 +1,7 @@
-import { formatMediumDateTime } from '../../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../utils/date-utils'
 import { GREEN } from '../../../../utils/colours'
 import urls from '../../../../../lib/urls'
 import groupExportCountries from '../../../../../lib/group-export-countries'
@@ -48,7 +51,10 @@ function createHistory(item) {
         label: 'By',
         value: item.history_user?.name ?? 'unknown',
       },
-      { label: 'Date', value: formatMediumDateTime(item.date) },
+      {
+        label: 'Date',
+        value: formatDate(item.date, DATE_FORMAT_MEDIUM_WITH_TIME),
+      },
     ],
   }
 }
@@ -91,7 +97,7 @@ function createInteraction(item) {
   return {
     headingText: item.subject,
     headingUrl: urls.interactions.detail(item.id),
-    subheading: `Created ${formatMediumDateTime(item.date)}`,
+    subheading: `Created ${formatDate(item.date, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
     badges: [
       {
         text: 'Interaction',

--- a/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportWins/index.jsx
@@ -5,7 +5,10 @@ import CompanyExportWins from '../../../../components/Resource/CompanyExportWins
 import { WIN_STATUS } from '../../../../modules/ExportWins/Status/constants'
 import { createRoleTags } from '../../../ExportWins/Status/utils'
 import { currencyGBP } from '../../../../utils/number-utils'
-import { formatShortDate } from '../../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../utils/date-utils'
 import { CollectionItem } from '../../../../components'
 import { BLACK } from '../../../../utils/colours'
 import State from '../../../../components/State'
@@ -44,7 +47,9 @@ export const CompanyExportWinsList = ({ exportWins, currentAdviserId }) =>
             },
             {
               label: 'Date won',
-              value: <Black>{formatShortDate(item.date)}</Black>,
+              value: (
+                <Black>{formatDate(item.date, DATE_FORMAT_MONTH_YEAR)}</Black>
+              ),
             },
             {
               label: 'Type of win',

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -1,8 +1,6 @@
 import { TAGS } from '../../../CompanyActivity/constants'
-import {
-  formatMediumDateParsed,
-  isDateInFuture,
-} from '../../../../../utils/date'
+import { isDateInFuture } from '../../../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../../../utils/date-utils'
 import { truncateData } from '../../../../../utils/truncate'
 import { INTERACTION_NAMES } from '../../../../../../apps/interactions/constants'
 import urls from '../../../../../../lib/urls'
@@ -78,7 +76,7 @@ export const transformReferralToListItem = (activity) => {
   const summary = `Company was referred to ${referral.recipient.name} by ${referral.created_by.name}`
 
   const date =
-    !referral.completedOn && formatMediumDateParsed(referral.created_on)
+    !referral.completedOn && formatDate(referral.created_on, DATE_FORMAT_MEDIUM)
 
   return {
     id: referral.id,
@@ -104,7 +102,9 @@ export const transformInteractionToListItem = (activity) => {
   const companyId = activity.company.id
   return {
     id: interaction.id,
-    date: interaction.date ? formatMediumDateParsed(interaction.date) : '',
+    date: interaction.date
+      ? formatDate(interaction.date, DATE_FORMAT_MEDIUM)
+      : '',
     tags: [
       {
         text: INTERACTION_NAMES[interaction.kind],
@@ -128,7 +128,7 @@ export const transformInvestmentToListItem = (activity) => {
 
   return {
     id: investment.id,
-    date: formatMediumDateParsed(activity.date),
+    date: formatDate(activity.date, DATE_FORMAT_MEDIUM),
     tags: [
       {
         text: 'New Investment Project',
@@ -161,7 +161,7 @@ export const transformOrderToListItem = (activity) => {
     : summary.push('')
   return {
     id: order.id,
-    date: formatMediumDateParsed(activity.date),
+    date: formatDate(activity.date, DATE_FORMAT_MEDIUM),
     tags: [
       {
         text: 'New Order',
@@ -179,7 +179,7 @@ export const transformGreatExportEnquiryToListItem = (activity) => {
   const great = activity.great_export_enquiry
   return {
     id: great.id,
-    date: formatMediumDateParsed(activity.date),
+    date: formatDate(activity.date, DATE_FORMAT_MEDIUM),
 
     tags: [
       {

--- a/src/client/modules/Contacts/CollectionList/transformers.js
+++ b/src/client/modules/Contacts/CollectionList/transformers.js
@@ -1,6 +1,9 @@
 import { get } from 'lodash'
 
-import { formatMediumDateTime } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils'
 
 import urls from '../../../../lib/urls'
 
@@ -33,7 +36,7 @@ export const transformContactToListItem = (companyId) => (contact) => {
     headingUrl: urls.contacts.details(contact.id),
     tags: tags.filter((item) => item.text),
     headingText: `${contact.first_name} ${contact.last_name}`.trim(),
-    subheading: `Updated on ${formatMediumDateTime(contact.modified_on)}`,
+    subheading: `Updated on ${(formatDate(contact.modified_on), DATE_FORMAT_MEDIUM_WITH_TIME)}`,
   }
 }
 

--- a/src/client/modules/Contacts/CollectionList/transformers.js
+++ b/src/client/modules/Contacts/CollectionList/transformers.js
@@ -36,7 +36,7 @@ export const transformContactToListItem = (companyId) => (contact) => {
     headingUrl: urls.contacts.details(contact.id),
     tags: tags.filter((item) => item.text),
     headingText: `${contact.first_name} ${contact.last_name}`.trim(),
-    subheading: `Updated on ${(formatDate(contact.modified_on), DATE_FORMAT_MEDIUM_WITH_TIME)}`,
+    subheading: `Updated on ${formatDate(contact.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
   }
 }
 

--- a/src/client/modules/Contacts/ContactActivity/transformers.js
+++ b/src/client/modules/Contacts/ContactActivity/transformers.js
@@ -1,5 +1,5 @@
 import urls from '../../../../lib/urls'
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 import {
   verifyLabel,
   formattedAdvisers,
@@ -19,7 +19,7 @@ export const transformContactActivityToListItem = ({
 }) => ({
   id,
   metadata: [
-    { label: 'Date', value: formatMediumDateParsed(date) },
+    { label: 'Date', value: formatDate(date, DATE_FORMAT_MEDIUM) },
     {
       label: verifyLabel(contacts, 'Contact'),
       value: formattedContacts(contacts),

--- a/src/client/modules/Contacts/ContactAuditHistory/transformers.js
+++ b/src/client/modules/Contacts/ContactAuditHistory/transformers.js
@@ -2,7 +2,11 @@ import { isBoolean, isNumber } from 'lodash'
 
 import { transformFieldName } from '../../../components/AuditHistory/transformers'
 import { CONTACT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { formatMediumDateTime, isUnparsedDateValid } from '../../../utils/date'
+import { isUnparsedDateValid } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils'
 import {
   ARCHIVED,
   NO,
@@ -26,5 +30,5 @@ export const getValue = (value, field) =>
       : isNumber(value)
         ? value.toString()
         : isUnparsedDateValid(value)
-          ? formatMediumDateTime(value)
+          ? formatDate(value, DATE_FORMAT_MEDIUM_WITH_TIME)
           : value || NOT_SET

--- a/src/client/modules/Events/AttendeeSearch/transformers.js
+++ b/src/client/modules/Events/AttendeeSearch/transformers.js
@@ -1,7 +1,10 @@
 import { get } from 'lodash'
 
 import urls from '../../../../lib/urls'
-import { formatMediumDateTime } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils'
 
 export const transformContactToListItem = (companyId, eventId) => (contact) => {
   const metadata = [
@@ -22,7 +25,7 @@ export const transformContactToListItem = (companyId, eventId) => (contact) => {
     headingUrl: urls.events.addAttendee(eventId, contact.id),
     badges: badges.filter((item) => item.text),
     headingText: `${contact.first_name} ${contact.last_name}`.trim(),
-    subheading: `Updated on ${formatMediumDateTime(contact.modified_on)}`,
+    subheading: `Updated on ${formatDate(contact.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
   }
 }
 

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -2,14 +2,11 @@ import { compact } from 'lodash'
 
 import urls from '../../../lib/urls'
 
-import {
-  getDifferenceInDays,
-  formatLongDate,
-  formatStartAndEndDate,
-} from '../../utils/date'
+import { getDifferenceInDays, formatStartAndEndDate } from '../../utils/date'
 
 import {
   formatDate,
+  DATE_FORMAT_FULL,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../utils/date-utils'
 
@@ -89,9 +86,9 @@ const transformEventToListItem = ({
     id,
     headingText: name,
     headingUrl: urls.events.details(id),
-    subheading: modified_on
-      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
-      : undefined,
+    subheading:
+      modified_on &&
+      `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
     tags: tags,
     metadata: metadata.filter((item) => item.value),
   }
@@ -126,8 +123,8 @@ const transformResponseToEventDetails = ({
 }) => ({
   name,
   eventType: event_type.name,
-  startDate: formatLongDate(start_date),
-  endDate: formatLongDate(end_date),
+  startDate: formatDate(start_date, DATE_FORMAT_FULL),
+  endDate: formatDate(end_date, DATE_FORMAT_FULL),
   eventDays:
     getDifferenceInDays(end_date) - getDifferenceInDays(start_date) + 1,
   locationType: location_type?.name,

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -3,11 +3,15 @@ import { compact } from 'lodash'
 import urls from '../../../lib/urls'
 
 import {
-  formatMediumDateTime,
   getDifferenceInDays,
   formatLongDate,
   formatStartAndEndDate,
 } from '../../utils/date'
+
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../utils/date-utils'
 
 import { transformIdNameToValueLabel } from '../../transformers'
 import {
@@ -86,7 +90,7 @@ const transformEventToListItem = ({
     headingText: name,
     headingUrl: urls.events.details(id),
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : undefined,
     tags: tags,
     metadata: metadata.filter((item) => item.value),

--- a/src/client/modules/ExportPipeline/ExportList/ResultItem.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ResultItem.jsx
@@ -7,9 +7,9 @@ import { get, capitalize } from 'lodash'
 import Tag, { TAG_COLOURS } from '../../../components/Tag'
 import { ToggleSection } from '../../../components/ToggleSection/index.jsx'
 import { DARK_GREY, MID_GREY, BLACK } from '../../../utils/colours.js'
-import { formatShortDate } from '../../../utils/date.js'
 import {
   formatDate,
+  DATE_FORMAT_MONTH_YEAR,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../../utils/date-utils.js'
 import { currencyGBP } from '../../../utils/number-utils.js'
@@ -138,7 +138,7 @@ const ResultItem = (item) => {
           <StyledDT>Estimated date for win:</StyledDT>
           <StyledDD>
             {item.estimated_win_date
-              ? formatShortDate(item.estimated_win_date)
+              ? formatDate(item.estimated_win_date, DATE_FORMAT_MONTH_YEAR)
               : 'Not set'}
           </StyledDD>
           <StyledDT>Main sector:</StyledDT>

--- a/src/client/modules/ExportPipeline/ExportList/ResultItem.jsx
+++ b/src/client/modules/ExportPipeline/ExportList/ResultItem.jsx
@@ -7,7 +7,11 @@ import { get, capitalize } from 'lodash'
 import Tag, { TAG_COLOURS } from '../../../components/Tag'
 import { ToggleSection } from '../../../components/ToggleSection/index.jsx'
 import { DARK_GREY, MID_GREY, BLACK } from '../../../utils/colours.js'
-import { formatShortDate, formatMediumDateTime } from '../../../utils/date.js'
+import { formatShortDate } from '../../../utils/date.js'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils.js'
 import { currencyGBP } from '../../../utils/number-utils.js'
 import { ToggleButton } from '../../../components/ToggleSection/BaseToggleSection.jsx'
 
@@ -142,7 +146,9 @@ const ResultItem = (item) => {
           <StyledDT>Owner:</StyledDT>
           <StyledDD>{item.owner.name}</StyledDD>
           <StyledDT>Created on:</StyledDT>
-          <StyledDD>{formatMediumDateTime(item.created_on)}</StyledDD>
+          <StyledDD>
+            {formatDate(item.created_on, DATE_FORMAT_MEDIUM_WITH_TIME)}
+          </StyledDD>
         </StyledDL>
       </DashboardToggleSection>
     </ListItem>

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -9,7 +9,10 @@ import pluralize from 'pluralize'
 import { Step, ButtonLink, FieldInput, SummaryTable } from '../../../components'
 import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
 import { useFormContext } from '../../../components/Form/hooks'
-import { formatMediumDateTimeWithoutParsing } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../utils/date-utils'
 import { WIN_STATUS } from '../Status/constants'
 import { ContactLink } from './ExportWinForm'
 import urls from '../../../../lib/urls'
@@ -365,10 +368,10 @@ const AdditionalInformation = ({ values, isEditing }) => {
         {winStatus === WIN_STATUS.PENDING && (
           <>
             <SummaryTable.Row heading="First sent">
-              {formatMediumDateTimeWithoutParsing(values.first_sent)}
+              {formatDate(values.first_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}
             </SummaryTable.Row>
             <SummaryTable.Row heading="Last Sent">
-              {formatMediumDateTimeWithoutParsing(values.last_sent)}
+              {formatDate(values.last_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}
             </SummaryTable.Row>
             <SummaryTable.Row heading="Export win confirmed">
               Pending

--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -28,7 +28,7 @@ import { WithoutOurSupport } from '../../../components/Resource'
 import MarketingSource from '../../../components/Resource/MarketingSource'
 import Err from '../../../components/Task/Error'
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 
 import AccesibilityStatement from './AccesibilityStatement'
 import PrivacyNotice from './PrivacyNotice'
@@ -168,7 +168,7 @@ const Step1 = ({ win, name }) => {
           {`${currencyGBP(totalAmount)} over ${totalYears} ${pluralize('year', totalYears)}`}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Date won">
-          {formatMediumDateParsed(win?.date)}
+          {formatDate(win?.date, DATE_FORMAT_MEDIUM)}
         </SummaryTable.Row>
         <SummaryTable.Row heading="Lead officer name">
           {win?.leadOfficer?.name}

--- a/src/client/modules/Interactions/ESSInteractionDetails/transformers.js
+++ b/src/client/modules/Interactions/ESSInteractionDetails/transformers.js
@@ -1,6 +1,9 @@
 const { get } = require('lodash')
 
-const { formatLongDate } = require('../../../../client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_FULL,
+} = require('../../../../client/utils/date-utils')
 
 const transformResponseToESSInteractionDetails = ({ id, object }) => {
   const formData = get(object, 'dit:directoryFormsApi:Submission:Data')
@@ -10,7 +13,7 @@ const transformResponseToESSInteractionDetails = ({ id, object }) => {
       ? formData.nature_of_enquiry
       : 'ESS Inbound Enquiry',
     question: formData.aaa_question,
-    dateOfInteraction: formatLongDate(object.published),
+    dateOfInteraction: formatDate(object.published, DATE_FORMAT_FULL),
     countries: formData.countries,
     companyName: formData.company_name,
     enquirer: formData.full_name,

--- a/src/client/modules/Interactions/InteractionDetails/index.jsx
+++ b/src/client/modules/Interactions/InteractionDetails/index.jsx
@@ -12,7 +12,7 @@ import ArchivePanel from '../../../components/ArchivePanel'
 import CompleteInteraction from './CompleteInteraction'
 
 import { currencyGBP } from '../../../utils/number-utils'
-import { formatLongDate } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
 import {
   getEditLink,
@@ -88,7 +88,7 @@ const InteractionDetails = ({ interactionId }) => {
             ) : null}
             <SummaryTable.Row
               heading={`Date of ${transformKind(interaction.kind)}`}
-              children={formatLongDate(interaction.date)}
+              children={formatDate(interaction.date, DATE_FORMAT_FULL)}
             />
             {interaction.ditParticipants ? (
               <SummaryTable.Row

--- a/src/client/modules/Investments/Opportunities/CollectionList/tasks.js
+++ b/src/client/modules/Investments/Opportunities/CollectionList/tasks.js
@@ -1,6 +1,6 @@
 import { apiProxyAxios } from '../../../../components/Task/utils'
 
-const { formatLongDate } = require('../../../../utils/date')
+const { formatDate, DATE_FORMAT_FULL } = require('../../../../utils/date-utils')
 const { investments } = require('../../../../../lib/urls')
 
 export function getOpportunities({ activePage, payload }) {
@@ -29,7 +29,10 @@ export function getOpportunities({ activePage, payload }) {
           metadata: [
             {
               label: 'Updated on',
-              value: formatLongDate(modified_on ? modified_on : created_on),
+              value: formatDate(
+                modified_on ? modified_on : created_on,
+                DATE_FORMAT_FULL
+              ),
             },
           ],
         }

--- a/src/client/modules/Investments/Opportunities/transformers.js
+++ b/src/client/modules/Investments/Opportunities/transformers.js
@@ -1,4 +1,7 @@
-const { formatMediumDateTime } = require('../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../utils/date-utils')
 
 const getNameAndId = (data) =>
   data ? { value: data.id, label: data.name } : {}
@@ -37,7 +40,7 @@ export const transformInvestmentOpportunityDetails = ({
   status: idNameToValueLabel(status),
   id,
   detailsFields: {
-    createdOn: formatMediumDateTime(created_on),
+    createdOn: formatDate(created_on, DATE_FORMAT_MEDIUM_WITH_TIME),
     name,
     description,
     ukRegions: uk_region_locations.map(idNameToValueLabel),

--- a/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
@@ -3,7 +3,11 @@ import { get } from 'lodash'
 import urls from '../../../../../../lib/urls'
 import labels from '../../../../Companies/CollectionList/labels'
 import { addressToString } from '../../../../../utils/addresses'
-import { format, formatMediumDateTime } from '../../../../../utils/date'
+import { format } from '../../../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../utils/date-utils'
 
 export const checkIfRecipientCompanyExists = (hasRecipientCompany) =>
   hasRecipientCompany ? 'Update recipient company' : 'Add recipient company'
@@ -67,7 +71,7 @@ const transformCompanyToListItem =
     return {
       id,
       subheading: modified_on
-        ? `Updated on ${formatMediumDateTime(modified_on)}`
+        ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
         : undefined,
       headingText: name,
       headingUrl: urls.investments.projects.editRecipientCompany(projectId, id),

--- a/src/client/modules/Investments/Projects/EditHistory/transformers.js
+++ b/src/client/modules/Investments/Projects/EditHistory/transformers.js
@@ -1,7 +1,8 @@
 import { isBoolean, isNumber } from 'lodash'
 
 import { PROJECT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { formatMediumDate, isUnparsedDateValid } from '../../../../utils/date'
+import { isUnparsedDateValid } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../../utils/date-utils'
 import { currencyGBP } from '../../../../utils/number-utils'
 import { NOT_SET, NO, YES } from '../../../../components/AuditHistory/constants'
 import { transformFieldName } from '../../../../components/AuditHistory/transformers'
@@ -36,5 +37,5 @@ export const getValue = (value, field) =>
           : Array.isArray(value)
             ? value.join(', ')
             : isUnparsedDateValid(value)
-              ? formatMediumDate(value)
+              ? formatDate(value, DATE_FORMAT_MEDIUM)
               : value || NOT_SET

--- a/src/client/modules/Investments/Projects/Propositions/PropositionDetails.jsx
+++ b/src/client/modules/Investments/Projects/Propositions/PropositionDetails.jsx
@@ -16,7 +16,7 @@ import {
   transformDocumentStatus,
 } from './transformers'
 import urls from '../../../../../lib/urls'
-import { formatLongDate } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../../../utils/date-utils'
 import { buildProjectBreadcrumbs } from '../../utils'
 import { ID, TASK_PROPOSITION_COMPLETE, propositionState2props } from '../state'
 import { PROPOSITION_COMPLETE } from '../../../../../client/actions'
@@ -95,15 +95,24 @@ const PropositionDetails = ({
                       />
                       <SummaryTable.TextRow
                         heading="Date created"
-                        value={formatLongDate(proposition.createdOn)}
+                        value={formatDate(
+                          proposition.createdOn,
+                          DATE_FORMAT_FULL
+                        )}
                       />
                       <SummaryTable.TextRow
                         heading="Modified on"
-                        value={formatLongDate(proposition.modifiedOn)}
+                        value={formatDate(
+                          proposition.modifiedOn,
+                          DATE_FORMAT_FULL
+                        )}
                       />
                       <SummaryTable.TextRow
                         heading="Deadline"
-                        value={formatLongDate(proposition.deadline)}
+                        value={formatDate(
+                          proposition.deadline,
+                          DATE_FORMAT_FULL
+                        )}
                       />
                       <SummaryTable.TextRow
                         heading="Assigned to"

--- a/src/client/modules/Omis/CollectionList/__test__/transformers.test.js
+++ b/src/client/modules/Omis/CollectionList/__test__/transformers.test.js
@@ -1,0 +1,23 @@
+import {
+  transformResponseToCollection,
+  transformResponseToReconciliationCollection,
+} from '../transformers'
+
+describe('transformers', () => {
+  const getInputAndExpected = () => ({
+    input: { count: 10, summary: 'Test summary' },
+    expected: { count: 10, summary: 'Test summary', results: [] },
+  })
+
+  it('should handle missing results by defaulting to an empty array in transformResponseToCollection', () => {
+    const { input, expected } = getInputAndExpected()
+    expect(transformResponseToCollection(input)).to.deep.equal(expected)
+  })
+
+  it('should handle missing results by defaulting to an empty array in transformResponseToReconciliationCollection', () => {
+    const { input, expected } = getInputAndExpected()
+    expect(transformResponseToReconciliationCollection(input)).to.deep.equal(
+      expected
+    )
+  })
+})

--- a/src/client/modules/Omis/CollectionList/transformers.js
+++ b/src/client/modules/Omis/CollectionList/transformers.js
@@ -4,11 +4,8 @@ import { STATUSES } from './constants'
 import { omis } from '../../../../lib/urls'
 import { currencyGBP } from '../../../utils/number-utils'
 
-const {
-  format,
-  formatMediumDate,
-  formatMediumDateTime,
-} = require('../../../utils/date')
+const { format, formatMediumDateTime } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_MEDIUM } = require('../../../utils/date-utils')
 
 export const transformOrderCost = (cost) => (cost ? cost * 100 : undefined)
 
@@ -88,7 +85,9 @@ export const transformOrderToReconciliationListItem = ({
   const metadata = [
     {
       label: 'Payment due date',
-      value: payment_due_date ? formatMediumDate(payment_due_date) : null,
+      value: payment_due_date
+        ? formatDate(payment_due_date, DATE_FORMAT_MEDIUM)
+        : null,
     },
     {
       label: 'Company name',

--- a/src/client/modules/Omis/CollectionList/transformers.js
+++ b/src/client/modules/Omis/CollectionList/transformers.js
@@ -4,8 +4,12 @@ import { STATUSES } from './constants'
 import { omis } from '../../../../lib/urls'
 import { currencyGBP } from '../../../utils/number-utils'
 
-const { format, formatMediumDateTime } = require('../../../utils/date')
-const { formatDate, DATE_FORMAT_MEDIUM } = require('../../../utils/date-utils')
+const { format } = require('../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../utils/date-utils')
 
 export const transformOrderCost = (cost) => (cost ? cost * 100 : undefined)
 
@@ -31,7 +35,9 @@ export const transformOrderToListItem = ({
     },
     {
       label: 'Created',
-      value: created_on ? formatMediumDateTime(created_on) : null,
+      value: created_on
+        ? formatDate(created_on, DATE_FORMAT_MEDIUM_WITH_TIME)
+        : null,
     },
     {
       label: 'Contact',
@@ -63,7 +69,7 @@ export const transformOrderToListItem = ({
     headingText: reference,
     headingUrl: omis.workOrder(id),
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : null,
   }
 
@@ -112,7 +118,7 @@ export const transformOrderToReconciliationListItem = ({
     headingText: reference,
     headingUrl: omis.paymentReconciliation(id),
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : null,
   }
 

--- a/src/client/modules/Omis/CollectionList/transformers.js
+++ b/src/client/modules/Omis/CollectionList/transformers.js
@@ -35,9 +35,7 @@ export const transformOrderToListItem = ({
     },
     {
       label: 'Created',
-      value: created_on
-        ? formatDate(created_on, DATE_FORMAT_MEDIUM_WITH_TIME)
-        : null,
+      value: created_on && formatDate(created_on, DATE_FORMAT_MEDIUM_WITH_TIME),
     },
     {
       label: 'Contact',
@@ -68,9 +66,9 @@ export const transformOrderToListItem = ({
     metadata,
     headingText: reference,
     headingUrl: omis.workOrder(id),
-    subheading: modified_on
-      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
-      : null,
+    subheading:
+      modified_on &&
+      `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
   }
 
   return retVal
@@ -91,9 +89,8 @@ export const transformOrderToReconciliationListItem = ({
   const metadata = [
     {
       label: 'Payment due date',
-      value: payment_due_date
-        ? formatDate(payment_due_date, DATE_FORMAT_MEDIUM)
-        : null,
+      value:
+        payment_due_date && formatDate(payment_due_date, DATE_FORMAT_MEDIUM),
     },
     {
       label: 'Company name',
@@ -117,30 +114,25 @@ export const transformOrderToReconciliationListItem = ({
     metadata,
     headingText: reference,
     headingUrl: omis.paymentReconciliation(id),
-    subheading: modified_on
-      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
-      : null,
+    subheading:
+      modified_on &&
+      `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
   }
 
   return retVal
 }
 
-export const transformResponseToCollection = ({
-  count,
-  results = [],
-  summary,
-}) => ({
-  count,
-  summary,
-  results: results.map(transformOrderToListItem),
-})
+const transformResponse =
+  (transformItem) =>
+  ({ count, results = [], summary }) => ({
+    count,
+    summary,
+    results: results.map(transformItem),
+  })
 
-export const transformResponseToReconciliationCollection = ({
-  count,
-  results = [],
-  summary,
-}) => ({
-  count,
-  summary,
-  results: results.map(transformOrderToReconciliationListItem),
-})
+export const transformResponseToCollection = transformResponse(
+  transformOrderToListItem
+)
+export const transformResponseToReconciliationCollection = transformResponse(
+  transformOrderToReconciliationListItem
+)

--- a/src/client/modules/Omis/CreateOrder/CompanySelect/transformers.js
+++ b/src/client/modules/Omis/CreateOrder/CompanySelect/transformers.js
@@ -5,7 +5,11 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format, formatMediumDateTime } = require('../../../../utils/date')
+const { format } = require('../../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../../../utils/date-utils')
 
 const transformCompanyToListItem = ({
   id,
@@ -67,7 +71,7 @@ const transformCompanyToListItem = ({
   return {
     id,
     subheading: modified_on
-      ? `Updated on ${formatMediumDateTime(modified_on)}`
+      ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       : undefined,
     headingText: name,
     headingUrl: urls.omis.create.form(id),

--- a/src/client/modules/Omis/OMISLocalHeader.jsx
+++ b/src/client/modules/Omis/OMISLocalHeader.jsx
@@ -4,11 +4,11 @@ import { Button, GridCol, GridRow, Link } from 'govuk-react'
 import { FONT_WEIGHTS } from '@govuk-react/constants'
 
 import LocalHeaderDetails from '../../components/LocalHeaderDetails'
+import { getDifferenceInWords, isDateInFuture } from '../../utils/date'
 import {
-  formatMediumDateTime,
-  getDifferenceInWords,
-  isDateInFuture,
-} from '../../utils/date'
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../utils/date-utils'
 import { STATUS } from './constants'
 import urls from '../../../lib/urls'
 
@@ -60,10 +60,13 @@ const setHeaderItems = (order, quote) => {
     { label: 'Country (market)', value: order.primaryMarket.name },
   ]
   const secondItems = [
-    { label: 'Created on', value: formatMediumDateTime(order.createdOn) },
+    {
+      label: 'Created on',
+      value: formatDate(order.createdOn, DATE_FORMAT_MEDIUM_WITH_TIME),
+    },
     {
       label: 'Updated on',
-      value: formatMediumDateTime(order.modifiedOn),
+      value: formatDate(order.modifiedOn, DATE_FORMAT_MEDIUM_WITH_TIME),
     },
     {
       label: 'Status',

--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -25,11 +25,11 @@ import { ORDERS__QUOTE_PREVIEW_LOADED } from '../../actions'
 import OMISTermsAndConditions from './OMISTermsAndConditions'
 import urls from '../../../lib/urls'
 import { DARK_GREY, RED_2 } from '../../utils/colours'
+import { formatMediumDateParsed, isDateInFuture } from '../../utils/date'
 import {
-  formatMediumDateParsed,
-  formatMediumDateTime,
-  isDateInFuture,
-} from '../../utils/date'
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../utils/date-utils'
 import { STATUS } from './constants'
 
 const StyledInsetText = styled(InsetText)`
@@ -111,7 +111,7 @@ const SentOn = ({ quote }) => (
   <>
     <StyledHeading data-test="sent-on-heading">Sent on</StyledHeading>
     <StyledP data-test="sent-on-date">
-      {formatMediumDateTime(quote.createdOn)}
+      {formatDate(quote.createdOn, DATE_FORMAT_MEDIUM_WITH_TIME)}
     </StyledP>
     <StyledHeading data-test="sent-by-heading">Sent by</StyledHeading>
     <StyledP data-test="sent-by-name">{quote.createdBy.name}</StyledP>
@@ -122,7 +122,7 @@ const AcceptedOn = ({ quote }) => (
   <>
     <StyledHeading data-test="accepted-on-heading">Accepted on</StyledHeading>
     <StyledP data-test="accepted-on-date">
-      {formatMediumDateTime(quote.acceptedOn)}
+      {formatDate(quote.acceptedOn, DATE_FORMAT_MEDIUM_WITH_TIME)}
     </StyledP>
     <StyledHeading data-test="accepted-by-heading">Accepted by</StyledHeading>
     <StyledP data-test="accepted-by-name">{quote.acceptedBy.name}</StyledP>
@@ -281,7 +281,10 @@ const OrderQuote = ({ quotePreview }) => {
                             Cancelled on
                           </StyledHeading>
                           <StyledP data-test="cancelled-on-date">
-                            {formatMediumDateTime(quote.cancelledOn)}
+                            {formatDate(
+                              quote.cancelledOn,
+                              DATE_FORMAT_MEDIUM_WITH_TIME
+                            )}
                           </StyledP>
                           <StyledHeading data-test="cancelled-by-heading">
                             Cancelled by

--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -25,9 +25,10 @@ import { ORDERS__QUOTE_PREVIEW_LOADED } from '../../actions'
 import OMISTermsAndConditions from './OMISTermsAndConditions'
 import urls from '../../../lib/urls'
 import { DARK_GREY, RED_2 } from '../../utils/colours'
-import { formatMediumDateParsed, isDateInFuture } from '../../utils/date'
+import { isDateInFuture } from '../../utils/date'
 import {
   formatDate,
+  DATE_FORMAT_MEDIUM,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../utils/date-utils'
 import { STATUS } from './constants'
@@ -201,7 +202,10 @@ const OrderQuote = ({ quotePreview }) => {
                           Will expire on
                         </StyledHeading>
                         <p data-test="expiry-date">
-                          {formatMediumDateParsed(quotePreview?.expires_on)}
+                          {formatDate(
+                            quotePreview?.expires_on,
+                            DATE_FORMAT_MEDIUM
+                          )}
                         </p>
                         <RenderQuote
                           quote={quotePreview ? quotePreview?.content : ''}
@@ -250,7 +254,7 @@ const OrderQuote = ({ quotePreview }) => {
                       {setExpiryLabel(quote)}
                     </StyledHeading>
                     <StyledP data-test="expires-on-date">
-                      {formatMediumDateParsed(quote.expiresOn)}
+                      {formatDate(quote.expiresOn, DATE_FORMAT_MEDIUM)}
                     </StyledP>
 
                     <SentOn quote={quote} />

--- a/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
+++ b/src/client/modules/Omis/WorkOrderTables/QuoteInformationTable.jsx
@@ -3,7 +3,7 @@ import { Link } from 'govuk-react'
 
 import { SummaryTable } from '../../../components'
 import { canEditOrder } from '../transformers'
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
 
 const QuoteInformationTable = ({ order }) => (
@@ -25,7 +25,7 @@ const QuoteInformationTable = ({ order }) => (
   >
     <SummaryTable.Row heading="Delivery date">
       {order.deliveryDate
-        ? formatMediumDateParsed(order.deliveryDate)
+        ? formatDate(order.deliveryDate, DATE_FORMAT_MEDIUM)
         : 'Not set'}
     </SummaryTable.Row>
     <SummaryTable.Row heading="Description of the activity">

--- a/src/client/modules/Reminders/ItemRenderers/Exports/ExportItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Exports/ExportItemRenderer.jsx
@@ -5,7 +5,7 @@ import { GREY_1 } from '../../../../utils/colours'
 
 import ItemRenderer from '../ItemRenderer'
 import { INTERACTION_NAMES } from '../../constants'
-import { formatMediumDateParsed } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../../utils/date-utils'
 import urls from '../../../../../lib/urls'
 
 const ItemHint = styled('span')({
@@ -16,7 +16,7 @@ const ItemContent = ({ item, hintLabel }) => (
   <ul>
     <li>
       <ItemHint>{`${hintLabel}: `}</ItemHint>
-      {formatMediumDateParsed(item.last_interaction_date)}
+      {formatDate(item.last_interaction_date, DATE_FORMAT_MEDIUM)}
     </li>
     {item.interaction ? (
       <>
@@ -66,7 +66,7 @@ const ExportItemRenderer = ({
     item={item}
     onDeleteReminder={onDeleteReminder}
     disableDelete={disableDelete}
-    deletedText={`Received ${formatMediumDateParsed(item.created_on)} for ${
+    deletedText={`Received ${formatDate(item.created_on, DATE_FORMAT_MEDIUM)} for ${
       item.company.name
     }`}
     headerLinkTitle={headerLinkTitle}

--- a/src/client/modules/Reminders/ItemRenderers/ItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/ItemRenderer.jsx
@@ -11,7 +11,7 @@ import {
   ItemHeaderLink,
   ItemFooter,
 } from './styled'
-import { formatMediumDateParsed } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 import { BLACK, DARK_GREY } from '../../../utils/colours'
 
 export const ItemRenderer = ({
@@ -39,7 +39,9 @@ export const ItemRenderer = ({
             <GridCol>
               <ItemHeader data-test="item-header">
                 <ul>
-                  <li>Received {formatMediumDateParsed(item.created_on)}</li>
+                  <li>
+                    Received {formatDate(item.created_on, DATE_FORMAT_MEDIUM)}
+                  </li>
                   {headerLinkHref && (
                     <li>
                       <ItemHeaderLink href={headerLinkHref}>

--- a/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
+++ b/src/client/modules/Tasks/TaskDetails/TaskDetailsTable.jsx
@@ -3,7 +3,7 @@ import { Link } from 'govuk-react'
 
 import { SummaryTable } from '../../../components'
 
-import { formatLongDate } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import { transformAdvisers } from './transformers'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 import urls from '../../../../lib/urls'
@@ -44,7 +44,11 @@ const TaskDetailsTable = ({ task, company, project }) => (
       )}
       <SummaryTable.Row
         heading="Date due"
-        children={task.dueDate ? formatLongDate(task.dueDate) : NOT_SET_TEXT}
+        children={
+          task.dueDate
+            ? formatDate(task.dueDate, DATE_FORMAT_FULL)
+            : NOT_SET_TEXT
+        }
       />
       <SummaryTable.Row
         heading="Assigned to"
@@ -64,7 +68,7 @@ const TaskDetailsTable = ({ task, company, project }) => (
       />
       <SummaryTable.Row
         heading="Date created"
-        children={formatLongDate(task.createdOn)}
+        children={formatDate(task.createdOn, DATE_FORMAT_FULL)}
       />
       <SummaryTable.Row heading="Created by" children={task.createdBy.name} />
     </SummaryTable>

--- a/src/client/utils/__test__/date-utils.test.js
+++ b/src/client/utils/__test__/date-utils.test.js
@@ -18,55 +18,128 @@ describe('formatDate', () => {
   const time = 'T10:41:45.425717Z'
   const dateAndTime = `${date}${time}`
 
-  it("should render '04 Dec 2024' (default format)", () => {
-    expect(formatDate(date)).to.equal('04 Dec 2024') // the default
-  })
+  context('Formnatting ISO date strings', () => {
+    it("should render '04 Dec 2024' (default format)", () => {
+      expect(formatDate(date)).to.equal('04 Dec 2024') // the default
+    })
 
-  it("should render '04 Dec 2024' (DATE_FORMAT_COMPACT)", () => {
-    expect(formatDate(date, DATE_FORMAT_COMPACT)).to.equal('04 Dec 2024')
-  })
+    it("should render '04 Dec 2024' (DATE_FORMAT_COMPACT)", () => {
+      expect(formatDate(date, DATE_FORMAT_COMPACT)).to.equal('04 Dec 2024')
+    })
 
-  it("should render '4 Dec 2024' (DATE_FORMAT_MEDIUM)", () => {
-    expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM)).to.equal('4 Dec 2024')
-  })
+    it("should render '4 Dec 2024' (DATE_FORMAT_MEDIUM)", () => {
+      expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM)).to.equal('4 Dec 2024')
+    })
 
-  it("should render '4 Dec 2024, 10:41am' (DATE_FORMAT_MEDIUM_WITH_TIME)", () => {
-    expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM_WITH_TIME)).to.equal(
-      '4 Dec 2024, 10:41am'
-    )
-  })
+    it("should render '4 Dec 2024, 10:41am' (DATE_FORMAT_MEDIUM_WITH_TIME)", () => {
+      expect(formatDate(dateAndTime, DATE_FORMAT_MEDIUM_WITH_TIME)).to.equal(
+        '4 Dec 2024, 10:41am'
+      )
+    })
 
-  it("should render '4 December 2024' (DATE_FORMAT_FULL)", () => {
-    expect(formatDate(date, DATE_FORMAT_FULL)).to.equal('4 December 2024')
-  })
+    it("should render '4 December 2024' (DATE_FORMAT_FULL)", () => {
+      expect(formatDate(date, DATE_FORMAT_FULL)).to.equal('4 December 2024')
+    })
 
-  it("should render 'Wed, 04 Dec 2024' (DATE_FORMAT_FULL_DAY)", () => {
-    expect(formatDate(date, DATE_FORMAT_FULL_DAY)).to.equal('Wed, 04 Dec 2024')
-  })
+    it("should render 'Wed, 04 Dec 2024' (DATE_FORMAT_FULL_DAY)", () => {
+      expect(formatDate(date, DATE_FORMAT_FULL_DAY)).to.equal(
+        'Wed, 04 Dec 2024'
+      )
+    })
 
-  it("should render '2024-12-04' (DATE_FORMAT_ISO)", () => {
-    expect(formatDate(date, DATE_FORMAT_ISO)).to.equal('2024-12-04')
-  })
+    it("should render '2024-12-04' (DATE_FORMAT_ISO)", () => {
+      expect(formatDate(date, DATE_FORMAT_ISO)).to.equal('2024-12-04')
+    })
 
-  it("should render '2024-12' (DATE_FORMAT_YEAR_MONTH)", () => {
-    expect(formatDate(date, DATE_FORMAT_YEAR_MONTH)).to.equal('2024-12')
-  })
+    it("should render '2024-12' (DATE_FORMAT_YEAR_MONTH)", () => {
+      expect(formatDate(date, DATE_FORMAT_YEAR_MONTH)).to.equal('2024-12')
+    })
 
-  it("should render 'December 2024' (DATE_FORMAT_MONTH_YEAR)", () => {
-    expect(formatDate(date, DATE_FORMAT_MONTH_YEAR)).to.equal('December 2024')
-  })
+    it("should render 'December 2024' (DATE_FORMAT_MONTH_YEAR)", () => {
+      expect(formatDate(date, DATE_FORMAT_MONTH_YEAR)).to.equal('December 2024')
+    })
 
-  it("should render 'Dec 2024' (DATE_FORMAT_MONTH_ABBR_YEAR)", () => {
-    expect(formatDate(date, DATE_FORMAT_MONTH_ABBR_YEAR)).to.equal('Dec 2024')
-  })
+    it("should render 'Dec 2024' (DATE_FORMAT_MONTH_ABBR_YEAR)", () => {
+      expect(formatDate(date, DATE_FORMAT_MONTH_ABBR_YEAR)).to.equal('Dec 2024')
+    })
 
-  it("should render '04 Dec' (DATE_FORMAT_DAY_MONTH)", () => {
-    expect(formatDate(date, DATE_FORMAT_DAY_MONTH)).to.equal('04 Dec')
-  })
+    it("should render '04 Dec' (DATE_FORMAT_DAY_MONTH)", () => {
+      expect(formatDate(date, DATE_FORMAT_DAY_MONTH)).to.equal('04 Dec')
+    })
 
-  it("should render '2024-12-4' (DATE_FORMAT_INTERACTION_TIMESTAMP)", () => {
-    expect(formatDate(date, DATE_FORMAT_INTERACTION_TIMESTAMP)).to.equal(
-      '2024-12-4'
-    )
+    it("should render '2024-12-4' (DATE_FORMAT_INTERACTION_TIMESTAMP)", () => {
+      expect(formatDate(date, DATE_FORMAT_INTERACTION_TIMESTAMP)).to.equal(
+        '2024-12-4'
+      )
+    })
+  })
+  context('Formnatting Date objects', () => {
+    it("should render '04 Dec 2024' (default format)", () => {
+      expect(formatDate(new Date(date))).to.equal('04 Dec 2024') // the default
+    })
+
+    it("should render '04 Dec 2024' (DATE_FORMAT_COMPACT)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_COMPACT)).to.equal(
+        '04 Dec 2024'
+      )
+    })
+
+    it("should render '4 Dec 2024' (DATE_FORMAT_MEDIUM)", () => {
+      expect(formatDate(new Date(dateAndTime), DATE_FORMAT_MEDIUM)).to.equal(
+        '4 Dec 2024'
+      )
+    })
+
+    it("should render '4 Dec 2024, 10:41am' (DATE_FORMAT_MEDIUM_WITH_TIME)", () => {
+      expect(
+        formatDate(new Date(dateAndTime), DATE_FORMAT_MEDIUM_WITH_TIME)
+      ).to.equal('4 Dec 2024, 10:41am')
+    })
+
+    it("should render '4 December 2024' (DATE_FORMAT_FULL)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_FULL)).to.equal(
+        '4 December 2024'
+      )
+    })
+
+    it("should render 'Wed, 04 Dec 2024' (DATE_FORMAT_FULL_DAY)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_FULL_DAY)).to.equal(
+        'Wed, 04 Dec 2024'
+      )
+    })
+
+    it("should render '2024-12-04' (DATE_FORMAT_ISO)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_ISO)).to.equal('2024-12-04')
+    })
+
+    it("should render '2024-12' (DATE_FORMAT_YEAR_MONTH)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_YEAR_MONTH)).to.equal(
+        '2024-12'
+      )
+    })
+
+    it("should render 'December 2024' (DATE_FORMAT_MONTH_YEAR)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_MONTH_YEAR)).to.equal(
+        'December 2024'
+      )
+    })
+
+    it("should render 'Dec 2024' (DATE_FORMAT_MONTH_ABBR_YEAR)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_MONTH_ABBR_YEAR)).to.equal(
+        'Dec 2024'
+      )
+    })
+
+    it("should render '04 Dec' (DATE_FORMAT_DAY_MONTH)", () => {
+      expect(formatDate(new Date(date), DATE_FORMAT_DAY_MONTH)).to.equal(
+        '04 Dec'
+      )
+    })
+
+    it("should render '2024-12-4' (DATE_FORMAT_INTERACTION_TIMESTAMP)", () => {
+      expect(
+        formatDate(new Date(date), DATE_FORMAT_INTERACTION_TIMESTAMP)
+      ).to.equal('2024-12-4')
+    })
   })
 })

--- a/src/client/utils/__test__/date-utils.test.js
+++ b/src/client/utils/__test__/date-utils.test.js
@@ -1,5 +1,6 @@
 import {
   formatDate,
+  normaliseToDate,
   DATE_FORMAT_FULL,
   DATE_FORMAT_FULL_DAY,
   DATE_FORMAT_COMPACT,
@@ -13,12 +14,12 @@ import {
   DATE_FORMAT_INTERACTION_TIMESTAMP,
 } from '../date-utils'
 
-describe('formatDate', () => {
+describe('date-utils', () => {
   const date = '2024-12-04'
   const time = 'T10:41:45.425717Z'
   const dateAndTime = `${date}${time}`
 
-  context('Formnatting ISO date strings', () => {
+  context('formatDate() - formnatting ISO date strings', () => {
     it("should render '04 Dec 2024' (default format)", () => {
       expect(formatDate(date)).to.equal('04 Dec 2024') // the default
     })
@@ -73,7 +74,7 @@ describe('formatDate', () => {
       )
     })
   })
-  context('Formnatting Date objects', () => {
+  context('formatDate() - formatting Date objects ', () => {
     it("should render '04 Dec 2024' (default format)", () => {
       expect(formatDate(new Date(date))).to.equal('04 Dec 2024') // the default
     })
@@ -140,6 +141,42 @@ describe('formatDate', () => {
       expect(
         formatDate(new Date(date), DATE_FORMAT_INTERACTION_TIMESTAMP)
       ).to.equal('2024-12-4')
+    })
+  })
+
+  context('normaliseToDate()', () => {
+    it('should return a valid Date object for a valid ISO string', () => {
+      const result = normaliseToDate('2024-12-10T14:30:00Z')
+      expect(result).to.be.an.instanceof(Date)
+      expect(result.toISOString()).to.equal('2024-12-10T14:30:00.000Z')
+    })
+
+    it('should return a valid Date object for a valid Date object input', () => {
+      const input = new Date('2024-12-10T14:30:00Z')
+      const result = normaliseToDate(input)
+      expect(result).to.be.an.instanceof(Date)
+      expect(result.getTime()).to.equal(input.getTime())
+    })
+
+    it('should return null for an invalid ISO string', () => {
+      const result = normaliseToDate('invalid-string')
+      expect(result).to.be.null
+    })
+
+    it('should return null for an invalid Date object', () => {
+      const invalidDate = new Date('invalid-date')
+      const result = normaliseToDate(invalidDate)
+      expect(result).to.be.null
+    })
+
+    it('should return null for a non-date input', () => {
+      const result = normaliseToDate(12345)
+      expect(result).to.be.null
+    })
+
+    it('should return null for a null or undefined input', () => {
+      expect(normaliseToDate(null)).to.be.null
+      expect(normaliseToDate(undefined)).to.be.null
     })
   })
 })

--- a/src/client/utils/__test__/date-utils.test.js
+++ b/src/client/utils/__test__/date-utils.test.js
@@ -1,6 +1,5 @@
 import {
   formatDate,
-  normaliseToDate,
   DATE_FORMAT_FULL,
   DATE_FORMAT_FULL_DAY,
   DATE_FORMAT_COMPACT,
@@ -141,42 +140,6 @@ describe('date-utils', () => {
       expect(
         formatDate(new Date(date), DATE_FORMAT_INTERACTION_TIMESTAMP)
       ).to.equal('2024-12-4')
-    })
-  })
-
-  context('normaliseToDate()', () => {
-    it('should return a valid Date object for a valid ISO string', () => {
-      const result = normaliseToDate('2024-12-10T14:30:00Z')
-      expect(result).to.be.an.instanceof(Date)
-      expect(result.toISOString()).to.equal('2024-12-10T14:30:00.000Z')
-    })
-
-    it('should return a valid Date object for a valid Date object input', () => {
-      const input = new Date('2024-12-10T14:30:00Z')
-      const result = normaliseToDate(input)
-      expect(result).to.be.an.instanceof(Date)
-      expect(result.getTime()).to.equal(input.getTime())
-    })
-
-    it('should return null for an invalid ISO string', () => {
-      const result = normaliseToDate('invalid-string')
-      expect(result).to.be.null
-    })
-
-    it('should return null for an invalid Date object', () => {
-      const invalidDate = new Date('invalid-date')
-      const result = normaliseToDate(invalidDate)
-      expect(result).to.be.null
-    })
-
-    it('should return null for a non-date input', () => {
-      const result = normaliseToDate(12345)
-      expect(result).to.be.null
-    })
-
-    it('should return null for a null or undefined input', () => {
-      expect(normaliseToDate(null)).to.be.null
-      expect(normaliseToDate(undefined)).to.be.null
     })
   })
 })

--- a/src/client/utils/__test__/date-utils.test.js
+++ b/src/client/utils/__test__/date-utils.test.js
@@ -18,7 +18,7 @@ describe('date-utils', () => {
   const time = 'T10:41:45.425717Z'
   const dateAndTime = `${date}${time}`
 
-  context('formatDate() - formnatting ISO date strings', () => {
+  context('formatDate() - formatting ISO date strings', () => {
     it("should render '04 Dec 2024' (default format)", () => {
       expect(formatDate(date)).to.equal('04 Dec 2024') // the default
     })

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -1,4 +1,4 @@
-const { format, parseISO } = require('date-fns')
+const { format, parseISO, isValid } = require('date-fns')
 
 /**
  * Full date format with day and full month name.
@@ -102,6 +102,43 @@ function formatDate(date, dateISOFormat = DATE_FORMAT_COMPACT) {
   return format(typeof date === 'string' ? parseISO(date) : date, dateISOFormat)
 }
 
+/**
+ * Normalises an input value to a valid Date object.
+ *
+ * This function accepts either an ISO 8601 string or a Date object as input.
+ * - If the input is a valid ISO string, it is parsed into a Date object.
+ * - If the input is a valid Date object, it is returned as-is.
+ * - If the input is invalid or not a recognised type, it returns `null`.
+ *
+ * @param {string|Date} value - The value to be normalised. Can be an ISO 8601 string or a Date object.
+ * @returns {Date|null} A valid Date object if the input is valid; otherwise, `null`.
+ *
+ * @example
+ * // Valid ISO string input
+ * normalizeToDate('2024-12-10T14:30:00Z') // Returns a Date object
+ *
+ * @example
+ * // Valid Date object input
+ * normalizeToDate(new Date('2024-12-10T14:30:00Z')) // Returns the same Date object
+ *
+ * @example
+ * // Invalid string input
+ * normalizeToDate('invalid-date') // Returns null
+ *
+ * @example
+ * // Non-date input
+ * normalizeToDate(12345) // Returns null
+ */
+function normaliseToDate(value) {
+  if (typeof value === 'string') {
+    const date = parseISO(value)
+    return isValid(date) ? date : null
+  } else if (value instanceof Date) {
+    return isValid(value) ? value : null
+  }
+  return null
+}
+
 module.exports = {
   DATE_FORMAT_FULL,
   DATE_FORMAT_FULL_DAY,
@@ -115,4 +152,5 @@ module.exports = {
   DATE_FORMAT_DAY_MONTH,
   DATE_FORMAT_INTERACTION_TIMESTAMP,
   formatDate,
+  normaliseToDate,
 }

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -1,4 +1,4 @@
-const { format, parseISO, isValid } = require('date-fns')
+const { format, parseISO } = require('date-fns')
 
 /**
  * Full date format with day and full month name.
@@ -102,43 +102,6 @@ function formatDate(date, dateISOFormat = DATE_FORMAT_COMPACT) {
   return format(typeof date === 'string' ? parseISO(date) : date, dateISOFormat)
 }
 
-/**
- * Normalises an input value to a valid Date object.
- *
- * This function accepts either an ISO 8601 string or a Date object as input.
- * - If the input is a valid ISO string, it is parsed into a Date object.
- * - If the input is a valid Date object, it is returned as-is.
- * - If the input is invalid or not a recognised type, it returns `null`.
- *
- * @param {string|Date} value - The value to be normalised. Can be an ISO 8601 string or a Date object.
- * @returns {Date|null} A valid Date object if the input is valid; otherwise, `null`.
- *
- * @example
- * // Valid ISO string input
- * normalizeToDate('2024-12-10T14:30:00Z') // Returns a Date object
- *
- * @example
- * // Valid Date object input
- * normalizeToDate(new Date('2024-12-10T14:30:00Z')) // Returns the same Date object
- *
- * @example
- * // Invalid string input
- * normalizeToDate('invalid-date') // Returns null
- *
- * @example
- * // Non-date input
- * normalizeToDate(12345) // Returns null
- */
-function normaliseToDate(value) {
-  if (typeof value === 'string') {
-    const date = parseISO(value)
-    return isValid(date) ? date : null
-  } else if (value instanceof Date) {
-    return isValid(value) ? value : null
-  }
-  return null
-}
-
 module.exports = {
   DATE_FORMAT_FULL,
   DATE_FORMAT_FULL_DAY,
@@ -152,5 +115,4 @@ module.exports = {
   DATE_FORMAT_DAY_MONTH,
   DATE_FORMAT_INTERACTION_TIMESTAMP,
   formatDate,
-  normaliseToDate,
 }

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -67,41 +67,39 @@ const DATE_FORMAT_DAY_MONTH = 'dd MMM'
 const DATE_FORMAT_INTERACTION_TIMESTAMP = 'y-MM-d'
 
 /**
- * Formats a given date string into a specified format using `date-fns`.
+ * Formats a date into the specified string format using predefined constants.
  *
- * @param {string} dateISO - The date string in ISO format (e.g., '2024-12-04').
- * @param {string} [dateISOFormat=DATE_FORMAT_COMPACT] - The format to use for formatting the date.
- *    Available format constants include:
- *    - `DATE_FORMAT_FULL`: Full date with day and full month name (e.g., '4 December 2024').
- *    - `DATE_FORMAT_FULL_DAY`: Full date with weekday included (e.g., 'Wed, 04 Dec 2024').
- *    - `DATE_FORMAT_COMPACT`: Compact date with abbreviated month name (e.g., '04 Dec 2024').
- *    - `DATE_FORMAT_ISO`: ISO standard format (e.g., '2024-12-04').
- *    - `DATE_FORMAT_MEDIUM`: Medium date format with single-digit day (e.g., '4 Dec 2024').
- *    - `DATE_FORMAT_MEDIUM_WITH_TIME`: Medium date with 12-hour time (e.g., '4 Dec 2024, 3:30PM').
- *    - `DATE_FORMAT_YEAR_MONTH`: Year and month format (e.g., '2024-12').
- *    - `DATE_FORMAT_MONTH_YEAR`: Full month and year (e.g., 'December 2024').
- *    - `DATE_FORMAT_MONTH_ABBR_YEAR`: Abbreviated month and year (e.g., 'Dec 2024').
- *    - `DATE_FORMAT_DAY_MONTH`: Day and abbreviated month (e.g., '04 Dec').
- *    - `DATE_FORMAT_INTERACTION_TIMESTAMP`: Interaction timestamp format (e.g., '2024-12-4').
- * @returns {string} - The formatted date string.
+ * @param {Date|string} date - The date to format. Can be a Date object or an ISO date string (e.g., '2024-12-04').
+ * @param {string} [dateISOFormat=DATE_FORMAT_COMPACT] - The desired format string. Defaults to the compact date format (`DATE_FORMAT_COMPACT`).
+ *   Available formats include:
+ *     - `DATE_FORMAT_FULL`: Full date with day and full month name (e.g., '4 December 2024').
+ *     - `DATE_FORMAT_FULL_DAY`: Full date including the weekday (e.g., 'Wed, 04 Dec 2024').
+ *     - `DATE_FORMAT_COMPACT`: Compact date format with abbreviated month (e.g., '04 Dec 2024').
+ *     - `DATE_FORMAT_ISO`: ISO standard date format (e.g., '2024-12-04').
+ *     - `DATE_FORMAT_MEDIUM`: Medium date with abbreviated month (e.g., '4 Dec 2024').
+ *     - `DATE_FORMAT_MEDIUM_WITH_TIME`: Medium date with time in 12-hour format (e.g., '4 Dec 2024, 3:30PM').
+ *     - `DATE_FORMAT_YEAR_MONTH`: Year and month in compact form (e.g., '2024-12').
+ *     - `DATE_FORMAT_MONTH_YEAR`: Full month name and year (e.g., 'December 2024').
+ *     - `DATE_FORMAT_MONTH_ABBR_YEAR`: Abbreviated month name and year (e.g., 'Dec 2024').
+ *     - `DATE_FORMAT_DAY_MONTH`: Day and abbreviated month (e.g., '04 Dec').
+ *     - `DATE_FORMAT_INTERACTION_TIMESTAMP`: Timestamp-like format (e.g., '2024-12-4').
  *
- * @example
- * // Format a date to the default compact format
- * formatDate('2024-12-04')
- * // Returns: '04 Dec 2024'
+ * @returns {string} The formatted date string based on the specified format.
  *
  * @example
- * // Format a date to a full format
- * formatDate('2024-12-04', DATE_FORMAT_FULL)
- * // Returns: '4 December 2024'
+ * // Formatting with default format (DATE_FORMAT_COMPACT)
+ * formatDate(new Date('2024-12-04')) // '04 Dec 2024'
  *
  * @example
- * // Format a date with abbreviated month and year
- * formatDate('2024-12-04', DATE_FORMAT_MONTH_ABBR_YEAR)
- * // Returns: 'Dec 2024'
+ * // Formatting with a different predefined format
+ * formatDate('2024-12-04', DATE_FORMAT_FULL) // '4 December 2024'
+ *
+ * @example
+ * // Formatting with a timestamp-like format
+ * formatDate(new Date(), DATE_FORMAT_INTERACTION_TIMESTAMP) // '2024-12-9'
  */
-function formatDate(dateISO, dateISOFormat = DATE_FORMAT_COMPACT) {
-  return format(parseISO(dateISO), dateISOFormat)
+function formatDate(date, dateISOFormat = DATE_FORMAT_COMPACT) {
+  return format(typeof date === 'string' ? parseISO(date) : date, dateISOFormat)
 }
 
 module.exports = {

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -36,7 +36,6 @@ const {
 const {
   DATE_LONG_FORMAT_2,
   DATE_LONG_FORMAT_3,
-  DATE_MEDIUM_FORMAT,
   DATE_TIME_MEDIUM_FORMAT,
   DATE_SHORT_FORMAT,
   DATE_SHORT_FORMAT_2,
@@ -133,10 +132,6 @@ function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
 
 function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
   return isUnparsedDateValid(date) ? formatFns(date, dateFormat) : null
-}
-
-function formatMediumDateParsed(dateString) {
-  return format(dateString, DATE_MEDIUM_FORMAT)
 }
 
 function formatShortDate(dateString) {
@@ -412,7 +407,6 @@ module.exports = {
   areDatesEqual,
   tomorrow,
   formatMediumDateTimeWithoutParsing,
-  formatMediumDateParsed,
   convertUnparsedDateToFieldDateObject,
   convertUnparsedDateToFieldShortDateObject,
   isDateInFutureParsed,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -36,7 +36,6 @@ const {
 const {
   DATE_LONG_FORMAT_2,
   DATE_LONG_FORMAT_3,
-  DATE_TIME_MEDIUM_FORMAT,
   DATE_SHORT_FORMAT,
   INTERACTION_TIMESTAMP_FORMAT,
   DATE_DAY_MONTH,
@@ -131,10 +130,6 @@ function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
 
 function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
   return isUnparsedDateValid(date) ? formatFns(date, dateFormat) : null
-}
-
-function formatMediumDateTimeWithoutParsing(dateString) {
-  return formatWithoutParsing(dateString, DATE_TIME_MEDIUM_FORMAT)
 }
 
 const formatMonthYearDate = (date) =>
@@ -377,6 +372,7 @@ module.exports = {
   getYesterday,
   isDateAfter,
   isDateValid,
+  isValid,
   isNormalisedDateValid,
   isShortDateValid,
   isUnparsedDateValid,
@@ -400,7 +396,6 @@ module.exports = {
   subtractMonths,
   areDatesEqual,
   tomorrow,
-  formatMediumDateTimeWithoutParsing,
   convertUnparsedDateToFieldDateObject,
   convertUnparsedDateToFieldShortDateObject,
   isDateInFutureParsed,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -34,7 +34,6 @@ const {
 } = require('date-fns')
 
 const {
-  DATE_LONG_FORMAT_1,
   DATE_LONG_FORMAT_2,
   DATE_LONG_FORMAT_3,
   DATE_MEDIUM_FORMAT,
@@ -138,10 +137,6 @@ function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
 
 function formatMediumDateParsed(dateString) {
   return format(dateString, DATE_MEDIUM_FORMAT)
-}
-
-function formatLongDate(dateString) {
-  return format(dateString, DATE_LONG_FORMAT_1)
 }
 
 function formatShortDate(dateString) {
@@ -381,7 +376,6 @@ module.exports = {
   addYears,
   createAndFormatDateObject,
   format,
-  formatLongDate,
   formatShortDate,
   formatMonthYearDate,
   formatWithoutParsing,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -38,7 +38,6 @@ const {
   DATE_LONG_FORMAT_3,
   DATE_TIME_MEDIUM_FORMAT,
   DATE_SHORT_FORMAT,
-  DATE_SHORT_FORMAT_2,
   INTERACTION_TIMESTAMP_FORMAT,
   DATE_DAY_MONTH,
 } = require('../../common/constants')
@@ -132,10 +131,6 @@ function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
 
 function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
   return isUnparsedDateValid(date) ? formatFns(date, dateFormat) : null
-}
-
-function formatShortDate(dateString) {
-  return format(dateString, DATE_SHORT_FORMAT_2)
 }
 
 function formatMediumDateTimeWithoutParsing(dateString) {
@@ -371,7 +366,6 @@ module.exports = {
   addYears,
   createAndFormatDateObject,
   format,
-  formatShortDate,
   formatMonthYearDate,
   formatWithoutParsing,
   generateFinancialYearLabel,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -148,10 +148,6 @@ function formatShortDate(dateString) {
   return format(dateString, DATE_SHORT_FORMAT_2)
 }
 
-function formatMediumDateTime(dateString) {
-  return format(dateString, DATE_TIME_MEDIUM_FORMAT)
-}
-
 function formatMediumDateTimeWithoutParsing(dateString) {
   return formatWithoutParsing(dateString, DATE_TIME_MEDIUM_FORMAT)
 }
@@ -385,7 +381,6 @@ module.exports = {
   addYears,
   createAndFormatDateObject,
   format,
-  formatMediumDateTime,
   formatLongDate,
   formatShortDate,
   formatMonthYearDate,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -136,10 +136,6 @@ function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
   return isUnparsedDateValid(date) ? formatFns(date, dateFormat) : null
 }
 
-function formatMediumDate(dateString) {
-  return formatWithoutParsing(dateString, DATE_MEDIUM_FORMAT)
-}
-
 function formatMediumDateParsed(dateString) {
   return format(dateString, DATE_MEDIUM_FORMAT)
 }
@@ -389,7 +385,6 @@ module.exports = {
   addYears,
   createAndFormatDateObject,
   format,
-  formatMediumDate,
   formatMediumDateTime,
   formatLongDate,
   formatShortDate,

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -6,7 +6,10 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 
 import { taskWithInvestmentProjectListFaker } from '../../../../../functional/cypress/fakers/task'
-import { formatDate } from '../../../../../../src/client/utils/date-utils'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+} from '../../../../../../src/client/utils/date-utils'
 import { MyTasksContent } from '../../../../../../src/client/components/Dashboard/my-tasks/MyTasks'
 import urls from '../../../../../../src/lib/urls'
 

--- a/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
+++ b/test/component/cypress/specs/Dashboard/MyTasks/MyTasksTable.cy.jsx
@@ -6,7 +6,7 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 
 import { taskWithInvestmentProjectListFaker } from '../../../../../functional/cypress/fakers/task'
-import { formatMediumDateParsed } from '../../../../../../src/client/utils/date'
+import { formatDate } from '../../../../../../src/client/utils/date-utils'
 import { MyTasksContent } from '../../../../../../src/client/components/Dashboard/my-tasks/MyTasks'
 import urls from '../../../../../../src/lib/urls'
 
@@ -40,7 +40,7 @@ describe('My Tasks on the Dashboard', () => {
         element: '[data-test="my-tasks-table"]',
         rows: [
           [
-            formatMediumDateParsed(myTaskResults[0].due_date),
+            formatDate(myTaskResults[0].due_date, DATE_FORMAT_MEDIUM),
             myTaskResults[0].title,
             myTaskResults[0].company.name,
             myTaskResults[0].investment_project.name,
@@ -50,7 +50,7 @@ describe('My Tasks on the Dashboard', () => {
             'Active',
           ],
           [
-            formatMediumDateParsed(myTaskResults[1].due_date),
+            formatDate(myTaskResults[1].due_date, DATE_FORMAT_MEDIUM),
             myTaskResults[1].title,
             myTaskResults[1].company.name,
             myTaskResults[1].investment_project.name,
@@ -60,7 +60,7 @@ describe('My Tasks on the Dashboard', () => {
             'Completed',
           ],
           [
-            formatMediumDateParsed(myTaskResults[2].due_date),
+            formatDate(myTaskResults[2].due_date, DATE_FORMAT_MEDIUM),
             myTaskResults[2].title,
             myTaskResults[2].company.name,
             myTaskResults[2].investment_project.name,

--- a/test/component/cypress/specs/Omis/PaymentReconciliation/InvoiceDetails.cy.jsx
+++ b/test/component/cypress/specs/Omis/PaymentReconciliation/InvoiceDetails.cy.jsx
@@ -2,10 +2,11 @@ import React from 'react'
 
 import { InvoiceDetails } from '../../../../../../src/client/modules/Omis/PaymentReconciliation'
 import { assertGovReactTable } from '../../../../../functional/cypress/support/assertions'
+import { getDifferenceInWords } from '../../../../../../src/client/utils/date'
 import {
-  formatLongDate,
-  getDifferenceInWords,
-} from '../../../../../../src/client/utils/date'
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../../src/client/utils/date-utils'
 
 const invoice = {
   paymentDueDate: '2017-09-27T08:59:20.381047',
@@ -27,7 +28,7 @@ describe('PaymentReconciliation invoice details', () => {
 
     it('should render the invoice details', () => {
       const paymentDueDate =
-        formatLongDate(invoice.paymentDueDate) +
+        formatDate(invoice.paymentDueDate, DATE_FORMAT_FULL) +
         ' (' +
         getDifferenceInWords(invoice.paymentDueDate) +
         ')'

--- a/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OMISLocalHeader.cy.jsx
@@ -3,10 +3,11 @@ import React from 'react'
 import OMISLocalHeader from '../../../../../../src/client/modules/Omis/OMISLocalHeader'
 import { orderFaker } from '../../../../../functional/cypress/fakers/orders'
 import { STATUS } from '../../../../../../src/client/modules/Omis/constants'
+import { getDifferenceInWords } from '../../../../../../src/client/utils/date'
 import {
-  formatMediumDateTime,
-  getDifferenceInWords,
-} from '../../../../../../src/client/utils/date'
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../../src/client/utils/date-utils'
 import {
   assertLink,
   assertLinkWithText,
@@ -30,10 +31,18 @@ const assertUkRegion = (region) =>
   assertLocalHeaderDetails(2, 'UK region', region)
 
 const assertCreatedOn = (index, date) =>
-  assertLocalHeaderDetails(index, 'Created on', formatMediumDateTime(date))
+  assertLocalHeaderDetails(
+    index,
+    'Created on',
+    formatDate(date, DATE_FORMAT_MEDIUM_WITH_TIME)
+  )
 
 const assertUpdatedOn = (index, date) =>
-  assertLocalHeaderDetails(index, 'Updated on', formatMediumDateTime(date))
+  assertLocalHeaderDetails(
+    index,
+    'Updated on',
+    formatDate(date, DATE_FORMAT_MEDIUM_WITH_TIME)
+  )
 
 const assertStatus = (index, status) =>
   assertLocalHeaderDetails(index, 'Status', status)

--- a/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
@@ -7,7 +7,7 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 import { STATUS } from '../../../../../../src/client/modules/Omis/constants'
 import urls from '../../../../../../src/lib/urls'
-import { formatMediumDateParsed } from '../../../../../../src/client/utils/date'
+import { formatDate } from '../../../../../../src/client/utils/date-utils'
 
 const order = {
   id: '123',
@@ -59,8 +59,9 @@ describe('QuoteInformationTable', () => {
         heading: 'Information for the quote',
         showEditLink: true,
         content: {
-          'Delivery date': formatMediumDateParsed(
-            orderWithAllFields.deliveryDate
+          'Delivery date': formatDate(
+            orderWithAllFields.deliveryDate,
+            DATE_FORMAT_MEDIUM
           ),
           'Description of the activity': orderWithAllFields.description,
         },

--- a/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/QuoteInformationTable.cy.jsx
@@ -7,7 +7,10 @@ import {
 } from '../../../../../functional/cypress/support/assertions'
 import { STATUS } from '../../../../../../src/client/modules/Omis/constants'
 import urls from '../../../../../../src/lib/urls'
-import { formatDate } from '../../../../../../src/client/utils/date-utils'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+} from '../../../../../../src/client/utils/date-utils'
 
 const order = {
   id: '123',

--- a/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
+++ b/test/component/cypress/specs/Tasks/TaskDetails/TaskDetailsTable.cy.jsx
@@ -9,7 +9,10 @@ import {
   taskWithInteractionFaker,
 } from '../../../../../functional/cypress/fakers/task'
 import urls from '../../../../../../src/lib/urls'
-import { formatLongDate } from '../../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../../src/client/utils/date-utils'
 import { NOT_SET_TEXT } from '../../../../../../src/apps/companies/constants'
 import TaskDetailsTable from '../../../../../../src/client/modules/Tasks/TaskDetails/TaskDetailsTable'
 import { companyFaker } from '../../../../../functional/cypress/fakers/companies'
@@ -42,13 +45,19 @@ describe('Task details table', () => {
             href: urls.investments.projects.details(project.id),
             name: project.name,
           },
-          ['Date due']: formatLongDate(investmentProjectTask.dueDate),
+          ['Date due']: formatDate(
+            investmentProjectTask.dueDate,
+            DATE_FORMAT_FULL
+          ),
           'Assigned to': investmentProjectTask.advisers
             .map((adviser) => adviser.name)
             .join(''),
           'Task description': investmentProjectTask.description,
           'Reminders set': `${investmentProjectTask.reminderDays} days before due date`,
-          'Date created': formatLongDate(investmentProjectTask.createdOn),
+          'Date created': formatDate(
+            investmentProjectTask.createdOn,
+            DATE_FORMAT_FULL
+          ),
           'Created by': investmentProjectTask.createdBy.name,
         },
       })
@@ -91,7 +100,10 @@ describe('Task details table', () => {
             .join(''),
           'Task description': NOT_SET_TEXT,
           'Reminders set': NOT_SET_TEXT,
-          'Date created': formatLongDate(taskWithNoInvestmentProject.createdOn),
+          'Date created': formatDate(
+            taskWithNoInvestmentProject.createdOn,
+            DATE_FORMAT_FULL
+          ),
           'Created by': taskWithNoInvestmentProject.createdBy.name,
         },
       })
@@ -120,13 +132,19 @@ describe('Task details table', () => {
             href: urls.interactions.detail(taskWithInteraction.interaction.id),
             name: taskWithInteraction.interaction.subject,
           },
-          ['Date due']: formatLongDate(taskWithInteraction.dueDate),
+          ['Date due']: formatDate(
+            taskWithInteraction.dueDate,
+            DATE_FORMAT_FULL
+          ),
           'Assigned to': taskWithInteraction.advisers
             .map((adviser) => adviser.name)
             .join(''),
           'Task description': taskWithInteraction.description,
           'Reminders set': `${taskWithInteraction.reminderDays} days before due date`,
-          'Date created': formatLongDate(taskWithInteraction.createdOn),
+          'Date created': formatDate(
+            taskWithInteraction.createdOn,
+            DATE_FORMAT_FULL
+          ),
           'Created by': taskWithInteraction.createdBy.name,
         },
       })

--- a/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
+++ b/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
@@ -1,4 +1,7 @@
-import { formatDate } from '../../../../../../src/client/utils/date-utils'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../../../src/client/utils/date-utils'
 import { companyExportWinFaker } from '../../../fakers/company-export-win'
 import { companyFaker } from '../../../fakers/companies'
 import urls from '../../../../../../src/lib/urls'

--- a/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
+++ b/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
@@ -1,4 +1,4 @@
-import { formatShortDate } from '../../../../../../src/client/utils/date'
+import { formatDate } from '../../../../../../src/client/utils/date-utils'
 import { companyExportWinFaker } from '../../../fakers/company-export-win'
 import { companyFaker } from '../../../fakers/companies'
 import urls from '../../../../../../src/lib/urls'
@@ -16,7 +16,7 @@ const getExpectedMetadata = (win) => ({
   'Company name': 'Not set',
   'Contact name': `${win.contact.name} (${win.contact.job_title} - ${win.contact.email})`,
   Destination: win.country,
-  'Date won': formatShortDate(win.date),
+  'Date won': formatDate(win.date, DATE_FORMAT_MONTH_YEAR),
   'Type of win': win.business_type,
   'Total value': `£${win.value.export.total}`,
   'Type of goods or services': win.name_of_export,

--- a/test/functional/cypress/specs/investments/project-details-meta-list-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-meta-list-spec.js
@@ -1,6 +1,9 @@
 import { upperFirst } from 'lodash'
 
-import { formatMediumDateTime } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../src/client/utils/date-utils'
 
 const urls = require('../../../../../src/lib/urls')
 const { investmentProjectFaker } = require('../../fakers/investment-projects')
@@ -69,7 +72,10 @@ describe('Investment project details', () => {
         .next('span')
         .should(
           'contain',
-          formatMediumDateTime(investmentProjectWithAllDetails.created_on)
+          formatDate(
+            investmentProjectWithAllDetails.created_on,
+            DATE_FORMAT_MEDIUM_WITH_TIME
+          )
         )
 
       cy.get('[data-test="meta-list-item-created-by"]')
@@ -132,7 +138,10 @@ describe('Investment project details', () => {
         .next('span')
         .should(
           'contain',
-          formatMediumDateTime(investmentProjectWithoutAllDetails.created_on)
+          formatDate(
+            investmentProjectWithoutAllDetails.created_on,
+            DATE_FORMAT_MEDIUM_WITH_TIME
+          )
         )
 
       cy.get('[data-test="meta-list-item-created-by"]').should('not.exist')

--- a/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
@@ -3,7 +3,10 @@ import fixture from '../../fixtures/investment/investment-needing-external-fundi
 import { collectionListRequest } from '../../support/actions'
 import { getCollectionList } from '../../support/collection-list-assertions'
 import { companyFaker } from '../../fakers/companies'
-import { formatMediumDateTime } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../src/client/utils/date-utils'
 
 describe('Edit the recipient company', () => {
   context('When searching for a recipient company', () => {
@@ -34,7 +37,7 @@ describe('Edit the recipient company', () => {
         )
       cy.get('h4').should(
         'contain',
-        `Updated on ${formatMediumDateTime(company.modified_on)}`
+        `Updated on ${formatDate(company.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       )
       cy.get('@metadataItems')
         .eq(0)

--- a/test/functional/cypress/specs/omis/quote-spec.js
+++ b/test/functional/cypress/specs/omis/quote-spec.js
@@ -5,10 +5,11 @@ import {
   assertFlashMessage,
   assertLocalHeader,
 } from '../../support/assertions'
+import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
 import {
-  formatMediumDateParsed,
-  formatMediumDateTime,
-} from '../../../../../src/client/utils/date'
+  formatDate,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} from '../../../../../src/client/utils/date-utils'
 
 const {
   cancelledOrder,
@@ -28,7 +29,10 @@ const assertSenderDetails = (quote) =>
       .should('have.text', 'Sent on')
     cy.get('[data-test="sent-on-date"]')
       .should('exist')
-      .should('have.text', formatMediumDateTime(quote.created_on))
+      .should(
+        'have.text',
+        formatDate(quote.created_on, DATE_FORMAT_MEDIUM_WITH_TIME)
+      )
     cy.get('[data-test="sent-by-heading"]')
       .should('exist')
       .should('have.text', 'Sent by')
@@ -44,7 +48,10 @@ const assertAcceptanceDetails = (quote) =>
       .should('have.text', 'Accepted on')
     cy.get('[data-test="accepted-on-date"]')
       .should('exist')
-      .should('have.text', formatMediumDateTime(quote.accepted_on))
+      .should(
+        'have.text',
+        formatDate(quote.accepted_on, DATE_FORMAT_MEDIUM_WITH_TIME)
+      )
     cy.get('[data-test="accepted-by-heading"]')
       .should('exist')
       .should('have.text', 'Accepted by')
@@ -224,7 +231,10 @@ describe('Order quote', () => {
         .should('have.text', 'Cancelled on')
       cy.get('[data-test="cancelled-on-date"]')
         .should('exist')
-        .should('have.text', formatMediumDateTime(quoteCancelled.cancelled_on))
+        .should(
+          'have.text',
+          formatDate(quoteCancelled.cancelled_on, DATE_FORMAT_MEDIUM_WITH_TIME)
+        )
       cy.get('[data-test="cancelled-by-heading"]')
         .should('exist')
         .should('have.text', 'Cancelled by')

--- a/test/functional/cypress/specs/omis/quote-spec.js
+++ b/test/functional/cypress/specs/omis/quote-spec.js
@@ -5,9 +5,9 @@ import {
   assertFlashMessage,
   assertLocalHeader,
 } from '../../support/assertions'
-import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
 import {
   formatDate,
+  DATE_FORMAT_MEDIUM,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../../../../src/client/utils/date-utils'
 
@@ -93,7 +93,10 @@ describe('Order quote', () => {
         .should('have.text', 'Will expire on')
       cy.get('[data-test="expiry-date"]')
         .should('exist')
-        .should('have.text', formatMediumDateParsed(quotePreview.expires_on))
+        .should(
+          'have.text',
+          formatDate(quotePreview.expires_on, DATE_FORMAT_MEDIUM)
+        )
     })
 
     it('should display the warning message', () => {
@@ -149,7 +152,7 @@ describe('Order quote', () => {
           .should('exist')
           .should(
             'have.text',
-            formatMediumDateParsed(quoteNotAccepted.expires_on)
+            formatDate(quoteNotAccepted.expires_on, DATE_FORMAT_MEDIUM)
           )
       })
 

--- a/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-new-interactions-list-spec.js
@@ -6,7 +6,10 @@ import {
   nestedInteractionFaker,
   reminderListFaker,
 } from '../../fakers/reminders'
-import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+} from '../../../../../src/client/utils/date-utils'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/new-export-interaction'
 
@@ -333,8 +336,9 @@ describe('Exports New Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Received ${formatMediumDateParsed(
-            deleted_reminder_date.toISOString()
+          `Received ${formatDate(
+            deleted_reminder_date.toISOString(),
+            DATE_FORMAT_MEDIUM
           )} for ${reminders[4].company.name}`
         )
         .find('a')

--- a/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
+++ b/test/functional/cypress/specs/reminders/export-no-recent-interactions-list-spec.js
@@ -6,7 +6,10 @@ import {
   nestedInteractionFaker,
   reminderListFaker,
 } from '../../fakers/reminders'
-import { formatMediumDateParsed } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MEDIUM,
+} from '../../../../../src/client/utils/date-utils'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/no-recent-export-interaction'
 
@@ -138,7 +141,7 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `${formatMediumDateParsed(reminders[0].last_interaction_date)}`
+          `${formatDate(reminders[0].last_interaction_date, DATE_FORMAT_MEDIUM)}`
         )
     })
   })
@@ -343,8 +346,9 @@ describe('Exports no recent Interaction Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Received ${formatMediumDateParsed(
-            deleted_reminder_date.toISOString()
+          `Received ${formatDate(
+            deleted_reminder_date.toISOString(),
+            DATE_FORMAT_MEDIUM
           )} for ${reminders[4].company.name}`
         )
         .find('a')


### PR DESCRIPTION
## Description of change
This PR replaces the following format functions with the `dateFormat` function:

- `formatMediumDate`
- `formatMediumDateTime`
- `formatMediumDateTimeWithoutParsing`
- `formatLongDate`
- `formatShortDate`
- `formatMediumDateParsed`

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
