### PR TITLE
Fix postcode field.

### DIFF
--- a/src/apps/companies/apps/add-company/__test__/postcodeRegionLookup.test.js
+++ b/src/apps/companies/apps/add-company/__test__/postcodeRegionLookup.test.js
@@ -17,11 +17,13 @@ describe('Postcode to region mapping', () => {
       const invalidPostcode3 = 'A12'
       const invalidPostcode4 = undefined
       const invalidPostcode5 = null
+      const invalidPostcode6 = 'SW11'
       expect(mapPostcodeToRegion(invalidPostcode1)).to.equal('')
       expect(mapPostcodeToRegion(invalidPostcode2)).to.equal('')
       expect(mapPostcodeToRegion(invalidPostcode3)).to.equal('')
       expect(mapPostcodeToRegion(invalidPostcode4)).to.equal('')
       expect(mapPostcodeToRegion(invalidPostcode5)).to.equal('')
+      expect(mapPostcodeToRegion(invalidPostcode6)).to.equal('')
     })
   })
 

--- a/src/apps/companies/apps/add-company/client/transformer.js
+++ b/src/apps/companies/apps/add-company/client/transformer.js
@@ -146,7 +146,11 @@ export const mapPostcodeToRegion = (postcode) => {
     ) {
       return postcode
     }
-    const area = outcode.split(outcode.match(/\d+/)[0])[0]
+    const numericMatch = outcode.match(/\d+/)
+    if (!numericMatch) {
+      return ''
+    }
+    const area = outcode.split(numericMatch[0])[0]
     return POSTCODE_AREA_TO_REGION[area]
   }
 }


### PR DESCRIPTION
## Description of change

When typing postcode in the add company form, if you enter certain postcode, the form will crash and display an error:
"Oops, something went wrong."

This is caused by a bug in `mapPostcodeToRegion` function that assumes that partial outcode will contain numbers.

The fix is adding a check that when there is no numbers in the outcode, it returns an empty string.

## Test instructions

Try to add a company. Enter `SW11` in the Postcode input field. The form shouldn't crash.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
