### PR TITLE
bugfix/exclude-consent-from-contact-audit-history

### DIFF
--- a/src/client/modules/Contacts/ContactAuditHistory/constants.js
+++ b/src/client/modules/Contacts/ContactAuditHistory/constants.js
@@ -1,4 +1,9 @@
-export const EXCLUDED_FIELDS = ['archived_by', 'archived_on', 'valid_email']
+export const EXCLUDED_FIELDS = [
+  'archived_by',
+  'archived_on',
+  'valid_email',
+  'consent_data',
+]
 
 export const CONTACT_FIELD_NAME_TO_LABEL_MAP = {
   address_1: 'Address line 1',

--- a/test/sandbox/fixtures/v3/contact/contact-audit-history.json
+++ b/test/sandbox/fixtures/v3/contact/contact-audit-history.json
@@ -1,292 +1,210 @@
 {
-    "count": 42,
-    "next": "https://datahub-api-dev.london.cloudapps.digital/v3/contact/715e8a58-6515-4d52-a4b5-84cb49566b01/audit?limit=10&offset=10",
-    "previous": null,
-    "results": [
-      {
-        "id": 5197,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-19T12:56:40.204557Z",
-        "comment": "",
-        "changes": {}
+  "count": 42,
+  "next": "https://datahub-api-dev.london.cloudapps.digital/v3/contact/715e8a58-6515-4d52-a4b5-84cb49566b01/audit?limit=10&offset=10",
+  "previous": null,
+  "results": [
+    {
+      "id": 5197,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
       },
-      {
-        "id": 5191,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:55:36.566382Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            true,
-            false
+      "timestamp": "2022-05-19T12:56:40.204557Z",
+      "comment": "",
+      "changes": {
+        "consent_data": [
+          [
+            {
+              "source_system": "System A",
+              "consent_domain": "Domestic",
+              "email_contact_consent": false
+            }
           ],
-          "archived_on": [
-            "2022-05-18T09:55:10.111000Z",
-            null
-          ],
-          "archived_reason": [
-            "Left the company",
-            ""
-          ],
-          "archived_by": [
-            "Joseph Woof",
-            null
-          ],
-          "address_same_as_company": [true, false],
-          "primary": [false, true],
-          "first_name": ["Andras", "Andreas"],
-          "last_name": ["Old last name", "New last name"],
-          "job_title": ["Old job title", "New job title"],
-          "full_telephone_number": [null, "01234567890"],
-          "email": [null, "test@example.com"],
-          "address_1": [null, "Test Line 1"],
-          "address_2": [null, "Test Line 2"],
-          "address_town": [null, "Test Town"],
-          "address_county": [null, "Test county"],
-          "address_country": [null, "Baker Island"],
-          "address_postcode": [null, "TE5 5ST"],
-          "notes": [null, "Notes about the contact"]
-        }
-      },
-      {
-        "id": 5190,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:55:10.064213Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            false,
-            true
+          [
+            {
+              "source_system": "System A",
+              "consent_domain": "Domestic",
+              "email_contact_consent": true
+            }
           ]
-        }
-      },
-      {
-        "id": 5189,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:50:35.811031Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            true,
-            false
-          ],
-          "archived_on": [
-            "2022-05-18T09:50:28.396000Z",
-            null
-          ],
-          "archived_reason": [
-            "Left the company",
-            ""
-          ],
-          "archived_by": [
-            "Joseph Woof",
-            null
-          ]
-        }
-      },
-      {
-        "id": 5188,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:50:28.355503Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            false,
-            true
-          ],
-          "archived_on": [
-            null,
-            "2022-05-18T09:50:28.396000Z"
-          ],
-          "archived_reason": [
-            "",
-            "Left the company"
-          ],
-          "archived_by": [
-            null,
-            "Joseph Woof"
-          ]
-        }
-      },
-      {
-        "id": 5187,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:17:31.165403Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            true,
-            false
-          ],
-          "archived_on": [
-            "2022-05-18T09:17:24.069000Z",
-            null
-          ],
-          "archived_reason": [
-            "Left the company",
-            ""
-          ],
-          "archived_by": [
-            "Joseph Woof",
-            null
-          ]
-        }
-      },
-      {
-        "id": 5186,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-18T09:17:24.031741Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            false,
-            true
-          ],
-          "archived_on": [
-            null,
-            "2022-05-18T09:17:24.069000Z"
-          ],
-          "archived_reason": [
-            "",
-            "Left the company"
-          ],
-          "archived_by": [
-            null,
-            "Joseph Woof"
-          ]
-        }
-      },
-      {
-        "id": 5164,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-17T14:28:10.289939Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            true,
-            false
-          ],
-          "archived_on": [
-            "2022-05-17T14:28:01.669000Z",
-            null
-          ],
-          "archived_reason": [
-            "Left the company",
-            ""
-          ],
-          "archived_by": [
-            "Joseph Woof",
-            null
-          ]
-        }
-      },
-      {
-        "id": 5163,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-17T14:28:01.626888Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            false,
-            true
-          ],
-          "archived_on": [
-            null,
-            "2022-05-17T14:28:01.669000Z"
-          ],
-          "archived_reason": [
-            "",
-            "Left the company"
-          ],
-          "archived_by": [
-            null,
-            "Joseph Woof"
-          ]
-        }
-      },
-      {
-        "id": 5162,
-        "user": {
-          "id": "681e4af7-707d-4913-aa44-3551dd83afad",
-          "first_name": "Joseph",
-          "last_name": "Woof",
-          "name": "Joseph Woof",
-          "email": "Joseph.Woof@example.com"
-        },
-        "timestamp": "2022-05-17T14:25:49.099689Z",
-        "comment": "",
-        "changes": {
-          "archived": [
-            true,
-            false
-          ],
-          "archived_on": [
-            "2022-05-17T14:23:52.389000Z",
-            null
-          ],
-          "archived_reason": [
-            "Left the company",
-            ""
-          ],
-          "archived_by": [
-            "Joseph Woof",
-            null
-          ]
-        }
+        ]
       }
-    ]
-  }
+    },
+    {
+      "id": 5191,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:55:36.566382Z",
+      "comment": "",
+      "changes": {
+        "archived": [true, false],
+        "archived_on": ["2022-05-18T09:55:10.111000Z", null],
+        "archived_reason": ["Left the company", ""],
+        "archived_by": ["Joseph Woof", null],
+        "address_same_as_company": [true, false],
+        "primary": [false, true],
+        "first_name": ["Andras", "Andreas"],
+        "last_name": ["Old last name", "New last name"],
+        "job_title": ["Old job title", "New job title"],
+        "full_telephone_number": [null, "01234567890"],
+        "email": [null, "test@example.com"],
+        "address_1": [null, "Test Line 1"],
+        "address_2": [null, "Test Line 2"],
+        "address_town": [null, "Test Town"],
+        "address_county": [null, "Test county"],
+        "address_country": [null, "Baker Island"],
+        "address_postcode": [null, "TE5 5ST"],
+        "notes": [null, "Notes about the contact"]
+      }
+    },
+    {
+      "id": 5190,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:55:10.064213Z",
+      "comment": "",
+      "changes": {
+        "archived": [false, true]
+      }
+    },
+    {
+      "id": 5189,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:50:35.811031Z",
+      "comment": "",
+      "changes": {
+        "archived": [true, false],
+        "archived_on": ["2022-05-18T09:50:28.396000Z", null],
+        "archived_reason": ["Left the company", ""],
+        "archived_by": ["Joseph Woof", null]
+      }
+    },
+    {
+      "id": 5188,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:50:28.355503Z",
+      "comment": "",
+      "changes": {
+        "archived": [false, true],
+        "archived_on": [null, "2022-05-18T09:50:28.396000Z"],
+        "archived_reason": ["", "Left the company"],
+        "archived_by": [null, "Joseph Woof"]
+      }
+    },
+    {
+      "id": 5187,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:17:31.165403Z",
+      "comment": "",
+      "changes": {
+        "archived": [true, false],
+        "archived_on": ["2022-05-18T09:17:24.069000Z", null],
+        "archived_reason": ["Left the company", ""],
+        "archived_by": ["Joseph Woof", null]
+      }
+    },
+    {
+      "id": 5186,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-18T09:17:24.031741Z",
+      "comment": "",
+      "changes": {
+        "archived": [false, true],
+        "archived_on": [null, "2022-05-18T09:17:24.069000Z"],
+        "archived_reason": ["", "Left the company"],
+        "archived_by": [null, "Joseph Woof"]
+      }
+    },
+    {
+      "id": 5164,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-17T14:28:10.289939Z",
+      "comment": "",
+      "changes": {
+        "archived": [true, false],
+        "archived_on": ["2022-05-17T14:28:01.669000Z", null],
+        "archived_reason": ["Left the company", ""],
+        "archived_by": ["Joseph Woof", null]
+      }
+    },
+    {
+      "id": 5163,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-17T14:28:01.626888Z",
+      "comment": "",
+      "changes": {
+        "archived": [false, true],
+        "archived_on": [null, "2022-05-17T14:28:01.669000Z"],
+        "archived_reason": ["", "Left the company"],
+        "archived_by": [null, "Joseph Woof"]
+      }
+    },
+    {
+      "id": 5162,
+      "user": {
+        "id": "681e4af7-707d-4913-aa44-3551dd83afad",
+        "first_name": "Joseph",
+        "last_name": "Woof",
+        "name": "Joseph Woof",
+        "email": "Joseph.Woof@example.com"
+      },
+      "timestamp": "2022-05-17T14:25:49.099689Z",
+      "comment": "",
+      "changes": {
+        "archived": [true, false],
+        "archived_on": ["2022-05-17T14:23:52.389000Z", null],
+        "archived_reason": ["Left the company", ""],
+        "archived_by": ["Joseph Woof", null]
+      }
+    }
+  ]
+}

--- a/test/sandbox/fixtures/v3/contact/contact-audit-history.json
+++ b/test/sandbox/fixtures/v3/contact/contact-audit-history.json
@@ -14,24 +14,7 @@
       },
       "timestamp": "2022-05-19T12:56:40.204557Z",
       "comment": "",
-      "changes": {
-        "consent_data": [
-          [
-            {
-              "source_system": "System A",
-              "consent_domain": "Domestic",
-              "email_contact_consent": false
-            }
-          ],
-          [
-            {
-              "source_system": "System A",
-              "consent_domain": "Domestic",
-              "email_contact_consent": true
-            }
-          ]
-        ]
-      }
+      "changes": {}
     },
     {
       "id": 5191,
@@ -62,7 +45,23 @@
         "address_county": [null, "Test county"],
         "address_country": [null, "Baker Island"],
         "address_postcode": [null, "TE5 5ST"],
-        "notes": [null, "Notes about the contact"]
+        "notes": [null, "Notes about the contact"],
+        "consent_data": [
+          [
+            {
+              "source_system": "System A",
+              "consent_domain": "Domestic",
+              "email_contact_consent": false
+            }
+          ],
+          [
+            {
+              "source_system": "System A",
+              "consent_domain": "Domestic",
+              "email_contact_consent": true
+            }
+          ]
+        ]
       }
     },
     {


### PR DESCRIPTION
## Description of change

The new `consent_data` field in the contact model contains raw json imported from a data flow pipeline. This should be excluded from the contacts audit history

## Test instructions

Running locally, use the contact http://localhost:3000/contacts/435f9fa1-2e54-4205-8500-f23de614620e/audit

## Screenshots

### Before

N/A

### After

N/A

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
