### PR TITLE
Format proposed investment city as Title Case

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadDetails.jsx
@@ -4,7 +4,10 @@ import { Link } from 'govuk-react'
 
 import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
 import urls from '../../../../lib/urls'
-import { convertEYBChoicesToLabels } from '../utils'
+import {
+  convertEYBChoicesToLabels,
+  formatProposedInvestmentCity,
+} from '../utils'
 import { EYBLeadResource } from '../../../components/Resource'
 import { EYBLeadLayout, NewWindowLink, SummaryTable } from '../../../components'
 import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
@@ -77,7 +80,9 @@ const EYBLeadDetails = () => {
               />
               <SummaryTable.Row
                 heading="Where do you want to set up in the UK?"
-                children={eybLead.proposedInvestmentCity}
+                children={formatProposedInvestmentCity(
+                  eybLead.proposedInvestmentCity
+                )}
               />
               <SummaryTable.Row
                 heading="How do you plan to expand your business in the UK?"

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -1,4 +1,7 @@
-import { convertEYBChoicesToLabels } from '../utils'
+import {
+  convertEYBChoicesToLabels,
+  formatProposedInvestmentCity,
+} from '../utils'
 
 describe('convertEYBChoicesToLabels', () => {
   const validCases = [
@@ -38,6 +41,30 @@ describe('convertEYBChoicesToLabels', () => {
     it(`should throw an error for the input ${errorCase.input}`, () => {
       expect(() => {
         convertEYBChoicesToLabels(errorCase.input)
+      }).to.throw()
+    })
+  })
+})
+
+describe('formatProposedInvestmentCity', () => {
+  const validCases = [
+    { input: null, output: null },
+    { input: 'MILTON_KEYNES', output: 'Milton Keynes' },
+    { input: 'CITY_OF_EDINBURGH', output: 'City Of Edinburgh' },
+    { input: 'MANCHESTER', output: 'Manchester' },
+  ]
+  validCases.forEach((validCase) => {
+    it(`should output ${validCase.output} for the input ${validCase.input}`, () => {
+      expect(formatProposedInvestmentCity(validCase.input)).to.deep.equal(
+        validCase.output
+      )
+    })
+  })
+  const errorCases = [{ input: undefined }, { input: 123 }]
+  errorCases.forEach((errorCase) => {
+    it(`should throw an error for the input ${errorCase.input}`, () => {
+      expect(() => {
+        formatProposedInvestmentCity(errorCase.input)
       }).to.throw()
     })
   })

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -50,8 +50,10 @@ describe('formatProposedInvestmentCity', () => {
   const validCases = [
     { input: null, output: null },
     { input: 'MILTON_KEYNES', output: 'Milton Keynes' },
-    { input: 'CITY_OF_EDINBURGH', output: 'City Of Edinburgh' },
+    { input: 'CITY_OF_EDINBURGH', output: 'City of Edinburgh' },
     { input: 'MANCHESTER', output: 'Manchester' },
+    { input: 'ANTRIM_AND_NEWTONABBEY', output: 'Antrim and Newtownabbey' },
+    { input: 'ALEXANDER_THE_GREAT', output: 'Alexander the Great' },
   ]
   validCases.forEach((validCase) => {
     it(`should output ${validCase.output} for the input ${validCase.input}`, () => {

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -55,6 +55,8 @@ describe('formatProposedInvestmentCity', () => {
     { input: 'ANTRIM_AND_NEWTONABBEY', output: 'Antrim and Newtonabbey' },
     { input: 'ALEXANDER_THE_GREAT', output: 'Alexander the Great' },
     { input: 'HENLEY-ON-THEMES', output: 'Henley-on-Themes' },
+    { input: 'NEWCASTLE_UPON_TYNE', output: 'Newcastle upon Tyne' },
+    { input: 'BARROW-IN-FURNESS', output: 'Barrow-in-Furness' },
   ]
   validCases.forEach((validCase) => {
     it(`should output ${validCase.output} for the input ${validCase.input}`, () => {

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -52,7 +52,7 @@ describe('formatProposedInvestmentCity', () => {
     { input: 'MILTON_KEYNES', output: 'Milton Keynes' },
     { input: 'CITY_OF_EDINBURGH', output: 'City of Edinburgh' },
     { input: 'MANCHESTER', output: 'Manchester' },
-    { input: 'ANTRIM_AND_NEWTONABBEY', output: 'Antrim and Newtownabbey' },
+    { input: 'ANTRIM_AND_NEWTONABBEY', output: 'Antrim and Newtonabbey' },
     { input: 'ALEXANDER_THE_GREAT', output: 'Alexander the Great' },
   ]
   validCases.forEach((validCase) => {

--- a/src/client/modules/Investments/__test__/utils.test.js
+++ b/src/client/modules/Investments/__test__/utils.test.js
@@ -54,6 +54,7 @@ describe('formatProposedInvestmentCity', () => {
     { input: 'MANCHESTER', output: 'Manchester' },
     { input: 'ANTRIM_AND_NEWTONABBEY', output: 'Antrim and Newtonabbey' },
     { input: 'ALEXANDER_THE_GREAT', output: 'Alexander the Great' },
+    { input: 'HENLEY-ON-THEMES', output: 'Henley-on-Themes' },
   ]
   validCases.forEach((validCase) => {
     it(`should output ${validCase.output} for the input ${validCase.input}`, () => {

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -77,8 +77,20 @@ export const formatProposedInvestmentCity = (choices) => {
   const lowercaseWords = choices.toLowerCase().split('_')
 
   const formattedWords = lowercaseWords.map((word) => {
+    // Handle special case for "-on-"
+    if (word.includes('-on-')) {
+      return word
+        .split('-')
+        .map((subWord, index) =>
+          index === 1
+            ? subWord
+            : subWord.charAt(0).toUpperCase() + subWord.slice(1)
+        )
+        .join('-')
+    }
+
     if (word === 'of' || word === 'the' || word === 'and') {
-      return word // Keep lowercase
+      return word // Keep lowercase for "of," "the," or "and"
     }
     return word.charAt(0).toUpperCase() + word.slice(1) // Capitalize the first letter
   })

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -1,4 +1,4 @@
-import { sentence } from 'case'
+import { sentence, title } from 'case'
 
 import urls from '../../../lib/urls'
 
@@ -59,4 +59,19 @@ export const convertEYBChoicesToLabels = (choices) => {
   }
 
   throw new Error('Input must be null, a string, or array of strings')
+}
+
+/**
+ * Formats EYB lead proposed investment city to Title Case labels
+ * @param {string|null} city - Single string or null to format
+ * @returns {string|null} - Formatted string
+ */
+export const formatProposedInvestmentCity = (choices) => {
+  if (choices === null) {
+    return null
+  }
+  if (typeof choices == 'string') {
+    return title(choices)
+  }
+  throw new Error('Input must be null or a string')
 }

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -1,4 +1,4 @@
-import { sentence, title } from 'case'
+import { sentence } from 'case'
 
 import urls from '../../../lib/urls'
 
@@ -70,8 +70,18 @@ export const formatProposedInvestmentCity = (choices) => {
   if (choices === null) {
     return null
   }
-  if (typeof choices == 'string') {
-    return title(choices)
+  if (typeof choices !== 'string') {
+    throw new Error('Input must be null or a string')
   }
-  throw new Error('Input must be null or a string')
+
+  const lowercaseWords = choices.toLowerCase().split('_')
+
+  const formattedWords = lowercaseWords.map((word) => {
+    if (word === 'of' || word === 'the' || word === 'and') {
+      return word // Keep lowercase
+    }
+    return word.charAt(0).toUpperCase() + word.slice(1) // Capitalize the first letter
+  })
+
+  return formattedWords.join(' ')
 }

--- a/src/client/modules/Investments/utils.js
+++ b/src/client/modules/Investments/utils.js
@@ -77,8 +77,8 @@ export const formatProposedInvestmentCity = (choices) => {
   const lowercaseWords = choices.toLowerCase().split('_')
 
   const formattedWords = lowercaseWords.map((word) => {
-    // Handle special case for "-on-"
-    if (word.includes('-on-')) {
+    // Handle special case for "-on-" or "-in-"
+    if (word.includes('-on-') || word.includes('-in-')) {
       return word
         .split('-')
         .map((subWord, index) =>
@@ -89,8 +89,8 @@ export const formatProposedInvestmentCity = (choices) => {
         .join('-')
     }
 
-    if (word === 'of' || word === 'the' || word === 'and') {
-      return word // Keep lowercase for "of," "the," or "and"
+    if (word === 'of' || word === 'the' || word === 'and' || word === 'upon') {
+      return word // Keep lowercase for "of," "the,", "and" or "upon"
     }
     return word.charAt(0).toUpperCase() + word.slice(1) // Capitalize the first letter
   })


### PR DESCRIPTION
## Description of change

Making a change to show human readable labels for investment city on EYB leads.

## Test instructions
  
When running the newly added test to format the string examples should appear like the following:
Previous value example: COLCHESTER
New: Colchester
Previous: ABERDEEN_CITY_OF
New: Aberdeen City of

## Screenshots

### Before

_Add a screenshot_

### After

<img width="564" alt="image" src="https://github.com/user-attachments/assets/42a8924a-bf67-40ee-ab38-83001a1f3319" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
