### PR TITLE
Feature/CLS2-981 Display EYB activity on Company Overview page

### DIFF
--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -225,7 +225,7 @@ export const transformEYBLeadToListItem = (activity) => {
       {
         text: 'EYB',
         colour: 'grey',
-        dataTest: 'eyb-service-label',
+        dataTest: 'eyb-label',
       },
     ].filter(({ text }) => Boolean(text)),
     headingUrl: urls.investments.eybLeads.details(activity.eyb_lead.id),

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -81,6 +81,8 @@ export const transformActivity = (activities) => {
         return transformOrderToListItem(activity)
       case 'great_export_enquiry':
         return transformGreatExportEnquiryToListItem(activity)
+      case 'eyb_lead':
+        return transformEYBLeadToListItem(activity)
       default:
         return {}
     }
@@ -145,6 +147,8 @@ export const transformInteractionToListItem = (activity) => {
 
 export const transformInvestmentToListItem = (activity) => {
   const investment = activity.investment
+  const from_eyb =
+    activity.investment.eyb_leads.length !== 0 ? 'from EYB lead' : ''
 
   return {
     id: investment.id,
@@ -154,8 +158,8 @@ export const transformInvestmentToListItem = (activity) => {
     headingText: investment.name,
     summary:
       investment.number_new_jobs == null
-        ? `${investment.investment_type.name} investment added by ${investment.created_by.name}`
-        : `${investment.investment_type.name} investment for ${checkNewJobs(investment.number_new_jobs)} ${pluraliseLabel(investment.number_new_jobs, 'new job')} added by ${investment.created_by.name}`,
+        ? `${investment.investment_type.name} investment added by ${investment.created_by.name} ${from_eyb}`
+        : `${investment.investment_type.name} investment for ${checkNewJobs(investment.number_new_jobs)} ${pluraliseLabel(investment.number_new_jobs, 'new job')} added by ${investment.created_by.name} ${from_eyb}`,
   }
 }
 
@@ -189,3 +193,33 @@ export const transformResponseToCollection = (activities) => ({
   count: activities.count,
   results: transformActivity(activities),
 })
+
+export const getEYBValue = (activity) => {
+  const eybValue = activity.eyb_lead.is_high_value
+
+  switch (eybValue) {
+    case true:
+      return 'A high'
+    case false:
+      return 'A low'
+    default:
+      return 'An unknown'
+  }
+}
+
+export const transformEYBLeadToListItem = (activity) => {
+  return {
+    id: activity.eyb_lead.id,
+    date: formatDate(activity.eyb_lead.created_on),
+    tags: [
+      {
+        text: 'EYB',
+        colour: 'grey',
+        dataTest: 'eyb-service-label',
+      },
+    ].filter(({ text }) => Boolean(text)),
+    headingUrl: urls.investments.eybLeads.details(activity.eyb_lead.id),
+    headingText: activity.eyb_lead.company_name,
+    summary: `${getEYBValue(activity)}-value EYB lead associated with this company has been added to Data Hub`,
+  }
+}

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -145,21 +145,31 @@ export const transformInteractionToListItem = (activity) => {
   }
 }
 
+function getInvestmentSummary(activity) {
+  let investment = activity.investment
+  let summary = `${investment.investment_type.name} investment`
+  if (investment.number_new_jobs === null) {
+    summary = summary + ` added by ${investment.created_by.name}`
+  } else {
+    summary =
+      summary +
+      ` for ${checkNewJobs(investment.number_new_jobs)} ${pluraliseLabel(investment.number_new_jobs, 'new job')} added by ${investment.created_by.name}`
+  }
+  if (activity.investment.eyb_leads.length !== 0) {
+    summary = summary + ' from EYB lead'
+  }
+  return summary
+}
+
 export const transformInvestmentToListItem = (activity) => {
   const investment = activity.investment
-  const from_eyb =
-    activity.investment.eyb_leads.length !== 0 ? 'from EYB lead' : ''
-
   return {
     id: investment.id,
     date: formatDate(activity.date, DATE_FORMAT_MEDIUM),
     tags: [NEW_PROJECT_TAG].filter(({ text }) => Boolean(text)),
     headingUrl: urls.investments.projects.details(investment.id),
     headingText: investment.name,
-    summary:
-      investment.number_new_jobs == null
-        ? `${investment.investment_type.name} investment added by ${investment.created_by.name} ${from_eyb}`
-        : `${investment.investment_type.name} investment for ${checkNewJobs(investment.number_new_jobs)} ${pluraliseLabel(investment.number_new_jobs, 'new job')} added by ${investment.created_by.name} ${from_eyb}`,
+    summary: getInvestmentSummary(activity),
   }
 }
 

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -229,7 +229,9 @@ export const transformEYBLeadToListItem = (activity) => {
       },
     ].filter(({ text }) => Boolean(text)),
     headingUrl: urls.investments.eybLeads.details(activity.eyb_lead.id),
-    headingText: activity.eyb_lead.company_name,
+    headingText: activity.company.name
+      ? activity.company.name
+      : activity.eyb_lead.company_name,
     summary: `${getEYBValue(activity)}-value EYB lead associated with this company has been added to Data Hub`,
   }
 }

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
@@ -1,0 +1,84 @@
+import React from 'react'
+
+import urls from '../../../../../../../src/lib/urls'
+
+import { transformEYBLeadToListItem } from '../../../../../../../src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers'
+import { ItemTemplate } from '../../../../../../../src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/ActivityCard'
+import { CollectionList } from '../../../../../../../src/client/components'
+import {
+  assertActivitySubject,
+  assertEYBLabel,
+} from '../../../../support/activity-assertions'
+
+const EYB_LEAD_ID = 'e686c9d9-d7ba-444d-a85b-a64c477fc1ba'
+const PROJECT_URL = urls.investments.eybLeads.details(EYB_LEAD_ID)
+const COMPANY_NAME = 'Booth Sykes'
+
+const buildAndMountActivity = (value = null) => {
+  const activity = {
+    eyb_lead: {
+      is_high_value: value,
+      created_on: '2024-12-02T09:59:03.911296+00:00',
+      company_name: COMPANY_NAME,
+      triage_created: '2024-12-01T09:59:03+00:00',
+      id: EYB_LEAD_ID,
+    },
+  }
+
+  cy.mountWithProvider(
+    <CollectionList
+      items={[transformEYBLeadToListItem(activity)]}
+      collectionItemTemplate={ItemTemplate}
+    />
+  )
+}
+
+describe('EYB lead activity card', () => {
+  context('When the card is rendered with a lead of unknown value', () => {
+    beforeEach(() => {
+      buildAndMountActivity()
+      cy.get('[data-test="activity-card-wrapper"]').should('exist')
+    })
+
+    it('should render the labels and metadata', () => {
+      assertEYBLabel()
+      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-summary"]').should(
+        'have.text',
+        `An unknown-value EYB lead associated with this company has been added to Data Hub`
+      )
+    })
+  })
+
+  context('When the card is rendered with a lead of high value', () => {
+    beforeEach(() => {
+      buildAndMountActivity(true)
+      cy.get('[data-test="activity-card-wrapper"]').should('exist')
+    })
+
+    it('should render the labels and metadata', () => {
+      assertEYBLabel()
+      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-summary"]').should(
+        'have.text',
+        `A high-value EYB lead associated with this company has been added to Data Hub`
+      )
+    })
+  })
+
+  context('When the card is rendered with a lead of low value', () => {
+    beforeEach(() => {
+      buildAndMountActivity(false)
+      cy.get('[data-test="activity-card-wrapper"]').should('exist')
+    })
+
+    it('should render the labels and metadata', () => {
+      assertEYBLabel()
+      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-summary"]').should(
+        'have.text',
+        `A low-value EYB lead associated with this company has been added to Data Hub`
+      )
+    })
+  })
+})

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
@@ -43,6 +43,7 @@ describe('EYB lead activity card', () => {
     it('should render the labels and metadata', () => {
       assertEYBLabel()
       assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
       cy.get('[data-test="activity-summary"]').should(
         'have.text',
         `An unknown-value EYB lead associated with this company has been added to Data Hub`
@@ -59,6 +60,7 @@ describe('EYB lead activity card', () => {
     it('should render the labels and metadata', () => {
       assertEYBLabel()
       assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
       cy.get('[data-test="activity-summary"]').should(
         'have.text',
         `A high-value EYB lead associated with this company has been added to Data Hub`
@@ -75,6 +77,7 @@ describe('EYB lead activity card', () => {
     it('should render the labels and metadata', () => {
       assertEYBLabel()
       assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
       cy.get('[data-test="activity-summary"]').should(
         'have.text',
         `A low-value EYB lead associated with this company has been added to Data Hub`

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/EYBActivityCard.cy.jsx
@@ -12,14 +12,18 @@ import {
 
 const EYB_LEAD_ID = 'e686c9d9-d7ba-444d-a85b-a64c477fc1ba'
 const PROJECT_URL = urls.investments.eybLeads.details(EYB_LEAD_ID)
-const COMPANY_NAME = 'Booth Sykes'
+const EYB_COMPANY_NAME = 'EYB Company Name'
+const LINKED_COMPANY_NAME = 'Linked Company Name'
 
-const buildAndMountActivity = (value = null) => {
+const buildAndMountActivity = (value = null, linked_company_name = null) => {
   const activity = {
+    company: {
+      name: linked_company_name,
+    },
     eyb_lead: {
       is_high_value: value,
       created_on: '2024-12-02T09:59:03.911296+00:00',
-      company_name: COMPANY_NAME,
+      company_name: EYB_COMPANY_NAME,
       triage_created: '2024-12-01T09:59:03+00:00',
       id: EYB_LEAD_ID,
     },
@@ -34,54 +38,147 @@ const buildAndMountActivity = (value = null) => {
 }
 
 describe('EYB lead activity card', () => {
-  context('When the card is rendered with a lead of unknown value', () => {
-    beforeEach(() => {
-      buildAndMountActivity()
-      cy.get('[data-test="activity-card-wrapper"]').should('exist')
-    })
+  context(
+    'When the card is rendered with a lead of unknown value and linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(null, LINKED_COMPANY_NAME)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
 
-    it('should render the labels and metadata', () => {
-      assertEYBLabel()
-      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
-      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
-      cy.get('[data-test="activity-summary"]').should(
-        'have.text',
-        `An unknown-value EYB lead associated with this company has been added to Data Hub`
-      )
-    })
-  })
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          LINKED_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `An unknown-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
 
-  context('When the card is rendered with a lead of high value', () => {
-    beforeEach(() => {
-      buildAndMountActivity(true)
-      cy.get('[data-test="activity-card-wrapper"]').should('exist')
-    })
+  context(
+    'When the card is rendered with a lead of high value and linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(true, LINKED_COMPANY_NAME)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
 
-    it('should render the labels and metadata', () => {
-      assertEYBLabel()
-      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
-      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
-      cy.get('[data-test="activity-summary"]').should(
-        'have.text',
-        `A high-value EYB lead associated with this company has been added to Data Hub`
-      )
-    })
-  })
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          LINKED_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `A high-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
 
-  context('When the card is rendered with a lead of low value', () => {
-    beforeEach(() => {
-      buildAndMountActivity(false)
-      cy.get('[data-test="activity-card-wrapper"]').should('exist')
-    })
+  context(
+    'When the card is rendered with a lead of low value and linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(false, LINKED_COMPANY_NAME)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
 
-    it('should render the labels and metadata', () => {
-      assertEYBLabel()
-      assertActivitySubject(COMPANY_NAME, PROJECT_URL, 'activity-card-wrapper')
-      cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
-      cy.get('[data-test="activity-summary"]').should(
-        'have.text',
-        `A low-value EYB lead associated with this company has been added to Data Hub`
-      )
-    })
-  })
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          LINKED_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `A low-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
+
+  context(
+    'When the card is rendered with a lead of unknown value and no linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity()
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
+
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          EYB_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `An unknown-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
+
+  context(
+    'When the card is rendered with a lead of high value and no linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(true)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
+
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          EYB_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `A high-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
+
+  context(
+    'When the card is rendered with a lead of low value and no linked company',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(false)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
+
+      it('should render the labels and metadata', () => {
+        assertEYBLabel()
+        assertActivitySubject(
+          EYB_COMPANY_NAME,
+          PROJECT_URL,
+          'activity-card-wrapper'
+        )
+        cy.get('[data-test="activity-date"]').should('have.text', '02 Dec 2024')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `A low-value EYB lead associated with this company has been added to Data Hub`
+        )
+      })
+    }
+  )
 })

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
@@ -14,7 +14,7 @@ import { CREATED_BY, CREATED_ON } from '../../../../support/activity-constants'
 const NAME = 'An investment project'
 const PROJECT_URL = urls.investments.projects.details('2')
 
-const buildAndMountActivity = (newJobs) => {
+const buildAndMountActivity = (newJobs, eybLeads = []) => {
   const activity = {
     date: CREATED_ON,
     investment: {
@@ -24,6 +24,7 @@ const buildAndMountActivity = (newJobs) => {
       investment_type: {
         name: 'FDI',
       },
+      eyb_leads: eybLeads,
       number_new_jobs: newJobs,
     },
   }
@@ -54,7 +55,7 @@ describe('Investment activity card', () => {
     })
   })
 
-  context('When the project has one new job', () => {
+  context('When the project has one new job and no linked EYB leads', () => {
     beforeEach(() => {
       buildAndMountActivity(1)
       cy.get('[data-test="activity-card-wrapper"]').should('exist')
@@ -71,7 +72,24 @@ describe('Investment activity card', () => {
     })
   })
 
-  context('When the project has no new jobs', () => {
+  context('When the project has one new job and one linked EYB lead', () => {
+    beforeEach(() => {
+      buildAndMountActivity(1, ['leadId1'])
+      cy.get('[data-test="activity-card-wrapper"]').should('exist')
+    })
+
+    it('should render the labels and metadata', () => {
+      assertProjectKindLabel()
+      assertActivitySubject(NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-date"]').should('have.text', '25 Nov 2058')
+      cy.get('[data-test="activity-summary"]').should(
+        'have.text',
+        `FDI investment for 1 new job added by ${CREATED_BY.name} from EYB lead`
+      )
+    })
+  })
+
+  context('When the project has no new jobs and no linked EYB leads', () => {
     beforeEach(() => {
       buildAndMountActivity(0)
       cy.get('[data-test="activity-card-wrapper"]').should('exist')
@@ -84,6 +102,23 @@ describe('Investment activity card', () => {
       cy.get('[data-test="activity-summary"]').should(
         'have.text',
         `FDI investment for no new jobs added by ${CREATED_BY.name}`
+      )
+    })
+  })
+
+  context('When the project has no new jobs and one linked EYB leads', () => {
+    beforeEach(() => {
+      buildAndMountActivity(0, ['leadId1'])
+      cy.get('[data-test="activity-card-wrapper"]').should('exist')
+    })
+
+    it('should render the labels and metadata', () => {
+      assertProjectKindLabel()
+      assertActivitySubject(NAME, PROJECT_URL, 'activity-card-wrapper')
+      cy.get('[data-test="activity-date"]').should('have.text', '25 Nov 2058')
+      cy.get('[data-test="activity-summary"]').should(
+        'have.text',
+        `FDI investment for no new jobs added by ${CREATED_BY.name} from EYB lead`
       )
     })
   })

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
@@ -14,6 +14,7 @@ import { CREATED_BY, CREATED_ON } from '../../../../support/activity-constants'
 const NAME = 'An investment project'
 const PROJECT_URL = urls.investments.projects.details('2')
 const EYB_LEAD = [{ id: '1' }]
+const EYB_LEADS = [{ id: '2' }, { id: '3' }, { id: '4' }]
 
 const buildAndMountActivity = (newJobs, eybLeads = []) => {
   const activity = {
@@ -90,6 +91,26 @@ describe('Investment activity card', () => {
     })
   })
 
+  context(
+    'When the project has one new job and multiple linked EYB lead',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(1, EYB_LEADS)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
+
+      it('should render the labels and metadata', () => {
+        assertProjectKindLabel()
+        assertActivitySubject(NAME, PROJECT_URL, 'activity-card-wrapper')
+        cy.get('[data-test="activity-date"]').should('have.text', '25 Nov 2058')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `FDI investment for 1 new job added by ${CREATED_BY.name} from EYB lead`
+        )
+      })
+    }
+  )
+
   context('When the project has no new jobs and no linked EYB leads', () => {
     beforeEach(() => {
       buildAndMountActivity(0)
@@ -123,4 +144,24 @@ describe('Investment activity card', () => {
       )
     })
   })
+
+  context(
+    'When the project has no new jobs and mutiple linked EYB leads',
+    () => {
+      beforeEach(() => {
+        buildAndMountActivity(0, EYB_LEADS)
+        cy.get('[data-test="activity-card-wrapper"]').should('exist')
+      })
+
+      it('should render the labels and metadata', () => {
+        assertProjectKindLabel()
+        assertActivitySubject(NAME, PROJECT_URL, 'activity-card-wrapper')
+        cy.get('[data-test="activity-date"]').should('have.text', '25 Nov 2058')
+        cy.get('[data-test="activity-summary"]').should(
+          'have.text',
+          `FDI investment for no new jobs added by ${CREATED_BY.name} from EYB lead`
+        )
+      })
+    }
+  )
 })

--- a/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/ActivityCard/InvestmentActivityCard.cy.jsx
@@ -13,6 +13,7 @@ import { CREATED_BY, CREATED_ON } from '../../../../support/activity-constants'
 
 const NAME = 'An investment project'
 const PROJECT_URL = urls.investments.projects.details('2')
+const EYB_LEAD = [{ id: '1' }]
 
 const buildAndMountActivity = (newJobs, eybLeads = []) => {
   const activity = {
@@ -74,7 +75,7 @@ describe('Investment activity card', () => {
 
   context('When the project has one new job and one linked EYB lead', () => {
     beforeEach(() => {
-      buildAndMountActivity(1, ['leadId1'])
+      buildAndMountActivity(1, EYB_LEAD)
       cy.get('[data-test="activity-card-wrapper"]').should('exist')
     })
 
@@ -108,7 +109,7 @@ describe('Investment activity card', () => {
 
   context('When the project has no new jobs and one linked EYB leads', () => {
     beforeEach(() => {
-      buildAndMountActivity(0, ['leadId1'])
+      buildAndMountActivity(0, EYB_LEAD)
       cy.get('[data-test="activity-card-wrapper"]').should('exist')
     })
 

--- a/test/component/cypress/support/activity-assertions.js
+++ b/test/component/cypress/support/activity-assertions.js
@@ -44,6 +44,10 @@ export const assertProjectKindLabel = () => {
   assertText('[data-test="investment-kind-label"]', 'New Investment Project')
 }
 
+export const assertEYBLabel = () => {
+  assertText('[data-test="eyb-label"]', 'EYB')
+}
+
 export const assertOrderKindLabel = () => {
   assertText('[data-test="order-kind-label"]', 'New Order')
 }

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -68,6 +68,7 @@ const companyActivityInvestmentFaker = (
       created_by: userFaker(),
       foreign_equity_investment: faker.number.int({ min: 50, max: 1000 }),
       gross_value_added: faker.number.int({ min: 100, max: 2000 }),
+      eyb_leads: [],
       ...investmentOverrides,
     },
     ...overrides,

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -64,7 +64,7 @@ const companyActivityInvestmentFaker = (
       name: faker.word.words(),
       client_contacts: [userFaker({ job_title: faker.person.jobTitle() })],
       id: faker.string.uuid(),
-      number_new_jobs: faker.number.int({ min: 0, max: 50 }),
+      number_new_jobs: faker.number.int({ min: 1, max: 50 }),
       created_by: userFaker(),
       foreign_equity_investment: faker.number.int({ min: 50, max: 1000 }),
       gross_value_added: faker.number.int({ min: 100, max: 2000 }),

--- a/test/functional/cypress/fakers/company-activity.js
+++ b/test/functional/cypress/fakers/company-activity.js
@@ -105,6 +105,28 @@ const companyActivityGreatFaker = (overrides = {}, orderOverrides = {}) => ({
   ...overrides,
 })
 
+const companyActivityEYBFaker = (overrides = {}, eybOverrides = {}) => {
+  return {
+    ...companyActivityFaker(),
+    activity_source: 'eyb_lead',
+    id: faker.string.uuid(),
+    company: {
+      name: faker.company.name,
+      id: '1c5f7b5f-acd0-4a17-ac9d-8600bb5ded86',
+    },
+    eyb_lead: {
+      is_high_value: faker.datatype.boolean(),
+      created_on: '2024-12-02T09:59:03.911296+00:00',
+      company_name: faker.company.name,
+      triage_created: '2024-12-01T09:59:03+00:00',
+      id: faker.string.uuid(),
+      duns_number: faker.number.int({ min: 1000000, max: 9999999 }).toString(),
+      ...eybOverrides,
+    },
+    ...overrides,
+  }
+}
+
 const companyActivityInteractionListFaker = (length = 1, overrides) =>
   listFaker({
     fakerFunction: companyActivityInteractionFaker,
@@ -151,6 +173,15 @@ const companyActivityInvestmentListFaker = (
   })
 }
 
+const companyActivityEYBListFaker = (length = 1, overrides, EYBOverrides) => {
+  return listFakerAdditionalOverrides({
+    fakerFunction: companyActivityEYBFaker,
+    length,
+    overrides,
+    additionalOverrides: EYBOverrides,
+  })
+}
+
 export {
   companyActivityInteractionFaker,
   companyActivityInvestmentFaker,
@@ -158,6 +189,7 @@ export {
   companyActivityInvestmentListFaker,
   companyActivityOrderListFaker,
   companyActivityGreatListFaker,
+  companyActivityEYBListFaker,
 }
 
 export default companyActivityInteractionListFaker

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -391,12 +391,21 @@ describe('Company overview page', () => {
   // TODO - Unskip relevant parts of this test when we have the associated DAGs in place
   context('when viewing all activity cards types', () => {
     const interactionsList = companyActivityListFaker(1)
-    const investmentsList = companyActivityInvestmentListFaker(1)
-    const investmentsListNullJobs = companyActivityInvestmentListFaker(
+    const investmentsListWithJobsNoEYBLead =
+      companyActivityInvestmentListFaker(1)
+    const investmentsListNullJobsNoEYBLead = companyActivityInvestmentListFaker(
       1,
       {},
       { number_new_jobs: null }
     )
+    const investmentsListWithJobsHasEYBLead =
+      companyActivityInvestmentListFaker(1, {}, { eyb_leads: [{ id: '1' }] })
+    const investmentsListNullJobsHasEYBLead =
+      companyActivityInvestmentListFaker(
+        1,
+        {},
+        { number_new_jobs: null, eyb_leads: [{ id: '1' }] }
+      )
     const orderList = companyActivityOrderListFaker(1)
     const orderListNoPrimaryMarket = companyActivityOrderListFaker(
       1,
@@ -511,33 +520,71 @@ describe('Company overview page', () => {
         activity.interaction.subject
       )
     })
-    it('should display Data Hub investment activity', () => {
+    it('should display Data Hub investment activity with jobs and no link to EYB leads', () => {
       collectionListRequest(
         'v4/search/company-activity',
-        investmentsList,
+        investmentsListWithJobsNoEYBLead,
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
-      const activity = investmentsList[0]
+      const activity = investmentsListWithJobsNoEYBLead[0]
       cy.get('[data-test="investment-kind-label"]').contains(
         'New Investment Project'
       )
       cy.get('[data-test="activity-summary"]').contains(
         `${activity.investment.investment_type.name} investment for ${activity.investment.number_new_jobs} new jobs added by ${activity.investment.created_by.name}`
       )
+      cy.get('[data-test="activity-summary"]').should(
+        'not.include.text',
+        'from EYB lead'
+      )
     })
 
-    it('should display Data Hub investment activity with empty number of new jobs', () => {
+    it('should display Data Hub investment activity with empty number of new jobs and no link to an EYB lead', () => {
       collectionListRequest(
         'v4/search/company-activity',
-        investmentsListNullJobs,
+        investmentsListNullJobsNoEYBLead,
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
-      const activity = investmentsListNullJobs[0]
+      const activity = investmentsListNullJobsNoEYBLead[0]
       cy.get('[data-test="investment-kind-label"]').contains(
         'New Investment Project'
       )
       cy.get('[data-test="activity-summary"]').contains(
         `${activity.investment.investment_type.name} investment added by ${activity.investment.created_by.name}`
+      )
+      cy.get('[data-test="activity-summary"]').should(
+        'not.include.text',
+        'from EYB lead'
+      )
+    })
+
+    it('should display Data Hub investment activity with jobs and link to an EYB lead', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        investmentsListWithJobsHasEYBLead,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      const activity = investmentsListWithJobsHasEYBLead[0]
+      cy.get('[data-test="investment-kind-label"]').contains(
+        'New Investment Project'
+      )
+      cy.get('[data-test="activity-summary"]').contains(
+        `${activity.investment.investment_type.name} investment for ${activity.investment.number_new_jobs} new jobs added by ${activity.investment.created_by.name} from EYB lead`
+      )
+    })
+
+    it('should display Data Hub investment activity with empty number of new jobs and link to an EYB lead', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        investmentsListNullJobsHasEYBLead,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      const activity = investmentsListNullJobsHasEYBLead[0]
+      cy.get('[data-test="investment-kind-label"]').contains(
+        'New Investment Project'
+      )
+      cy.get('[data-test="activity-summary"]').contains(
+        `${activity.investment.investment_type.name} investment added by ${activity.investment.created_by.name} from EYB lead`
       )
     })
 

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -6,6 +6,7 @@ import {
 import { getCollectionList } from '../../support/collection-list-assertions'
 import { collectionListRequest } from '../../support/actions'
 import companyActivityListFaker, {
+  companyActivityEYBListFaker,
   companyActivityGreatListFaker,
   companyActivityInvestmentListFaker,
   companyActivityOrderListFaker,
@@ -420,6 +421,21 @@ describe('Company overview page', () => {
         urls.companies.overview.index(fixtures.company.venusLtd.id)
       )
     })
+    const EYBListHighValue = companyActivityEYBListFaker(
+      1,
+      {},
+      { is_high_value: true }
+    )
+    const EYBListLowValue = companyActivityEYBListFaker(
+      1,
+      {},
+      { is_high_value: false }
+    )
+    const EYBListUnknownValue = companyActivityEYBListFaker(
+      1,
+      {},
+      { is_high_value: null }
+    )
 
     it.skip('should display aventri event activity', () => {
       cy.get('[data-test="aventri-event-summary"]')
@@ -642,6 +658,42 @@ describe('Company overview page', () => {
       cy.get('[data-test="activity-subject"]').contains(subject)
       cy.get('[data-test="activity-summary"]').contains(
         `Enquirer ${activity.great_export_enquiry.contact.first_name} ${activity.great_export_enquiry.contact.last_name}`
+      )
+    })
+
+    it('should display Data Hub EYB lead activity with high value', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        EYBListHighValue,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      cy.get('[data-test="eyb-label"]').contains('EYB')
+      cy.get('[data-test="activity-summary"]').contains(
+        'A high-value EYB lead associated with this company has been added to Data Hub'
+      )
+    })
+
+    it('should display Data Hub EYB lead activity with low value', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        EYBListLowValue,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      cy.get('[data-test="eyb-label"]').contains('EYB')
+      cy.get('[data-test="activity-summary"]').contains(
+        'A low-value EYB lead associated with this company has been added to Data Hub'
+      )
+    })
+
+    it('should display Data Hub EYB lead activity with unknown value', () => {
+      collectionListRequest(
+        'v4/search/company-activity',
+        EYBListUnknownValue,
+        urls.companies.overview.index(fixtures.company.venusLtd.id)
+      )
+      cy.get('[data-test="eyb-label"]').contains('EYB')
+      cy.get('[data-test="activity-summary"]').contains(
+        'An unknown-value EYB lead associated with this company has been added to Data Hub'
       )
     })
   })

--- a/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
+++ b/test/sandbox/fixtures/v4/search/company-activity/activity-by-company-id.json
@@ -163,7 +163,8 @@
           "first_name": ""
         },
         "foreign_equity_investment": 234432,
-        "gross_value_added": "2000"
+        "gross_value_added": "2000",
+        "eyb_leads": []
       }
     },
     {
@@ -181,7 +182,7 @@
       "order": {
         "reference": "HAM/100",
         "uk_region": {
-          "name": "England", 
+          "name": "England",
           "id": "a80ff5fd-8904-4940-gd91-fe8047e34be5"
         },
         "created_on": "2024-10-16T13:21:06.209056+00:00",


### PR DESCRIPTION
## Description of change

This PR displays EYB activity on the relevant company overview page.

- EYB leads are displayed as recent activity cards and show their value (high/low/unknown) in the summary.
- Investment projects that have been created from an EYB lead have an updated summary that displays 'from EYB Lead' at the end.

## Test instructions
**EYB leads:**
- Add an EYB lead to your environment
- To populate your database with EYB Lead instances:

  - In Docker, go to the api container
  - Go to the 'Exec' tab
  - Run the following commands

```
python manage.py shell
from datahub.investment_lead.test.factories import EYBLeadFactory
EYBLeadFactory.create_batch(1)
```

- Ensure the EYB Lead is linked to a company
- Visit the company overview page for that company
- A card displaying the EYB lead should be displayed under 'Recent activity'
- The card should have the 'EYB' tag
- In Django Admin update the 'Is high value' field to yes/no/unknown and check that the EYB activity card summary updates accordingly ('yes' = 'A high-value', 'no' = 'A low-value', 'unknown' = 'An unknown-value')

<img width="476" alt="Screenshot 2024-12-18 at 09 53 05" src="https://github.com/user-attachments/assets/efe1c8e9-daa6-4d9d-9834-4ac7fccb48ef" />
<img width="476" alt="Screenshot 2024-12-18 at 09 53 40" src="https://github.com/user-attachments/assets/bb307318-e8af-4f32-8873-00f138652623" />
<img width="476" alt="Screenshot 2024-12-18 at 09 54 22" src="https://github.com/user-attachments/assets/07fd20b6-382c-451d-967a-7f0f97e92e25" />

**Linked investment projects:**
- Visit the details page for your EYB Lead
- Click on the 'Add investment project' button
- Complete the process of creating an investment project. This project will be linked to your EYB lead
- Return to the company overview page
- A card displaying the investment project should be displayed under 'Recent activity'
- Check that the end of the summary text includes 'from EYB lead'
- Any investment projects not linked to an EYB lead should not display this additional text

<img width="476" alt="Screenshot 2024-12-18 at 09 42 32" src="https://github.com/user-attachments/assets/64030dd5-aac5-4705-9fa3-73bc332da82c" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
