### PR TITLE
Convert EYB lead choices into formatted labels

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -4,7 +4,7 @@ import { Link } from 'govuk-react'
 
 import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
-import { camelCaseToSentenceCase } from '../utils'
+import { convertEYBChoicesToLabels } from '../utils'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
@@ -69,7 +69,7 @@ const EYBLeadDetails = () => {
               </SummaryTable.Row>
               <SummaryTable.Row
                 heading="When do you want to set up?"
-                children={camelCaseToSentenceCase(eybLead.landingTimeframe)}
+                children={convertEYBChoicesToLabels(eybLead.landingTimeframe)}
               />
               <SummaryTable.Row
                 heading="Do you know where you want to set up in the UK?"
@@ -81,11 +81,11 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="How do you plan to expand your business in the UK?"
-                children={camelCaseToSentenceCase(eybLead.intent)}
+                children={convertEYBChoicesToLabels(eybLead.intent)}
               />
               <SummaryTable.Row
                 heading="How many people do you want to hire in the UK in the first 3 years?"
-                children={camelCaseToSentenceCase(eybLead.hiring)}
+                children={convertEYBChoicesToLabels(eybLead.hiring)}
               />
               <SummaryTable.Row
                 heading="How much do you want to spend on setting up in the first 3 years?"

--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -2,6 +2,7 @@ import urls from '../../../../lib/urls'
 import { TAG_COLOURS } from '../../../components/Tag'
 import { VALUES_VALUE_TO_LABEL_MAP } from './constants'
 import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
+import { convertEYBChoicesToLabels } from '../utils'
 
 export const transformLeadToListItem = ({
   id,
@@ -33,7 +34,10 @@ export const transformLeadToListItem = ({
     },
     { label: 'Estimated spend', value: spend },
     { label: 'Sector', value: sector ? sector.name : '' },
-    { label: 'Estimated land date', value: landing_timeframe },
+    {
+      label: 'Estimated land date',
+      value: convertEYBChoicesToLabels(landing_timeframe),
+    },
     {
       label: 'Location',
       value: proposed_investment_region ? proposed_investment_region.name : '',

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -1,0 +1,44 @@
+import { convertEYBChoicesToLabels } from '../utils'
+
+describe('convertEYBChoicesToLabels', () => {
+  const validCases = [
+    { input: null, output: null },
+    { input: 'UNDER_SIX_MONTHS', output: 'Under six months' },
+    { input: 'SIX_TO_TWELVE_MONTHS', output: 'Six to twelve months' },
+    { input: 'ONE_TO_TWO_YEARS', output: 'One to two years' },
+    { input: 'MORE_THAN_TWO_YEARS', output: 'More than two years' },
+    {
+      input: [
+        'SET_UP_NEW_PREMISES',
+        'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+        'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
+        'RESEARCH_DEVELOP_AND_COLLABORATE',
+        'FIND_PEOPLE_WITH_SPECIALIST_SKILLS',
+        'OTHER',
+      ],
+      output: [
+        'Set up new premises',
+        'Set up a new distribution centre',
+        'Onward sales and exports from the UK',
+        'Research develop and collaborate',
+        'Find people with specialist skills',
+        'Other',
+      ],
+    },
+  ]
+  validCases.forEach((validCase) => {
+    it(`should output ${validCase.output} for the input ${validCase.input}`, () => {
+      expect(convertEYBChoicesToLabels(validCase.input)).to.deep.equal(
+        validCase.output
+      )
+    })
+  })
+  const errorCases = [{ input: undefined }, { input: 123 }]
+  errorCases.forEach((errorCase) => {
+    it(`should throw an error for the input ${errorCase.input}`, () => {
+      expect(() => {
+        convertEYBChoicesToLabels(errorCase.input)
+      }).to.throw()
+    })
+  })
+})

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -1,12 +1,6 @@
-import urls from '../../../lib/urls'
+import { sentence } from 'case'
 
-const transformToSentenceCase = (text) => {
-  let result = text.replace(/_/g, ' ')
-  return (
-    result.charAt(0).toUpperCase() +
-    result.slice(1).toLowerCase().replace(/uk/g, 'UK')
-  )
-}
+import urls from '../../../lib/urls'
 
 export const buildProjectBreadcrumbs = (pageBreadcrumbs) => {
   const initialBreadcrumbs = [
@@ -38,16 +32,31 @@ export const buildEYBLeadBreadcrumbs = (pageBreadcrumbs) => {
   return initialBreadcrumbs.concat(pageBreadcrumbs)
 }
 
-export const camelCaseToSentenceCase = (text) => {
-  if (typeof text === 'string') {
-    return transformToSentenceCase(text)
-  } else if (Array.isArray(text)) {
-    return text.map((item) => {
-      if (typeof item === 'string') {
-        return transformToSentenceCase(item)
-      } else {
-        return item
-      }
-    })
+/**
+ * Converts EYB choices to sentence case labels
+ * @param {string|string[]|null} choices - Single string, or array of strings, or null to convert
+ * @returns {string|string[]|null} - Converted string(s) in the same format as the input
+ */
+export const convertEYBChoicesToLabels = (choices) => {
+  if (choices === null) {
+    return null
   }
+
+  // Helper function to handle capitalisation of UK
+  const capitaliseUK = (str) => {
+    return str.replace(/\b[Uu][Kk]\b/g, 'UK')
+  }
+  // Helper function to process a single string
+  const processString = (str) => {
+    return capitaliseUK(sentence(str))
+  }
+
+  if (typeof choices == 'string') {
+    return processString(choices)
+  }
+  if (Array.isArray(choices)) {
+    return choices.map((choice) => processString(choice))
+  }
+
+  throw new Error('Input must be null, a string, or array of strings')
 }

--- a/test/functional/cypress/fakers/eyb-leads.js
+++ b/test/functional/cypress/fakers/eyb-leads.js
@@ -22,12 +22,12 @@ const ALBERTA = {
 }
 
 const INTENT_CHOICES = [
-  'Set up new premises',
-  'Set up a new distribution centre',
-  'Onward sales and exports from the UK',
-  'Research, develop and collaborate',
-  'Find people with specialist skills',
-  'Other',
+  'SET_UP_NEW_PREMISES',
+  'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+  'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
+  'RESEARCH_DEVELOP_AND_COLLABORATE',
+  'FIND_PEOPLE_WITH_SPECIALIST_SKILLS',
+  'OTHER',
 ]
 
 const HIRING_CHOICES = [
@@ -49,10 +49,10 @@ const SPEND_CHOICES = [
 ]
 
 const LANDING_TIMEFRAME_CHOICES = [
-  'In the next 6 months',
-  '6 to 12 months',
-  '1 to 2 years',
-  "In more than 2 years' time",
+  'UNDER_SIX_MONTHS',
+  'SIX_TO_TWELVE_MONTHS',
+  'ONE_TO_TWO_YEARS',
+  'MORE_THAN_TWO_YEARS',
 ]
 
 /**

--- a/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-lead-details-spec.js
@@ -3,7 +3,7 @@ import {
   assertLeadBreadcrumbs,
 } from '../../support/assertions'
 import { investments } from '../../../../../src/lib/urls'
-import { camelCaseToSentenceCase } from '../../../../../src/client/modules/Investments/utils'
+import { convertEYBChoicesToLabels } from '../../../../../src/client/modules/Investments/utils'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
 import { NOT_SET_TEXT } from '../../../../../src/apps/companies/constants'
 import { VALUES_VALUE_TO_LABEL_MAP } from '../../../../../src/client/modules/Investments/EYBLeads/constants'
@@ -32,19 +32,19 @@ describe('EYB lead details', () => {
       },
       triage_created: '2023-06-07T10:00:00Z',
       intent: [
-        'Find people with specialist skills',
-        'Set up a new distribution centre',
-        'Other',
-        'Onward sales and exports from the UK',
+        'FIND_PEOPLE_WITH_SPECIALIST_SKILLS',
+        'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+        'OTHER',
+        'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
       ],
-      hiring: '6-50',
-      spend: '500000-1000000',
+      hiring: '6 to 50',
+      spend: '£500,000 to £1 million',
       is_high_value: true,
       full_name: 'Joe Bloggs',
       role: 'CEO',
       email: 'email@example.com',
       telephone_number: '01234567890',
-      landing_timeframe: 'In the next 6 months',
+      landing_timeframe: 'UNDER_SIX_MONTHS',
       company_website: 'fake.website.com',
       investment_projects: [],
     })
@@ -52,18 +52,6 @@ describe('EYB lead details', () => {
       setup(eybLeadWithValues)
       cy.visit(investments.eybLeads.details(eybLeadWithValues.id))
       cy.wait('@getEYBLeadDetails')
-    })
-
-    it('should return non-string, non-array items as it is', () => {
-      const input = [123, true, { key: 'value' }]
-      const output = camelCaseToSentenceCase(input)
-      expect(output).to.deep.equal([123, true, { key: 'value' }])
-    })
-
-    it('should transform a camelCase string to sentence case', () => {
-      expect(
-        camelCaseToSentenceCase('find people_with specialist skills_in uk')
-      ).to.equal('Find people with specialist skills in UK')
     })
 
     it('should render all the fields of the details table', () => {
@@ -78,11 +66,11 @@ describe('EYB lead details', () => {
           'Submitted to EYB': '07 Jun 2023',
           'Company website address':
             eybLeadWithValues.company_website + ' (opens in new tab)',
-          'When do you want to set up?': eybLeadWithValues.landing_timeframe,
+          'When do you want to set up?': convertEYBChoicesToLabels(eybLeadWithValues.landing_timeframe),
           'Do you know where you want to set up in the UK?': 'Yes',
           'Where do you want to set up in the UK?': 'Cardiff',
           'How do you plan to expand your business in the UK?':
-            eybLeadWithValues.intent.join(''),
+          convertEYBChoicesToLabels(eybLeadWithValues.intent).join(''),
           'How many people do you want to hire in the UK in the first 3 years?':
             eybLeadWithValues.hiring,
           'How much do you want to spend on setting up in the first 3 years?':
@@ -159,19 +147,19 @@ describe('EYB lead details', () => {
       sector: null,
       triage_created: '2023-06-07T10:00:00Z',
       intent: [
-        'Find people with specialist skills',
-        'Set up a new distribution centre',
-        'Other',
-        'Onward sales and exports from the UK',
+        'FIND_PEOPLE_WITH_SPECIALIST_SKILLS',
+        'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+        'OTHER',
+        'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
       ],
-      hiring: '6-50',
-      spend: '500000-1000000',
+      hiring: '6 to 50',
+      spend: '£500,000 to £1 million',
       is_high_value: true,
       full_name: 'Joe Bloggs',
       role: 'CEO',
       email: 'email@example.com',
       telephone_number: '01234567890',
-      landing_timeframe: 'In the next 6 months',
+      landing_timeframe: 'UNDER_SIX_MONTHS',
       company_website: null,
       company_name: 'Mars Temp',
       investment_projects: [],
@@ -193,11 +181,11 @@ describe('EYB lead details', () => {
           'Location of company headquarters': 'Canada',
           'Submitted to EYB': '07 Jun 2023',
           'Company website address': NOT_SET_TEXT,
-          'When do you want to set up?': eybLeadWithoutCompany.landing_timeframe,
+          'When do you want to set up?': convertEYBChoicesToLabels(eybLeadWithoutCompany.landing_timeframe),
           'Do you know where you want to set up in the UK?': 'Yes',
           'Where do you want to set up in the UK?': 'Cardiff',
           'How do you plan to expand your business in the UK?':
-            eybLeadWithoutCompany.intent.join(''),
+          convertEYBChoicesToLabels(eybLeadWithoutCompany.intent).join(''),
           'How many people do you want to hire in the UK in the first 3 years?':
             eybLeadWithoutCompany.hiring,
           'How much do you want to spend on setting up in the first 3 years?':
@@ -315,19 +303,19 @@ describe('EYB lead details', () => {
       },
       triage_created: '2023-06-07T10:00:00Z',
       intent: [
-        'Find people with specialist skills',
-        'Set up a new distribution centre',
-        'Other',
-        'Onward sales and exports from the UK',
+        'FIND_PEOPLE_WITH_SPECIALIST_SKILLS',
+        'SET_UP_A_NEW_DISTRIBUTION_CENTRE',
+        'OTHER',
+        'ONWARD_SALES_AND_EXPORTS_FROM_THE_UK',
       ],
-      hiring: '6-50',
-      spend: '500000-1000000',
+      hiring: '6 to 50',
+      spend: '£500,000 to £1 million',
       is_high_value: true,
       full_name: 'Joe Bloggs',
       role: 'CEO',
       email: null,
       telephone_number: '01234567890',
-      landing_timeframe: 'In the next 6 months',
+      landing_timeframe: 'UNDER_SIX_MONTHS',
       company_website: 'fake.website.com',
       investment_projects: [],
     })
@@ -349,11 +337,11 @@ describe('EYB lead details', () => {
           'Submitted to EYB': '07 Jun 2023',
           'Company website address':
             eybLeadWithNoEmail.company_website + ' (opens in new tab)',
-          'When do you want to set up?': eybLeadWithNoEmail.landing_timeframe,
+          'When do you want to set up?': convertEYBChoicesToLabels(eybLeadWithNoEmail.landing_timeframe),
           'Do you know where you want to set up in the UK?': 'Yes',
           'Where do you want to set up in the UK?': 'Cardiff',
           'How do you plan to expand your business in the UK?':
-            eybLeadWithNoEmail.intent.join(''),
+          convertEYBChoicesToLabels(eybLeadWithNoEmail.intent).join(''),
           'How many people do you want to hire in the UK in the first 3 years?':
             eybLeadWithNoEmail.hiring,
           'How much do you want to spend on setting up in the first 3 years?':

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -19,6 +19,7 @@ import {
 } from '../../../../../src/client/utils/date-utils'
 import { eybLeadFaker } from '../../fakers/eyb-leads'
 import { VALUES_VALUE_TO_LABEL_MAP } from '../../../../../src/client/modules/Investments/EYBLeads/constants'
+import { convertEYBChoicesToLabels } from '../../../../../src/client/modules/Investments/utils'
 
 const EYB_RETRIEVE_API_ROUTE = '/api-proxy/v4/investment-lead/eyb'
 
@@ -212,7 +213,10 @@ describe('EYB leads collection page', () => {
         )
         .should('contain', `Estimated spend ${eybLead.spend}`)
         .should('contain', `Sector ${eybLead.sector.name}`)
-        .should('contain', `Estimated land date ${eybLead.landing_timeframe}`)
+        .should(
+          'contain',
+          `Estimated land date ${convertEYBChoicesToLabels(eybLead.landing_timeframe)}`
+        )
         .should(
           'contain',
           `Location ${eybLead.proposed_investment_region.name}`


### PR DESCRIPTION
## Description of change

Some EYB lead fields (`landing_timeframe` and `intent`) contain `UPPER_CASE` values. This PR builds off #7452 to ensure these values are formatted both on the EYB lead collection page (which we accidentally missed in the previous PR) and the EYB lead details page. 

Specifically, it converts the `UPPER_CASE` values to `Sentence case`, with the exception of the acronym `UK`, which remains capitalised.

## Screenshots

### Before

<img width="665" alt="image" src="https://github.com/user-attachments/assets/7003b9d3-daa3-482f-b0dd-0a16fa28124c" />

### After

<img width="665" alt="image" src="https://github.com/user-attachments/assets/3ce55731-020c-4c47-a433-431240240ba4" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
