### PR TITLE
Remove `format` function and replace with `formatDate`

### DIFF
--- a/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
+++ b/src/apps/companies/apps/referrals/details/client/ReferralDetails.jsx
@@ -15,7 +15,10 @@ import Task from '../../../../../../client/components/Task'
 
 import { REFERRAL_DETAILS } from '../../../../../../client/actions'
 
-const { format } = require('../../../../../../client/utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} = require('../../../../../../client/utils/date-utils')
 
 export const AdviserDetails = ({ name, email, team }) => (
   <>
@@ -87,14 +90,14 @@ export default connect(({ referrerUrl, ...state }) => ({
                 {receivingAdviser && <AdviserDetails {...receivingAdviser} />}
               </SummaryTable.Row>
               <SummaryTable.Row heading="Date of referral">
-                {format(date)}
+                {formatDate(date, DATE_FORMAT_COMPACT)}
               </SummaryTable.Row>
               <SummaryTable.Row heading="Notes">{notes}</SummaryTable.Row>
             </SummaryTable>
             {completed ? (
               <SummaryTable caption="Referral accepted">
                 <SummaryTable.Row heading="Date">
-                  {format(completed.on)}
+                  {formatDate(completed.on, DATE_FORMAT_COMPACT)}
                 </SummaryTable.Row>
                 <SummaryTable.Row heading="By">
                   <AdviserDetails {...completed.by} />

--- a/src/apps/interactions/client/transformers.js
+++ b/src/apps/interactions/client/transformers.js
@@ -1,6 +1,9 @@
 import { get } from 'lodash'
 
-import { format } from '../../../client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../client/utils/date-utils'
 import urls from '../../../lib/urls'
 import { LABELS } from './constants'
 
@@ -52,7 +55,7 @@ export const transformInteractionToListItem = ({
 } = {}) => ({
   id,
   metadata: [
-    { label: 'Date', value: format(date, 'dd MMMM yyyy') },
+    { label: 'Date', value: formatDate(date, DATE_FORMAT_DAY_MONTH_YEAR) },
     {
       label: 'Contact(s)',
       value: contacts && formatContacts(contacts),

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseAccount.jsx
@@ -13,7 +13,7 @@ import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityOverviewSummary from './card/item-renderers/ActivityOverviewSummary'
 import OverviewActivityCardWrapper from './card/OverviewActivityCardWrapper'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 export default class CompaniesHouseAccount extends React.PureComponent {
   static propTypes = {
@@ -32,8 +32,9 @@ export default class CompaniesHouseAccount extends React.PureComponent {
     const { activity, isOverview } = this.props
     const startTime = get(activity, 'object.startTime')
     const summary = get(activity, 'summary')
-    const balanceSheetDate = format(
-      get(activity, 'object.dit:balanceSheetDate')
+    const balanceSheetDate = formatDate(
+      get(activity, 'object.dit:balanceSheetDate'),
+      DATE_FORMAT_COMPACT
     )
     const netAssetsLiabilities = currencyGBP(
       get(
@@ -41,12 +42,18 @@ export default class CompaniesHouseAccount extends React.PureComponent {
         'object.dit:netAssetsLiabilitiesIncludingPensionAssetLiability'
       )
     )
-    const periodEnd = format(get(activity, 'object.dit:periodEnd'))
-    const periodStart = format(get(activity, 'object.dit:periodStart'))
+    const periodEnd = formatDate(
+      get(activity, 'object.dit:periodEnd'),
+      DATE_FORMAT_COMPACT
+    )
+    const periodStart = formatDate(
+      get(activity, 'object.dit:periodStart'),
+      DATE_FORMAT_COMPACT
+    )
     const shareholderFunds = currencyGBP(
       get(activity, 'object.dit:shareholderFunds')
     )
-    const date = format(startTime)
+    const date = formatDate(startTime, DATE_FORMAT_COMPACT)
     const metadata = [
       { label: 'Date', value: date },
       { label: 'Balance sheet date', value: balanceSheetDate },

--- a/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
+++ b/src/client/components/ActivityFeed/activities/CompaniesHouseCompany.jsx
@@ -11,7 +11,7 @@ import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityOverviewSummary from './card/item-renderers/ActivityOverviewSummary'
 import OverviewActivityCardWrapper from './card/OverviewActivityCardWrapper'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 export default class CompaniesHouseCompany extends React.PureComponent {
   static propTypes = {
@@ -35,21 +35,27 @@ export default class CompaniesHouseCompany extends React.PureComponent {
     const subject = get(activity, 'summary')
     const address = get(activity, 'object.location:dit:address')
     const postcode = get(activity, 'object.location:dit:postcode')
-    const confStmtLastMadeUpDate = format(
+    const confStmtLastMadeUpDate = formatDate(
       get(activity, 'object.dit:confStmtLastMadeUpDate')
     )
-    const confStmtNextDueDate = format(
-      get(activity, 'object.dit:confStmtNextDueDate')
+    const confStmtNextDueDate = formatDate(
+      get(activity, 'object.dit:confStmtNextDueDate'),
+      DATE_FORMAT_COMPACT
     )
-    const incorporationDate = format(
+    const incorporationDate = formatDate(
       get(activity, 'object.dit:incorporationDate')
     )
-    const nextDueDate = format(get(activity, 'object.dit:nextDueDate'))
-    const returnsLastMadeUpDate = format(
-      get(activity, 'object.dit:returnsLastMadeUpDate')
+    const nextDueDate = formatDate(
+      get(activity, 'object.dit:nextDueDate'),
+      DATE_FORMAT_COMPACT
     )
-    const returnsNextDueDate = format(
-      get(activity, 'object.dit:returnsNextDueDate')
+    const returnsLastMadeUpDate = formatDate(
+      get(activity, 'object.dit:returnsLastMadeUpDate'),
+      DATE_FORMAT_COMPACT
+    )
+    const returnsNextDueDate = formatDate(
+      get(activity, 'object.dit:returnsNextDueDate'),
+      DATE_FORMAT_COMPACT
     )
     const sicCodes = get(activity, 'object.dit:sicCodes')
 
@@ -60,7 +66,7 @@ export default class CompaniesHouseCompany extends React.PureComponent {
       </span>
     ))
 
-    const date = format(startTime)
+    const date = formatDate(startTime, DATE_FORMAT_COMPACT)
 
     const metadata = [
       { label: 'Date', value: date },

--- a/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
+++ b/src/client/components/ActivityFeed/activities/DirectoryFormsApi.jsx
@@ -11,7 +11,7 @@ import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 import ActivityOverviewSummary from './card/item-renderers/ActivityOverviewSummary'
 
-import { format } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import OverviewActivityCardWrapper from './card/OverviewActivityCardWrapper'
 
 export default class DirectoryFormsApi extends React.PureComponent {
@@ -67,7 +67,7 @@ export default class DirectoryFormsApi extends React.PureComponent {
           )
         )
       const metadata = [
-        { label: 'Date', value: format(sentDate) },
+        { label: 'Date', value: formatDate(sentDate, DATE_FORMAT_COMPACT) },
         {
           label: 'Contact(s)',
           value: formattedContacts(),
@@ -83,7 +83,7 @@ export default class DirectoryFormsApi extends React.PureComponent {
         <OverviewActivityCardWrapper dataTest="export-support-service-summary">
           <ActivityOverviewSummary
             activity={activity}
-            date={format(sentDate)}
+            date={formatDate(sentDate, DATE_FORMAT_COMPACT)}
             kind={kind}
             url={url}
             subject={subject}

--- a/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
+++ b/src/client/components/ActivityFeed/activities/HmrcExporter.jsx
@@ -11,7 +11,7 @@ import ActivityCardMetadata from './card/ActivityCardMetadata'
 import ActivityOverviewSummary from './card/item-renderers/ActivityOverviewSummary'
 import OverviewActivityCardWrapper from './card/OverviewActivityCardWrapper'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 export default class HmrcExporter extends React.PureComponent {
   static propTypes = {
@@ -40,7 +40,7 @@ export default class HmrcExporter extends React.PureComponent {
         </span>
       )
     )
-    const date = format(startTime)
+    const date = formatDate(startTime, DATE_FORMAT_COMPACT)
     const metadata = [
       { label: 'Date', value: date },
       { label: 'Export item code(s)', value: exportItemCodesList },

--- a/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
+++ b/src/client/components/ActivityFeed/activities/MaxemailCampaign.jsx
@@ -11,7 +11,7 @@ import ActivityCardLabels from './card/ActivityCardLabels'
 import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 export default class MaxemailCampaign extends React.PureComponent {
   static propTypes = {
@@ -39,7 +39,7 @@ export default class MaxemailCampaign extends React.PureComponent {
     ))
 
     const metadata = [
-      { label: 'Date', value: format(published) },
+      { label: 'Date', value: formatDate(published, DATE_FORMAT_COMPACT) },
       { label: 'Senders name', value: name },
       { label: 'Senders email', value: from },
       { label: 'Content', value: content },

--- a/src/client/components/ActivityFeed/activities/card/CardHeader.jsx
+++ b/src/client/components/ActivityFeed/activities/card/CardHeader.jsx
@@ -16,7 +16,10 @@ import { BLUE, GREY_1, GREY_4 } from '../../../../utils/colours'
 import Badge from '../../../Badge'
 import { SOURCE_TYPES } from '../../constants'
 
-const { format } = require('../../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} = require('../../../../utils/date-utils')
 
 const StyledBlockText = styled(H3)`
   display: inline-block;
@@ -118,7 +121,9 @@ const CardHeader = ({
       </StyledHeadingWrapper>
 
       <StyledMetaItems>
-        {startTime && <ListItem>{format(startTime)}</ListItem>}
+        {startTime && (
+          <ListItem>{formatDate(startTime, DATE_FORMAT_COMPACT)}</ListItem>
+        )}
 
         {badge && (
           <ListItem>

--- a/src/client/components/ArchivePanel/index.jsx
+++ b/src/client/components/ArchivePanel/index.jsx
@@ -6,7 +6,7 @@ import { SPACING, FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import Link from '@govuk-react/link'
 
 import StatusMessage from '../../../client/components/StatusMessage'
-import { format } from '../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../utils/date-utils'
 
 const negativeSpacing = '-' + SPACING.SCALE_4
 
@@ -48,10 +48,11 @@ const ArchivePanel = ({
     <StatusMessage>
       <StyledMessage data-test="archive-message">
         {archivedBy
-          ? `This ${type} was ${archiveMessage} on ${format(
-              archivedOn
+          ? `This ${type} was ${archiveMessage} on ${formatDate(
+              archivedOn,
+              DATE_FORMAT_COMPACT
             )} by ${checkArchiverFormat(archivedBy)}.`
-          : `This ${type} was automatically archived on ${format(archivedOn)}.`}
+          : `This ${type} was automatically archived on ${formatDate(archivedOn, DATE_FORMAT_COMPACT)}.`}
       </StyledMessage>
       <StyledReason data-test="archive-reason">{`Reason: ${archiveReason}`}</StyledReason>
       {unarchiveUrl && (

--- a/src/client/components/CompanyLists/Table.jsx
+++ b/src/client/components/CompanyLists/Table.jsx
@@ -18,7 +18,7 @@ import urls from '../../../lib/urls'
 import { MEDIA_QUERIES } from '../../utils/responsive'
 import SecondaryButton from '../SecondaryButton'
 
-const { format } = require('../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../utils/date-utils')
 
 const StyledButtonLink = styled.a({
   marginBottom: 0,
@@ -159,7 +159,9 @@ const CompaniesTable = ({ companies }) => (
               />
             </StyledLink>
           </TitleCell>
-          <ColumnLabelCell>{date ? format(date) : '-'}</ColumnLabelCell>
+          <ColumnLabelCell>
+            {date ? formatDate(date, DATE_FORMAT_COMPACT) : '-'}
+          </ColumnLabelCell>
           <StyledTableCell>
             {interactionId ? (
               <StyledLink href={urls.interactions.detail(interactionId)}>

--- a/src/client/components/ContactLocalHeader/index.jsx
+++ b/src/client/components/ContactLocalHeader/index.jsx
@@ -100,8 +100,8 @@ const ContactLocalHeader = ({ contact, writeFlashMessage }) => {
         </GridRow>
         {contact.archived && (
           <ArchivePanel
-            archivedBy={contact.archivedBy ? contact.archivedBy : ''}
-            archivedOn={contact.archivedOn ? contact.archivedOn : ''}
+            archivedBy={contact.archivedBy}
+            archivedOn={contact.archivedOn}
             archiveReason={contact.archivedReason}
             unarchiveUrl={urls.contacts.unarchive(contact.id)}
             onClick={() => {

--- a/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
+++ b/src/client/components/MyInvestmentProjects/InvestmentDetails.jsx
@@ -6,7 +6,7 @@ import { SPACING, FONT_SIZE, FONT_WEIGHTS } from '@govuk-react/constants'
 import { companies, interactions } from '../../../lib/urls'
 import { GREY_3, DARK_GREY } from '../../utils/colours'
 
-const { format } = require('../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../utils/date-utils')
 
 const StyledDiv = styled('div')({
   height: '100%',
@@ -75,7 +75,9 @@ const InvestmentDetails = ({
       {latestInteraction && (
         <>
           <StyledDT>Last interaction:</StyledDT>
-          <StyledDD>{format(latestInteraction.date)}</StyledDD>
+          <StyledDD>
+            {formatDate(latestInteraction.date, DATE_FORMAT_COMPACT)}
+          </StyledDD>
           <StyledDT>Interaction subject:</StyledDT>
           <StyledDD>
             <Link href={interactions.detail(latestInteraction.id)}>

--- a/src/client/components/ReferralList/Referral.jsx
+++ b/src/client/components/ReferralList/Referral.jsx
@@ -9,7 +9,7 @@ import { AdviserDetails } from '../../../apps/companies/apps/referrals/details/c
 import { Card, CardHeader } from '../ActivityFeed/activities/card'
 import SummaryList from '../../components/SummaryList'
 import urls from '../../../lib/urls'
-import { format } from '../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../utils/date-utils'
 
 const StyledSummaryListWrapper = styled.div({
   flexGrow: 1,
@@ -75,7 +75,7 @@ const Referral = ({
             ? [
                 {
                   label: 'Accepted on',
-                  value: format(dateAccepted),
+                  value: formatDate(dateAccepted, DATE_FORMAT_COMPACT),
                 },
               ]
             : []),

--- a/src/client/modules/Companies/AccountManagement/ArchivedObjectives.jsx
+++ b/src/client/modules/Companies/AccountManagement/ArchivedObjectives.jsx
@@ -11,7 +11,7 @@ import {
 } from '../../../components/Resource'
 import { buildCompanyBreadcrumbs } from '../utils'
 import { DARK_GREY, GREY_2 } from '../../../utils/colours'
-import { format } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
 
 const BorderContainer = styled('div')`
@@ -42,7 +42,7 @@ const objectiveMetadata = (objective) => {
     },
     {
       label: 'Due date',
-      value: format(objective.targetDate),
+      value: formatDate(objective.targetDate, DATE_FORMAT_COMPACT),
     },
     {
       label: 'Progress',
@@ -102,13 +102,13 @@ const ArchivedObjectives = () => {
                               <LastUpdatedHeading data-test="last-updated-details">
                                 <span>{`Objective complete. Updated by ${
                                   objective?.modifiedBy?.name
-                                }: ${format(objective.modifiedOn)}`}</span>
+                                }: ${formatDate(objective.modifiedOn, DATE_FORMAT_COMPACT)}`}</span>
                               </LastUpdatedHeading>
                             ) : (
                               <LastUpdatedHeading data-test="last-updated-details">
                                 <span>{`Objective incomplete. Archived by ${
                                   objective?.modifiedBy?.name
-                                }: ${format(objective.modifiedOn)}`}</span>
+                                }: ${formatDate(objective.modifiedOn, DATE_FORMAT_COMPACT)}`}</span>
                               </LastUpdatedHeading>
                             )}
                           </GridCol>

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -15,7 +15,10 @@ import {
   CompanyResource,
 } from '../../../components/Resource'
 import urls from '../../../../lib/urls'
-import { format } from '../../../../client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../client/utils/date-utils'
 import { DARK_GREY, GREY_2, GREY_3, TEXT_COLOUR } from '../../../utils/colours'
 import { LeadITA } from './LeadAdvisers'
 import { CoreTeamAdvisers } from '../CoreTeam/CoreTeam'
@@ -113,8 +116,9 @@ const Strategy = ({ company }) => (
           <GridRow>
             <GridCol>
               <LastUpdatedHeading data-test="last-updated-strategy-details">
-                <span>{`Last updated by ${company?.modifiedBy?.name}: ${format(
-                  company.modifiedOn
+                <span>{`Last updated by ${company?.modifiedBy?.name}: ${formatDate(
+                  company.modifiedOn,
+                  DATE_FORMAT_COMPACT
                 )}. `}</span>
                 <span>
                   View changes in{' '}
@@ -181,7 +185,7 @@ const Objectives = ({ company }) => (
                   <LastUpdatedHeading data-test="last-updated-details">
                     <span>{`Last updated by ${
                       objective?.modifiedBy?.name
-                    }: ${format(objective.modifiedOn)}`}</span>
+                    }: ${formatDate(objective.modifiedOn, DATE_FORMAT_COMPACT)}`}</span>
                   </LastUpdatedHeading>
                 </GridCol>
               </GridRow>
@@ -234,7 +238,7 @@ const objectiveMetadata = (objective) => {
     },
     {
       label: 'Due date',
-      value: format(objective.targetDate),
+      value: formatDate(objective.targetDate, DATE_FORMAT_COMPACT),
     },
     {
       label: 'Progress',

--- a/src/client/modules/Companies/CollectionList/transformers.js
+++ b/src/client/modules/Companies/CollectionList/transformers.js
@@ -2,12 +2,11 @@ import { get } from 'lodash'
 
 import labels from './labels'
 import urls from '../../../../lib/urls'
-
 import { addressToString } from '../../../utils/addresses'
 
-const { format } = require('../../../utils/date')
 const {
   formatDate,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../../utils/date-utils')
 
@@ -58,7 +57,7 @@ const transformCompanyToListItem = ({
   if (latest_interaction_date) {
     metadata.push({
       label: 'Last interaction date',
-      value: format(latest_interaction_date),
+      value: formatDate(latest_interaction_date, DATE_FORMAT_COMPACT),
     })
   }
 

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyBusinessDetails.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyBusinessDetails.jsx
@@ -23,7 +23,7 @@ import {
 import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import Task from '../../../components/Task'
 import urls from '../../../../lib/urls'
-import { format } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 
 import {
   ID,
@@ -90,7 +90,10 @@ const CompanyBusinessDetails = ({
                 .
               </div>
               {lastUpdated(company) && (
-                <div>Last updated on: {format(lastUpdated(company))}</div>
+                <div>
+                  Last updated on:{' '}
+                  {formatDate(lastUpdated(company), DATE_FORMAT_COMPACT)}
+                </div>
               )}
               <Task.Status
                 name={DNB__CHECK_PENDING_REQUEST}

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkGlobalHQ/transformers.js
@@ -5,9 +5,9 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format } = require('../../../../utils/date')
 const {
   formatDate,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../../../utils/date-utils')
 
@@ -46,7 +46,7 @@ const transformGlobalHQToListItem = (childCompanyId) => (company) => {
   if (latest_interaction_date) {
     metadata.push({
       label: 'Last interaction date',
-      value: format(latest_interaction_date),
+      value: formatDate(latest_interaction_date, DATE_FORMAT_COMPACT),
     })
   }
 

--- a/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/transformers.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/LinkSubsidiary/transformers.js
@@ -5,9 +5,9 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format } = require('../../../../utils/date')
 const {
   formatDate,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../../../utils/date-utils')
 
@@ -54,7 +54,7 @@ const transformSubsidiaryToListItem = (parentCompanyId) => (company) => {
   if (latest_interaction_date) {
     metadata.push({
       label: 'Last interaction date',
-      value: format(latest_interaction_date),
+      value: formatDate(latest_interaction_date, DATE_FORMAT_COMPACT),
     })
   }
 

--- a/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
+++ b/src/client/modules/Companies/CompanyHierarchy/CompanyTree.jsx
@@ -39,7 +39,7 @@ import {
 } from './styled'
 import { addressToString } from '../../../utils/addresses'
 import { GREY_4, BLACK, WHITE, BLUE } from '../../../utils/colours'
-import { format } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import { hqLabels } from '../../../../apps/companies/labels'
 
 const ToggleSubsidiariesButton = ({
@@ -405,7 +405,10 @@ const HierarchyItem = ({
               <dt>Last interaction date</dt>
               <dd>
                 {company.latest_interaction_date
-                  ? format(company.latest_interaction_date)
+                  ? formatDate(
+                      company.latest_interaction_date,
+                      DATE_FORMAT_COMPACT
+                    )
                   : 'Not set'}
               </dd>
             </InlineDescriptionList>

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/ProfileDetailsTable.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/ProfileDetailsTable.jsx
@@ -2,7 +2,10 @@ import React from 'react'
 
 import { SummaryTable } from '../../../../components'
 import { requiredCheckTypes } from './constants'
-import { formatDate, DATE_FORMAT_COMPACT } from '../../../../utils/date-utils'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../../utils/date-utils'
 
 const buildRequiredCheckField = (
   requiredChecks,
@@ -18,7 +21,7 @@ const buildRequiredCheckField = (
       `\n` +
       `Date of most recent background checks: ${formatDate(
         requiredChecksConductedOn,
-        DATE_FORMAT_COMPACT
+        DATE_FORMAT_DAY_MONTH_YEAR
       )}` +
       `\n` +
       `Person responsible for most recent background checks: ${requiredChecksConductedBy?.name}`

--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/ProfileDetailsTable.jsx
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/ProfileDetailsTable.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { SummaryTable } from '../../../../components'
 import { requiredCheckTypes } from './constants'
-import { format } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../../utils/date-utils'
 
 const buildRequiredCheckField = (
   requiredChecks,
@@ -16,9 +16,9 @@ const buildRequiredCheckField = (
     return (
       requiredChecks.name +
       `\n` +
-      `Date of most recent background checks: ${format(
+      `Date of most recent background checks: ${formatDate(
         requiredChecksConductedOn,
-        'dd MM yyyy'
+        DATE_FORMAT_COMPACT
       )}` +
       `\n` +
       `Person responsible for most recent background checks: ${requiredChecksConductedBy?.name}`

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ExportStatusCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ExportStatusCard.jsx
@@ -13,7 +13,7 @@ import {
   exportWinsState2props,
 } from './state'
 import { OVERVIEW__EXPORT_WINS_SUMMARY } from '../../../../actions'
-import { format } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../../utils/date-utils'
 import { transformExportCountries } from '../../CompanyExports/transformers'
 import { companies } from '../../../../../lib/urls'
 import { buildCellContents } from './transformers'
@@ -185,7 +185,7 @@ export const ExportStatusDetails = ({
         latestExportWin.error ? (
           <StyledSpan>{latestExportWin.error}</StyledSpan>
         ) : (
-          `${format(latestExportWin.date)}, ${latestExportWin.country}`
+          `${formatDate(latestExportWin.date, DATE_FORMAT_COMPACT)}, ${latestExportWin.country}`
         )
       ) : (
         'No export wins recorded'

--- a/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
@@ -19,7 +19,10 @@ import {
   StyledTableRow,
 } from './components'
 
-const { format } = require('../../../../utils/date')
+const {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} = require('../../../../utils/date-utils')
 
 const buildProjectStatusUrl = (companyId, param) =>
   urls.companies.investments.companyInvestmentProjects(companyId) + param
@@ -74,7 +77,7 @@ const InvestmentStatusCard = ({
                 )}
                 data-test="latest-won-project-link"
               >
-                {`${format(summary.won.last_won_project.last_changed)} - ${
+                {`${formatDate(summary.won.last_won_project.last_changed, DATE_FORMAT_COMPACT)} - ${
                   summary.won.last_won_project.name
                 }`}
               </Link>

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -12,7 +12,10 @@ import { EXPORT_LOADED } from '../../../actions'
 import { DefaultLayout, SummaryTable } from '../../../components'
 import Task from '../../../components/Task'
 import { ID, state2props, TASK_GET_EXPORT_DETAIL } from './state'
-import { format } from '../../../../client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../../client/utils/date-utils'
 import { currencyGBP } from '../../../../client/utils/number-utils'
 import { BLACK, GREY_3 } from '../../../utils/colours'
 import { transformIdNameToValueLabel } from '../../../transformers'
@@ -136,7 +139,10 @@ const ExportDetailsForm = ({ exportItem }) => {
                   >
                     {isEmpty(exportItem.estimated_win_date)
                       ? 'Not set'
-                      : format(exportItem.estimated_win_date, 'MMMM yyyy')}
+                      : formatDate(
+                          exportItem.estimated_win_date,
+                          DATE_FORMAT_DAY_MONTH_YEAR
+                        )}
                   </SummaryTable.Row>
                   <SummaryTable.Row heading="Status" hideWhenEmpty={false}>
                     {isEmpty(exportItem.status)

--- a/src/client/modules/ExportPipeline/ExportDetails/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportDetails/index.jsx
@@ -14,7 +14,7 @@ import Task from '../../../components/Task'
 import { ID, state2props, TASK_GET_EXPORT_DETAIL } from './state'
 import {
   formatDate,
-  DATE_FORMAT_DAY_MONTH_YEAR,
+  DATE_FORMAT_MONTH_YEAR,
 } from '../../../../client/utils/date-utils'
 import { currencyGBP } from '../../../../client/utils/number-utils'
 import { BLACK, GREY_3 } from '../../../utils/colours'
@@ -141,7 +141,7 @@ const ExportDetailsForm = ({ exportItem }) => {
                       ? 'Not set'
                       : formatDate(
                           exportItem.estimated_win_date,
-                          DATE_FORMAT_DAY_MONTH_YEAR
+                          DATE_FORMAT_MONTH_YEAR
                         )}
                   </SummaryTable.Row>
                   <SummaryTable.Row heading="Status" hideWhenEmpty={false}>

--- a/src/client/modules/Interactions/CollectionList/transformers.js
+++ b/src/client/modules/Interactions/CollectionList/transformers.js
@@ -1,7 +1,10 @@
 /* eslint-disable camelcase */
 import { get } from 'lodash'
 
-import { format } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../utils/date-utils'
 
 import urls from '../../../../lib/urls'
 
@@ -55,7 +58,7 @@ export const transformInteractionToListItem = ({
 } = {}) => ({
   id,
   metadata: [
-    { label: 'Date', value: format(date, 'dd MMMM yyyy') },
+    { label: 'Date', value: formatDate(date, DATE_FORMAT_DAY_MONTH_YEAR) },
     {
       label: 'Contact(s)',
       value: contacts && formatContacts(contacts),

--- a/src/client/modules/Interactions/InteractionDetails/InteractionReferralDetails.jsx
+++ b/src/client/modules/Interactions/InteractionDetails/InteractionReferralDetails.jsx
@@ -6,7 +6,7 @@ import styled from 'styled-components'
 import { SummaryTable } from '../../../components'
 import urls from '../../../../lib/urls'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 const StyledSummaryTable = styled(SummaryTable)({
   'margin-top': SPACING_POINTS[8],
@@ -24,7 +24,7 @@ const InteractionReferralDetails = ({ referral, companyId }) => {
         </Link>
       </SummaryTable.Row>
       <SummaryTable.Row heading="Sent on">
-        {format(referral.createdOn)}
+        {formatDate(referral.createdOn, DATE_FORMAT_COMPACT)}
       </SummaryTable.Row>
       <SummaryTable.Row heading="By">
         {referral.createdBy.name}

--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { useParams } from 'react-router-dom'
 import { Link } from 'govuk-react'
 
-import { format } from '../../../utils/date'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
@@ -49,7 +49,10 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="Submitted to EYB"
-                children={format(eybLead.triageCreated, 'dd MMM yyyy')}
+                children={formatDate(
+                  eybLead.triageCreated,
+                  DATE_FORMAT_COMPACT
+                )}
               />
               <SummaryTable.Row heading="Company website address">
                 {eybLead.companyWebsite ? (

--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -1,7 +1,7 @@
 import urls from '../../../../lib/urls'
 import { TAG_COLOURS } from '../../../components/Tag'
-import { format } from '../../../utils/date'
 import { VALUES_VALUE_TO_LABEL_MAP } from './constants'
+import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 
 export const transformLeadToListItem = ({
   id,
@@ -29,7 +29,7 @@ export const transformLeadToListItem = ({
   const metadata = [
     {
       label: 'Submitted to EYB',
-      value: format(triage_created, 'dd MMM yyyy'),
+      value: formatDate(triage_created, DATE_FORMAT_COMPACT),
     },
     { label: 'Estimated spend', value: spend },
     { label: 'Sector', value: sector ? sector.name : '' },

--- a/src/client/modules/Investments/Profiles/transformers.js
+++ b/src/client/modules/Investments/Profiles/transformers.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import { companies } from '../../../../lib/urls'
 
-const { format } = require('../../../utils/date')
+const { formatDate, DATE_FORMAT_COMPACT } = require('../../../utils/date-utils')
 
 const transformLargeCapitalProfiles = ({ investor_company, created_on }) => ({
   headingText: investor_company.name,
@@ -10,7 +10,7 @@ const transformLargeCapitalProfiles = ({ investor_company, created_on }) => ({
   metadata: [
     {
       label: 'Updated on',
-      value: format(created_on),
+      value: formatDate(created_on, DATE_FORMAT_COMPACT),
     },
   ],
 })

--- a/src/client/modules/Investments/Projects/Details/EditAssociatedProject/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/EditAssociatedProject/transformers.js
@@ -1,5 +1,8 @@
 import urls from '../../../../../../lib/urls'
-import { format } from '../../../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../../utils/date-utils'
 
 export const checkIfAssociatedProjectExists = (hasAssociatedProject) =>
   hasAssociatedProject ? 'Update associated project' : 'Add associated project'
@@ -28,7 +31,9 @@ const transformNonFdiProjectToListItem = (projectId) => (project) => {
     { label: 'Sector', value: sector ? sector.name : '' },
     {
       label: 'Estimated land date',
-      value: estimated_land_date && format(estimated_land_date, 'MMMM yyyy'),
+      value:
+        estimated_land_date &&
+        formatDate(estimated_land_date, DATE_FORMAT_MONTH_YEAR),
     },
   ].filter((metadata) => metadata.value)
 

--- a/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/EditRecipientCompany/transformers.js
@@ -3,9 +3,9 @@ import { get } from 'lodash'
 import urls from '../../../../../../lib/urls'
 import labels from '../../../../Companies/CollectionList/labels'
 import { addressToString } from '../../../../../utils/addresses'
-import { format } from '../../../../../utils/date'
 import {
   formatDate,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../../../../utils/date-utils'
 
@@ -51,7 +51,7 @@ const transformCompanyToListItem =
     if (latest_interaction_date) {
       metadata.push({
         label: 'Last interaction date',
-        value: format(latest_interaction_date),
+        value: formatDate(latest_interaction_date, DATE_FORMAT_COMPACT),
       })
     }
 

--- a/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
@@ -23,8 +23,11 @@ import { transformBusinessActivity } from './transformers'
 import urls from '../../../../../lib/urls'
 import { state2props } from './state'
 import { transformArray } from '../../../Companies/CompanyInvestments/LargeCapitalProfile/transformers'
-import { format } from '../../../../utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../../common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_FULL,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../utils/date-utils'
 import { GREY_3, BLACK } from '../../../../utils/colours'
 import { currencyGBP } from '../../../../utils/number-utils'
 import InvestmentName from '../InvestmentName'
@@ -157,7 +160,10 @@ const ProjectDetails = ({ currentAdviserId }) => {
               {project.estimatedLandDate ? (
                 <SummaryTable.TextRow
                   heading="Estimated land date"
-                  value={format(project.estimatedLandDate, 'MMMM yyyy')}
+                  value={formatDate(
+                    project.estimatedLandDate,
+                    DATE_FORMAT_MONTH_YEAR
+                  )}
                 />
               ) : null}
               {project.likelihoodToLand ? (
@@ -169,7 +175,7 @@ const ProjectDetails = ({ currentAdviserId }) => {
               {project.actualLandDate ? (
                 <SummaryTable.TextRow
                   heading="Actual land date"
-                  value={format(project.actualLandDate, DATE_LONG_FORMAT_1)}
+                  value={formatDate(project.actualLandDate, DATE_FORMAT_FULL)}
                 />
               ) : null}
               {project.investorType ? (

--- a/src/client/modules/Investments/Projects/ProjectEvaluation.jsx
+++ b/src/client/modules/Investments/Projects/ProjectEvaluation.jsx
@@ -17,8 +17,7 @@ import {
   transformFdiType,
 } from './transformers'
 import urls from '../../../../lib/urls'
-import { format } from '../../../utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../../common/constants'
+import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import ProjectLayoutNew from '../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from './InvestmentName'
 
@@ -92,7 +91,9 @@ const landingTable = (ukCompany = null, actualLandDate) => (
     <SummaryTable.TextRow
       heading="Actual land date"
       value={
-        actualLandDate ? format(actualLandDate, DATE_LONG_FORMAT_1) : NOT_KNOWN
+        actualLandDate
+          ? formatDate(actualLandDate, DATE_FORMAT_FULL)
+          : NOT_KNOWN
       }
     />
   </SummaryTable>

--- a/src/client/modules/Investments/Projects/Team/EditProjectManagement.jsx
+++ b/src/client/modules/Investments/Projects/Team/EditProjectManagement.jsx
@@ -21,7 +21,10 @@ import {
   InvestmentResource,
 } from '../../../../components/Resource'
 import ProjectLayout from '../../../../components/Layout/ProjectLayout'
-import { format } from '../../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../utils/date-utils'
 import { currencyGBP } from '../../../../utils/number-utils'
 
 const EditProjectManagement = () => {
@@ -125,7 +128,10 @@ const EditProjectManagement = () => {
                   />
                   <SummaryTable.Row
                     heading="Estimated land date"
-                    children={format(project.estimatedLandDate, 'MMMM yyyy')}
+                    children={formatDate(
+                      project.estimatedLandDate,
+                      DATE_FORMAT_MONTH_YEAR
+                    )}
                   />
                   <SummaryTable.Row
                     heading="Total investment"

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -18,7 +18,10 @@ import {
   STAGE_VERIFY_WIN,
   STAGE_WON,
 } from './constants'
-import { format } from '../../../utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../utils/date-utils'
 
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 import { idNamesToValueLabels } from '../../../utils'
@@ -220,8 +223,14 @@ export const transformPropositionToListItem = ({
 }) => ({
   id,
   metadata: [
-    { label: 'Deadline', value: format(deadline, 'dd MMMM yyyy') },
-    { label: 'Created on', value: format(created_on, 'dd MMMM yyyy') },
+    {
+      label: 'Deadline',
+      value: formatDate(deadline, DATE_FORMAT_DAY_MONTH_YEAR),
+    },
+    {
+      label: 'Created on',
+      value: formatDate(created_on, DATE_FORMAT_DAY_MONTH_YEAR),
+    },
     {
       label: 'Adviser',
       value: adviser.name,
@@ -266,7 +275,9 @@ export const transformInvestmentProjectToListItem = ({
     { label: 'Sector', value: sector ? sector.name : '' },
     {
       label: 'Estimated land date',
-      value: estimated_land_date && format(estimated_land_date, 'MMMM yyyy'),
+      value:
+        estimated_land_date &&
+        formatDate(estimated_land_date, DATE_FORMAT_DAY_MONTH_YEAR),
     },
   ].filter((metadata) => metadata.value)
 
@@ -303,10 +314,15 @@ export const transformTaskToListItem = ({
   headingText: title,
   subheading: getTaskSubheading(archived),
   metadata: [
-    { label: 'Date created', value: format(createdOn, 'dd MMMM yyyy') },
+    {
+      label: 'Date created',
+      value: formatDate(createdOn, DATE_FORMAT_DAY_MONTH_YEAR),
+    },
     {
       label: 'Due date',
-      value: dueDate ? format(dueDate, 'dd MMMM yyyy') : NOT_SET_TEXT,
+      value: dueDate
+        ? formatDate(dueDate, DATE_FORMAT_DAY_MONTH_YEAR)
+        : NOT_SET_TEXT,
     },
     { label: 'Assigned to', value: advisers.map((a) => a.name).join(', ') },
   ],

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -20,6 +20,7 @@ import {
 } from './constants'
 import {
   formatDate,
+  DATE_FORMAT_MONTH_YEAR,
   DATE_FORMAT_DAY_MONTH_YEAR,
 } from '../../../utils/date-utils'
 
@@ -277,7 +278,7 @@ export const transformInvestmentProjectToListItem = ({
       label: 'Estimated land date',
       value:
         estimated_land_date &&
-        formatDate(estimated_land_date, DATE_FORMAT_DAY_MONTH_YEAR),
+        formatDate(estimated_land_date, DATE_FORMAT_MONTH_YEAR),
     },
   ].filter((metadata) => metadata.value)
 

--- a/src/client/modules/Omis/CollectionList/transformers.js
+++ b/src/client/modules/Omis/CollectionList/transformers.js
@@ -4,10 +4,10 @@ import { STATUSES } from './constants'
 import { omis } from '../../../../lib/urls'
 import { currencyGBP } from '../../../utils/number-utils'
 
-const { format } = require('../../../utils/date')
 const {
   formatDate,
   DATE_FORMAT_MEDIUM,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../../utils/date-utils')
 
@@ -51,7 +51,9 @@ export const transformOrderToListItem = ({
     },
     {
       label: 'Delivery date',
-      value: delivery_date ? format(delivery_date) : null,
+      value: delivery_date
+        ? formatDate(delivery_date, DATE_FORMAT_COMPACT)
+        : null,
     },
   ].filter((item) => item.value)
 

--- a/src/client/modules/Omis/CreateOrder/CompanySelect/transformers.js
+++ b/src/client/modules/Omis/CreateOrder/CompanySelect/transformers.js
@@ -5,9 +5,9 @@ import urls from '../../../../../lib/urls'
 
 import { addressToString } from '../../../../utils/addresses'
 
-const { format } = require('../../../../utils/date')
 const {
   formatDate,
+  DATE_FORMAT_COMPACT,
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } = require('../../../../utils/date-utils')
 
@@ -48,7 +48,7 @@ const transformCompanyToListItem = ({
   if (latest_interaction_date) {
     metadata.push({
       label: 'Last interaction date',
-      value: format(latest_interaction_date),
+      value: formatDate(latest_interaction_date, DATE_FORMAT_COMPACT),
     })
   }
 

--- a/src/client/modules/Omis/PaymentReceipt.jsx
+++ b/src/client/modules/Omis/PaymentReceipt.jsx
@@ -12,8 +12,7 @@ import {
 } from '../../components/Resource'
 import OMISLayout from './OMISLayout'
 import { DARK_GREY } from '../../utils/colours'
-import { format } from '../../utils/date'
-import { DATE_LONG_FORMAT_1 } from '../../../common/constants'
+import { formatDate, DATE_FORMAT_FULL } from '../../utils/date-utils'
 import { currencyGBP } from '../../utils/number-utils'
 import { ButtonLink } from '../../components'
 import urls from '../../../lib/urls'
@@ -78,7 +77,7 @@ export const AddressSection = ({ invoice, paymentDate }) => (
           Receipt date
         </StyledSectionHeading>
         <p data-test="receipt-date">
-          {format(paymentDate, DATE_LONG_FORMAT_1)}
+          {formatDate(paymentDate, DATE_FORMAT_FULL)}
         </p>
       </>
     </StyledGridColLeft>
@@ -169,7 +168,7 @@ export const PaymentSection = ({
       <StyledSectionHeading>Amount received</StyledSectionHeading>
       <p>{currencyGBP(payment[0].amount / 100)}</p>
       <StyledSectionHeading>Received on</StyledSectionHeading>
-      <p>{format(payment[0].receivedOn, DATE_LONG_FORMAT_1)}</p>
+      <p>{formatDate(payment[0].receivedOn, DATE_FORMAT_FULL)}</p>
       {payment[0].transactionReference && (
         <>
           <StyledSectionHeading>Transaction reference</StyledSectionHeading>

--- a/src/client/modules/Omis/PaymentReconciliation.jsx
+++ b/src/client/modules/Omis/PaymentReconciliation.jsx
@@ -18,8 +18,9 @@ import {
 } from '../../components/Resource'
 import urls from '../../../lib/urls'
 import { currencyGBP } from '../../utils/number-utils'
-import { format, getDifferenceInWords } from '../../utils/date'
-import { DATE_LONG_FORMAT_1, FORM_LAYOUT } from '../../../common/constants'
+import { getDifferenceInWords } from '../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../utils/date-utils'
+import { FORM_LAYOUT } from '../../../common/constants'
 import { validateAmountRecieved, validateIfDateInPast } from './validators'
 import { TASK_RECONCILE_OMIS_PAYMENT } from './state'
 import {
@@ -106,7 +107,7 @@ export const InvoiceDetails = ({ invoice, reference }) => (
       <Table.Row>
         <Table.CellHeader>Payment due date</Table.CellHeader>
         <Table.Cell>
-          {format(invoice.paymentDueDate, DATE_LONG_FORMAT_1) +
+          {formatDate(invoice.paymentDueDate, DATE_FORMAT_FULL) +
             ' (' +
             getDifferenceInWords(invoice.paymentDueDate) +
             ')'}

--- a/src/client/modules/Reminders/ItemRenderers/Investments/InvestmentOPListItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Investments/InvestmentOPListItemRenderer.jsx
@@ -6,8 +6,7 @@ import { Link } from 'govuk-react'
 import styled from 'styled-components'
 
 import { ListItem, ItemHeader, ItemFooter } from '../styled'
-import { DATE_DAY_LONG_FORMAT } from '../../../../../common/constants'
-import { format } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL_DAY } from '../../../../utils/date-utils'
 import urls from '../../../../../lib/urls'
 
 const ItemContent = styled('div')({
@@ -20,7 +19,7 @@ const InvestmentOPListItemRenderer = (item) => (
     <GridRow>
       <GridCol>
         <ItemHeader data-test="item-header">
-          Due {format(item.deadline, DATE_DAY_LONG_FORMAT)}
+          Due {formatDate(item.deadline, DATE_FORMAT_FULL_DAY)}
         </ItemHeader>
         <ItemContent data-test="item-content">
           <Link

--- a/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
+++ b/src/client/modules/Reminders/ItemRenderers/Tasks/MyTasksItemRenderer.jsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
 
-import { DATE_LONG_FORMAT_1 } from '../../../../../common/constants'
-import { format } from '../../../../utils/date'
+import { formatDate, DATE_FORMAT_FULL } from '../../../../utils/date-utils'
 import urls from '../../../../../lib/urls'
 import { GREY_1 } from '../../../../utils/colours'
 import ItemRenderer from '../ItemRenderer'
@@ -25,7 +24,7 @@ const ItemContent = ({ item }) => (
 
     <li>
       <ItemHint>Date due: </ItemHint>
-      {format(item.task.due_date, DATE_LONG_FORMAT_1)}
+      {formatDate(item.task.due_date, DATE_FORMAT_FULL)}
     </li>
   </ul>
 )

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -120,12 +120,17 @@ function isShortDateValid(year, month) {
 }
 
 /**
- * Date formatting and parsing functions
+ * @deprecated This function is deprecated. Use `formatDate` instead.
+ *
+ * This function will be removed in the near future.
  */
-
 function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
   return isDateValid(dateStr) ? formatFns(parseISO(dateStr), dateFormat) : null
 }
+
+/**
+ * Parsing functions
+ */
 
 const padZero = (value) => {
   const parsedValue = parseInt(value, 10)

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,14 +1,8 @@
 // These are date-fns format codes - see https://date-fns.org/v2.23.0/docs/format
-const DATE_LONG_FORMAT_1 = 'd MMMM yyyy'
 const DATE_LONG_FORMAT_2 = 'dd MMM yyyy'
 const DATE_LONG_FORMAT_3 = 'yyyy-MM-dd'
-const DATE_DAY_LONG_FORMAT = 'E, dd MMM yyyy'
-const DATE_MEDIUM_FORMAT = 'd MMM yyyy'
-const DATE_TIME_MEDIUM_FORMAT = 'd MMM yyyy, h:mmaaa'
 const DATE_SHORT_FORMAT = 'yyyy-MM'
-const DATE_SHORT_FORMAT_2 = 'MMMM yyyy'
 const DATE_DAY_MONTH = 'dd MMM'
-const INTERACTION_TIMESTAMP_FORMAT = 'y-MM-d'
 
 const UNITED_KINGDOM_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
 const UNITED_STATES_ID = '81756b9a-5d95-e211-a939-e4115bead28a'
@@ -66,16 +60,10 @@ const EXPORT_INTEREST_STATUS = {
 }
 
 module.exports = {
-  DATE_DAY_LONG_FORMAT,
   DATE_DAY_MONTH,
-  DATE_LONG_FORMAT_1,
   DATE_LONG_FORMAT_2,
   DATE_LONG_FORMAT_3,
-  DATE_MEDIUM_FORMAT,
-  DATE_TIME_MEDIUM_FORMAT,
   DATE_SHORT_FORMAT,
-  DATE_SHORT_FORMAT_2,
-  INTERACTION_TIMESTAMP_FORMAT,
   UNITED_KINGDOM_ID,
   UNITED_STATES_ID,
   CANADA_ID,

--- a/test/component/cypress/specs/Companies/CompanyHierarchy/Hierarchy.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyHierarchy/Hierarchy.cy.jsx
@@ -14,7 +14,10 @@ import {
   rgb,
   DARK_BLUE_LEGACY,
 } from '../../../../../../src/client/utils/colours'
-import { format } from '../../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../../src/client/utils/date-utils'
 
 const {
   company: { dnbGlobalUltimate, allOverviewDetails },
@@ -490,9 +493,10 @@ describe('D&B Company Tree Hierarchy component', () => {
   })
 
   context('When a company has a mix of known and unknown subsidiaries', () => {
-    const formattedDate = format(
+    const formattedDate = formatDate(
       companyManuallyLinkedSubsidiaries.ultimate_global_company.subsidiaries[0]
-        .latest_interaction_date
+        .latest_interaction_date,
+      DATE_FORMAT_COMPACT
     )
 
     beforeEach(() => {

--- a/test/component/cypress/specs/Contacts/ContactLocalHeader.cy.jsx
+++ b/test/component/cypress/specs/Contacts/ContactLocalHeader.cy.jsx
@@ -3,9 +3,27 @@ import React from 'react'
 import ContactLocalHeader from '../../../../../src/client/components/ContactLocalHeader'
 import urls from '../../../../../src/lib/urls'
 
-const primaryContact = require('../../../../sandbox/fixtures/v3/contact/contact-complete-details-uk.json')
-const archivedContact = require('../../../../sandbox/fixtures/v3/contact/contact-archived.json')
 const notPrimaryContact = require('../../../../sandbox/fixtures/v3/contact/contact-incomplete-details-uk.json')
+const primaryContact = require('../../../../sandbox/fixtures/v3/contact/contact-complete-details-uk.json')
+
+const archivedContact = {
+  name: 'Joseph Woof',
+  company: {
+    name: 'Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978',
+    id: '4cd4128b-1bad-4f1e-9146-5d4678c6a018',
+  },
+  primary: true,
+  archived: true,
+
+  archivedOn: '2019-07-04T15:59:14.267412Z',
+  archivedReason: 'Left the company',
+  archivedBy: {
+    name: 'Bernard Harris-Patel',
+    first_name: 'Bernard',
+    last_name: 'Harris-Patel',
+    id: '7d19d407-9aec-4d06-b190-d3f404627f21',
+  },
+}
 
 const companyName = primaryContact.company.name
 const companyLink = urls.companies.overview.index(primaryContact.company.id)
@@ -93,6 +111,20 @@ describe('ContactLocalHeader', () => {
 
     it('should render the archive panel', () => {
       cy.get('[data-test=archive-panel]').should('exist')
+    })
+
+    it('should render an archived message', () => {
+      cy.get('[data-test="archive-message"]').should(
+        'have.text',
+        'This contact was archived on 04 Jul 2019 by Bernard Harris-Patel.'
+      )
+    })
+
+    it('should render an archived reason', () => {
+      cy.get('[data-test="archive-reason"]').should(
+        'have.text',
+        'Reason: Left the company'
+      )
     })
   })
 })

--- a/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Omis/WorkOrder/OrderIncompleteFields.cy.jsx
@@ -7,7 +7,10 @@ import {
   VAT_STATUS,
 } from '../../../../../../src/client/modules/Omis/constants'
 import urls from '../../../../../../src/lib/urls'
-import { format } from '../../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../../src/client/utils/date-utils'
 
 const quoteAwaitingOrder = {
   id: '123',
@@ -83,8 +86,9 @@ describe('OrderIncompleteFields', () => {
         .should('exist')
         .should(
           'have.text',
-          `This order was cancelled on ${format(
-            cancelledOrder.cancelledOn
+          `This order was cancelled on ${formatDate(
+            cancelledOrder.cancelledOn,
+            DATE_FORMAT_COMPACT
           )} by ${cancelledOrder.cancelledBy.name}.`
         )
       cy.get('[data-test="archive-reason"]')

--- a/test/end-to-end/cypress/specs/DIT/order-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/order-spec.js
@@ -1,14 +1,14 @@
 const fixtures = require('../../fixtures')
 const {
   formatDate,
-  DATE_MEDIUM_FORMAT,
+  DATE_FORMAT_MEDIUM,
 } = require('../../../../../src/client/utils/date-utils')
 const { omis } = require('../../../../../src/lib/urls')
 const {
   assertSummaryTable,
 } = require('../../../../functional/cypress/support/assertions')
 
-const today = formatDate(new Date(), DATE_MEDIUM_FORMAT)
+const today = formatDate(new Date(), DATE_FORMAT_MEDIUM)
 
 describe('Order', () => {
   const company = fixtures.company.create.defaultCompany('order testing')

--- a/test/functional/cypress/specs/companies/account-management-add-edit-objective-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-add-edit-objective-spec.js
@@ -1,5 +1,7 @@
-import { format } from '../../../../../src/client/utils/date'
-import { DATE_LONG_FORMAT_3 } from '../../../../../src/common/constants'
+import {
+  formatDate,
+  DATE_FORMAT_ISO,
+} from '../../../../../src/client/utils/date-utils'
 import { companyFaker } from '../../fakers/companies'
 import { objectiveFaker } from '../../fakers/objective'
 import { clickButton } from '../../support/actions'
@@ -120,9 +122,9 @@ describe('Company account management', () => {
         has_blocker: withBlockersObjective.has_blocker,
         progress: withBlockersObjective.progress,
         subject: withBlockersObjective.subject,
-        target_date: format(
+        target_date: formatDate(
           withBlockersObjective.target_date,
-          DATE_LONG_FORMAT_3
+          DATE_FORMAT_ISO
         ),
       })
     })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -1,11 +1,12 @@
-import { format } from 'date-fns'
-
 import { faker } from '../../../../sandbox/utils/random'
-
 import { companyFaker } from '../../fakers/companies'
 import { userFaker } from '../../fakers/users'
 import objectiveListFaker, { objectiveFaker } from '../../fakers/objective'
 import { adviserFaker } from '../../fakers/advisers'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../src/client/utils/date-utils'
 import {
   assertCompanyBreadcrumbs,
   assertGovReactTable,
@@ -88,9 +89,9 @@ describe('Company account management', () => {
       cy.get('[data-test="last-updated-strategy-details"] > span')
         .eq(0)
         .contains(
-          `Last updated by ${companyWithStrategy.modifiedBy.name}: ${format(
+          `Last updated by ${companyWithStrategy.modifiedBy.name}: ${formatDate(
             companyWithStrategy.modifiedOn,
-            'dd MMM yyyy'
+            DATE_FORMAT_COMPACT
           )}. `
         )
     })

--- a/test/functional/cypress/specs/companies/archived-objectives-spec.js
+++ b/test/functional/cypress/specs/companies/archived-objectives-spec.js
@@ -1,4 +1,7 @@
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../src/client/utils/date-utils'
 import { objectiveFaker } from '../../fakers/objective'
 
 const fixtures = require('../../fixtures')
@@ -32,12 +35,18 @@ context('When visiting the archived objective page with objectives', () => {
   it('should display 2 archived objectives with correct details', () => {
     cy.get('[data-test="objective-1"]')
       .should('contain.text', incompleteObjective.detail)
-      .should('contain.text', format(incompleteObjective.target_date))
+      .should(
+        'contain.text',
+        formatDate(incompleteObjective.target_date, DATE_FORMAT_COMPACT)
+      )
       .should('contain.text', incompleteObjective.progress)
       .should('contain.text', incompleteObjective.modifiedBy.name)
     cy.get('[data-test="objective-2"]')
       .should('contain.text', completeObjective.detail)
-      .should('contain.text', format(completeObjective.target_date))
+      .should(
+        'contain.text',
+        formatDate(completeObjective.target_date, DATE_FORMAT_COMPACT)
+      )
       .should('contain.text', completeObjective.progress)
       .should('contain.text', completeObjective.modifiedBy.name)
   })

--- a/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
+++ b/test/functional/cypress/specs/companies/investments/large-capital-profile-spec.js
@@ -92,7 +92,7 @@ describe('Company Investments and Large capital profile', () => {
             'Investable capital': 30000,
             'Investor description': 'incomplete',
             'Has this investor cleared the required checks within the last 12 months?':
-              'Cleared\nDate of most recent background checks: 29 04 2019\nPerson responsible for most recent background checks: Aaron Chan',
+              'Cleared\nDate of most recent background checks: 29 April 2019\nPerson responsible for most recent background checks: Aaron Chan',
           },
         })
       })

--- a/test/functional/cypress/specs/export-pipeline/export-details-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-details-spec.js
@@ -2,7 +2,10 @@ import { capitalize } from 'lodash'
 
 import urls from '../../../../../src/lib/urls'
 import { currencyGBP } from '../../../../../src/client/utils/number-utils'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_MONTH_YEAR,
+} from '../../../../../src/client/utils/date-utils'
 import { exportFaker } from '../../fakers/export'
 
 const {
@@ -33,9 +36,9 @@ describe('Export Details summary ', () => {
         exportItem.estimated_export_value_years?.name
       } / ${currencyGBP(exportItem.estimated_export_value_amount)}`
 
-      const estimatedWinDate = format(
-        exportItem.estimated_win_date.toISOString(),
-        'MMMM yyyy'
+      const estimatedWinDate = formatDate(
+        exportItem.estimated_win_date,
+        DATE_FORMAT_MONTH_YEAR
       )
       assertKeyValueTable('bodyMainContent', {
         'Export title': exportItem.title,

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -13,7 +13,10 @@ import {
   selectFirstTypeaheadOption,
 } from '../../support/actions'
 import { investments } from '../../../../../src/lib/urls'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+} from '../../../../../src/client/utils/date-utils'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
 import { VALUES_VALUE_TO_LABEL_MAP } from '../../../../../src/client/modules/Investments/EYBLeads/constants'
 
@@ -171,7 +174,7 @@ describe('EYB leads collection page', () => {
         .should('contain', eybLead.company.name)
         .should(
           'contain',
-          `Submitted to EYB ${format(eybLead.triage_created, 'dd MMM yyyy')}`
+          `Submitted to EYB ${formatDate(eybLead.triage_created, DATE_FORMAT_COMPACT)}`
         )
         .should('contain', `Estimated spend ${eybLead.spend}`)
         .should('contain', `Sector ${eybLead.sector.name}`)

--- a/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
@@ -9,7 +9,10 @@ const {
   assertBreadcrumbs,
   assertQueryParams,
 } = require('../../support/assertions')
-const { formatDate } = require('../../../../../src/client/utils/date-utils')
+const {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} = require('../../../../../src/client/utils/date-utils')
 
 const interaction = interactionFaker()
 const interactionsList = interactionsListFaker(10)

--- a/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
@@ -9,7 +9,7 @@ const {
   assertBreadcrumbs,
   assertQueryParams,
 } = require('../../support/assertions')
-const { format } = require('../../../../../src/client/utils/date')
+const { formatDate } = require('../../../../../src/client/utils/date-utils')
 
 const interaction = interactionFaker()
 const interactionsList = interactionsListFaker(10)
@@ -65,7 +65,10 @@ describe('The interactions tab on an opportunity page', () => {
 
       cy.get('[data-test="collection-item"]')
         .find('[data-test="metadata"]')
-        .should('contain', `Date ${format(interaction.date, 'dd MMMM yyyy')}`)
+        .should(
+          'contain',
+          `Date ${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
+        )
         .and('contain', `Contact(s) ${interaction.contacts[0].name}`)
         .and('contain', `Company ${interaction.companies[0].name}`)
         .and(

--- a/test/functional/cypress/specs/investments/project-interactions-spec.js
+++ b/test/functional/cypress/specs/investments/project-interactions-spec.js
@@ -5,7 +5,10 @@ import {
   interactionFaker,
 } from '../../fakers/interactions'
 import { assertQueryParams } from '../../support/assertions'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../../../src/client/utils/date-utils'
 
 const interaction = interactionFaker()
 const interactionsList = interactionsListFaker(10)
@@ -51,7 +54,10 @@ describe('Investment project interactions', () => {
 
       cy.get('[data-test="collection-item"]')
         .find('[data-test="metadata"]')
-        .should('contain', `Date ${format(interaction.date, 'dd MMMM yyyy')}`)
+        .should(
+          'contain',
+          `Date ${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
+        )
         .and('contain', `Contact(s) ${interaction.contacts[0].name}`)
         .and('contain', `Company ${interaction.companies[0].name}`)
         .and(

--- a/test/functional/cypress/specs/investments/project-tasks-spec.js
+++ b/test/functional/cypress/specs/investments/project-tasks-spec.js
@@ -1,7 +1,10 @@
 import fixtures from '../../fixtures'
 import urls from '../../../../../src/lib/urls'
 import { taskWithInvestmentProjectFaker } from '../../fakers/task'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY_MONTH_YEAR,
+} from '../../../../../src/client/utils/date-utils'
 import { NOT_SET_TEXT } from '../../../../../src/apps/companies/constants'
 import { assertQueryParams } from '../../support/assertions'
 
@@ -49,13 +52,13 @@ const assertTaskItem = (index, investmentTask) => {
     .find('[data-test="metadata"]')
     .should(
       'contain',
-      `Date created ${format(investmentTask.createdOn, 'dd MMMM yyyy')}`
+      `Date created ${formatDate(investmentTask.createdOn, DATE_FORMAT_DAY_MONTH_YEAR)}`
     )
     .and(
       'contain',
       `Due date ${
         investmentTask.dueDate
-          ? format(investmentTask.dueDate, 'dd MMMM yyyy')
+          ? formatDate(investmentTask.dueDate, DATE_FORMAT_DAY_MONTH_YEAR)
           : NOT_SET_TEXT
       }`
     )

--- a/test/functional/cypress/specs/tasks/create-similar-task-spec.js
+++ b/test/functional/cypress/specs/tasks/create-similar-task-spec.js
@@ -10,8 +10,10 @@ import {
   assertPayload,
   assertFlashMessage,
 } from '../../../cypress/support/assertions'
-import { DATE_LONG_FORMAT_3 } from '../../../../../src/common/constants'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_ISO,
+} from '../../../../../src/client/utils/date-utils'
 
 describe('Copy task from generic task task', () => {
   const genericTask = taskFaker()
@@ -89,7 +91,7 @@ function assertTaskForm(
     interaction: interactionId,
     title: 'test copy task',
     description: 'test copy description',
-    due_date: format(task.dueDate, DATE_LONG_FORMAT_3),
+    due_date: formatDate(task.dueDate, DATE_FORMAT_ISO),
     email_reminders_enabled: task.emailRemindersEnabled,
     reminder_days: task.reminderDays,
     advisers: task.advisers.map((adviser) => adviser.id),

--- a/test/functional/cypress/specs/tasks/edit-task-spec.js
+++ b/test/functional/cypress/specs/tasks/edit-task-spec.js
@@ -13,8 +13,10 @@ import {
   taskWithCompanyFaker,
   taskWithInvestmentProjectFaker,
 } from '../../fakers/task'
-import { DATE_LONG_FORMAT_3 } from '../../../../../src/common/constants'
-import { format } from '../../../../../src/client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_ISO,
+} from '../../../../../src/client/utils/date-utils'
 import { companyFaker } from '../../fakers/companies'
 import { investmentProjectFaker } from '../../fakers/investment-projects'
 
@@ -45,7 +47,7 @@ describe('Edit generic task', () => {
       assertPayload('@apiRequest', {
         title: 'new task',
         description: 'new description',
-        due_date: format(task.dueDate, DATE_LONG_FORMAT_3),
+        due_date: formatDate(task.dueDate, DATE_FORMAT_ISO),
         email_reminders_enabled: task.emailRemindersEnabled,
         investment_project: null,
         company: null,
@@ -110,7 +112,7 @@ describe('Edit investment project task', () => {
       assertPayload('@apiRequest', {
         title: 'new task',
         description: 'new description',
-        due_date: format(investmentProjectTask.dueDate, DATE_LONG_FORMAT_3),
+        due_date: formatDate(investmentProjectTask.dueDate, DATE_FORMAT_ISO),
         email_reminders_enabled: investmentProjectTask.emailRemindersEnabled,
         company: null,
         investment_project: investmentProjectTask.investmentProject.id,
@@ -252,7 +254,7 @@ describe('Edit company task', () => {
       assertPayload('@apiRequest', {
         title: 'new task',
         description: 'new description',
-        due_date: format(companyTask.dueDate, DATE_LONG_FORMAT_3),
+        due_date: formatDate(companyTask.dueDate, DATE_FORMAT_ISO),
         email_reminders_enabled: companyTask.emailRemindersEnabled,
         investment_project: null,
         company: companyTask.company.id,


### PR DESCRIPTION
## Description of change
This PR simplifies the use of date utilities by replacing instances of `format` with `formatDate`.

There are still a few remaining `format` functions that require further refactoring in the following files:

* `src/apps/transformers.js`
* `src/client/transformers/index.js`
* `src/client/utils/date.js`
* `src/config/nunjucks/trade-elements-filters.js`

These will be addressed in a future PR, for now I've deprecated the `format` function.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
