### PR TITLE
Render OMIS order quote `accepted_by` only if defined

### DIFF
--- a/src/client/modules/Omis/OrderQuote.jsx
+++ b/src/client/modules/Omis/OrderQuote.jsx
@@ -128,7 +128,9 @@ const AcceptedOn = ({ quote }) => (
       {formatDate(quote.acceptedOn, DATE_FORMAT_MEDIUM_WITH_TIME)}
     </StyledP>
     <StyledHeading data-test="accepted-by-heading">Accepted by</StyledHeading>
-    <StyledP data-test="accepted-by-name">{quote.acceptedBy.name}</StyledP>
+    {quote.acceptedBy && (
+      <StyledP data-test="accepted-by-name">{quote.acceptedBy.name}</StyledP>
+    )}
   </>
 )
 

--- a/test/functional/cypress/specs/omis/quote-spec.js
+++ b/test/functional/cypress/specs/omis/quote-spec.js
@@ -214,6 +214,13 @@ describe('Order quote', () => {
     })
   })
 
+  context('When the quote has been accepted, but accepted_by is null', () => {
+    it('should not render accepted-by-name', () => {
+      cy.visit(urls.omis.quote(quoteAccepted.id))
+      cy.get('[data-test="accepted-by-name"]').should('not.exist')
+    })
+  })
+
   context('When the order has been cancelled', () => {
     beforeEach(() => {
       cy.visit(urls.omis.quote(cancelledOrder.id))


### PR DESCRIPTION
## Description of change
Display the `accepted_by` field for OMIS order quotes only when it contains a valid object, preventing potential issues with null.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
