### PR TITLE
Add EYB leads page sort by filter

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -29,6 +29,7 @@ const EYBLeadCollection = ({
   filterOptions,
   payload,
   optionMetadata,
+  sortOptions,
   ...props
 }) => {
   const location = useLocation()
@@ -111,10 +112,12 @@ const EYBLeadCollection = ({
       <FilteredCollectionList
         {...props}
         collectionName="EYB lead"
+        sortOptions={sortOptions}
         taskProps={collectionListTask}
         entityName="eybLead"
         defaultQueryParams={{
           page: 1,
+          sortby: '-triage_created',
         }}
         selectedFilters={selectedFilters}
       >

--- a/src/client/modules/Investments/EYBLeads/constants.js
+++ b/src/client/modules/Investments/EYBLeads/constants.js
@@ -23,3 +23,14 @@ export const VALUE_OPTIONS = [
   { value: 'low', label: VALUES.LOW_VALUE },
   { value: 'unknown', label: VALUES.UNKNOWN },
 ]
+
+export const SORT_OPTIONS = [
+  {
+    name: 'Recently created',
+    value: '-triage_created',
+  },
+  {
+    name: 'Company A-Z',
+    value: 'company__name',
+  },
+]

--- a/src/client/modules/Investments/EYBLeads/state.js
+++ b/src/client/modules/Investments/EYBLeads/state.js
@@ -1,4 +1,5 @@
 import { parseQueryString } from '../../../utils'
+import { SORT_OPTIONS } from './constants'
 import { transformLeadToListItem } from './transformers'
 
 export const INVESTMENT_EYB_LEADS_ID = 'eybLeads'
@@ -16,5 +17,6 @@ export const state2props = ({ router: { location }, ...state }) => {
     results: results.map(transformLeadToListItem),
     payload: queryParams,
     filterOptions,
+    sortOptions: SORT_OPTIONS,
   }
 }

--- a/src/client/modules/Investments/EYBLeads/tasks.js
+++ b/src/client/modules/Investments/EYBLeads/tasks.js
@@ -13,11 +13,13 @@ export const getEYBLeads = ({
   country = [],
   sector = [],
   value = [],
+  sortby,
 }) => {
   let params = new URLSearchParams({
     limit,
     offset: limit * (parseInt(page, 10) - 1) || 0,
     ...(company ? { company } : null),
+    sortby: sortby ? sortby : '-triage_created',
   })
   overseas_region.forEach((overseasRegionId) =>
     params.append('overseas_region', overseasRegionId)

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -96,7 +96,7 @@ const EYB_LEAD_LIST = Array(
 )
 
 const PAYLOADS = {
-  minimum: { limit: '10', offset: '0' },
+  minimum: { limit: '10', offset: '0', sortby: '-triage_created' },
   companyFilter: { company: COMPANY_NAME },
   sectorFilter: { sector: SECTOR_ID },
   highValueFilter: { value: HIGH_VALUE },
@@ -247,10 +247,14 @@ describe('EYB leads collection page', () => {
     })
 
     it('should filter from user input', () => {
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.company) {
+          req.alias = 'filteredRequest'
+        }
+      })
       cy.visit(`${investments.eybLeads.index()}`)
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
       cy.get(FILTER_ELEMENTS.company).type(`${COMPANY_NAME}{enter}`)
-      cy.wait('@apiRequest')
+      cy.wait('@filteredRequest')
         .its('request.query')
         .should('include', expectedPayload)
       assertQueryParams('company', COMPANY_NAME)
@@ -294,8 +298,12 @@ describe('EYB leads collection page', () => {
     })
 
     it('should filter from user input', () => {
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.sector) {
+          req.alias = 'filteredRequest'
+        }
+      })
       cy.visit(`${investments.eybLeads.index()}`)
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
       assertTypeaheadHints({
         element: FILTER_ELEMENTS.sector,
         label: 'Sector of interest',
@@ -309,7 +317,7 @@ describe('EYB leads collection page', () => {
         element: FILTER_ELEMENTS.sector,
         expectedOption: SECTOR_NAME,
       })
-      cy.wait('@apiRequest')
+      cy.wait('@filteredRequest')
         .its('request.query')
         .should('include', expectedPayload)
       assertQueryParams('sector[0]', SECTOR_ID)
@@ -389,14 +397,17 @@ describe('EYB leads collection page', () => {
         })
 
         it('should filter from user input', () => {
-          cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
+          cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+            if (req.query.value) {
+              req.alias = 'filteredRequest'
+            }
+          })
           cy.visit(`${investments.eybLeads.index()}`)
-          cy.wait('@apiRequest')
           clickCheckboxGroupOption({
             element: FILTER_ELEMENTS.value,
             value: testCase.queryParamValue,
           })
-          cy.wait('@apiRequest')
+          cy.wait('@filteredRequest')
             .its('request.query')
             .should('include', testCase.expectedPayload)
           assertQueryParams('value[0]', testCase.queryParamValue)
@@ -443,8 +454,12 @@ describe('EYB leads collection page', () => {
     })
 
     it('should filter from user input', () => {
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.country) {
+          req.alias = 'filteredRequest'
+        }
+      })
       cy.visit(`${investments.eybLeads.index()}`)
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
       assertTypeaheadHints({
         element: FILTER_ELEMENTS.country,
         label: 'Country',
@@ -458,7 +473,7 @@ describe('EYB leads collection page', () => {
         element: FILTER_ELEMENTS.country,
         expectedOption: COUNTRY_NAME_1,
       })
-      cy.wait('@apiRequest')
+      cy.wait('@filteredRequest')
         .its('request.query')
         .should('include', expectedPayload)
       assertQueryParams('country[0]', COUNTRY_ID_1)
@@ -506,8 +521,12 @@ describe('EYB leads collection page', () => {
       })
 
       it('should filter from user input', () => {
+        cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+          if (req.query.overseas_region) {
+            req.alias = 'filteredRequest'
+          }
+        })
         cy.visit(`${investments.eybLeads.index()}`)
-        cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
         assertTypeaheadHints({
           element: FILTER_ELEMENTS.overseas_region,
           label: 'HMTC region',
@@ -521,7 +540,7 @@ describe('EYB leads collection page', () => {
           element: FILTER_ELEMENTS.overseas_region,
           expectedOption: OVERSEAS_REGION_NAME_1,
         })
-        cy.wait('@apiRequest')
+        cy.wait('@filteredRequest')
           .its('request.query')
           .should('include', expectedPayload)
         assertQueryParams('overseas_region[0]', OVERSEAS_REGION_ID_1)
@@ -553,17 +572,8 @@ describe('EYB leads collection page', () => {
   )
   context('When sorting the EYB leads collection', () => {
     beforeEach(() => {
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, {
-        statusCode: 200,
-        body: {
-          count: EYB_LEAD_LIST.length,
-          next: null,
-          previous: null,
-          results: EYB_LEAD_LIST,
-        },
-      }).as('apiRequest')
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`).as('apiRequest')
       cy.visit(investments.eybLeads.index())
-      cy.wait('@apiRequest')
     })
 
     it('should load sort by dropdown', () => {
@@ -575,32 +585,30 @@ describe('EYB leads collection page', () => {
 
     it('should sort by most recently created by default', () => {
       assertQueryParams('sortby', '-triage_created')
-
       cy.wait('@apiRequest')
         .its('request.query')
         .should('include', PAYLOADS.sortByCreated)
     })
 
     it('should sort by company name A-Z', () => {
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, {
-        statusCode: 200,
-      }).as('sortRequest')
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.sortby === 'company__name') req.alias = 'sortedRequest'
+      })
       cy.get('[data-test="sortby"] select').select('company__name')
       assertQueryParams('sortby', 'company__name')
-      cy.wait('@sortRequest')
+      cy.wait('@sortedRequest')
         .its('request.query')
         .should('include', PAYLOADS.sortByCompanyAZ)
     })
 
-    it('should sort by most recently created when another option is selected', () => {
+    it('should sort by most recently created when another sort option is selected', () => {
       cy.get('[data-test="sortby"] select').select('company__name')
-      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, {
-        statusCode: 200,
-      }).as('sortRequest')
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.sortby === '-triage_created') req.alias = 'sortedRequest'
+      })
       cy.get('[data-test="sortby"] select').select('-triage_created')
       assertQueryParams('sortby', '-triage_created')
-
-      cy.wait('@sortRequest')
+      cy.wait('@sortedRequest')
         .its('request.query')
         .should('include', PAYLOADS.sortByCreated)
     })


### PR DESCRIPTION
## Description of change

Added a sort by dropdown filter to the EYB leads page. The filter sorts by most recently created and company name A-Z. 

API part of the work: https://github.com/uktrade/data-hub-api/pull/5896

## Test instructions

Navigate to the EYB leads tab. The sort by filter should be visible above the leads collection list.

## Screenshots

### Before
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/921f3a88-1465-40ce-b48f-a725d039b8f5" />

### After
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/c38935bf-f8e7-4f9b-8a69-de442c542483" />


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
