### PR TITLE
Remove `createDateFromObject` and replace with `parseDateWithYearMonth`

### DIFF
--- a/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/validators.js
+++ b/src/client/modules/Companies/CompanyInvestments/LargeCapitalProfile/validators.js
@@ -1,9 +1,15 @@
-import { createDateFromObject } from '../../../../utils/date'
+import { isValid } from 'date-fns'
+
+import { parseDateWithYearMonth } from '../../../../utils/date'
 
 export const validateDateWithinTheLastYear = (value, field, { values }) => {
   if (values && values.date) {
-    const date = createDateFromObject(values.date)
-    if (date) {
+    const date = parseDateWithYearMonth(
+      values.date.year,
+      values.date.month,
+      values.date.day
+    )
+    if (isValid(date)) {
       const now = new Date()
       const oneYearPrior = new Date()
       oneYearPrior.setFullYear(oneYearPrior.getFullYear() - 1)

--- a/src/client/modules/Events/EventForm/validators.jsx
+++ b/src/client/modules/Events/EventForm/validators.jsx
@@ -1,4 +1,6 @@
-import { createDateFromObject } from '../../../utils/date'
+import { isValid } from 'date-fns'
+
+import { parseDateWithYearMonth } from '../../../utils/date'
 
 export const validateStartDateBeforeOrEqualToEndDate = (
   value,
@@ -6,9 +8,17 @@ export const validateStartDateBeforeOrEqualToEndDate = (
   { values }
 ) => {
   if (values && values.start_date && values.end_date) {
-    const startDate = createDateFromObject(values.start_date)
-    const endDate = createDateFromObject(values.end_date)
-    if (startDate && endDate) {
+    const startDate = parseDateWithYearMonth(
+      values.start_date.year,
+      values.start_date.month,
+      values.start_date.day
+    )
+    const endDate = parseDateWithYearMonth(
+      values.end_date.year,
+      values.end_date.month,
+      values.end_date.day
+    )
+    if (isValid(startDate) && isValid(endDate)) {
       const result =
         startDate > endDate
           ? 'Enter a valid end date. This must be after the start date.'

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -125,12 +125,6 @@ function getDifferenceInWords(date, suffix = true) {
   }
 }
 
-function createDateFromObject({ day, month, year }) {
-  const monthIndex = parseInt(month, 10) - 1
-  const result = new Date(year, monthIndex, day)
-  return result
-}
-
 function formatStartAndEndDate(startDate, endDate) {
   if (startDate) {
     const startDateParsed = startDate ? parseISO(startDate) : startDate
@@ -270,7 +264,6 @@ module.exports = {
   getFinancialYearStart,
   parseDateWithYearMonth,
   formatDateWithYearMonth,
-  createDateFromObject,
   formatStartAndEndDate,
   convertDateToFieldShortDateObject,
   convertDateToFieldDateObject,


### PR DESCRIPTION
## Description of change
Refactor codebase to eliminate the `createDateFromObject` function, replacing its usage with the `parseDateWithYearMonth` function. This simplifies date parsing logic and improves code consistency.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
