### PR TITLE
Update test date format to match date format used in component

### DIFF
--- a/test/end-to-end/cypress/specs/DIT/audit-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/audit-spec.js
@@ -3,7 +3,7 @@ const selectors = require('../../../../selectors')
 const urls = require('../../../../../src/lib/urls')
 const {
   formatDate,
-  DATE_FORMAT_COMPACT,
+  DATE_FORMAT_MEDIUM,
 } = require('../../../../../src/client/utils/date-utils')
 const {
   assertFlashMessage,
@@ -16,7 +16,7 @@ const {
   assertBadgeNotPresent,
 } = require('../../../../functional/cypress/support/collection-list-assertions')
 
-const todaysDate = formatDate(new Date(), DATE_FORMAT_COMPACT)
+const todaysDate = formatDate(new Date(), DATE_FORMAT_MEDIUM)
 let companyObj
 let contactObj
 let investmentProjectObj


### PR DESCRIPTION
## Description of change

Fix flaky test for wrong format in the contact audit log.

Audit log format example: 3 January 2024
Test expected: **0**3 January 2024

This should fix the other failing tests.

## Checklist
- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
