### PR TITLE
Add field to support form to request a data amendment

### DIFF
--- a/src/apps/support/macros.js
+++ b/src/apps/support/macros.js
@@ -18,6 +18,10 @@ const feedbackFormConfig = (browserInfo) => ({
           label: "I don't have access",
         },
         {
+          value: 'data_amendment',
+          label: 'I require a data amendment',
+        },
+        {
           value: 'bug',
           label: 'I have another problem',
         },


### PR DESCRIPTION
## Description of change

We've been asked to add a new field to the support form to allow users to send requests for data to be amended. Previously these requests were sent via the 'I have another problem' option, which Zendesk tags as bugs. This is causing issues when compiling the monthly support stats, as the number of bugs reported is inflated by data amendment requests (which should be tracked separately).

## Test instructions

Go to the support form. You should see a new radio button to request a data amendment. 

<img width="739" alt="Screenshot 2025-01-03 at 10 48 40" src="https://github.com/user-attachments/assets/cb96b989-a5d6-4155-882f-7c3644204608" />


Select this option and submit the form. Then go to the non-prod Zendesk environment (ask SRE for access if you don't have it) and you should see your new support ticket is tagged as `data_amendment`.

<img width="773" alt="Screenshot 2025-01-03 at 10 54 02" src="https://github.com/user-attachments/assets/b638be4d-0a4b-4d23-8521-dbab7e8812ab" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
