### PR TITLE
Feature/tet 812 add stova service tag

### DIFF
--- a/src/client/components/ActivityFeed/activities/InteractionUtils.js
+++ b/src/client/components/ActivityFeed/activities/InteractionUtils.js
@@ -50,7 +50,9 @@ export const getServiceText = (service) => {
         : service.includes('Investment Enquiry') ||
             service.includes('Investment enquiry')
           ? 'Enquiry'
-          : INTERACTION_SERVICES[serviceType]
+          : service.includes('Stova Event Service')
+            ? 'Stova Event'
+            : INTERACTION_SERVICES[serviceType]
   return serviceText
 }
 

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -4,6 +4,7 @@ import urls from '../../../lib/urls'
 
 import { getDifferenceInDays, formatStartAndEndDate } from '../../utils/date'
 
+import { TAG_COLOURS } from '../../components/Tag'
 import {
   formatDate,
   DATE_FORMAT_FULL,
@@ -32,7 +33,7 @@ const transformEventToListItem = ({
   if (event_type) {
     tags.push({
       text: event_type.name,
-      colour: 'grey',
+      colour: TAG_COLOURS.GREY,
       dataTest: 'event-kind-label',
     })
   }
@@ -40,7 +41,7 @@ const transformEventToListItem = ({
   if (service) {
     tags.push({
       text: getServiceText(service.name),
-      colour: 'govBlue',
+      colour: TAG_COLOURS.GOV_BLUE,
       dataTest: 'event-theme-label',
     })
   }
@@ -48,7 +49,7 @@ const transformEventToListItem = ({
   if (service && service2) {
     tags.push({
       text: getServiceOtherText(service2),
-      colour: 'blue',
+      colour: TAG_COLOURS.BLUE,
       dataTest: 'event-service-label',
     })
   }

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -40,7 +40,7 @@ const transformEventToListItem = ({
   if (service) {
     tags.push({
       text: getServiceText(service.name),
-      colour: 'default',
+      colour: 'govBlue',
       dataTest: 'event-theme-label',
     })
   }

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -53,12 +53,28 @@ describe('Event Collection List Page', () => {
     },
   })
 
-  const eventsList = [event1, event2]
+  const stovaEvent = eventFaker({
+    id: 'd848746d-e7dd-4bf2-98ce-05f9833be662',
+    event_type: {
+      name: 'Exhibition',
+      id: '2fade471-e868-4ea9-b125-945eb90ae5d4',
+    },
+    lead_team: null,
+    name: 'Empty one-day exhibition',
+    organiser: null,
+    service: {
+      name: 'Stova Event Service',
+      id: '8053f984-fac6-4d35-b3df-4ac0eeb3b542',
+    },
+  })
+
+  const eventsList = [event1, event2, stovaEvent]
   context('when there is not an error', () => {
     beforeEach(() => {
       collectionListRequest('v3/search/event', eventsList, events.index())
       getCollectionList()
       cy.get('@collectionItems').eq(1).as('secondListItem')
+      cy.get('@collectionItems').eq(2).as('thirdListItem')
     })
 
     assertCollectionBreadcrumbs('Events')
@@ -68,7 +84,7 @@ describe('Event Collection List Page', () => {
     })
 
     it('should display the events result count header', () => {
-      cy.get('h2').contains('2 events')
+      cy.get('h2').contains('3 events')
     })
 
     it('should have a link to add event', () => {
@@ -121,6 +137,10 @@ describe('Event Collection List Page', () => {
     it('should not display missing metadata items', () => {
       assertMetadataItemNotPresent('@secondListItem', 'Lead team')
       assertMetadataItemNotPresent('@secondListItem', 'Organiser')
+    })
+
+    it('should display the stova event service type', () => {
+      assertMetadataItem('@thirdListItem', 'Stova Event')
     })
   })
 })


### PR DESCRIPTION
## Description of change

Add a new event service tag for a new `Stova Event Service` service. Without it, there is an empty tag shown.
Also fixes a console warning for an invalid prop value.

This is required to be merged and released before: https://github.com/uktrade/data-hub-api/pull/5866

## Test instructions

The existing service tags allowing the new (to be released) Stova Event Service to be shown.

## Screenshots
### Before

<img width="1242" alt="Screenshot 2024-12-20 at 12 23 28" src="https://github.com/user-attachments/assets/6b3825e8-5f42-4164-8c9e-2a987b9c4e34" />

### After

<img width="1242" alt="Screenshot 2024-12-20 at 12 23 37" src="https://github.com/user-attachments/assets/381bbd07-86fe-4d5e-b2a1-7c012f6ac0c1" />


## Checklist

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
