### PR TITLE
EYB human readable labels

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -4,6 +4,7 @@ import { Link } from 'govuk-react'
 
 import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
+import { camelCaseToSentenceCase } from '../utils'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
@@ -68,7 +69,7 @@ const EYBLeadDetails = () => {
               </SummaryTable.Row>
               <SummaryTable.Row
                 heading="When do you want to set up?"
-                children={eybLead.landingTimeframe}
+                children={camelCaseToSentenceCase(eybLead.landingTimeframe)}
               />
               <SummaryTable.Row
                 heading="Do you know where you want to set up in the UK?"
@@ -80,11 +81,11 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="How do you plan to expand your business in the UK?"
-                children={eybLead.intent}
+                children={camelCaseToSentenceCase(eybLead.intent)}
               />
               <SummaryTable.Row
                 heading="How many people do you want to hire in the UK in the first 3 years?"
-                children={eybLead.hiring}
+                children={camelCaseToSentenceCase(eybLead.hiring)}
               />
               <SummaryTable.Row
                 heading="How much do you want to spend on setting up in the first 3 years?"

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -1,5 +1,13 @@
 import urls from '../../../lib/urls'
 
+const transformToSentenceCase = (text) => {
+  let result = text.replace(/_/g, ' ')
+  return (
+    result.charAt(0).toUpperCase() +
+    result.slice(1).toLowerCase().replace(/uk/g, 'UK')
+  )
+}
+
 export const buildProjectBreadcrumbs = (pageBreadcrumbs) => {
   const initialBreadcrumbs = [
     { link: urls.dashboard.index(), text: 'Home' },
@@ -28,4 +36,18 @@ export const buildEYBLeadBreadcrumbs = (pageBreadcrumbs) => {
     },
   ]
   return initialBreadcrumbs.concat(pageBreadcrumbs)
+}
+
+export const camelCaseToSentenceCase = (text) => {
+  if (typeof text === 'string') {
+    return transformToSentenceCase(text)
+  } else if (Array.isArray(text)) {
+    return text.map((item) => {
+      if (typeof item === 'string') {
+        return transformToSentenceCase(item)
+      } else {
+        return item
+      }
+    })
+  }
 }

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -3,6 +3,7 @@ import {
   assertLeadBreadcrumbs,
 } from '../../support/assertions'
 import { investments } from '../../../../../src/lib/urls'
+import { camelCaseToSentenceCase } from '../../../../../src/client/modules/Investments/utils'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
 import { NOT_SET_TEXT } from '../../../../../src/apps/companies/constants'
 import { VALUES_VALUE_TO_LABEL_MAP } from '../../../../../src/client/modules/Investments/EYBLeads/constants'
@@ -51,6 +52,18 @@ describe('EYB lead details', () => {
       setup(eybLeadWithValues)
       cy.visit(investments.eybLeads.details(eybLeadWithValues.id))
       cy.wait('@getEYBLeadDetails')
+    })
+
+    it('should return non-string, non-array items as it is', () => {
+      const input = [123, true, { key: 'value' }]
+      const output = camelCaseToSentenceCase(input)
+      expect(output).to.deep.equal([123, true, { key: 'value' }])
+    })
+
+    it('should transform a camelCase string to sentence case', () => {
+      expect(
+        camelCaseToSentenceCase('find people_with specialist skills_in uk')
+      ).to.equal('Find people with specialist skills in UK')
     })
 
     it('should render all the fields of the details table', () => {


### PR DESCRIPTION
## Description of change

As Part of the EYB work , converting some fields to human readable fields.

## Test instructions
Should see Sentence case in the below fields:

When do you want to set up?
How do you plan to expand your business in the UK?
How many people do you want to hire in the UK in the first 3 years?

## Screenshots

### Before

<img width="1316" alt="image" src="https://github.com/user-attachments/assets/f1e21ce0-a331-4fdb-8043-f32b17640918" />

### After

<img width="1298" alt="image" src="https://github.com/user-attachments/assets/058aa04a-282e-4b4e-896b-dfe262432ea6" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
