### PR TITLE
Render OMIS order quote `created_by` only if defined

### DIFF
--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -115,7 +115,9 @@ const SentOn = ({ quote }) => (
       {formatDate(quote.createdOn, DATE_FORMAT_MEDIUM_WITH_TIME)}
     </StyledP>
     <StyledHeading data-test="sent-by-heading">Sent by</StyledHeading>
-    <StyledP data-test="sent-by-name">{quote.createdBy.name}</StyledP>
+    {quote.createdBy && (
+      <StyledP data-test="sent-by-name">{quote.createdBy.name}</StyledP>
+    )}
   </>
 )
 

--- a/test/functional/cypress/specs/omis/quote-spec.js
+++ b/test/functional/cypress/specs/omis/quote-spec.js
@@ -207,6 +207,13 @@ describe('Order quote', () => {
     })
   })
 
+  context('When the quote has been accepted, but created_by is null', () => {
+    it('should not render sent-by-name', () => {
+      cy.visit(urls.omis.quote(quoteAccepted.id))
+      cy.get('[data-test="sent-by-name"]').should('not.exist')
+    })
+  })
+
   context('When the order has been cancelled', () => {
     beforeEach(() => {
       cy.visit(urls.omis.quote(cancelledOrder.id))


### PR DESCRIPTION
## Description of change
Display the `created_by` field for OMIS order quotes only when it contains a valid object, preventing potential issues with null.

## Test instructions
Go to: `/omis/<omis-uuid>/quote`

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
