### PR TITLE
Add D&B Duns number in the business details page

### DIFF
--- a/src/client/modules/Companies/CompanyBusinessDetails/SectionAbout.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/SectionAbout.jsx
@@ -10,6 +10,7 @@ import { currencyGBP } from '../../../utils/number-utils'
 import { NewWindowLink, SummaryTable } from '../../../components'
 import { exportSegmentsLabels, exportSubSegmentsLabels } from './labels'
 import urls from '../../../../lib/urls'
+import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
 const TableDetails = styled('div')`
   display: flex;
@@ -54,7 +55,7 @@ const SectionAbout = ({ company, isDnbCompany, isArchived }) => (
     )}
 
     <SummaryTable.Row heading="Trading name">
-      {isEmpty(company.tradingNames) ? 'Not set' : company.tradingNames}
+      {isEmpty(company.tradingNames) ? NOT_SET_TEXT : company.tradingNames}
     </SummaryTable.Row>
 
     <SummaryTable.Row heading="CDMS reference" hideWhenEmpty={true}>
@@ -72,6 +73,10 @@ const SectionAbout = ({ company, isDnbCompany, isArchived }) => (
         </NewWindowLink>
       </SummaryTable.Row>
     )}
+
+    <SummaryTable.Row heading="DUNS number">
+      {company.dunsNumber ? company.dunsNumber : NOT_SET_TEXT}
+    </SummaryTable.Row>
 
     <SummaryTable.Row heading="Annual turnover">
       {company.turnoverGbp && (
@@ -93,7 +98,7 @@ const SectionAbout = ({ company, isDnbCompany, isArchived }) => (
         </>
       )}
       {!company.turnoverGbp &&
-        (company.turnoverRange ? company.turnoverRange.name : 'Not set')}
+        (company.turnoverRange ? company.turnoverRange.name : NOT_SET_TEXT)}
     </SummaryTable.Row>
 
     <SummaryTable.Row heading="Number of employees">
@@ -114,14 +119,14 @@ const SectionAbout = ({ company, isDnbCompany, isArchived }) => (
         </>
       )}
       {!company.numberOfEmployees &&
-        (company.employeeRange ? company.employeeRange.name : 'Not set')}
+        (company.employeeRange ? company.employeeRange.name : NOT_SET_TEXT)}
     </SummaryTable.Row>
 
     <SummaryTable.Row heading="Website">
       {company.website ? (
         <NewWindowLink href={company.website}>{company.website}</NewWindowLink>
       ) : (
-        'Not set'
+        NOT_SET_TEXT
       )}
     </SummaryTable.Row>
 

--- a/test/component/cypress/specs/Companies/BusinessDetails/SectionAbout.cy.jsx
+++ b/test/component/cypress/specs/Companies/BusinessDetails/SectionAbout.cy.jsx
@@ -19,6 +19,7 @@ describe('Section about', () => {
     tradingNames: ['Venus company'],
     referenceCode: 'ORG-10096257',
     companyNumber: '12345678',
+    dunsNumber: '987654321',
     turnoverGbp: '1000000',
     numberOfEmployees: '5',
     website: 'www.example.com',
@@ -52,6 +53,7 @@ describe('Section about', () => {
             'Companies House number':
               companyWithDetails.companyNumber +
               'View on Companies House website (opens in new tab)',
+            'DUNS number': '987654321',
             'Annual turnover': '£1,000,000',
             'Number of employees': companyWithDetails.numberOfEmployees,
             Website: companyWithDetails.website + ' (opens in new tab)',
@@ -78,6 +80,7 @@ describe('Section about', () => {
           showEditLink: true,
           content: {
             'Trading name': 'Not set',
+            'DUNS number': 'Not set',
             'Annual turnover': 'Not set',
             'Number of employees': 'Not set',
             Website: 'Not set',
@@ -104,6 +107,7 @@ describe('Section about', () => {
           showEditLink: false,
           content: {
             'Trading name': 'Not set',
+            'DUNS number': 'Not set',
             'Annual turnover': 'Not set',
             'Number of employees': 'Not set',
             Website: 'Not set',


### PR DESCRIPTION
## Description of change

Add D&B Duns number to Companies details page.

Also refactored the file to use constant for 'Not set' text.

## Test instructions

When viewing an company's details (Company > Business details) the DUNS number should be shown above Annual turnover. If not available 'Not set' should be displayed.

## Screenshots

### Before

With DUNS number

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/04332d09-c645-49fe-9d2a-9e6bb68f1563" />

Without DUNS number
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/012496d1-a170-4ee0-877c-cdcd2d183151" />


### After

With DUNS number

<img width="1028" alt="image" src="https://github.com/user-attachments/assets/1334e120-c377-4766-a3af-8929301a7b02" />

Without DUNS number set

<img width="1010" alt="image" src="https://github.com/user-attachments/assets/4f7c70fb-d001-48c8-8138-734996fd8860" />


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
