### PR TITLE
Render OMIS payment date only if defined

### DIFF
--- a/src/client/modules/Omis/PaymentReceipt.jsx
+++ b/src/client/modules/Omis/PaymentReceipt.jsx
@@ -76,9 +76,11 @@ export const AddressSection = ({ invoice, paymentDate }) => (
         <StyledSectionHeading data-test="receipt-date-heading">
           Receipt date
         </StyledSectionHeading>
-        <p data-test="receipt-date">
-          {formatDate(paymentDate, DATE_FORMAT_FULL)}
-        </p>
+        {paymentDate && (
+          <p data-test="receipt-date">
+            {formatDate(paymentDate, DATE_FORMAT_FULL)}
+          </p>
+        )}
       </>
     </StyledGridColLeft>
     <StyledGridColRight setWidth="one-half">

--- a/test/component/cypress/specs/Omis/PaymentReceipt/AddressSection.cy.jsx
+++ b/test/component/cypress/specs/Omis/PaymentReceipt/AddressSection.cy.jsx
@@ -130,6 +130,19 @@ describe('AddressSection', () => {
     })
   })
 
+  context('When the invoice has all the fields but no payment date', () => {
+    beforeEach(() => {
+      cy.viewport(1024, 768)
+      cy.mount(
+        <AddressSection invoice={invoiceIncomplete} paymentDate={null} />
+      )
+    })
+
+    it('should not render the receipt date', () => {
+      cy.get('[data-test="receipt-date"]').should('not.exist')
+    })
+  })
+
   context('When the invoice does not have all the fields', () => {
     beforeEach(() => {
       cy.viewport(1024, 768)


### PR DESCRIPTION
## Description of change
Ensure the payment date for OMIS orders is rendered only when a valid value is set, avoiding potential display issues with `null` dates.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
