### PR TITLE
Remove date wrappers

### DIFF
--- a/src/client/components/Form/validators.js
+++ b/src/client/components/Form/validators.js
@@ -1,4 +1,5 @@
-import { isDateInFutureParsed } from '../../utils/date'
+import { isFuture, parseISO } from 'date-fns'
+
 import { transformDateObjectToDateString } from '../../transformers'
 
 const EMAIL_PATTERN =
@@ -18,7 +19,7 @@ export const validateIfDateInPast = (date) => {
   const transformedDate = transformDateObjectToDateString(date)
 
   return transformedDate
-    ? isDateInFutureParsed(transformedDate)
+    ? isFuture(parseISO(transformedDate))
       ? 'Actual land date cannot be in the future'
       : null
     : null

--- a/src/client/modules/Companies/CompanyBusinessDetails/tasks.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/tasks.js
@@ -1,9 +1,8 @@
 import axios from 'axios'
+import { subDays, isAfter } from 'date-fns'
 
 import urls from '../../../../lib/urls'
 import { apiProxyAxios } from '../../../components/Task/utils'
-
-const { isDateAfter, subtractDays, today } = require('../../../utils/date')
 
 export function checkIfPendingRequest(duns_number) {
   if (duns_number) {
@@ -17,9 +16,9 @@ export function checkIfPendingRequest(duns_number) {
 }
 
 const isDNBDateValid = (date) => {
-  const todaysDate = today()
-  const timeInterval = subtractDays(todaysDate, 20)
-  return isDateAfter(date, timeInterval)
+  const todaysDate = new Date()
+  const timeInterval = subDays(todaysDate, 20)
+  return isAfter(date, timeInterval)
 }
 
 const checkIfRequestIsValid = ({ count, results }) => {

--- a/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/ActivityCards/transformers.js
@@ -1,10 +1,11 @@
+import { isFuture } from 'date-fns'
+
 import {
   TAGS,
   NEW_PROJECT_TAG,
   NEW_ORDER_TAG,
   GREAT_EXPORT_TAG,
 } from '../../../CompanyActivity/constants'
-import { isDateInFuture } from '../../../../../utils/date'
 import { formatDate, DATE_FORMAT_MEDIUM } from '../../../../../utils/date-utils'
 import { truncateData } from '../../../../../utils/truncate'
 import { INTERACTION_NAMES } from '../../../../../../apps/interactions/constants'
@@ -44,9 +45,9 @@ const buildSummary = (advisers, communicationChannel, contacts, date) => {
     advisers.length > 1 ? transformAdvisers(advisers) : advisers[0].adviser.name
   const transformedContacts =
     contacts.length > 1 ? transformContacts(contacts) : contacts[0].name
-  const isFuture = isDateInFuture(date) ? 'will have' : 'had'
+  const isFutureDate = isFuture(date) ? 'will have' : 'had'
 
-  return `${transformedAdvisers} ${isFuture} ${transformCommunicationChannel(communicationChannel)} contact with ${transformedContacts}`
+  return `${transformedAdvisers} ${isFutureDate} ${transformCommunicationChannel(communicationChannel)} contact with ${transformedContacts}`
 }
 
 const checkNewJobs = (jobs) => (jobs > 0 ? jobs : 'no')

--- a/src/client/modules/Omis/OMISLocalHeader.jsx
+++ b/src/client/modules/Omis/OMISLocalHeader.jsx
@@ -1,10 +1,11 @@
 import React from 'react'
+import { isFuture } from 'date-fns'
 import styled from 'styled-components'
 import { Button, GridCol, GridRow, Link } from 'govuk-react'
 import { FONT_WEIGHTS } from '@govuk-react/constants'
 
 import LocalHeaderDetails from '../../components/LocalHeaderDetails'
-import { getDifferenceInWords, isDateInFuture } from '../../utils/date'
+import { getDifferenceInWords } from '../../utils/date'
 import {
   formatDate,
   DATE_FORMAT_MEDIUM_WITH_TIME,
@@ -25,7 +26,7 @@ const StyledLink = styled(Link)`
 `
 
 const getExpiryDate = (expiresOn) =>
-  isDateInFuture(expiresOn)
+  isFuture(expiresOn)
     ? ` (expires ${getDifferenceInWords(expiresOn)})`
     : ` (expired ${getDifferenceInWords(expiresOn)})`
 

--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { isFuture } from 'date-fns'
 import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
@@ -25,7 +26,6 @@ import { ORDERS__QUOTE_PREVIEW_LOADED } from '../../actions'
 import OMISTermsAndConditions from './OMISTermsAndConditions'
 import urls from '../../../lib/urls'
 import { DARK_GREY, RED_2 } from '../../utils/colours'
-import { isDateInFuture } from '../../utils/date'
 import {
   formatDate,
   DATE_FORMAT_MEDIUM,
@@ -106,7 +106,7 @@ export const RenderQuote = ({ quote, reference }) => (
 )
 
 const setExpiryLabel = (quote) =>
-  isDateInFuture(quote.expiresOn) ? 'Expires on' : 'Expired on'
+  isFuture(quote.expiresOn) ? 'Expires on' : 'Expired on'
 
 const SentOn = ({ quote }) => (
   <>

--- a/src/client/modules/Omis/transformers.js
+++ b/src/client/modules/Omis/transformers.js
@@ -1,4 +1,5 @@
 import { filter } from 'lodash'
+import { addDays, isAfter, parseISO } from 'date-fns'
 
 import { transformDateObjectToDateString } from '../../transformers'
 import {
@@ -6,7 +7,6 @@ import {
   transformRadioOptionToBool,
 } from '../Investments/Projects/transformers'
 import { INCOMPLETE_FIELD_MESSAGES, STATUS, VAT_STATUS } from './constants'
-import { addDays, isDateAfter, parseDateISO } from '../../utils/date'
 import { omis } from '../../../lib/urls'
 
 export const transformQuoteInformationForApi = ({
@@ -216,7 +216,7 @@ export const getIncompleteFields = (order, assignees) => {
 
   if (
     !order.deliveryDate ||
-    !isDateAfter(parseDateISO(order.deliveryDate), addDays(new Date(), 20))
+    !isAfter(parseISO(order.deliveryDate), addDays(new Date(), 20))
   ) {
     incompleteFields.push(INCOMPLETE_FIELD_MESSAGES.DELIVERY_DATE)
   }

--- a/src/client/modules/Omis/validators.js
+++ b/src/client/modules/Omis/validators.js
@@ -1,18 +1,14 @@
-import {
-  addDays,
-  isDateAfter,
-  isDateInFuture,
-  parseDateISO,
-} from '../../utils/date'
+import { addDays, isAfter, isFuture, parseISO } from 'date-fns'
+
 import { transformDateObjectToDateString } from '../../transformers'
 import { EU_VAT_NUMBER_REGEX } from './constants'
 
 export const validateIfDateInFuture = (values) => {
   if (values?.year) {
-    const deliveryDate = parseDateISO(transformDateObjectToDateString(values))
+    const deliveryDate = parseISO(transformDateObjectToDateString(values))
     const twentyDaysLater = addDays(new Date(), 20)
 
-    return isDateAfter(deliveryDate, twentyDaysLater)
+    return isAfter(deliveryDate, twentyDaysLater)
       ? null
       : 'Delivery date must be at least 21 days in the future'
   }
@@ -20,7 +16,7 @@ export const validateIfDateInFuture = (values) => {
 }
 
 export const validateIfDateInPast = (values) =>
-  isDateInFuture(transformDateObjectToDateString(values))
+  isFuture(transformDateObjectToDateString(values))
     ? 'Payment received date must be in the past'
     : null
 

--- a/src/client/modules/Tasks/TaskForm/validators.js
+++ b/src/client/modules/Tasks/TaskForm/validators.js
@@ -1,9 +1,9 @@
-import { isDateInFuture, transformValueForAPI } from '../../../utils/date'
+import { isFuture } from 'date-fns'
+
+import { transformValueForAPI } from '../../../utils/date'
 
 export const validateIfDateInFuture = (values) =>
-  isDateInFuture(transformValueForAPI(values))
-    ? null
-    : 'Enter a date in the future'
+  isFuture(transformValueForAPI(values)) ? null : 'Enter a date in the future'
 
 export const validateDaysRange = (value) =>
   !value || value < 1 || value > 365 ? 'Enter a number between 1 and 365' : null

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -1,8 +1,7 @@
+import { subMonths, subYears, addDays } from 'date-fns'
+
 import {
-  addDays,
   areDatesEqual,
-  subtractYears,
-  subtractMonths,
   getStartOfMonth,
   getRandomDateInRange,
   isWithinLastTwelveMonths,
@@ -63,7 +62,7 @@ describe('getStartDateOfTwelveMonthsAgo', () => {
       'date and includes the 1st of the month',
     () => {
       const today = new Date()
-      const expectedDate = subtractMonths(getStartOfMonth(today), 12)
+      const expectedDate = subMonths(getStartOfMonth(today), 12)
       const actualDate = getStartDateOfTwelveMonthsAgo()
       expect(actualDate).to.be.instanceOf(Date)
       expect(areDatesEqual(actualDate, expectedDate)).to.equal(true)
@@ -74,10 +73,10 @@ describe('getStartDateOfTwelveMonthsAgo', () => {
 describe('isWithinLastTwelveMonths', () => {
   const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
   const twelveMonthsAgoAddOneDay = addDays(twelveMonthsAgo, 1)
-  const twelveMonthsAgoSubOneDay = subtractYears(twelveMonthsAgo, 1)
+  const twelveMonthsAgoSubOneDay = subYears(twelveMonthsAgo, 1)
   const today = new Date()
   const tomorrow = addDays(today, 1)
-  const yesterday = subtractYears(today, 1)
+  const yesterday = subYears(today, 1)
 
   it('should be valid for the 1st of the month twelve months ago', () => {
     expect(isWithinLastTwelveMonths(twelveMonthsAgo)).to.equal(true)

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -7,30 +7,22 @@
  */
 
 const {
-  addDays: addDaysFns,
-  addMonths: addMonthsFns,
-  addYears: addYearsFns,
+  addDays,
   differenceInDays,
   differenceInCalendarDays,
   isSameDay,
   endOfToday,
   startOfMonth: getStartOfMonth,
   isWithinInterval,
-  endOfYesterday,
   format: formatFns,
   formatDistanceToNowStrict,
   isAfter,
   isValid,
   parse,
   parseISO,
-  subDays,
   subMonths,
-  subYears,
-  subWeeks,
   differenceInCalendarMonths,
-  isFuture,
   isEqual: areDatesEqual,
-  endOfTomorrow,
 } = require('date-fns')
 
 const {
@@ -39,64 +31,6 @@ const {
   DATE_SHORT_FORMAT,
   DATE_DAY_MONTH,
 } = require('../../common/constants')
-
-/**
- * Simple wrappers around date-fns and native Date functions
- */
-function addYears(date, yearsToAdd) {
-  return addYearsFns(date, yearsToAdd)
-}
-
-function subtractYears(date, yearsToSubtract) {
-  return subYears(date, yearsToSubtract)
-}
-
-function addDays(date, daysToAdd) {
-  return addDaysFns(date, daysToAdd)
-}
-
-function subtractDays(date, daysToSubtract) {
-  return subDays(date, daysToSubtract)
-}
-
-function isDateAfter(date1, date2) {
-  return isAfter(date1, date2)
-}
-
-function today() {
-  return format(new Date())
-}
-
-function addMonths(date, numberOfMonths) {
-  return addMonthsFns(date, numberOfMonths)
-}
-function subtractWeeks(date, numberOfweeks) {
-  return subWeeks(date, numberOfweeks)
-}
-
-function getYesterday() {
-  return endOfYesterday()
-}
-
-function subtractMonths(date, numberOfMonths) {
-  return subMonths(date, numberOfMonths)
-}
-
-function isDateInFuture(date) {
-  return isFuture(date)
-}
-
-function isDateInFutureParsed(date) {
-  return isFuture(parseISO(date))
-}
-
-function parseDateISO(date) {
-  return parseISO(date)
-}
-
-function tomorrow() {
-  return endOfTomorrow()
-}
 
 /**
  * Date validation functions
@@ -204,7 +138,7 @@ function formatStartAndEndDate(startDate, endDate) {
     const endDateFormatted = endDate ? format(endDate) : endDate
 
     //When end date is missing or before start date
-    if (!endDate || !isDateAfter(endDateParsed, startDateParsed)) {
+    if (!endDate || !isAfter(endDateParsed, startDateParsed)) {
       return startDateFormatted
     }
     //When start and end date are on same day
@@ -326,42 +260,27 @@ function isWithinLastTwelveMonths(date) {
 }
 
 module.exports = {
-  addDays,
-  addMonths,
-  addYears,
   format,
   generateFinancialYearLabel,
   getDifferenceInDays,
   getDifferenceInDaysLabel,
   getDifferenceInWords,
   getFinancialYearStart,
-  getYesterday,
-  isDateAfter,
   isDateValid,
   isValid,
   isNormalisedDateValid,
   isShortDateValid,
   isUnparsedDateValid,
-  subtractDays,
-  subtractMonths,
-  subtractYears,
-  subtractWeeks,
-  today,
   transformValueForAPI,
   createDateFromObject,
   formatStartAndEndDate,
   convertDateToFieldShortDateObject,
-  isDateInFuture,
-  parseDateISO,
   convertDateToFieldDateObject,
   getRandomDateInRange,
   isWithinLastTwelveMonths,
   getStartDateOfTwelveMonthsAgo,
   getStartOfMonth,
-  subtractMonths,
   areDatesEqual,
-  tomorrow,
   convertUnparsedDateToFieldDateObject,
   convertUnparsedDateToFieldShortDateObject,
-  isDateInFutureParsed,
 }

--- a/src/lib/__test__/options.test.js
+++ b/src/lib/__test__/options.test.js
@@ -1,10 +1,10 @@
-const { subtractDays, subtractWeeks } = require('../../client/utils/date')
+const { subDays, subWeeks } = require('date-fns')
 
 const config = require('../../config')
 
 const today = new Date()
-const yesterday = subtractDays(today, 1)
-const lastWeek = subtractWeeks(today, 1)
+const yesterday = subDays(today, 1)
+const lastWeek = subWeeks(today, 1)
 
 const { getOptions, fetchOptions } = require('../options')
 const serviceOptionData = require('../../../test/unit/data/interactions/service-options-data.json')

--- a/src/modules/permissions/__test__/filters.test.js
+++ b/src/modules/permissions/__test__/filters.test.js
@@ -1,9 +1,9 @@
-const { addMonths, subtractMonths } = require('../../../client/utils/date')
+const { addMonths, subMonths } = require('date-fns')
 
 const { filterDisabledOption, filterNonPermittedItem } = require('../filters')
 
 const today = new Date()
-const lastMonth = subtractMonths(today, 1)
+const lastMonth = subMonths(today, 1)
 const nextMonth = addMonths(today, 1)
 
 describe('filters', () => {

--- a/test/functional/cypress/fakers/dates.js
+++ b/test/functional/cypress/fakers/dates.js
@@ -1,6 +1,6 @@
-import { faker } from '../../../sandbox/utils/random'
+import { addDays } from 'date-fns'
 
-import { addDays } from '../../../../src/client/utils/date'
+import { faker } from '../../../sandbox/utils/random'
 
 const relativeDateFaker = ({ minDays, maxDays }) =>
   faker.date.between({

--- a/test/functional/cypress/specs/export-win/utils.js
+++ b/test/functional/cypress/specs/export-win/utils.js
@@ -1,6 +1,6 @@
+import { addMonths, subMonths } from 'date-fns'
+
 import {
-  subtractMonths,
-  addMonths,
   getRandomDateInRange,
   getStartDateOfTwelveMonthsAgo,
 } from '../../../../../src/client/utils/date'
@@ -175,7 +175,7 @@ export const getDateWithinLastTwelveMonths = () =>
   )
 
 export const getDateThirteenMonthsAgo = () =>
-  getMonthAndYearFromDate(subtractMonths(new Date(), 13))
+  getMonthAndYearFromDate(subMonths(new Date(), 13))
 
 export const getDateNextMonth = () =>
   getMonthAndYearFromDate(addMonths(new Date(), 1))


### PR DESCRIPTION
## Description of change
This PR removes all date wrappers from `date.js`. 

All previous wrapper function calls are now calling functions directly from `date-fns`.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
