### PR TITLE
Move activity feed date utilities to local module

### DIFF
--- a/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriAttendee.jsx
@@ -11,7 +11,7 @@ import ActivityCardWrapper from './card/ActivityCardWrapper'
 import ActivityCardSubject from './card/ActivityCardSubject'
 import ActivityCardMetadata from './card/ActivityCardMetadata'
 import ActivityCardLabels from './card/ActivityCardLabels'
-import { formatStartAndEndDate } from '../../../utils/date'
+import { formatStartAndEndDate } from './date'
 
 export const AVENTRI_ATTENDEE_REG_STATUSES = {
   Attended: 'Attended',

--- a/src/client/components/ActivityFeed/activities/AventriEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/AventriEvent.jsx
@@ -3,7 +3,7 @@ import Link from '@govuk-react/link'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { formatStartAndEndDate } from '../../../utils/date'
+import { formatStartAndEndDate } from './date'
 import { ACTIVITY_TYPE } from '../constants'
 
 import CardUtils from './card/CardUtils'

--- a/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
+++ b/src/client/components/ActivityFeed/activities/DataHubEvent.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 
 import CardUtils from './card/CardUtils'
 
-import { formatStartAndEndDate } from '../../../utils/date'
+import { formatStartAndEndDate } from './date'
 import { ACTIVITY_TYPE } from '../constants'
 
 import ActivityCardWrapper from './card/ActivityCardWrapper'

--- a/src/client/components/ActivityFeed/activities/__test__/date.test.js
+++ b/src/client/components/ActivityFeed/activities/__test__/date.test.js
@@ -1,4 +1,4 @@
-const { formatStartAndEndDate } = require('../../client/utils/date')
+const { formatStartAndEndDate } = require('../date')
 
 describe('Date tests', () => {
   describe('#formatStartAndEndDate', () => {

--- a/src/client/components/ActivityFeed/activities/date.js
+++ b/src/client/components/ActivityFeed/activities/date.js
@@ -1,0 +1,38 @@
+const { isAfter, parseISO, differenceInCalendarMonths } = require('date-fns')
+
+const {
+  formatDate,
+  DATE_FORMAT_COMPACT,
+  DATE_FORMAT_DAY_MONTH,
+} = require('./date-utils')
+
+export const formatStartAndEndDate = (startDate, endDate) => {
+  if (startDate) {
+    const startDateParsed = startDate ? parseISO(startDate) : startDate
+    const endDateParsed = endDate ? parseISO(endDate) : endDate
+    const startDateFormatted = startDate
+      ? formatDate(startDate, DATE_FORMAT_COMPACT)
+      : startDate
+    const endDateFormatted = endDate ? formatDate(endDate) : endDate
+
+    //When end date is missing or before start date
+    if (!endDate || !isAfter(endDateParsed, startDateParsed)) {
+      return startDateFormatted
+    }
+    //When start and end date are on same day
+    if (startDateParsed.toDateString() === endDateParsed.toDateString()) {
+      return startDateFormatted
+    }
+    // When start and end date are in the same month
+    if (differenceInCalendarMonths(endDateParsed, startDateParsed) == 0) {
+      return `${startDateParsed.getDate()} to ${endDateFormatted}`
+    }
+    // When start and end date are in the same year
+    if (startDateParsed.getFullYear() === endDateParsed.getFullYear()) {
+      return `${formatDate(startDate, DATE_FORMAT_DAY_MONTH)} to ${endDateFormatted}`
+    }
+    // When start and end date are in different years
+    return `${startDateFormatted} to ${endDateFormatted}`
+  }
+  return null
+}

--- a/src/client/components/ActivityFeed/activities/date.js
+++ b/src/client/components/ActivityFeed/activities/date.js
@@ -1,10 +1,10 @@
-const { isAfter, parseISO, differenceInCalendarMonths } = require('date-fns')
+import { isAfter, parseISO, differenceInCalendarMonths } from 'date-fns'
 
-const {
+import {
   formatDate,
   DATE_FORMAT_COMPACT,
   DATE_FORMAT_DAY_MONTH,
-} = require('./date-utils')
+} from '../../../../client/utils/date-utils'
 
 export const formatStartAndEndDate = (startDate, endDate) => {
   if (startDate) {

--- a/src/client/modules/Events/transformers.js
+++ b/src/client/modules/Events/transformers.js
@@ -2,7 +2,8 @@ import { compact } from 'lodash'
 
 import urls from '../../../lib/urls'
 
-import { getDifferenceInDays, formatStartAndEndDate } from '../../utils/date'
+import { getDifferenceInDays } from '../../utils/date'
+import { formatStartAndEndDate } from '../../components/ActivityFeed/activities/date'
 
 import { TAG_COLOURS } from '../../components/Tag'
 import {

--- a/src/client/utils/date.js
+++ b/src/client/utils/date.js
@@ -10,18 +10,14 @@ const {
   differenceInCalendarDays,
   endOfToday,
   formatDistanceToNowStrict,
-  isAfter,
   isValid,
   parse,
   parseISO,
-  differenceInCalendarMonths,
 } = require('date-fns')
 
 const {
   formatDate,
   DATE_FORMAT_ISO,
-  DATE_FORMAT_COMPACT,
-  DATE_FORMAT_DAY_MONTH,
   DATE_FORMAT_YEAR_MONTH,
 } = require('./date-utils')
 
@@ -118,37 +114,6 @@ function getDifferenceInWords(date, suffix = true) {
   }
 }
 
-function formatStartAndEndDate(startDate, endDate) {
-  if (startDate) {
-    const startDateParsed = startDate ? parseISO(startDate) : startDate
-    const endDateParsed = endDate ? parseISO(endDate) : endDate
-    const startDateFormatted = startDate
-      ? formatDate(startDate, DATE_FORMAT_COMPACT)
-      : startDate
-    const endDateFormatted = endDate ? formatDate(endDate) : endDate
-
-    //When end date is missing or before start date
-    if (!endDate || !isAfter(endDateParsed, startDateParsed)) {
-      return startDateFormatted
-    }
-    //When start and end date are on same day
-    if (startDateParsed.toDateString() === endDateParsed.toDateString()) {
-      return startDateFormatted
-    }
-    // When start and end date are in the same month
-    if (differenceInCalendarMonths(endDateParsed, startDateParsed) == 0) {
-      return `${startDateParsed.getDate()} to ${endDateFormatted}`
-    }
-    // When start and end date are in the same year
-    if (startDateParsed.getFullYear() === endDateParsed.getFullYear()) {
-      return `${formatDate(startDate, DATE_FORMAT_DAY_MONTH)} to ${endDateFormatted}`
-    }
-    // When start and end date are in different years
-    return `${startDateFormatted} to ${endDateFormatted}`
-  }
-  return null
-}
-
 /**
  * Convert a date to a short object format required by the FieldDate component
  * @param {*} date a string representing a date or a Date type
@@ -216,7 +181,6 @@ module.exports = {
   getFinancialYearStart,
   parseDateWithYearMonth,
   formatDateWithYearMonth,
-  formatStartAndEndDate,
   convertDateToFieldShortDateObject,
   convertDateToFieldDateObject,
   convertUnparsedDateToFieldDateObject,


### PR DESCRIPTION
## Description of change
This PR moves the activity feed date utility function `formatStartAndEndDate` from `src/client/utils/date.js` to `src/client/components/ActivityFeed/activities/date.js`. The function is only used within the activity feed, so relocating it improves organisation and aligns the function more closely with its usage.

As mentioned on a previous PR, the goal is to keep `src/client/utils/date.js` focused and lightweight, containing only date utility functions that are reused across the codebase.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
