### PR TITLE
Chore/dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "get-form-data": "^3.0.0",
         "govuk_frontend_toolkit": "^9.0.1",
         "govuk-elements-sass": "^3.1.3",
-        "govuk-frontend": "^5.7.1",
+        "govuk-frontend": "^5.8.0",
         "govuk-react": "^0.10.7",
         "hawk": "^9.0.2",
         "history": "^5.3.0",
@@ -13747,9 +13747,9 @@
       "integrity": "sha512-BlJsYnC0HJomBNCiBm2oQCqgbvP7vaA06XyJ2NocpWM4vFcK/AxAC/7gAU6iCjP3LVhyobR+o2MTFFGozPIE6A=="
     },
     "node_modules/govuk-frontend": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
-      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.8.0.tgz",
+      "integrity": "sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "get-form-data": "^3.0.0",
     "govuk_frontend_toolkit": "^9.0.1",
     "govuk-elements-sass": "^3.1.3",
-    "govuk-frontend": "^5.7.1",
+    "govuk-frontend": "^5.8.0",
     "govuk-react": "^0.10.7",
     "hawk": "^9.0.2",
     "history": "^5.3.0",

--- a/test/sandbox/package-lock.json
+++ b/test/sandbox/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
-        "@babel/eslint-parser": "^7.25.9",
+        "@babel/eslint-parser": "^7.26.5",
         "@babel/plugin-syntax-import-assertions": "^7.26.0",
         "@babel/runtime": "^7.26.0",
         "@faker-js/faker": "^9.3.0",
@@ -107,9 +107,9 @@
       }
     },
     "node_modules/@babel/eslint-parser": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.25.9.tgz",
-      "integrity": "sha512-5UXfgpK0j0Xr/xIdgdLEhOFxaDZ0bRPWJJchRpqOSur/3rZoPbqqki5mm0p4NE2cs28krBEiSM2MB7//afRSQQ==",
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.26.5.tgz",
+      "integrity": "sha512-Kkm8C8uxI842AwQADxl0GbcG1rupELYLShazYEZO/2DYjhyWXJIOUVOE3tBYm6JXzUCNJOZEzqc4rCW/jsEQYQ==",
       "dev": true,
       "dependencies": {
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",

--- a/test/sandbox/package.json
+++ b/test/sandbox/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
-    "@babel/eslint-parser": "^7.25.9",
+    "@babel/eslint-parser": "^7.26.5",
     "@babel/plugin-syntax-import-assertions": "^7.26.0",
     "@babel/runtime": "^7.26.0",
     "@faker-js/faker": "^9.3.0",


### PR DESCRIPTION
## Description of change

- [Bump govuk-frontend from 5.7.1 to 5.8.0](https://github.com/uktrade/data-hub-frontend/pull/7464/commits/abda146c9804c66adb827e92def59283463b6d76)
- Bump @babel/eslint-parser from 7.25.9 to 7.26.5 in /test/sandbox

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
