### PR TITLE
Move export win date utilities to local module

### DIFF
--- a/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
+++ b/src/client/modules/ExportWins/Form/WinDetailsStep.jsx
@@ -8,7 +8,7 @@ import Countries from '../../../components/Resource/Countries'
 import Sector from '../../../components/Resource/Sector'
 
 import { useFormContext } from '../../../../client/components/Form/hooks'
-import { getStartDateOfTwelveMonthsAgo } from '../../../utils/date'
+import { getStartDateOfTwelveMonthsAgo } from './date'
 import { formatValue, sumAllWinTypeYearlyValues } from './utils'
 import { BLACK, WHITE } from '../../../../client/utils/colours'
 import { validateWinDate, validateTextField } from './validators'

--- a/src/client/modules/ExportWins/Form/__test__/date.test.js
+++ b/src/client/modules/ExportWins/Form/__test__/date.test.js
@@ -1,0 +1,81 @@
+import { addDays, subMonths, subYears, startOfMonth, isEqual } from 'date-fns'
+
+import {
+  getRandomDateInRange,
+  isWithinLastTwelveMonths,
+  getStartDateOfTwelveMonthsAgo,
+} from '../date'
+
+describe('getStartDateOfTwelveMonthsAgo', () => {
+  it(
+    'should return a date that is 12 months ago from the current ' +
+      'date and includes the 1st of the month',
+    () => {
+      const today = new Date()
+      const expectedDate = subMonths(startOfMonth(today), 12)
+      const actualDate = getStartDateOfTwelveMonthsAgo()
+      expect(actualDate).to.be.instanceOf(Date)
+      expect(isEqual(actualDate, expectedDate)).to.equal(true)
+    }
+  )
+})
+
+describe('isWithinLastTwelveMonths', () => {
+  const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
+  const twelveMonthsAgoAddOneDay = addDays(twelveMonthsAgo, 1)
+  const twelveMonthsAgoSubOneDay = subYears(twelveMonthsAgo, 1)
+  const today = new Date()
+  const tomorrow = addDays(today, 1)
+  const yesterday = subYears(today, 1)
+
+  it('should be valid for the 1st of the month twelve months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgo)).to.equal(true)
+  })
+
+  it('should be valid for the 2nd of the month twelve months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgoAddOneDay)).to.equal(true)
+  })
+
+  it('should be invalid one day before the 1st of the month, thirteen months ago', () => {
+    expect(isWithinLastTwelveMonths(twelveMonthsAgoSubOneDay)).to.equal(false)
+  })
+
+  it('should be valid for today', () => {
+    expect(isWithinLastTwelveMonths(today)).to.equal(true)
+  })
+
+  it('should be invalid for tomorrow', () => {
+    expect(isWithinLastTwelveMonths(tomorrow)).to.equal(false)
+  })
+
+  it('should be valid for yesterday', () => {
+    expect(isWithinLastTwelveMonths(yesterday)).to.equal(true)
+  })
+})
+
+describe('getRandomDateInRange', () => {
+  it('should return a random date within the specified range', () => {
+    const startDate = new Date(2024, 0, 1) // January 1, 2024
+    const endDate = new Date(2024, 0, 10) // January 10, 2024
+    const randomDate = getRandomDateInRange(startDate, endDate)
+    expect(randomDate).to.be.instanceOf(Date)
+    expect(randomDate.getTime()).to.be.at.least(startDate.getTime())
+    expect(randomDate.getTime()).to.be.at.most(endDate.getTime())
+  })
+
+  it('should throw an error if the start date and the end date are the same', () => {
+    const startDate = new Date(2024, 0, 1)
+    const endDate = new Date(2024, 0, 1)
+    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
+      'Start date and end date cannot be the same.'
+    )
+  })
+
+  it('should throw error if the start date is greater than the end date', () => {
+    const startDate = new Date(2024, 0, 10)
+    const endDate = new Date(2024, 0, 1)
+    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
+      'Start date cannot be greater than end date.'
+    )
+  })
+})

--- a/src/client/modules/ExportWins/Form/__test__/date.test.js
+++ b/src/client/modules/ExportWins/Form/__test__/date.test.js
@@ -1,4 +1,4 @@
-import { addDays, subMonths, subYears, startOfMonth, isEqual } from 'date-fns'
+import { addDays, subMonths, subDays, startOfMonth, isEqual } from 'date-fns'
 
 import {
   getRandomDateInRange,
@@ -23,10 +23,10 @@ describe('getStartDateOfTwelveMonthsAgo', () => {
 describe('isWithinLastTwelveMonths', () => {
   const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
   const twelveMonthsAgoAddOneDay = addDays(twelveMonthsAgo, 1)
-  const twelveMonthsAgoSubOneDay = subYears(twelveMonthsAgo, 1)
+  const twelveMonthsAgoSubOneDay = subDays(twelveMonthsAgo, 1)
   const today = new Date()
   const tomorrow = addDays(today, 1)
-  const yesterday = subYears(today, 1)
+  const yesterday = subDays(today, 1)
 
   it('should be valid for the 1st of the month twelve months ago', () => {
     expect(isWithinLastTwelveMonths(twelveMonthsAgo)).to.equal(true)

--- a/src/client/modules/ExportWins/Form/date.js
+++ b/src/client/modules/ExportWins/Form/date.js
@@ -1,0 +1,49 @@
+import {
+  addDays,
+  subMonths,
+  isSameDay,
+  startOfMonth,
+  differenceInDays,
+  isWithinInterval,
+} from 'date-fns'
+
+/**
+ * Generates a random date within the range specified by startDate and endDate (inclusive).
+ * @param {Date} startDate - The start date of the range.
+ * @param {Date} endDate - The end date of the range.
+ * @returns {Date} A random date within the specified range.
+ * @throws {Error} If startDate is greater than endDate or if startDate and endDate are the same date.
+ */
+export const getRandomDateInRange = (startDate, endDate) => {
+  if (isSameDay(startDate, endDate)) {
+    throw new Error('Start date and end date cannot be the same.')
+  }
+  if (startDate > endDate) {
+    throw new Error('Start date cannot be greater than end date.')
+  }
+  const daysDifference = differenceInDays(endDate, startDate)
+  const randomNumberOfDays = Math.floor(Math.random() * (daysDifference + 1))
+  return addDays(startDate, randomNumberOfDays)
+}
+
+/**
+ * Returns the start date (1st day) of the month twelve months ago from the current date.
+ * @returns {Date} The start date (1st day) of the month twelve months ago from the current date.
+ */
+export const getStartDateOfTwelveMonthsAgo = () => {
+  return subMonths(startOfMonth(new Date()), 12)
+}
+
+/**
+ * Checks if a given date falls within the last twelve months from the current date.
+ * The last twelve months include the 1st of the month.
+ * @param {Date} date - The date to be checked.
+ * @returns {boolean} Returns true if the date falls within the last twelve months
+ * from the current date, otherwise false.
+ */
+export const isWithinLastTwelveMonths = (date) => {
+  return isWithinInterval(date, {
+    start: getStartDateOfTwelveMonthsAgo(),
+    end: new Date(),
+  })
+}

--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -3,10 +3,8 @@ import { isEmpty } from 'lodash'
 import { OPTION_YES, OPTION_NO } from '../../../../common/constants'
 import { idNameToValueLabel } from '../../../../client/utils'
 import { sumWinTypeYearlyValues } from './utils'
-import {
-  convertDateToFieldDateObject,
-  isWithinLastTwelveMonths,
-} from '../../../utils/date'
+import { isWithinLastTwelveMonths } from './date'
+import { convertDateToFieldDateObject } from '../../../utils/date'
 import {
   winTypeId,
   GOODS_ID,

--- a/src/client/modules/ExportWins/Form/validators.js
+++ b/src/client/modules/ExportWins/Form/validators.js
@@ -1,4 +1,4 @@
-import { isWithinLastTwelveMonths } from '../../../utils/date'
+import { isWithinLastTwelveMonths } from './date'
 
 const TEXT_FIELD_MAX_LENGTH = 128
 

--- a/src/client/utils/__test__/date.test.js
+++ b/src/client/utils/__test__/date.test.js
@@ -1,15 +1,10 @@
-import { subMonths, subYears, addDays, isValid, format } from 'date-fns'
+import { isValid, format } from 'date-fns'
 
 import {
-  areDatesEqual,
-  getStartOfMonth,
-  getRandomDateInRange,
   parseDateWithYearMonth,
   formatDateWithYearMonth,
-  isWithinLastTwelveMonths,
   convertDateToFieldDateObject,
   convertDateToFieldShortDateObject,
-  getStartDateOfTwelveMonthsAgo,
 } from '../date'
 
 describe('convertDateToFieldShortDateObject', () => {
@@ -55,80 +50,6 @@ describe('convertDateToFieldDateObject', () => {
         }
       )
     })
-  })
-})
-
-describe('getStartDateOfTwelveMonthsAgo', () => {
-  it(
-    'should return a date that is 12 months ago from the current ' +
-      'date and includes the 1st of the month',
-    () => {
-      const today = new Date()
-      const expectedDate = subMonths(getStartOfMonth(today), 12)
-      const actualDate = getStartDateOfTwelveMonthsAgo()
-      expect(actualDate).to.be.instanceOf(Date)
-      expect(areDatesEqual(actualDate, expectedDate)).to.equal(true)
-    }
-  )
-})
-
-describe('isWithinLastTwelveMonths', () => {
-  const twelveMonthsAgo = getStartDateOfTwelveMonthsAgo()
-  const twelveMonthsAgoAddOneDay = addDays(twelveMonthsAgo, 1)
-  const twelveMonthsAgoSubOneDay = subYears(twelveMonthsAgo, 1)
-  const today = new Date()
-  const tomorrow = addDays(today, 1)
-  const yesterday = subYears(today, 1)
-
-  it('should be valid for the 1st of the month twelve months ago', () => {
-    expect(isWithinLastTwelveMonths(twelveMonthsAgo)).to.equal(true)
-  })
-
-  it('should be valid for the 2nd of the month twelve months ago', () => {
-    expect(isWithinLastTwelveMonths(twelveMonthsAgoAddOneDay)).to.equal(true)
-  })
-
-  it('should be invalid one day before the 1st of the month, thirteen months ago', () => {
-    expect(isWithinLastTwelveMonths(twelveMonthsAgoSubOneDay)).to.equal(false)
-  })
-
-  it('should be valid for today', () => {
-    expect(isWithinLastTwelveMonths(today)).to.equal(true)
-  })
-
-  it('should be invalid for tomorrow', () => {
-    expect(isWithinLastTwelveMonths(tomorrow)).to.equal(false)
-  })
-
-  it('should be valid for yesterday', () => {
-    expect(isWithinLastTwelveMonths(yesterday)).to.equal(true)
-  })
-})
-
-describe('getRandomDateInRange', () => {
-  it('should return a random date within the specified range', () => {
-    const startDate = new Date(2024, 0, 1) // January 1, 2024
-    const endDate = new Date(2024, 0, 10) // January 10, 2024
-    const randomDate = getRandomDateInRange(startDate, endDate)
-    expect(randomDate).to.be.instanceOf(Date)
-    expect(randomDate.getTime()).to.be.at.least(startDate.getTime())
-    expect(randomDate.getTime()).to.be.at.most(endDate.getTime())
-  })
-
-  it('should throw an error if the start date and the end date are the same', () => {
-    const startDate = new Date(2024, 0, 1)
-    const endDate = new Date(2024, 0, 1)
-    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
-      'Start date and end date cannot be the same.'
-    )
-  })
-
-  it('should throw error if the start date is greater than the end date', () => {
-    const startDate = new Date(2024, 0, 10)
-    const endDate = new Date(2024, 0, 1)
-    expect(() => getRandomDateInRange(startDate, endDate)).to.throw(
-      'Start date cannot be greater than end date.'
-    )
   })
 })
 

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -7,21 +7,14 @@
  */
 
 const {
-  addDays,
-  differenceInDays,
   differenceInCalendarDays,
-  isSameDay,
   endOfToday,
-  startOfMonth: getStartOfMonth,
-  isWithinInterval,
   formatDistanceToNowStrict,
   isAfter,
   isValid,
   parse,
   parseISO,
-  subMonths,
   differenceInCalendarMonths,
-  isEqual: areDatesEqual,
 } = require('date-fns')
 
 const {
@@ -215,47 +208,6 @@ function convertUnparsedDateToFieldDateObject(date) {
   return { day: '', month: '', year: '' }
 }
 
-/**
- * Generates a random date within the range specified by startDate and endDate (inclusive).
- * @param {Date} startDate - The start date of the range.
- * @param {Date} endDate - The end date of the range.
- * @returns {Date} A random date within the specified range.
- * @throws {Error} If startDate is greater than endDate or if startDate and endDate are the same date.
- */
-function getRandomDateInRange(startDate, endDate) {
-  if (isSameDay(startDate, endDate)) {
-    throw new Error('Start date and end date cannot be the same.')
-  }
-  if (startDate > endDate) {
-    throw new Error('Start date cannot be greater than end date.')
-  }
-  const daysDifference = differenceInDays(endDate, startDate)
-  const randomNumberOfDays = Math.floor(Math.random() * (daysDifference + 1))
-  return addDays(startDate, randomNumberOfDays)
-}
-
-/**
- * Returns the start date (1st day) of the month twelve months ago from the current date.
- * @returns {Date} The start date (1st day) of the month twelve months ago from the current date.
- */
-function getStartDateOfTwelveMonthsAgo() {
-  return subMonths(getStartOfMonth(new Date()), 12)
-}
-
-/**
- * Checks if a given date falls within the last twelve months from the current date.
- * The last twelve months include the 1st of the month.
- * @param {Date} date - The date to be checked.
- * @returns {boolean} Returns true if the date falls within the last twelve months
- * from the current date, otherwise false.
- */
-function isWithinLastTwelveMonths(date) {
-  return isWithinInterval(date, {
-    start: getStartDateOfTwelveMonthsAgo(),
-    end: new Date(),
-  })
-}
-
 module.exports = {
   generateFinancialYearLabel,
   getDifferenceInDays,
@@ -267,11 +219,6 @@ module.exports = {
   formatStartAndEndDate,
   convertDateToFieldShortDateObject,
   convertDateToFieldDateObject,
-  getRandomDateInRange,
-  isWithinLastTwelveMonths,
-  getStartDateOfTwelveMonthsAgo,
-  getStartOfMonth,
-  areDatesEqual,
   convertUnparsedDateToFieldDateObject,
   convertUnparsedDateToFieldShortDateObject,
 }

--- a/test/functional/cypress/specs/export-win/utils.js
+++ b/test/functional/cypress/specs/export-win/utils.js
@@ -3,7 +3,7 @@ import { addMonths, subMonths } from 'date-fns'
 import {
   getRandomDateInRange,
   getStartDateOfTwelveMonthsAgo,
-} from '../../../../../src/client/utils/date'
+} from '../../../../../src/client/modules/ExportWins/Form/date'
 import { clickContinueButton } from '../../support/actions'
 import { assertUrl } from '../../support/assertions'
 import { formFields } from './constants'


### PR DESCRIPTION
## Description of change
This PR relocates the export win date utility functions from `src/client/utils/date.js` to `src/client/modules/ExportWins/Form/date.js`. Since these functions are not reused elsewhere in the codebase, it makes sense to move them closer to the export win functionality.

The goal is to keep `src/client/utils/date.js` focused and lightweight, containing only date utility functions that are reused across the codebase. This is part of an ongoing effort to streamline shared date utilities.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
