### PR TITLE
Replace `format` with `formatDate` and clean up unused code

### DIFF
--- a/src/apps/__test__/transformers.test.js
+++ b/src/apps/__test__/transformers.test.js
@@ -109,44 +109,6 @@ describe('Global transformers', () => {
     })
   })
 
-  describe('#transformDateStringToDateObject', () => {
-    context('when invalid date string', () => {
-      it('should return empty date object for no args', () => {
-        const actual = this.transformers.transformDateStringToDateObject()
-
-        expect(actual).to.deep.equal({
-          year: '',
-          month: '',
-          day: '',
-        })
-      })
-
-      it('should return empty date object for invalid date', () => {
-        const actual =
-          this.transformers.transformDateStringToDateObject('12345-098-11')
-
-        expect(actual).to.deep.equal({
-          year: '',
-          month: '',
-          day: '',
-        })
-      })
-    })
-
-    context('when valid date string', () => {
-      it('should return correct date object from date string', () => {
-        const actual =
-          this.transformers.transformDateStringToDateObject('2017-09-25')
-
-        expect(actual).to.deep.equal({
-          year: '2017',
-          month: '09',
-          day: '25',
-        })
-      })
-    })
-  })
-
   describe('#transformCountryToOptionWithIsoCode', () => {
     it('should return object with id, name as label and code as value', () => {
       const actual = this.transformers.transformCountryToOptionWithIsoCode({

--- a/src/apps/transformers.js
+++ b/src/apps/transformers.js
@@ -1,6 +1,5 @@
 const { filter, upperFirst } = require('lodash')
 
-const { format, isDateValid } = require('../client/utils/date')
 const { OPTION_NO, OPTION_YES } = require('../common/constants')
 const groupExportCountries = require('../lib/group-export-countries')
 
@@ -38,16 +37,6 @@ function transformDateObjectToDateString(key) {
       .join('-')
 
     return dateString === '--' ? null : dateString
-  }
-}
-
-function transformDateStringToDateObject(dateString) {
-  const isValidDate = dateString && isDateValid(dateString)
-
-  return {
-    year: isValidDate ? format(dateString, 'yyyy') : '',
-    month: isValidDate ? format(dateString, 'MM') : '',
-    day: isValidDate ? format(dateString, 'dd') : '',
   }
 }
 
@@ -94,7 +83,6 @@ module.exports = {
   transformContactToOption,
   transformCountryToOptionWithIsoCode,
   transformDateObjectToDateString,
-  transformDateStringToDateObject,
   transformOptionToValue,
   transformArrayOfOptionsToValues,
   transformToYesNo,

--- a/src/client/modules/Omis/EditQuoteInformation.jsx
+++ b/src/client/modules/Omis/EditQuoteInformation.jsx
@@ -46,9 +46,10 @@ const EditQuoteInformation = ({ csrfToken }) => {
                 name="delivery_date"
                 label="Delivery date of work"
                 hint="For example 28 10 2018"
-                initialValue={transformDateStringToDateObject(
-                  order.deliveryDate
-                )}
+                initialValue={
+                  order.deliveryDate &&
+                  transformDateStringToDateObject(order.deliveryDate)
+                }
                 validate={validateIfDateInFuture}
               />
             </Form>

--- a/src/client/modules/Omis/EditQuoteInformation.jsx
+++ b/src/client/modules/Omis/EditQuoteInformation.jsx
@@ -8,7 +8,7 @@ import urls from '../../../lib/urls'
 import { state2props, TASK_EDIT_OMIS_QUOTE_INFORMATION } from './state'
 import { FORM_LAYOUT } from '../../../common/constants'
 import { transformQuoteInformationForApi } from './transformers'
-import { transformDateStringToDateObject } from '../../../apps/transformers'
+import { transformDateStringToDateObject } from '../../../client/transformers'
 import { validateIfDateInFuture } from './validators'
 import OMISLayout from './OMISLayout'
 

--- a/src/client/transformers/index.js
+++ b/src/client/transformers/index.js
@@ -1,7 +1,12 @@
 import { uniq } from 'lodash'
 
 import { OPTION_NO, OPTION_YES } from '../../common/constants'
-import { format, isDateValid } from '../../client/utils/date'
+import {
+  formatDate,
+  DATE_FORMAT_DAY,
+  DATE_FORMAT_YEAR,
+  DATE_FORMAT_MONTH,
+} from '../../client/utils/date-utils'
 
 export const transformDateObjectToDateString = (value) => {
   if (value) {
@@ -54,13 +59,11 @@ export const transformIdNameToValueLabel = (value) => {
   return null
 }
 
-export const transformDateStringToDateObject = (dateString) => {
-  const isValidDate = dateString && isDateValid(dateString)
-
+export const transformDateStringToDateObject = (dateISO) => {
   return {
-    year: isValidDate ? format(dateString, 'yyyy') : '',
-    month: isValidDate ? format(dateString, 'MM') : '',
-    day: isValidDate ? format(dateString, 'dd') : '',
+    year: formatDate(dateISO, DATE_FORMAT_YEAR),
+    month: formatDate(dateISO, DATE_FORMAT_MONTH),
+    day: formatDate(dateISO, DATE_FORMAT_DAY),
   }
 }
 

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -14,7 +14,6 @@ const {
   endOfToday,
   startOfMonth: getStartOfMonth,
   isWithinInterval,
-  format: formatFns,
   formatDistanceToNowStrict,
   isAfter,
   isValid,
@@ -26,11 +25,12 @@ const {
 } = require('date-fns')
 
 const {
-  DATE_LONG_FORMAT_2,
-  DATE_LONG_FORMAT_3,
-  DATE_SHORT_FORMAT,
-  DATE_DAY_MONTH,
-} = require('../../common/constants')
+  formatDate,
+  DATE_FORMAT_ISO,
+  DATE_FORMAT_COMPACT,
+  DATE_FORMAT_DAY_MONTH,
+  DATE_FORMAT_YEAR_MONTH,
+} = require('./date-utils')
 
 /**
  * Date validation functions
@@ -44,22 +44,13 @@ function isUnparsedDateValid(date) {
   return isValid(date)
 }
 
-function isNormalisedDateValid(year, month, day, format = DATE_LONG_FORMAT_3) {
+function isNormalisedDateValid(year, month, day, format = DATE_FORMAT_ISO) {
   const date = normaliseAndFormatDate(year, month, day)
   return isValid(parse(date, format, new Date()))
 }
 
 function isShortDateValid(year, month) {
-  return isNormalisedDateValid(year, month, null, DATE_SHORT_FORMAT)
-}
-
-/**
- * @deprecated This function is deprecated. Use `formatDate` instead.
- *
- * This function will be removed in the near future.
- */
-function format(dateStr, dateFormat = DATE_LONG_FORMAT_2) {
-  return isDateValid(dateStr) ? formatFns(parseISO(dateStr), dateFormat) : null
+  return isNormalisedDateValid(year, month, null, DATE_FORMAT_YEAR_MONTH)
 }
 
 /**
@@ -134,8 +125,10 @@ function formatStartAndEndDate(startDate, endDate) {
   if (startDate) {
     const startDateParsed = startDate ? parseISO(startDate) : startDate
     const endDateParsed = endDate ? parseISO(endDate) : endDate
-    const startDateFormatted = startDate ? format(startDate) : startDate
-    const endDateFormatted = endDate ? format(endDate) : endDate
+    const startDateFormatted = startDate
+      ? formatDate(startDate, DATE_FORMAT_COMPACT)
+      : startDate
+    const endDateFormatted = endDate ? formatDate(endDate) : endDate
 
     //When end date is missing or before start date
     if (!endDate || !isAfter(endDateParsed, startDateParsed)) {
@@ -151,7 +144,7 @@ function formatStartAndEndDate(startDate, endDate) {
     }
     // When start and end date are in the same year
     if (startDateParsed.getFullYear() === endDateParsed.getFullYear()) {
-      return `${format(startDate, DATE_DAY_MONTH)} to ${endDateFormatted}`
+      return `${formatDate(startDate, DATE_FORMAT_DAY_MONTH)} to ${endDateFormatted}`
     }
     // When start and end date are in different years
     return `${startDateFormatted} to ${endDateFormatted}`
@@ -260,7 +253,6 @@ function isWithinLastTwelveMonths(date) {
 }
 
 module.exports = {
-  format,
   generateFinancialYearLabel,
   getDifferenceInDays,
   getDifferenceInDaysLabel,

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -1,9 +1,3 @@
-// These are date-fns format codes - see https://date-fns.org/v2.23.0/docs/format
-const DATE_LONG_FORMAT_2 = 'dd MMM yyyy'
-const DATE_LONG_FORMAT_3 = 'yyyy-MM-dd'
-const DATE_SHORT_FORMAT = 'yyyy-MM'
-const DATE_DAY_MONTH = 'dd MMM'
-
 const UNITED_KINGDOM_ID = '80756b9a-5d95-e211-a939-e4115bead28a'
 const UNITED_STATES_ID = '81756b9a-5d95-e211-a939-e4115bead28a'
 const CANADA_ID = '5daf72a6-5d95-e211-a939-e4115bead28a'
@@ -60,10 +54,6 @@ const EXPORT_INTEREST_STATUS = {
 }
 
 module.exports = {
-  DATE_DAY_MONTH,
-  DATE_LONG_FORMAT_2,
-  DATE_LONG_FORMAT_3,
-  DATE_SHORT_FORMAT,
   UNITED_KINGDOM_ID,
   UNITED_STATES_ID,
   CANADA_ID,

--- a/test/sandbox/fixtures/v3/omis/paid-order.json
+++ b/test/sandbox/fixtures/v3/omis/paid-order.json
@@ -59,7 +59,7 @@
   "further_info": "legacy further info",
   "existing_agents": "legacy existing agents",
   "permission_to_approach_contacts": "legacy permission to approach contacts",
-  "delivery_date": "",
+  "delivery_date": null,
   "po_number": "123PO",
   "vat_status": "eu",
   "vat_number": "0123456789",


### PR DESCRIPTION
## Description of change
Replaced the `format` function with `formatDate`. Removed unused constants, an unused function and its corresponding tests.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
