### PR TITLE
Fix excessive calls to `window.history.pushState`

### DIFF
--- a/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
+++ b/src/apps/companies/apps/dnb-hierarchy/client/DnbHierarchy.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import PropTypes from 'prop-types'
 import axios from 'axios'
 import useSearchParam from 'react-use/lib/useSearchParam'
@@ -10,14 +11,13 @@ const DnbHierarchy = ({ dataEndpoint, isGlobalHQ }) => {
   const [companies, setCompanies] = useState([])
   const [totalItems, setTotalItems] = useState(0)
   const [isLoading, setIsLoading] = useState(true)
+  const navigate = useNavigate()
 
   const activePage = parseInt(useSearchParam('page'), 10) || 1
   const getPageUrl = (page) => `${window.location.pathname}?page=${page}`
-  const setActivePage = (page) =>
-    window.history.pushState({}, '', getPageUrl(page))
 
   const onPageClick = (page) => {
-    setActivePage(page)
+    navigate(getPageUrl(page))
   }
 
   useEffect(() => {

--- a/src/client/modules/Investments/Projects/ProjectTasks.jsx
+++ b/src/client/modules/Investments/Projects/ProjectTasks.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { H2 } from 'govuk-react'
 import { LEVEL_SIZE } from '@govuk-react/constants'
-import { useParams } from 'react-router-dom'
+import { useParams, useNavigate } from 'react-router-dom'
 import useSearchParam from 'react-use/lib/useSearchParam'
 import { connect } from 'react-redux'
 import qs from 'qs'
@@ -18,15 +18,14 @@ import InvestmentName from './InvestmentName'
 import ProjectLayoutNew from '../../../components/Layout/ProjectLayoutNew'
 
 const ProjectTasks = () => {
+  const navigate = useNavigate()
   const { projectId } = useParams()
   const parsedQueryString = qs.parse(location.search.slice(1))
   const activePage = parseInt(useSearchParam('page'), 10) || 1
   const getPageUrl = (page) => `${window.location.pathname}?page=${page}`
-  const setActivePage = (page) =>
-    window.history.pushState({}, '', getPageUrl(page))
 
   const onPageClick = (page) => {
-    setActivePage(page)
+    navigate(getPageUrl(page))
   }
   const returnUrl = encodeURIComponent(location.pathname + location.search)
 


### PR DESCRIPTION
## Description of change
The error occurs because we're invoking `history.pushState` too frequently, which exceeds the browser's limit of 100 calls per 10 seconds.

The `onPageClick` handler is being called repeatedly in a short time frame due to a re-render loop which can trigger this error.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
