### PR TITLE
TET-758: Only replace history if params has values

### DIFF
--- a/assets/javascripts/lib/xhr.js
+++ b/assets/javascripts/lib/xhr.js
@@ -39,7 +39,7 @@ const XHR = {
   updateOutlet(res, params, win = window) {
     this.injectResponseInHtml(res.data)
 
-    if (params) {
+    if (params && Object.keys(params).length > 0) {
       const url = `?${queryString.stringify(params)}`
       try {
         history.replace(url, { data: res.data })

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "govuk-frontend": "^5.7.1",
         "govuk-react": "^0.10.7",
         "hawk": "^9.0.2",
-        "history": "^4.10.1",
+        "history": "^5.3.0",
         "http-proxy-middleware": "^3.0.0",
         "joi": "^17.13.1",
         "lodash": "^4.17.21",
@@ -13943,16 +13943,12 @@
       }
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -22086,11 +22082,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
-    },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -24417,12 +24408,8 @@
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
-      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.2.3",
@@ -25205,11 +25192,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "govuk-frontend": "^5.7.1",
     "govuk-react": "^0.10.7",
     "hawk": "^9.0.2",
-    "history": "^4.10.1",
+    "history": "^5.3.0",
     "http-proxy-middleware": "^3.0.0",
     "joi": "^17.13.1",
     "lodash": "^4.17.21",

--- a/test/unit-client/assets/javascripts/lib/xhr.test.js
+++ b/test/unit-client/assets/javascripts/lib/xhr.test.js
@@ -40,7 +40,6 @@ describe('XHR', () => {
       const res = { data: {} }
       const params = {}
       XHR.updateOutlet(res, params)
-      // expect(Object.keys(params).length).to.equal(1)
       expect(history.location.search).to.equal('')
     })
     it('should perform page load if unable to pushState', () => {

--- a/test/unit-client/assets/javascripts/lib/xhr.test.js
+++ b/test/unit-client/assets/javascripts/lib/xhr.test.js
@@ -40,7 +40,7 @@ describe('XHR', () => {
       const res = { data: {} }
       const params = {}
       XHR.updateOutlet(res, params)
-      expect(Object.keys(params).length).to.equal(0)
+      // expect(Object.keys(params).length).to.equal(1)
       expect(history.location.search).to.equal('')
     })
     it('should perform page load if unable to pushState', () => {

--- a/test/unit-client/assets/javascripts/lib/xhr.test.js
+++ b/test/unit-client/assets/javascripts/lib/xhr.test.js
@@ -40,6 +40,7 @@ describe('XHR', () => {
       const res = { data: {} }
       const params = {}
       XHR.updateOutlet(res, params)
+      expect(Object.keys(params).length).to.equal(0)
       expect(history.location.search).to.equal('')
     })
     it('should perform page load if unable to pushState', () => {


### PR DESCRIPTION
## Description of change

Prior to V5 ` history.replace(url, { data: res.data })` used to strip trailing `?`s. It now doesn't causing a test to fail, this may be related to https://github.com/remix-run/history/issues/701.

This PR checks if we actually have any data in the params object before calling `history.replace()` at all, since that seems in like with the test intentions.

Alternative approaches:
We could adjust the test expectations (there's not much harm in leaving the trailing `?`), or we could strip trailing `?`s from `url` before passing it into `history.replace`.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
