### PR TITLE
Refactor and simplify date utility functions

### DIFF
--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -36,7 +36,7 @@ import {
   DATE_FORMAT_YEAR,
 } from '../../../../../client/utils/date-utils'
 
-const { transformValueForAPI } = require('../../../../../client/utils/date')
+const { formatDateWithYearMonth } = require('../../../../../client/utils/date')
 
 const FIELDS_TO_OMIT = [
   'currently_exporting',
@@ -276,7 +276,7 @@ export function saveInteraction({ values, companyIds, referralId }) {
     dit_participants: values.dit_participants.map((a) => ({
       adviser: a.value,
     })),
-    date: transformValueForAPI(values.date),
+    date: formatDateWithYearMonth(values.date),
     policy_areas: transformArrayOfOptionsToValues(values.policy_areas),
     communication_channel: transformOptionToValue(values.communication_channel),
     event: transformOptionToValue(values.event),

--- a/src/client/components/Form/elements/FieldDate/index.jsx
+++ b/src/client/components/Form/elements/FieldDate/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { isValid } from 'date-fns'
 import { castArray, snakeCase } from 'lodash'
 import styled from 'styled-components'
 import ErrorText from '@govuk-react/error-text'
@@ -16,10 +17,7 @@ import FieldWrapper from '../FieldWrapper'
 import useField from '../../hooks/useField'
 import { useFormContext } from '../../hooks'
 
-const {
-  isNormalisedDateValid,
-  isShortDateValid,
-} = require('../../../../utils/date')
+const { parseDateWithYearMonth } = require('../../../../utils/date')
 
 const DAY = 'day'
 const MONTH = 'month'
@@ -56,10 +54,8 @@ const StyledList = styled.div`
 const getValidator =
   (required, invalid, format) =>
   ({ day, month, year }) => {
+    const isDateValid = isValid(parseDateWithYearMonth(year, month, day))
     const isLong = format === FORMAT_LONG
-    const isValid = isLong
-      ? isNormalisedDateValid(year, month, day)
-      : isShortDateValid(year, month)
 
     const isDateEmpty = isLong ? !day && !month && !year : !month && !year
 
@@ -71,7 +67,7 @@ const getValidator =
       return required
     }
 
-    if (!isValid && !isDateEmpty) {
+    if (!isDateValid && !isDateEmpty) {
       return invalid || 'Enter a valid date'
     }
 

--- a/src/client/modules/Companies/AccountManagement/transformers.js
+++ b/src/client/modules/Companies/AccountManagement/transformers.js
@@ -1,5 +1,5 @@
 import { transformDateStringToDateObject } from '../../../transformers'
-import { transformValueForAPI } from '../../../utils/date'
+import { formatDateWithYearMonth } from '../../../utils/date'
 import {
   transformBoolToRadioOption,
   transformRadioOptionToBool,
@@ -16,7 +16,7 @@ export const transformFormValuesForAPI = ({
 }) => ({
   subject,
   detail,
-  target_date: transformValueForAPI(target_date),
+  target_date: formatDateWithYearMonth(target_date),
   company,
   has_blocker: transformRadioOptionToBool(has_blocker),
   blocker_description,

--- a/src/client/modules/Contacts/ContactAuditHistory/transformers.js
+++ b/src/client/modules/Contacts/ContactAuditHistory/transformers.js
@@ -1,8 +1,8 @@
 import { isBoolean, isNumber } from 'lodash'
+import { isValid } from 'date-fns'
 
 import { transformFieldName } from '../../../components/AuditHistory/transformers'
 import { CONTACT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { isUnparsedDateValid } from '../../../utils/date'
 import {
   formatDate,
   DATE_FORMAT_MEDIUM_WITH_TIME,
@@ -29,6 +29,6 @@ export const getValue = (value, field) =>
         : NO
       : isNumber(value)
         ? value.toString()
-        : isUnparsedDateValid(value)
+        : isValid(value)
           ? formatDate(value, DATE_FORMAT_MEDIUM_WITH_TIME)
           : value || NOT_SET

--- a/src/client/modules/Investments/Opportunities/tasks.js
+++ b/src/client/modules/Investments/Opportunities/tasks.js
@@ -1,7 +1,7 @@
 import urls from '../../../../lib/urls'
 import { idNamesToValueLabels } from '../../../utils'
 import { apiProxyAxios } from '../../../components/Task/utils'
-import { transformValueForAPI } from '../../../utils/date'
+import { formatDateWithYearMonth } from '../../../utils/date'
 import { getMetadataOptions } from '../../../metadata'
 
 import { transformInvestmentOpportunityDetails } from './transformers'
@@ -47,7 +47,7 @@ export function saveOpportunityDetails({ values, opportunityId }) {
         : undefined,
       required_checks_conducted_by: values.requiredChecksConductedBy?.value,
       required_checks_conducted_on: values.requiredChecksConductedOn
-        ? transformValueForAPI(values.requiredChecksConductedOn)
+        ? formatDateWithYearMonth(values.requiredChecksConductedOn)
         : undefined,
       lead_dit_relationship_manager: values.leadRelationshipManager?.value,
       other_dit_contacts: values.otherDitContacts?.map(({ value }) => value),

--- a/src/client/modules/Investments/Projects/EditHistory/transformers.js
+++ b/src/client/modules/Investments/Projects/EditHistory/transformers.js
@@ -1,7 +1,7 @@
 import { isBoolean, isNumber } from 'lodash'
+import { isValid } from 'date-fns'
 
 import { PROJECT_FIELD_NAME_TO_LABEL_MAP } from './constants'
-import { isUnparsedDateValid } from '../../../../utils/date'
 import { formatDate, DATE_FORMAT_MEDIUM } from '../../../../utils/date-utils'
 import { currencyGBP } from '../../../../utils/number-utils'
 import { NOT_SET, NO, YES } from '../../../../components/AuditHistory/constants'
@@ -36,6 +36,6 @@ export const getValue = (value, field) =>
           ? value.toString()
           : Array.isArray(value)
             ? value.join(', ')
-            : isUnparsedDateValid(value)
+            : isValid(value)
               ? formatDate(value, DATE_FORMAT_MEDIUM)
               : value || NOT_SET

--- a/src/client/modules/Investments/Projects/Propositions/transformers.js
+++ b/src/client/modules/Investments/Projects/Propositions/transformers.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { Link } from 'govuk-react'
 import styled from 'styled-components'
 
-import { transformValueForAPI } from '../../../../utils/date'
+import { formatDateWithYearMonth } from '../../../../utils/date'
 import { VIRUS_SCAN_STATUSES } from '../constants'
 
 import urls from '../../../../../lib/urls'
@@ -32,7 +32,7 @@ export const transformPropositionForAPI = ({ projectId, values }) => {
     deadline_day: proposition_deadline.day,
     deadline_month: proposition_deadline.month,
     deadline_year: proposition_deadline.year,
-    deadline: transformValueForAPI(proposition_deadline),
+    deadline: formatDateWithYearMonth(proposition_deadline),
   }
 }
 

--- a/src/client/modules/Tasks/TaskForm/__test__/validators.test.js
+++ b/src/client/modules/Tasks/TaskForm/__test__/validators.test.js
@@ -1,0 +1,63 @@
+import { addDays, subDays, format } from 'date-fns'
+
+import { validateIfDateInFuture } from '../validators'
+
+describe('validateIfDateInFuture', () => {
+  it('should return null for a date in the future (with day provided)', () => {
+    const futureDate = addDays(new Date(), 10)
+    const year = format(futureDate, 'yyyy')
+    const month = format(futureDate, 'MM')
+    const day = format(futureDate, 'dd')
+
+    const result = validateIfDateInFuture({ year, month, day })
+    expect(result).to.be.null
+  })
+
+  it('should return null for a date in the future (year and month only)', () => {
+    const futureDate = addDays(new Date(), 40) // Ensures crossing month boundary
+    const year = format(futureDate, 'yyyy')
+    const month = format(futureDate, 'MM')
+
+    const result = validateIfDateInFuture({ year, month })
+    expect(result).to.be.null
+  })
+
+  it('should return error message for a past date (with day provided)', () => {
+    const pastDate = subDays(new Date(), 10)
+    const year = format(pastDate, 'yyyy')
+    const month = format(pastDate, 'MM')
+    const day = format(pastDate, 'dd')
+
+    const result = validateIfDateInFuture({ year, month, day })
+    expect(result).to.equal('Enter a date in the future')
+  })
+
+  it('should return error message for a past date (year and month only)', () => {
+    const pastDate = subDays(new Date(), 40)
+    const year = format(pastDate, 'yyyy')
+    const month = format(pastDate, 'MM')
+
+    const result = validateIfDateInFuture({ year, month })
+    expect(result).to.equal('Enter a date in the future')
+  })
+
+  it('should handle edge cases correctly (today is not in the future)', () => {
+    const today = new Date()
+    const year = format(today, 'yyyy')
+    const month = format(today, 'MM')
+    const day = format(today, 'dd')
+
+    const result = validateIfDateInFuture({ year, month, day })
+    expect(result).to.equal('Enter a date in the future')
+  })
+
+  it('should handle invalid inputs gracefully', () => {
+    const invalidMessage = 'Enter a date in the future'
+
+    expect(validateIfDateInFuture({})).to.equal(invalidMessage)
+    expect(validateIfDateInFuture({ year: '2025' })).to.equal(invalidMessage)
+    expect(validateIfDateInFuture({ year: '2025', month: '13' })).to.equal(
+      invalidMessage
+    )
+  })
+})

--- a/src/client/modules/Tasks/TaskForm/transformers.js
+++ b/src/client/modules/Tasks/TaskForm/transformers.js
@@ -7,7 +7,7 @@ import {
   transformIdNameToValueLabel,
 } from '../../../transformers'
 import {
-  transformValueForAPI,
+  formatDateWithYearMonth,
   convertDateToFieldDateObject,
 } from '../../../utils/date'
 import { formatDate, DATE_FORMAT_ISO } from '../../../utils/date-utils'
@@ -61,7 +61,7 @@ export const getDueDate = (dueDate, customDate) => {
   const today = new Date()
 
   const handlers = {
-    custom: () => transformValueForAPI(customDate),
+    custom: () => formatDateWithYearMonth(customDate),
     month: () => formatDate(addMonths(today, 1), DATE_FORMAT_ISO),
     week: () => formatDate(addDays(today, 7), DATE_FORMAT_ISO),
   }

--- a/src/client/modules/Tasks/TaskForm/validators.js
+++ b/src/client/modules/Tasks/TaskForm/validators.js
@@ -1,9 +1,11 @@
 import { isFuture } from 'date-fns'
 
-import { transformValueForAPI } from '../../../utils/date'
+import { parseDateWithYearMonth } from '../../../utils/date'
 
-export const validateIfDateInFuture = (values) =>
-  isFuture(transformValueForAPI(values)) ? null : 'Enter a date in the future'
+export const validateIfDateInFuture = ({ year, month, day }) =>
+  isFuture(parseDateWithYearMonth(year, month, day))
+    ? null
+    : 'Enter a date in the future'
 
 export const validateDaysRange = (value) =>
   !value || value < 1 || value > 365 ? 'Enter a number between 1 and 365' : null

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -1,9 +1,10 @@
-import { subMonths, subYears, addDays } from 'date-fns'
+import { subMonths, subYears, addDays, isValid, format } from 'date-fns'
 
 import {
   areDatesEqual,
   getStartOfMonth,
   getRandomDateInRange,
+  parseDateWithYearMonth,
   isWithinLastTwelveMonths,
   convertDateToFieldDateObject,
   convertDateToFieldShortDateObject,
@@ -127,5 +128,67 @@ describe('getRandomDateInRange', () => {
     expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
       'Start date cannot be greater than end date.'
     )
+  })
+})
+
+describe('parseDateWithYearMonth', () => {
+  it('should parse a valid full date (yyyy-MM-dd)', () => {
+    const date = parseDateWithYearMonth('2024', '12', '31')
+    expect(isValid(date)).to.be.true
+    expect(format(date, 'yyyy-MM-dd')).to.equal('2024-12-31')
+  })
+
+  it('should parse a valid year and month (yyyy-MM)', () => {
+    const date = parseDateWithYearMonth('2024', '12')
+    expect(isValid(date)).to.be.true
+    expect(format(date, 'yyyy-MM')).to.equal('2024-12')
+  })
+
+  it('should handle invalid year (non-numeric)', () => {
+    const date = parseDateWithYearMonth('abcd', '12', '31')
+    expect(isValid(date)).to.be.false
+  })
+
+  it('should handle invalid month (out of range)', () => {
+    const date = parseDateWithYearMonth('2024', '13', '31')
+    expect(isValid(date)).to.be.false
+  })
+
+  it('should handle invalid day (out of range)', () => {
+    const date = parseDateWithYearMonth('2024', '12', '32')
+    expect(isValid(date)).to.be.false
+  })
+
+  it('should handle missing day gracefully (assume first of month)', () => {
+    const date = parseDateWithYearMonth('2024', '12')
+    expect(isValid(date)).to.be.true
+    expect(format(date, 'yyyy-MM-dd')).to.equal('2024-12-01')
+  })
+
+  it('should handle single-digit month and day', () => {
+    const date = parseDateWithYearMonth('2024', '2', '9')
+    expect(isValid(date)).to.be.true
+    expect(format(date, 'yyyy-MM-dd')).to.equal('2024-02-09')
+  })
+
+  it('should handle valid leap year date', () => {
+    const date = parseDateWithYearMonth('2024', '2', '29')
+    expect(isValid(date)).to.be.true
+    expect(format(date, 'yyyy-MM-dd')).to.equal('2024-02-29')
+  })
+
+  it('should handle invalid non-leap year date', () => {
+    const date = parseDateWithYearMonth('2023', '2', '29')
+    expect(isValid(date)).to.be.false
+  })
+
+  it('should handle missing month (invalid case)', () => {
+    const date = parseDateWithYearMonth('2024', null, '31')
+    expect(isValid(date)).to.be.false
+  })
+
+  it('should handle missing year (invalid case)', () => {
+    const date = parseDateWithYearMonth(null, '12', '31')
+    expect(isValid(date)).to.be.false
   })
 })

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -5,6 +5,7 @@ import {
   getStartOfMonth,
   getRandomDateInRange,
   parseDateWithYearMonth,
+  formatDateWithYearMonth,
   isWithinLastTwelveMonths,
   convertDateToFieldDateObject,
   convertDateToFieldShortDateObject,
@@ -190,5 +191,51 @@ describe('parseDateWithYearMonth', () => {
   it('should handle missing year (invalid case)', () => {
     const date = parseDateWithYearMonth(null, '12', '31')
     expect(isValid(date)).to.be.false
+  })
+})
+
+describe('formatDateWithYearMonth', () => {
+  it('should format a full date (year, month, day)', () => {
+    const result = formatDateWithYearMonth({ year: 2025, month: 1, day: 6 })
+    expect(result).to.equal('2025-01-06')
+  })
+
+  it('should format a date when only year and month are provided', () => {
+    const result = formatDateWithYearMonth({ year: 2025, month: 11 })
+    expect(result).to.equal('2025-11')
+  })
+
+  it('should handle single-digit months and days', () => {
+    const result = formatDateWithYearMonth({ year: 2025, month: 4, day: 9 })
+    expect(result).to.equal('2025-04-09')
+  })
+
+  it('should throw an error for invalid year', () => {
+    expect(() =>
+      formatDateWithYearMonth({ year: 'invalid', month: 1, day: 1 })
+    ).to.throw()
+  })
+
+  it('should throw an error for invalid month', () => {
+    expect(() =>
+      formatDateWithYearMonth({ year: 2025, month: 13, day: 1 })
+    ).to.throw()
+  })
+
+  it('should throw an error for invalid day', () => {
+    expect(() =>
+      formatDateWithYearMonth({ year: 2025, month: 2, day: 30 })
+    ).to.throw()
+  })
+
+  it('should handle edge case: February 29 on a leap year', () => {
+    const result = formatDateWithYearMonth({ year: 2024, month: 2, day: 29 })
+    expect(result).to.equal('2024-02-29')
+  })
+
+  it('should throw an error for February 29 on a non-leap year', () => {
+    expect(() =>
+      formatDateWithYearMonth({ year: 2023, month: 2, day: 29 })
+    ).to.throw()
   })
 })

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -33,14 +33,6 @@ const {
 } = require('./date-utils')
 
 /**
- * Date validation functions
- */
-
-function isDateValid(date) {
-  return isValid(parseISO(date))
-}
-
-/**
  * Parses a date string given a year, month, and optional day.
  *
  * @param {string} year - The year as a string (e.g., '2024').
@@ -276,7 +268,6 @@ module.exports = {
   getDifferenceInDaysLabel,
   getDifferenceInWords,
   getFinancialYearStart,
-  isDateValid,
   parseDateWithYearMonth,
   formatDateWithYearMonth,
   createDateFromObject,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -40,10 +40,6 @@ function isDateValid(date) {
   return isValid(parseISO(date))
 }
 
-function isUnparsedDateValid(date) {
-  return isValid(date)
-}
-
 /**
  * Parses a date string given a year, month, and optional day.
  *
@@ -283,7 +279,6 @@ module.exports = {
   isDateValid,
   isValid,
   parseDateWithYearMonth,
-  isUnparsedDateValid,
   formatDateWithYearMonth,
   createDateFromObject,
   formatStartAndEndDate,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -277,7 +277,6 @@ module.exports = {
   getDifferenceInWords,
   getFinancialYearStart,
   isDateValid,
-  isValid,
   parseDateWithYearMonth,
   formatDateWithYearMonth,
   createDateFromObject,

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -44,40 +44,62 @@ function isUnparsedDateValid(date) {
   return isValid(date)
 }
 
-function isNormalisedDateValid(year, month, day, format = DATE_FORMAT_ISO) {
-  const date = normaliseAndFormatDate(year, month, day)
-  return isValid(parse(date, format, new Date()))
-}
-
-function isShortDateValid(year, month) {
-  return isNormalisedDateValid(year, month, null, DATE_FORMAT_YEAR_MONTH)
+/**
+ * Parses a date string given a year, month, and optional day.
+ *
+ * @param {string} year - The year as a string (e.g., '2024').
+ * @param {string} month - The month as a string (1-based, e.g., '12' for December).
+ * @param {string} [day] - The optional day as a string (e.g., '31'). If omitted, defaults to the first day of the month.
+ * @returns {Date} A `Date` object representing the parsed date. If the input values are invalid,
+ *                 the returned `Date` object will be invalid (check with `isValid(date)`).
+ *
+ * @example
+ * // Full date parsing
+ * const date = parseDateWithYearMonth('2024', '12', '31')
+ * console.log(date) // Outputs: Tue Dec 31 2024 00:00:00 GMT+0000 (UTC)
+ *
+ * @example
+ * // Parsing only year and month
+ * const date = parseDateWithYearMonth('2024', '12')
+ * console.log(date) // Outputs: Sun Dec 01 2024 00:00:00 GMT+0000 (UTC)
+ *
+ * @example
+ * // Invalid date
+ * const date = parseDateWithYearMonth('2024', '13', '31')
+ * console.log(isValid(date)) // Outputs: false
+ *
+ * @note This function does not throw errors for invalid inputs but returns an invalid `Date` object instead.
+ */
+function parseDateWithYearMonth(year, month, day) {
+  const dateString = day ? `${year}-${month}-${day}` : `${year}-${month}`
+  const format = day ? DATE_FORMAT_ISO : DATE_FORMAT_YEAR_MONTH
+  return parse(dateString, format, new Date())
 }
 
 /**
- * Parsing functions
+ * Formats a date string based on a given year, month, and optional day.
+ *
+ * @param {Object} params - The date components to format.
+ * @param {string} params.year - The year as a string (e.g., '2024').
+ * @param {string} params.month - The month as a string (1-based, e.g., '12' for December).
+ * @param {string} [params.day] - The optional day as a string (e.g., '31'). If omitted, defaults to the first day of the month.
+ * @returns {string} The formatted date string in either 'yyyy-MM-dd' or 'yyyy-MM'.
+ *
+ * @example
+ * // Format full date
+ * const formattedDate = formatDateWithYearMonth({ year: '2024', month: '12', day: '31' })
+ * console.log(formattedDate) // Outputs: '2024-12-31'
+ *
+ * @example
+ * // Format year and month only
+ * const formattedDate = formatDateWithYearMonth({ year: '2024', month: '12' })
+ * console.log(formattedDate) // Outputs: '2024-12'
  */
-
-const padZero = (value) => {
-  const parsedValue = parseInt(value, 10)
-  if (Number.isNaN(parsedValue)) {
-    return value
-  }
-  return parsedValue < 10 ? `0${parsedValue}` : parsedValue.toString()
-}
-
-function normaliseAndFormatDate(year, month, day) {
-  const y = padZero(year)
-  const m = padZero(month)
-  const yearAndMonth = `${padZero(y)}-${padZero(m)}`
-  return day ? `${yearAndMonth}-${padZero(day)}` : yearAndMonth
-}
-
-function transformValueForAPI({ year, month, day = 1 }) {
-  if (year && month && day) {
-    return normaliseAndFormatDate(year, month, day)
-  }
-
-  return null
+const formatDateWithYearMonth = ({ year, month, day }) => {
+  return formatDate(
+    parseDateWithYearMonth(year, month, day),
+    day ? DATE_FORMAT_ISO : DATE_FORMAT_YEAR_MONTH
+  )
 }
 
 /**
@@ -260,10 +282,9 @@ module.exports = {
   getFinancialYearStart,
   isDateValid,
   isValid,
-  isNormalisedDateValid,
-  isShortDateValid,
+  parseDateWithYearMonth,
   isUnparsedDateValid,
-  transformValueForAPI,
+  formatDateWithYearMonth,
   createDateFromObject,
   formatStartAndEndDate,
   convertDateToFieldShortDateObject,


### PR DESCRIPTION
## Description of change

This refactor streamlines date-related utilities by introducing new functions and removing redundant ones:

Added Functions

* `parseDateWithYearMonth`: Parses dates using year and month formats (day is optional)
* `formatDateWithYearMonth`: Formats dates into a year-month representation (day is optional)

Removed Functions
* `isNormalisedDateValid`: Removed as part of simplification.
* `isShortDateValid`: No longer necessary with new parsing logic.
* `padZero`: Superseded by other utilities.
* `normaliseAndFormatDate`: No longer necessary with new parsing logic.
* `transformValueForAPI`: Removed as part of simplification.
* `isUnparsedDateValid`: Removed as part of simplification.
* `isDateValid`: Removed as part of simplification.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
