### PR TITLE
Modify `site_address_is_company_address` field label in project edit history

### DIFF
--- a/src/client/modules/Investments/Projects/EditHistory/constants.js
+++ b/src/client/modules/Investments/Projects/EditHistory/constants.js
@@ -29,4 +29,6 @@ export const PROJECT_FIELD_NAME_TO_LABEL_MAP = {
   associated_non_fdi_r_and_d_project: 'Non-FDI R&D project',
   client_considering_other_countries:
     'Is the client considering other countries?',
+  site_address_is_company_address:
+    "Is the site address the same as the UK recipient company's address?",
 }


### PR DESCRIPTION
## Description of change

_Document what the PR does and why the change is needed_

In preparation for changes to how the site address is recorded for an investment project (see [CLS2-957](https://uktrade.atlassian.net/browse/CLS2-957)), the `site_address_is_company_address` field was added to the API response when GET-ing an investment project.

When changes are made to this field, it automatically shows up in the edit history tab, but with it's default label. This PR modifies the label to be more descriptive.

## Screenshots

### Before

<img width="761" alt="image" src="https://github.com/user-attachments/assets/9b9a7f17-fe65-49bf-a8ff-863336221633" />

### After

<img width="761" alt="image" src="https://github.com/user-attachments/assets/524b1eda-eaa5-4a4d-88e0-9cbbe2b2a24c" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
