### PR TITLE
Remove `formatWithoutParsing` function and replace it with `formatDate`

### DIFF
--- a/src/apps/companies/apps/dnb-hierarchy/__test__/transformers.test.js
+++ b/src/apps/companies/apps/dnb-hierarchy/__test__/transformers.test.js
@@ -75,7 +75,7 @@ describe('Edit company form transformers', () => {
         expect(actual).to.deep.equal({
           headingText: undefined,
           headingUrl: urls.companies.detail('123'),
-          subheading: 'Updated on undefined',
+          subheading: undefined,
           metadata: [],
           badges: [],
         })

--- a/src/apps/companies/apps/dnb-hierarchy/transformers.js
+++ b/src/apps/companies/apps/dnb-hierarchy/transformers.js
@@ -74,7 +74,7 @@ function transformCompanyToDnbHierarchyList({
   return {
     headingText: name,
     headingUrl: urls.companies.detail(id),
-    subheading: `Updated on ${formatDateTime(modified_on)}`,
+    subheading: modified_on && `Updated on ${formatDateTime(modified_on)}`,
     metadata,
     badges,
   }

--- a/src/apps/companies/middleware/__test__/last-interaction-date.test.js
+++ b/src/apps/companies/middleware/__test__/last-interaction-date.test.js
@@ -1,6 +1,6 @@
-const { getInteractionTimestamp } = require('../../../../client/utils/date')
-const middleware = require('../last-interaction-date')
 const buildMiddlewareParameters = require('../../../../../test/unit/helpers/middleware-parameters-builder')
+const { getInteractionTimestamp } = require('../utils')
+const middleware = require('../last-interaction-date')
 
 const QUERY_PARAM = 'interaction_between'
 const START_DATE_PARAM = 'latest_interaction_date_before'

--- a/src/apps/companies/middleware/last-interaction-date.js
+++ b/src/apps/companies/middleware/last-interaction-date.js
@@ -1,5 +1,5 @@
 const { QUERY_FIELDS_MAP } = require('../constants')
-const { getInteractionTimestamp } = require('../../../client/utils/date')
+const { getInteractionTimestamp } = require('./utils')
 
 const QUERY_PARAM = QUERY_FIELDS_MAP.lastInteractionDate
 const START_DATE_PARAM = 'latest_interaction_date_before'

--- a/src/apps/companies/middleware/utils.js
+++ b/src/apps/companies/middleware/utils.js
@@ -1,0 +1,20 @@
+const { subMonths } = require('date-fns')
+
+const {
+  formatDate,
+  DATE_FORMAT_INTERACTION_TIMESTAMP,
+} = require('../../../client/utils/date-utils')
+
+function getInteractionTimestamp({ offset }) {
+  const date = new Date()
+
+  if (offset > 0) {
+    subMonths(date, offset)
+  }
+
+  return formatDate(date, DATE_FORMAT_INTERACTION_TIMESTAMP)
+}
+
+module.exports = {
+  getInteractionTimestamp,
+}

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -29,7 +29,12 @@ import {
   transformExportCountriesToGroupStatus,
 } from '../../../../transformers'
 
-import { formatWithoutParsing } from '../../../../../client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY,
+  DATE_FORMAT_MONTH,
+  DATE_FORMAT_YEAR,
+} from '../../../../../client/utils/date-utils'
 
 const { transformValueForAPI } = require('../../../../../client/utils/date')
 
@@ -139,9 +144,9 @@ const transformInteractionToValues = (interaction, companyId, investmentId) => {
       transformObjectToOption(adviser)
     ),
     date: {
-      day: formatWithoutParsing(date, 'dd'),
-      month: formatWithoutParsing(date, 'MM'),
-      year: formatWithoutParsing(date, 'yyyy'),
+      day: formatDate(date, DATE_FORMAT_DAY),
+      month: formatDate(date, DATE_FORMAT_MONTH),
+      year: formatDate(date, DATE_FORMAT_YEAR),
     },
     companies: [companyId],
     investment_project: investmentId,
@@ -237,9 +242,9 @@ export async function getInitialFormValues({
       companies: [companyId],
       investment_project: investmentId,
       date: {
-        day: formatWithoutParsing(date, 'dd'),
-        month: formatWithoutParsing(date, 'MM'),
-        year: formatWithoutParsing(date, 'yyyy'),
+        day: formatDate(date, DATE_FORMAT_DAY),
+        month: formatDate(date, DATE_FORMAT_MONTH),
+        year: formatDate(date, DATE_FORMAT_YEAR),
       },
       contacts:
         referral && referral.contact

--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -1,18 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-
 import { H3 } from '@govuk-react/heading'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
-import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
-import urls from '../../../lib/urls'
 import { DARK_GREY, LINK_COLOUR, RED, TEXT_COLOUR } from '../../utils/colours'
-
-const {
-  formatWithoutParsing,
-  getDifferenceInDaysLabel,
-} = require('../../utils/date')
+import { formatDate, DATE_FORMAT_FULL_DAY } from '../../utils/date-utils'
+import { getDifferenceInDaysLabel } from '../../utils/date'
+import urls from '../../../lib/urls'
 
 const StyledSubHeading = styled(H3)`
   color: ${RED};
@@ -92,11 +87,7 @@ const OutstandingPropositions = ({ results, count }) => (
                   {investment_project.project_code}
                 </StyledProjectCode>
                 <StyledDueDate data-test="outstanding-proposition-deadline">
-                  Due{' '}
-                  {formatWithoutParsing(
-                    new Date(deadline),
-                    DATE_DAY_LONG_FORMAT
-                  )}
+                  Due {formatDate(new Date(deadline), DATE_FORMAT_FULL_DAY)}
                 </StyledDueDate>
               </StyledDetails>
               <StyledDueCountdown data-test="outstanding-proposition-countdown">

--- a/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
+++ b/src/client/components/InvestmentReminders/OutstandingPropositions.jsx
@@ -87,7 +87,7 @@ const OutstandingPropositions = ({ results, count }) => (
                   {investment_project.project_code}
                 </StyledProjectCode>
                 <StyledDueDate data-test="outstanding-proposition-deadline">
-                  Due {formatDate(new Date(deadline), DATE_FORMAT_FULL_DAY)}
+                  Due {formatDate(deadline, DATE_FORMAT_FULL_DAY)}
                 </StyledDueDate>
               </StyledDetails>
               <StyledDueCountdown data-test="outstanding-proposition-countdown">

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { FONT_SIZE, FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
 
-import { DATE_DAY_LONG_FORMAT } from '../../../common/constants'
 import {
   BLACK,
   BUTTON_COLOUR,
@@ -14,10 +13,11 @@ import {
 } from '../../../client/utils/colours'
 
 const {
-  formatWithoutParsing,
   getDifferenceInDays,
   getDifferenceInDaysLabel,
 } = require('../../utils/date')
+
+const { formatDate, DATE_FORMAT_FULL_DAY } = require('../../utils/date-utils')
 
 const StyledPanel = styled('div')`
   padding: ${SPACING.SCALE_2};
@@ -72,10 +72,7 @@ const InvestmentEstimatedLandDate = ({ estimatedLandDate, ...props }) => {
         {getDifferenceInDaysLabel(estimatedLandDate)}
       </StyledTitle>
       <StyledBody data-test="estimated-land-date-date">
-        {formatWithoutParsing(
-          new Date(estimatedLandDate),
-          DATE_DAY_LONG_FORMAT
-        )}
+        {formatDate(new Date(estimatedLandDate), DATE_FORMAT_FULL_DAY)}
       </StyledBody>
     </Panel>
   )

--- a/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate.jsx
@@ -72,7 +72,7 @@ const InvestmentEstimatedLandDate = ({ estimatedLandDate, ...props }) => {
         {getDifferenceInDaysLabel(estimatedLandDate)}
       </StyledTitle>
       <StyledBody data-test="estimated-land-date-date">
-        {formatDate(new Date(estimatedLandDate), DATE_FORMAT_FULL_DAY)}
+        {formatDate(estimatedLandDate, DATE_FORMAT_FULL_DAY)}
       </StyledBody>
     </Panel>
   )

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/RecentActivityCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/RecentActivityCard.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { subMonths } from 'date-fns'
 
-import ActivityCard from './ActivityCard'
-import { OVERVIEW_RECENT_ACTIVITY_ID, recentState2props } from './state'
-import { formatWithoutParsing, subtractMonths } from '../../../../../utils/date'
-import { DATE_LONG_FORMAT_3 } from '../../../../../../common/constants'
 import { COMPANIES__OVERVIEW_RECENT_ACTIVITY_LOADED } from '../../../../../actions'
+import { formatDate, DATE_FORMAT_ISO } from '../../../../../utils/date-utils'
+import { OVERVIEW_RECENT_ACTIVITY_ID, recentState2props } from './state'
+import ActivityCard from './ActivityCard'
 
 const RecentActivityCard = ({ company, results }) => (
   <ActivityCard
@@ -16,11 +16,8 @@ const RecentActivityCard = ({ company, results }) => (
     stateId={OVERVIEW_RECENT_ACTIVITY_ID}
     action={COMPANIES__OVERVIEW_RECENT_ACTIVITY_LOADED}
     additionalPayload={{
-      date_before: formatWithoutParsing(new Date(), DATE_LONG_FORMAT_3),
-      date_after: formatWithoutParsing(
-        subtractMonths(new Date(), 6),
-        DATE_LONG_FORMAT_3
-      ),
+      date_before: formatDate(new Date(), DATE_FORMAT_ISO),
+      date_after: formatDate(subMonths(new Date(), 6), DATE_FORMAT_ISO),
     }}
   />
 )

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/UpcomingActivityCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/UpcomingActivityCard.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import { endOfTomorrow } from 'date-fns'
 
-import ActivityCard from './ActivityCard'
-import { OVERVIEW_UPCOMING_ACTIVITY_ID, upcomingState2props } from './state'
-import { formatWithoutParsing, tomorrow } from '../../../../../utils/date'
-import { DATE_LONG_FORMAT_3 } from '../../../../../../common/constants'
 import { COMPANIES__OVERVIEW_UPCOMING_ACTIVITY_LOADED } from '../../../../../actions'
+import { formatDate, DATE_FORMAT_ISO } from '../../../../../utils/date-utils'
+import { OVERVIEW_UPCOMING_ACTIVITY_ID, upcomingState2props } from './state'
+import ActivityCard from './ActivityCard'
 
 const UpcomingActivityCard = ({ company, results }) => (
   <ActivityCard
@@ -16,7 +16,7 @@ const UpcomingActivityCard = ({ company, results }) => (
     stateId={OVERVIEW_UPCOMING_ACTIVITY_ID}
     action={COMPANIES__OVERVIEW_UPCOMING_ACTIVITY_LOADED}
     additionalPayload={{
-      date_after: formatWithoutParsing(tomorrow(), DATE_LONG_FORMAT_3),
+      date_after: formatDate(endOfTomorrow(), DATE_FORMAT_ISO),
       sortby: 'date:asc',
     }}
   />

--- a/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
@@ -70,9 +70,9 @@ const transformCompanyToListItem =
 
     return {
       id,
-      subheading: modified_on
-        ? `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
-        : undefined,
+      subheading:
+        modified_on &&
+        `Updated on ${formatDate(modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`,
       headingText: name,
       headingUrl: urls.investments.projects.editRecipientCompany(projectId, id),
       badges,

--- a/src/client/modules/Investments/Projects/landDateTransformer.js
+++ b/src/client/modules/Investments/Projects/landDateTransformer.js
@@ -4,7 +4,7 @@
  * put this back into the main transformers file.
  */
 
-const { formatMonthYearDate } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_ISO } = require('../../../utils/date-utils')
 
 const MONTH_DATE_FIELD_LIST = [
   'estimated_land_date_before',
@@ -17,7 +17,7 @@ const transformLandDateFilters = (params) => {
   // The API only accepts yyyy-MM-dd format, so month-year filters have to be updated
   MONTH_DATE_FIELD_LIST.forEach((field) => {
     if (field in params) {
-      params[field] = formatMonthYearDate(params[field])
+      params[field] = formatDate(params[field], DATE_FORMAT_ISO)
     }
   })
   return params

--- a/src/client/modules/Tasks/TaskForm/__test__/transformer.test.js
+++ b/src/client/modules/Tasks/TaskForm/__test__/transformer.test.js
@@ -1,6 +1,5 @@
-import { formatDate, addMonths, addDays } from 'date-fns'
+import { format, addMonths, addDays } from 'date-fns'
 
-import { DATE_FORMAT_ISO } from '../../../../../client/utils/date-utils'
 import { getDueDate } from '../transformers'
 
 describe('getDueDate', () => {
@@ -15,7 +14,7 @@ describe('getDueDate', () => {
   it('should return the correct due date for the next month', () => {
     const today = new Date()
     const nextMonthDate = addMonths(today, 1)
-    const formattedDate = formatDate(nextMonthDate, DATE_FORMAT_ISO)
+    const formattedDate = format(nextMonthDate, 'yyyy-MM-dd')
 
     const result = getDueDate('month')
     expect(result).to.equal(formattedDate)
@@ -24,14 +23,9 @@ describe('getDueDate', () => {
   it('should return the correct due date for the next week', () => {
     const today = new Date()
     const nextWeekDate = addDays(today, 7)
-    const formattedDate = formatDate(nextWeekDate, DATE_FORMAT_ISO)
+    const formattedDate = format(nextWeekDate, 'yyyy-MM-dd')
 
     const result = getDueDate('week')
     expect(result).to.equal(formattedDate)
-  })
-
-  it('should return null for an unknown due date type', () => {
-    const result = getDueDate('unknown')
-    expect(result).to.be.null
   })
 })

--- a/src/client/modules/Tasks/TaskForm/__test__/transformer.test.js
+++ b/src/client/modules/Tasks/TaskForm/__test__/transformer.test.js
@@ -1,0 +1,37 @@
+import { formatDate, addMonths, addDays } from 'date-fns'
+
+import { DATE_FORMAT_ISO } from '../../../../../client/utils/date-utils'
+import { getDueDate } from '../transformers'
+
+describe('getDueDate', () => {
+  it('should return the transformed value for a custom date', () => {
+    const customDate = { year: 2024, month: 12, day: 31 }
+    const expectedTransformedValue = '2024-12-31'
+
+    const result = getDueDate('custom', customDate)
+    expect(result).to.equal(expectedTransformedValue)
+  })
+
+  it('should return the correct due date for the next month', () => {
+    const today = new Date()
+    const nextMonthDate = addMonths(today, 1)
+    const formattedDate = formatDate(nextMonthDate, DATE_FORMAT_ISO)
+
+    const result = getDueDate('month')
+    expect(result).to.equal(formattedDate)
+  })
+
+  it('should return the correct due date for the next week', () => {
+    const today = new Date()
+    const nextWeekDate = addDays(today, 7)
+    const formattedDate = formatDate(nextWeekDate, DATE_FORMAT_ISO)
+
+    const result = getDueDate('week')
+    expect(result).to.equal(formattedDate)
+  })
+
+  it('should return null for an unknown due date type', () => {
+    const result = getDueDate('unknown')
+    expect(result).to.be.null
+  })
+})

--- a/src/client/modules/Tasks/TaskForm/transformers.js
+++ b/src/client/modules/Tasks/TaskForm/transformers.js
@@ -66,7 +66,7 @@ export const getDueDate = (dueDate, customDate) => {
     week: () => formatDate(addDays(today, 7), DATE_FORMAT_ISO),
   }
 
-  return handlers[dueDate]?.() || null
+  return handlers[dueDate]?.()
 }
 
 const transformAdvisor = (advisers, currentAdviserId) =>

--- a/src/client/modules/Tasks/TaskForm/transformers.js
+++ b/src/client/modules/Tasks/TaskForm/transformers.js
@@ -57,17 +57,16 @@ const getUniquePKValue = (formValues) => {
   return { investment_project: null, company: null, interaction: null }
 }
 
-const getDueDate = (dueDate, customDate) => {
-  switch (dueDate) {
-    case 'custom':
-      return transformValueForAPI(customDate)
-    case 'month':
-      return formatDate(addMonths(new Date(), 1), DATE_FORMAT_ISO)
-    case 'week':
-      return formatDate(addDays(new Date(), 7), DATE_FORMAT_ISO)
-    default:
-      null
+export const getDueDate = (dueDate, customDate) => {
+  const today = new Date()
+
+  const handlers = {
+    custom: () => transformValueForAPI(customDate),
+    month: () => formatDate(addMonths(today, 1), DATE_FORMAT_ISO),
+    week: () => formatDate(addDays(today, 7), DATE_FORMAT_ISO),
   }
+
+  return handlers[dueDate]?.() || null
 }
 
 const transformAdvisor = (advisers, currentAdviserId) =>

--- a/src/client/modules/Tasks/TaskForm/transformers.js
+++ b/src/client/modules/Tasks/TaskForm/transformers.js
@@ -1,20 +1,17 @@
+import { addDays, addMonths } from 'date-fns'
+
 import { transformOptionToValue } from '../../../../apps/transformers'
-import {
-  OPTION_YES,
-  DATE_LONG_FORMAT_3,
-  OPTION_NO,
-} from '../../../../common/constants'
+import { OPTION_YES, OPTION_NO } from '../../../../common/constants'
 import {
   transformArrayIdNameToValueLabel,
   transformIdNameToValueLabel,
 } from '../../../transformers'
 import {
-  formatWithoutParsing,
   transformValueForAPI,
-  addMonths,
-  addDays,
   convertDateToFieldDateObject,
 } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_ISO } from '../../../utils/date-utils'
+
 import { OPTIONS } from './constants'
 
 export const transformTaskFormValuesForAPI = (
@@ -65,9 +62,9 @@ const getDueDate = (dueDate, customDate) => {
     case 'custom':
       return transformValueForAPI(customDate)
     case 'month':
-      return formatWithoutParsing(addMonths(new Date(), 1), DATE_LONG_FORMAT_3)
+      return formatDate(addMonths(new Date(), 1), DATE_FORMAT_ISO)
     case 'week':
-      return formatWithoutParsing(addDays(new Date(), 7), DATE_LONG_FORMAT_3)
+      return formatDate(addDays(new Date(), 7), DATE_FORMAT_ISO)
     default:
       null
   }

--- a/src/client/utils/date-utils.js
+++ b/src/client/utils/date-utils.js
@@ -1,6 +1,24 @@
 const { format, parseISO } = require('date-fns')
 
 /**
+ * Two-digit day format.
+ * Example: 04
+ */
+const DATE_FORMAT_DAY = 'dd'
+
+/**
+ * Two-digit month format.
+ * Example: 12
+ */
+const DATE_FORMAT_MONTH = 'MM'
+
+/**
+ * Four-digit year format.
+ * Example: 2024
+ */
+const DATE_FORMAT_YEAR = 'yyyy'
+
+/**
  * Full date format with day and full month name.
  * Example: 4 December 2024
  */
@@ -19,6 +37,12 @@ const DATE_FORMAT_FULL_DAY = 'E, dd MMM yyyy'
 const DATE_FORMAT_COMPACT = 'dd MMM yyyy'
 
 /**
+ * Full date format with two-digit day and full month name.
+ * Example: 04 December 2024
+ */
+const DATE_FORMAT_DAY_MONTH_YEAR = 'dd MMMM yyyy'
+
+/**
  * ISO standard date format.
  * Example: 2024-12-04
  */
@@ -35,6 +59,12 @@ const DATE_FORMAT_MEDIUM = 'd MMM yyyy'
  * Example: 4 Dec 2024, 3:30PM
  */
 const DATE_FORMAT_MEDIUM_WITH_TIME = 'd MMM yyyy, h:mmaaa'
+
+/**
+ * ISO 8601 date format with full time precision.
+ * Example: 2024-12-04T15:30:45
+ */
+const DATE_FORMAT_ISO_WITH_TIME_FULL = "yyyy-MM-dd'T'HH:mm:ss"
 
 /**
  * Year and month format for compact representations.
@@ -103,16 +133,21 @@ function formatDate(date, dateISOFormat = DATE_FORMAT_COMPACT) {
 }
 
 module.exports = {
+  DATE_FORMAT_DAY,
+  DATE_FORMAT_MONTH,
+  DATE_FORMAT_YEAR,
   DATE_FORMAT_FULL,
   DATE_FORMAT_FULL_DAY,
   DATE_FORMAT_COMPACT,
   DATE_FORMAT_ISO,
   DATE_FORMAT_MEDIUM,
   DATE_FORMAT_MEDIUM_WITH_TIME,
+  DATE_FORMAT_ISO_WITH_TIME_FULL,
   DATE_FORMAT_YEAR_MONTH,
   DATE_FORMAT_MONTH_YEAR,
   DATE_FORMAT_MONTH_ABBR_YEAR,
   DATE_FORMAT_DAY_MONTH,
+  DATE_FORMAT_DAY_MONTH_YEAR,
   DATE_FORMAT_INTERACTION_TIMESTAMP,
   formatDate,
 }

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -37,7 +37,6 @@ const {
   DATE_LONG_FORMAT_2,
   DATE_LONG_FORMAT_3,
   DATE_SHORT_FORMAT,
-  INTERACTION_TIMESTAMP_FORMAT,
   DATE_DAY_MONTH,
 } = require('../../common/constants')
 
@@ -128,10 +127,6 @@ function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
   return isDateValid(dateStr) ? formatFns(parseISO(dateStr), dateFormat) : null
 }
 
-function formatWithoutParsing(date, dateFormat = DATE_LONG_FORMAT_2) {
-  return isUnparsedDateValid(date) ? formatFns(date, dateFormat) : null
-}
-
 const formatMonthYearDate = (date) =>
   formatFns(parse(date, DATE_SHORT_FORMAT, new Date()), DATE_LONG_FORMAT_3)
 
@@ -197,16 +192,6 @@ function getFinancialYearStart(date) {
 
 function generateFinancialYearLabel(yearStart) {
   return `${yearStart}-${(yearStart + 1).toString().slice(-2)}`
-}
-
-function getInteractionTimestamp({ offset }) {
-  const date = new Date()
-
-  if (offset > 0) {
-    subMonths(date, offset)
-  }
-
-  return formatWithoutParsing(date, INTERACTION_TIMESTAMP_FORMAT)
 }
 
 function getDifferenceInWords(date, suffix = true) {
@@ -362,12 +347,10 @@ module.exports = {
   createAndFormatDateObject,
   format,
   formatMonthYearDate,
-  formatWithoutParsing,
   generateFinancialYearLabel,
   getDifferenceInDays,
   getDifferenceInDaysLabel,
   getDifferenceInWords,
-  getInteractionTimestamp,
   getFinancialYearStart,
   getYesterday,
   isDateAfter,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -127,9 +127,6 @@ function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
   return isDateValid(dateStr) ? formatFns(parseISO(dateStr), dateFormat) : null
 }
 
-const formatMonthYearDate = (date) =>
-  formatFns(parse(date, DATE_SHORT_FORMAT, new Date()), DATE_LONG_FORMAT_3)
-
 const padZero = (value) => {
   const parsedValue = parseInt(value, 10)
   if (Number.isNaN(parsedValue)) {
@@ -346,7 +343,6 @@ module.exports = {
   addYears,
   createAndFormatDateObject,
   format,
-  formatMonthYearDate,
   generateFinancialYearLabel,
   getDifferenceInDays,
   getDifferenceInDaysLabel,

--- a/src/config/nunjucks/__test__/filters.test.js
+++ b/src/config/nunjucks/__test__/filters.test.js
@@ -292,10 +292,11 @@ describe('nunjucks filters', () => {
 
   describe('#formatDate', () => {
     context('when given an invalid date', () => {
-      it('should return input value', () => {
-        const formattedDate = filters.formatDate('not-a-date')
-
-        expect(formattedDate).to.equal('not-a-date')
+      it('should throw an error', () => {
+        expect(() => filters.formatDate('not-a-date')).to.throw(
+          Error,
+          'Invalid time value'
+        )
       })
     })
 
@@ -320,10 +321,11 @@ describe('nunjucks filters', () => {
 
   describe('#formatDateTime', () => {
     context('when given an invalid datetime', () => {
-      it('should return input value', () => {
-        const formattedDate = filters.formatDateTime('not-a-date')
-
-        expect(formattedDate).to.equal('not-a-date')
+      it('should throw an error', () => {
+        expect(() => filters.formatDate('not-a-date')).to.throw(
+          Error,
+          'Invalid time value'
+        )
       })
     })
 

--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -34,16 +34,12 @@ const {
 const { newlineToBr } = require('../../lib/text-formatting')
 const { joinPaths } = require('../../lib/path')
 const {
-  formatWithoutParsing,
-  isUnparsedDateValid,
-  isDateValid,
-  format,
-} = require('../../client/utils/date')
+  formatDate: dateFormatter,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_MEDIUM_WITH_TIME,
+} = require('../../client/utils/date-utils')
+
 require('numeral/locales/en-gb')
-const {
-  DATE_LONG_FORMAT_1,
-  DATE_TIME_MEDIUM_FORMAT,
-} = require('../../common/constants')
 
 numeral.locale('en-gb')
 
@@ -158,29 +154,11 @@ const filters = {
     return number.toLocaleString(locales)
   },
 
-  formatDate: (value, format = DATE_LONG_FORMAT_1) => {
-    if (!value) {
-      return value
-    }
+  formatDate: (value, format = DATE_FORMAT_FULL) =>
+    dateFormatter(new Date(value), format),
 
-    if (!isUnparsedDateValid(new Date(value))) {
-      return value
-    }
-
-    return formatWithoutParsing(new Date(value), format)
-  },
-
-  formatDateTime: (value, dateFormat = DATE_TIME_MEDIUM_FORMAT) => {
-    if (!value) {
-      return value
-    }
-
-    if (!isDateValid(value)) {
-      return value
-    }
-
-    return format(value, dateFormat).replace('AM', 'am').replace('PM', 'pm')
-  },
+  formatDateTime: (value, dateFormat = DATE_FORMAT_MEDIUM_WITH_TIME) =>
+    dateFormatter(value, dateFormat),
 
   formatAddress: (address, join = ', ', featureFlag = false) => {
     if (!address) {

--- a/src/config/nunjucks/filters.js
+++ b/src/config/nunjucks/filters.js
@@ -34,7 +34,7 @@ const {
 const { newlineToBr } = require('../../lib/text-formatting')
 const { joinPaths } = require('../../lib/path')
 const {
-  formatDate: dateFormatter,
+  formatDate,
   DATE_FORMAT_FULL,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../client/utils/date-utils')
@@ -155,10 +155,10 @@ const filters = {
   },
 
   formatDate: (value, format = DATE_FORMAT_FULL) =>
-    dateFormatter(new Date(value), format),
+    formatDate(new Date(value), format),
 
   formatDateTime: (value, dateFormat = DATE_FORMAT_MEDIUM_WITH_TIME) =>
-    dateFormatter(value, dateFormat),
+    formatDate(value, dateFormat),
 
   formatAddress: (address, join = ', ', featureFlag = false) => {
     if (!address) {

--- a/test/component/cypress/specs/components/MyInvestmentProjects/InvestmentEstimatedLandDate.cy.jsx
+++ b/test/component/cypress/specs/components/MyInvestmentProjects/InvestmentEstimatedLandDate.cy.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
+import { addDays, subDays } from 'date-fns'
 
 import InvestmentEstimatedLandDate from '../../../../../../src/client/components/MyInvestmentProjects/InvestmentEstimatedLandDate'
-import { DATE_DAY_LONG_FORMAT } from '../../../../../../src/common/constants'
 import {
   BUTTON_COLOUR,
   GREY_2,
@@ -11,17 +11,16 @@ import {
 } from '../../../../../../src/client/utils/colours'
 
 const {
-  addDays,
-  formatWithoutParsing,
-  subtractDays,
-} = require('../../../../../../src/client/utils/date')
+  formatDate,
+  DATE_FORMAT_FULL_DAY,
+} = require('../../../../../../src/client/utils/date-utils')
 
 const today = new Date()
 const futureDate = addDays(today, 100)
 const tomorrow = addDays(today, 1)
 const twoMonthsAhead = addDays(today, 60)
-const pastDate = subtractDays(today, 10)
-const yesterday = subtractDays(today, 1)
+const pastDate = subDays(today, 10)
+const yesterday = subDays(today, 1)
 
 describe('InvestmentEstimatedLandDate', () => {
   const Component = (props) => <InvestmentEstimatedLandDate {...props} />
@@ -42,7 +41,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(futureDate, DATE_DAY_LONG_FORMAT)
+        formatDate(futureDate, DATE_FORMAT_FULL_DAY)
       )
     })
 
@@ -70,7 +69,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(today, DATE_DAY_LONG_FORMAT)
+        formatDate(today, DATE_FORMAT_FULL_DAY)
       )
     })
 
@@ -98,7 +97,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(tomorrow, DATE_DAY_LONG_FORMAT)
+        formatDate(tomorrow, DATE_FORMAT_FULL_DAY)
       )
     })
 
@@ -126,7 +125,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(twoMonthsAhead, DATE_DAY_LONG_FORMAT)
+        formatDate(twoMonthsAhead, DATE_FORMAT_FULL_DAY)
       )
     })
 
@@ -154,7 +153,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(pastDate, DATE_DAY_LONG_FORMAT)
+        formatDate(pastDate, DATE_FORMAT_FULL_DAY)
       )
     })
 
@@ -182,7 +181,7 @@ describe('InvestmentEstimatedLandDate', () => {
       )
       cy.get('[data-test="estimated-land-date-date"]').should(
         'have.text',
-        formatWithoutParsing(yesterday, DATE_DAY_LONG_FORMAT)
+        formatDate(yesterday, DATE_FORMAT_FULL_DAY)
       )
     })
 

--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -1,8 +1,10 @@
 const { company, contact, investmentProject } = require('../../fixtures')
 const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
-const { formatWithoutParsing } = require('../../../../../src/client/utils/date')
-const { DATE_MEDIUM_FORMAT } = require('../../../../../src/common/constants')
+const {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} = require('../../../../../src/client/utils/date-utils')
 const {
   assertFlashMessage,
 } = require('../../../../functional/cypress/support/assertions')
@@ -14,7 +16,7 @@ const {
   assertBadgeNotPresent,
 } = require('../../../../functional/cypress/support/collection-list-assertions')
 
-const todaysDate = formatWithoutParsing(new Date(), DATE_MEDIUM_FORMAT)
+const todaysDate = formatDate(new Date(), DATE_FORMAT_COMPACT)
 let companyObj
 let contactObj
 let investmentProjectObj

--- a/test/end-to-end/cypress/specs/DIT/event-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/event-spec.js
@@ -2,7 +2,12 @@ const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
 const { assertKeyValueTable } = require('../../support/assertions')
-const { formatWithoutParsing } = require('../../../../../src/client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_DAY,
+  DATE_FORMAT_MONTH,
+  DATE_FORMAT_YEAR,
+} = require('../../../../../src/client/utils/date-utils')
 const {
   clickSaveAndReturnButton,
 } = require('../../../../functional/cypress/support/form-fillers')
@@ -23,9 +28,9 @@ const createEvent = () => {
     town: 'Campinas',
     country: 'Brazil',
     endDate: {
-      year: formatWithoutParsing(today, 'yyyy'),
-      month: formatWithoutParsing(today, 'MM'),
-      day: formatWithoutParsing(today, 'dd'),
+      year: formatDate(today, DATE_FORMAT_YEAR),
+      month: formatDate(today, DATE_FORMAT_MONTH),
+      day: formatDate(today, DATE_FORMAT_DAY),
     },
     eventType: 'Account management',
     leadTeam: 'Advanced Manufacturing Sector',
@@ -40,9 +45,9 @@ const createEvent = () => {
     ],
     relatedProgrammes: ['CEN Energy', 'CEN Services'],
     startDate: {
-      year: formatWithoutParsing(today, 'yyyy'),
-      month: formatWithoutParsing(today, 'MM'),
-      day: formatWithoutParsing(today, 'dd'),
+      year: formatDate(today, DATE_FORMAT_YEAR),
+      month: formatDate(today, DATE_FORMAT_MONTH),
+      day: formatDate(today, DATE_FORMAT_DAY),
     },
     eventShared: true,
     teams: ['Biopartner'],

--- a/test/end-to-end/cypress/specs/DIT/interaction-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/interaction-spec.js
@@ -1,13 +1,15 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
-const { formatWithoutParsing } = require('../../../../../src/client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_FULL,
+} = require('../../../../../src/client/utils/date-utils')
 const { companies, interactions } = require('../../../../../src/lib/urls')
-const { DATE_LONG_FORMAT_1 } = require('../../../../../src/common/constants')
 const {
   assertSummaryTable,
 } = require('../../../../functional/cypress/support/assertions')
 
-const today = formatWithoutParsing(new Date(), DATE_LONG_FORMAT_1)
+const today = formatDate(new Date(), DATE_FORMAT_FULL)
 
 const selectInteractionType = (theme, kind) => {
   cy.contains('label', theme).click()

--- a/test/end-to-end/cypress/specs/DIT/investment-proposition-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/investment-proposition-spec.js
@@ -1,8 +1,14 @@
 const fixtures = require('../../fixtures')
 const selectors = require('../../../../selectors')
 const { investments } = require('../../../../../src/lib/urls')
-const { formatWithoutParsing } = require('../../../../../src/client/utils/date')
-const { DATE_LONG_FORMAT_1 } = require('../../../../../src/common/constants')
+const {
+  formatDate,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_DAY,
+  DATE_FORMAT_MONTH,
+  DATE_FORMAT_YEAR,
+} = require('../../../../../src/client/utils/date-utils')
+
 const {
   selectFirstMockedTypeaheadOption,
 } = require('../../../../functional/cypress/support/actions')
@@ -12,17 +18,17 @@ const {
 } = require('../../../../functional/cypress/support/assertions')
 
 const today = new Date()
-const todayFormatted = formatWithoutParsing(today, DATE_LONG_FORMAT_1)
+const todayFormatted = formatDate(today, DATE_FORMAT_FULL)
 
 const createProposition = (data) => {
   cy.get(selectors.entityCollection.addProposition).click()
   cy.get('[data-test=proposition-name-input]').type(data.name)
   cy.get('[data-test=proposition-scope-input]').type(data.scope)
   cy.get('[data-test=proposition_deadline-day]').type(
-    formatWithoutParsing(data.date, 'dd')
+    formatDate(data.date, DATE_FORMAT_DAY)
   )
   cy.get('[data-test=proposition_deadline-month]').type(
-    formatWithoutParsing(data.date, 'MM')
+    formatDate(data.date, DATE_FORMAT_MONTH)
   )
   selectFirstMockedTypeaheadOption({
     element: '[data-test="field-proposition_assignee"]',
@@ -30,7 +36,7 @@ const createProposition = (data) => {
     mockAdviserResponse: false,
   })
   cy.get('[data-test=proposition_deadline-year]').type(
-    formatWithoutParsing(data.date, 'yyyy')
+    formatDate(data.date, DATE_FORMAT_YEAR)
   )
   cy.get('[data-test=submit-button]').click()
 }

--- a/test/end-to-end/cypress/specs/DIT/order-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/order-spec.js
@@ -1,12 +1,14 @@
 const fixtures = require('../../fixtures')
-const { formatWithoutParsing } = require('../../../../../src/client/utils/date')
+const {
+  formatDate,
+  DATE_MEDIUM_FORMAT,
+} = require('../../../../../src/client/utils/date-utils')
 const { omis } = require('../../../../../src/lib/urls')
-const { DATE_MEDIUM_FORMAT } = require('../../../../../src/common/constants')
 const {
   assertSummaryTable,
 } = require('../../../../functional/cypress/support/assertions')
 
-const today = formatWithoutParsing(new Date(), DATE_MEDIUM_FORMAT)
+const today = formatDate(new Date(), DATE_MEDIUM_FORMAT)
 
 describe('Order', () => {
   const company = fixtures.company.create.defaultCompany('order testing')

--- a/test/functional/cypress/fakers/dnb-hierarchy.js
+++ b/test/functional/cypress/fakers/dnb-hierarchy.js
@@ -4,7 +4,10 @@ import { listFaker } from './utils'
 import { addressFaker } from './addresses'
 import { ukRegionFaker } from './regions'
 import { EMPLOYEE_RANGE, HEADQUARTER_TYPE, ONE_LIST_TIER } from './constants'
-import { formatWithoutParsing } from '../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_ISO_WITH_TIME_FULL,
+} from '../../../../src/client/utils/date-utils'
 
 const companyTreeItemFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
@@ -26,9 +29,9 @@ const companyTreeItemFaker = (overrides = {}) => ({
       name: faker.commerce.productName(),
     },
   ],
-  latest_interaction_date: formatWithoutParsing(
+  latest_interaction_date: formatDate(
     faker.date.past(),
-    "yyyy-MM-dd'T'HH:mm:ss"
+    DATE_FORMAT_ISO_WITH_TIME_FULL
   ),
   one_list_tier: faker.helpers.arrayElement(ONE_LIST_TIER),
   archived: false,

--- a/test/functional/cypress/fakers/objective.js
+++ b/test/functional/cypress/fakers/objective.js
@@ -1,15 +1,17 @@
 import { faker } from '../../../sandbox/utils/random'
 
 import { listFaker } from './utils'
-import { formatWithoutParsing } from '../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_3 } from '../../../../src/common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_ISO,
+} from '../../../../src/client/utils/date-utils'
 
 const objectiveFaker = (overrides = {}) => ({
   id: faker.string.uuid(),
   company: { id: faker.string.uuid(), name: faker.company.name() },
   subject: faker.word.sample(),
   detail: faker.word.words(),
-  target_date: formatWithoutParsing(faker.date.future(), DATE_LONG_FORMAT_3),
+  target_date: formatDate(faker.date.future(), DATE_FORMAT_ISO),
   has_blocker: true,
   blocker_description: faker.word.words(),
   progress: faker.helpers.rangeToNumber({ min: 0, max: 100 }),

--- a/test/functional/cypress/specs/dashboard/estimated-land-date-spec.js
+++ b/test/functional/cypress/specs/dashboard/estimated-land-date-spec.js
@@ -1,13 +1,13 @@
+import { addDays, subDays } from 'date-fns'
+
 import { investmentProjectFaker } from '../../fakers/investment-projects'
 import { investmentProjectSummaryFaker } from '../../fakers/investment-project-summary'
 import urls from '../../../../../src/lib/urls'
 
-const { DATE_DAY_LONG_FORMAT } = require('../../../../../src/common/constants')
 const {
-  addDays,
-  formatWithoutParsing,
-  subtractDays,
-} = require('../../../../../src/client/utils/date')
+  formatDate,
+  DATE_FORMAT_FULL_DAY,
+} = require('../../../../../src/client/utils/date-utils')
 
 const assertEstimatedLandDate = ({ index, date, countdown, colour }) => {
   cy.get('@projectListItems')
@@ -24,13 +24,13 @@ const assertEstimatedLandDate = ({ index, date, countdown, colour }) => {
 
   cy.get('@estimatedLandDate')
     .find('[data-test="estimated-land-date-date"]')
-    .should('have.text', formatWithoutParsing(date, DATE_DAY_LONG_FORMAT))
+    .should('have.text', formatDate(date, DATE_FORMAT_FULL_DAY))
 }
 
 describe('Dashboard items - estimated land date', () => {
   const today = new Date()
   const myProjects = [
-    subtractDays(today, 14),
+    subDays(today, 14),
     today,
     addDays(today, 29),
     addDays(today, 89),
@@ -65,7 +65,7 @@ describe('Dashboard items - estimated land date', () => {
     it('should show a grey panel when the project has under 0 days remaining', () => {
       assertEstimatedLandDate({
         index: 0,
-        date: subtractDays(new Date(), 14),
+        date: subDays(new Date(), 14),
         countdown: '-14 days',
         colour: 'rgba(191, 193, 195, 0.5)',
       })

--- a/test/functional/cypress/specs/dashboard/investment-details-spec.js
+++ b/test/functional/cypress/specs/dashboard/investment-details-spec.js
@@ -1,10 +1,12 @@
-import { faker } from '../../../../sandbox/utils/random'
-
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { investmentProjectFaker } from '../../fakers/investment-projects'
 import { companies, dashboard, interactions } from '../../../../../src/lib/urls'
+import { investmentProjectFaker } from '../../fakers/investment-projects'
+import { faker } from '../../../../sandbox/utils/random'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../src/client/utils/date-utils'
 
-const todayFormatted = formatWithoutParsing(new Date())
+const todayFormatted = formatDate(new Date(), DATE_FORMAT_COMPACT)
 
 describe('Dashboard - Investment details', () => {
   const investmentProject = investmentProjectFaker({

--- a/test/functional/cypress/specs/investments/project-edit-associated-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-associated-spec.js
@@ -3,7 +3,10 @@ import fixture from '../../fixtures/investment/investment-needing-external-fundi
 import { collectionListRequest } from '../../support/actions'
 import { getCollectionList } from '../../support/collection-list-assertions'
 import { investmentProjectFaker } from '../../fakers/investment-projects'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../../src/client/utils/date-utils'
 
 describe('Edit the associated FDI R&D project', () => {
   context('When adding a new linked project', () => {
@@ -41,9 +44,9 @@ describe('Edit the associated FDI R&D project', () => {
         .eq(2)
         .should(
           'contain',
-          `Estimated land date ${formatWithoutParsing(
+          `Estimated land date ${formatDate(
             project.estimated_land_date,
-            'MMMM yyyy'
+            DATE_FORMAT_MONTH_YEAR
           )}`
         )
     })

--- a/test/functional/cypress/specs/investments/project-propositions-spec.js
+++ b/test/functional/cypress/specs/investments/project-propositions-spec.js
@@ -1,6 +1,9 @@
 import fixtures from '../../fixtures'
 import urls from '../../../../../src/lib/urls'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../../../src/client/utils/date-utils'
 
 describe('Investment project propositions', () => {
   context('When the project has one proposition linked', () => {
@@ -44,7 +47,7 @@ describe('Investment project propositions', () => {
         .find('[data-test="metadata"]')
         .should(
           'contain',
-          'Deadline ' + formatWithoutParsing(new Date(), 'dd MMMM yyyy')
+          'Deadline ' + formatDate(new Date(), DATE_FORMAT_DAY_MONTH_YEAR)
         )
         .and('contain', 'Created on 15 June 2017')
         .and('contain', 'Adviser Paula Churing')

--- a/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-due-date-approaching-list-spec.js
@@ -1,8 +1,10 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../src/client/utils/date-utils'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/my-tasks-due-date-approaching'
 
@@ -131,9 +133,9 @@ describe('My Tasks Due Date Approaching Reminders', () => {
         )
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             reminders[0].task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
     })
@@ -278,9 +280,9 @@ describe('My Tasks Due Date Approaching Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             nextReminder.task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
         .should('contain', `Company: ${nextReminder.task.company.name}`)

--- a/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
+++ b/test/functional/cypress/specs/reminders/my-tasks-task-overdue-list-spec.js
@@ -1,8 +1,10 @@
+import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
-import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../src/client/utils/date-utils'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/my-tasks-task-overdue'
 
@@ -128,9 +130,9 @@ describe('My Tasks Task Overdue Reminders', () => {
         )
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             reminders[0].task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
     })
@@ -275,9 +277,9 @@ describe('My Tasks Task Overdue Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             nextReminder.task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
         .should('contain', `Company: ${nextReminder.task.company.name}`)

--- a/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-amended-by-others-list-spec.js
@@ -1,8 +1,10 @@
+import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../src/client/utils/date-utils'
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
-import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
 
 const remindersEndpoint =
   '/api-proxy/v4/reminder/my-tasks-task-amended-by-others'
@@ -132,9 +134,9 @@ describe('Task Amended By Others Reminders', () => {
         )
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             reminders[0].task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
     })
@@ -279,9 +281,9 @@ describe('Task Amended By Others Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             nextReminder.task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
         .should('contain', `Company: ${nextReminder.task.company.name}`)

--- a/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-assigned-to-me-from-others-list-spec.js
@@ -1,8 +1,10 @@
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
 import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../src/client/utils/date-utils'
 
 const remindersEndpoint =
   '/api-proxy/v4/reminder/my-tasks-task-assigned-to-me-from-others'
@@ -132,9 +134,9 @@ describe('My Tasks Task Assigned To Me From Others Reminders', () => {
         )
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             reminders[0].task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
     })
@@ -279,9 +281,9 @@ describe('My Tasks Task Assigned To Me From Others Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             nextReminder.task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
         .should('contain', `Company: ${nextReminder.task.company.name}`)

--- a/test/functional/cypress/specs/reminders/task-completed-list-spec.js
+++ b/test/functional/cypress/specs/reminders/task-completed-list-spec.js
@@ -1,8 +1,10 @@
+import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+} from '../../../../../src/client/utils/date-utils'
 import { assertBreadcrumbs } from '../../support/assertions'
 import urls from '../../../../../src/lib/urls'
-import { myTasksReminderFaker, reminderListFaker } from '../../fakers/reminders'
-import { formatWithoutParsing } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../src/common/constants'
 
 const remindersEndpoint = '/api-proxy/v4/reminder/my-tasks-task-completed'
 
@@ -128,9 +130,9 @@ describe('My Tasks Task Completed Reminders', () => {
         )
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             reminders[0].task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
     })
@@ -275,9 +277,9 @@ describe('My Tasks Task Completed Reminders', () => {
         .find('[data-test="item-content"]')
         .should(
           'contain',
-          `Date due: ${formatWithoutParsing(
+          `Date due: ${formatDate(
             nextReminder.task.due_date,
-            DATE_LONG_FORMAT_1
+            DATE_FORMAT_FULL
           )}`
         )
         .should('contain', `Company: ${nextReminder.task.company.name}`)


### PR DESCRIPTION
## Description of change
This PR simplifies the use of date utilities by replacing all instances of `formatWithoutParsing` with `formatDate`. Importantly, it introduces the practice of importing `date-fns` functions directly in source files, bypassing the centralised `date.js` module. This change reduces the reliance on redundant wrappers like those in `date.js`, making the codebase cleaner and more maintainable. In a subsequent PR, the remaining `date.js` wrappers and imports from `date-fns` will be removed entirely.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
