### PR TITLE
Export project interactions `Sort by` functionality

### DIFF
--- a/src/client/modules/ExportPipeline/Export.jsx
+++ b/src/client/modules/ExportPipeline/Export.jsx
@@ -22,12 +22,12 @@ const StyledLink = styled('a')({
 
 export const CompanyLink = (props) => (
   <ExportResource.Inline {...props}>
-    {(exportProject) => (
+    {({ company }) => (
       <StyledLink
         data-test="export-company-link"
-        href={urls.companies.detail(exportProject.company.id)}
+        href={urls.companies.detail(company.id)}
       >
-        {exportProject.company.name.toUpperCase()}
+        {company.name.toUpperCase()}
       </StyledLink>
     )}
   </ExportResource.Inline>

--- a/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
@@ -5,6 +5,7 @@ import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import { CollectionItem } from '../../../components'
 import { ExportProjectTitle } from '../Export'
 import urls from '../../../../lib/urls'
+import { SORT_OPTIONS_EXPORT_INTERACTION } from '../constants'
 
 const ExportInteractionsList = ({ interactions = [], exportId }) =>
   interactions.length === 0 ? null : (
@@ -46,12 +47,7 @@ export default ({ exportId }) => (
     shouldPluralize={true}
     noResults="You don't have any export interactions."
     payload={{ company_export_id: exportId }}
-    sortOptions={[
-      // These values are assumed as the BE work hasn't been implemented yet
-      { value: 'created_on:desc', name: 'Recently created' },
-      { value: 'company.name:asc', name: 'Company A-Z' },
-      { value: 'subject:asc', name: 'Subject A-Z' },
-    ]}
+    sortOptions={SORT_OPTIONS_EXPORT_INTERACTION}
   >
     {(page) => (
       <ExportInteractionsList interactions={page} exportId={exportId} />

--- a/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 
+import { LEVEL_SIZE } from '@govuk-react/constants'
+import { H2 } from 'govuk-react'
+
 import Interactions from '../../../components/Resource/Interactions'
 import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import { CollectionItem } from '../../../components'
@@ -41,16 +44,23 @@ const ExportInteractionsList = ({ interactions = [], exportId }) =>
   )
 
 export default ({ exportId }) => (
-  <Interactions.Paginated
-    id="export-interactions"
-    heading="interactions"
-    shouldPluralize={true}
-    noResults="You don't have any export interactions."
-    payload={{ company_export_id: exportId }}
-    sortOptions={SORT_OPTIONS_EXPORT_INTERACTION}
-  >
-    {(page) => (
-      <ExportInteractionsList interactions={page} exportId={exportId} />
-    )}
-  </Interactions.Paginated>
+  <>
+    <H2 size={LEVEL_SIZE[3]}>Interactions</H2>
+    <p>
+      An interaction could be a meeting, call, email or another activity
+      associated with this export.
+    </p>
+    <Interactions.Paginated
+      id="export-interactions"
+      heading="interactions"
+      shouldPluralize={true}
+      noResults="You don't have any export interactions."
+      payload={{ company_export_id: exportId }}
+      sortOptions={SORT_OPTIONS_EXPORT_INTERACTION}
+    >
+      {(page) => (
+        <ExportInteractionsList interactions={page} exportId={exportId} />
+      )}
+    </Interactions.Paginated>
+  </>
 )

--- a/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
@@ -6,18 +6,17 @@ import { H2 } from 'govuk-react'
 import Interactions from '../../../components/Resource/Interactions'
 import { formatDate, DATE_FORMAT_FULL } from '../../../utils/date-utils'
 import { CollectionItem } from '../../../components'
-import { ExportProjectTitle } from '../Export'
 import urls from '../../../../lib/urls'
 import { SORT_OPTIONS_EXPORT_INTERACTION } from '../constants'
 
-const ExportInteractionsList = ({ interactions = [], exportId }) =>
+const ExportInteractionsList = ({ interactions = [] }) =>
   interactions.length === 0 ? null : (
     <ul data-test="export-interactions-list">
       {interactions.map((item) => (
         <CollectionItem
           key={item.id}
-          headingText={<ExportProjectTitle id={exportId} />}
-          headingUrl={urls.exportPipeline.interactions.details(exportId)}
+          headingText={item.subject}
+          headingUrl={urls.exportPipeline.interactions.details(item.id)}
           metadata={[
             {
               label: 'Date:',
@@ -58,9 +57,7 @@ export default ({ exportId }) => (
       payload={{ company_export_id: exportId }}
       sortOptions={SORT_OPTIONS_EXPORT_INTERACTION}
     >
-      {(page) => (
-        <ExportInteractionsList interactions={page} exportId={exportId} />
-      )}
+      {(page) => <ExportInteractionsList interactions={page} />}
     </Interactions.Paginated>
   </>
 )

--- a/src/client/modules/ExportPipeline/constants.js
+++ b/src/client/modules/ExportPipeline/constants.js
@@ -38,6 +38,12 @@ export const SORT_OPTIONS = [
   },
 ]
 
+export const SORT_OPTIONS_EXPORT_INTERACTION = [
+  { name: 'Recently created', value: '-created_on' },
+  { name: 'Company name A-Z', value: 'company__name' },
+  { name: 'Subject A-Z', value: 'subject' },
+]
+
 export const EXPORT_POTENTIAL_OPTIONS = [
   { label: 'High', value: 'high' },
   { label: 'Medium', value: 'medium' },

--- a/test/component/cypress/specs/ExportPipeline/ExportInteractionsList.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/ExportInteractionsList.cy.jsx
@@ -11,6 +11,7 @@ describe('ExportInteractionsList', () => {
     }
 
     const interaction = {
+      id: 123,
       date: '2024-12-23',
       contacts: [
         {
@@ -30,6 +31,7 @@ describe('ExportInteractionsList', () => {
       service: {
         name: 'Account management : General',
       },
+      subject: 'Video call meeting to Baileys',
     }
 
     const interactionList = [
@@ -56,8 +58,8 @@ describe('ExportInteractionsList', () => {
 
     cy.get('@firstItem').within(() => {
       cy.get('h3 a')
-        .should('have.text', 'Baileys export to Brazil')
-        .and('have.attr', 'href', '/export/1/interactions/details')
+        .should('have.text', 'Video call meeting to Baileys')
+        .and('have.attr', 'href', '/export/123/interactions/details')
 
       const items = '[data-test="metadata-item"]'
       cy.get(items).should('have.length', 4)
@@ -77,6 +79,7 @@ describe('ExportInteractionsList', () => {
 
   it('should render a list of multiple contacts', () => {
     const interaction = {
+      id: 224,
       date: '2024-12-23',
       contacts: [
         {
@@ -93,6 +96,7 @@ describe('ExportInteractionsList', () => {
       service: {
         name: 'Account management : General',
       },
+      subject: 'Video call meeting to Baileys',
     }
     cy.mountWithProvider(<ExportInteractionsList />, {
       tasks: {
@@ -138,6 +142,7 @@ describe('ExportInteractionsList', () => {
       service: {
         name: 'Account management : General',
       },
+      subject: 'Send email to Baileys',
     }
     cy.mountWithProvider(<ExportInteractionsList />, {
       tasks: {

--- a/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/TabNav.cy.jsx
@@ -4,77 +4,65 @@ import Export from '../../../../../src/client/modules/ExportPipeline/Export'
 import { assertBreadcrumbs } from '../../../../functional/cypress/support/assertions'
 import { assertTabNav } from '../../../../end-to-end/cypress/support/assertions'
 import urls from '../../../../../src/lib/urls'
+import fixtures from '../../../../functional/cypress/fixtures'
 
-const exportProject = {
-  id: '1',
-  title: 'Rolls Royce to UAE',
-  company: {
-    id: '2',
-    name: 'Rolls Royce',
-  },
-  team_members: [
-    {
-      name: 'David Jones',
-      id: '1',
-    },
-  ],
-  contacts: [
-    {
-      name: 'Johan Person',
-      email: 'johan@nederlands.com',
-      id: '1',
-    },
-  ],
-}
+const exportProjectDetails = fixtures.export.exportProjectDetails
 
 describe('Export project tab navigation', () => {
   it('should render the breadcrumbs for details', () => {
     cy.mountWithProvider(<Export />, {
-      initialPath: '/export/1/details',
+      initialPath: `/export/${exportProjectDetails.id}/details`,
       tasks: {
-        Export: () => exportProject,
+        Export: () => exportProjectDetails,
       },
     })
     assertBreadcrumbs({
       Home: urls.exportPipeline.index(),
-      [exportProject.title]: null,
+      [exportProjectDetails.title]: null,
     })
   })
 
   it('should render the same breadcrumbs for interactions', () => {
     cy.mountWithProvider(<Export />, {
-      initialPath: '/export/1/interactions/',
+      initialPath: `/export/${exportProjectDetails.id}/interactions/`,
       tasks: {
-        Export: () => exportProject,
+        Export: () => exportProjectDetails,
       },
     })
     assertBreadcrumbs({
       Home: urls.exportPipeline.index(),
-      [exportProject.title]: null,
+      [exportProjectDetails.title]: null,
     })
   })
 
   it('should render a company link and page heading', () => {
     cy.mountWithProvider(<Export />, {
-      initialPath: '/export/1/details',
+      initialPath: `/export/${exportProjectDetails.id}/details`,
       tasks: {
-        Export: () => exportProject,
+        Export: () => exportProjectDetails,
       },
     })
 
     cy.get('[data-test=export-company-link]')
-      .should('have.text', exportProject.company.name.toUpperCase())
-      .should('have.attr', 'href', `/companies/${exportProject.company.id}`)
+      .should('have.text', exportProjectDetails.company.name.toUpperCase())
+      .should(
+        'have.attr',
+        'href',
+        `/companies/${exportProjectDetails.company.id}`
+      )
 
-    cy.get('[data-test="heading"]').should('have.text', 'Rolls Royce to UAE')
+    cy.get('[data-test="heading"]').should(
+      'have.text',
+      exportProjectDetails.title
+    )
   })
 
   it('should render two tabs: Project details and Interactions', () => {
     cy.mountWithProvider(<Export />, {
-      initialPath: '/export/1/details',
+      initialPath: `/export/${exportProjectDetails.id}/details`,
       tasks: {
-        Export: () => Promise.resolve(exportProject),
-        TASK_GET_EXPORT_DETAIL: () => Promise.resolve(exportProject),
+        Export: () => Promise.resolve(exportProjectDetails),
+        TASK_GET_EXPORT_DETAIL: () => Promise.resolve(exportProjectDetails),
       },
     })
     assertTabNav({

--- a/test/functional/cypress/fixtures/index.js
+++ b/test/functional/cypress/fixtures/index.js
@@ -73,6 +73,7 @@ module.exports = {
   },
   export: {
     historyWithInteractions: require('../../../sandbox/fixtures/v4/export/history-with-interactions.json'),
+    exportProjectDetails: require('../../../sandbox/fixtures/v4/company/company-with-export-project-details.json'),
   },
 
   omis: {

--- a/test/functional/cypress/specs/export-pipeline/export-interaction-sort-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-interaction-sort-spec.js
@@ -1,0 +1,68 @@
+import urls from '../../../../../src/lib/urls'
+import { exportFaker } from '../../fakers/export'
+import { assertUrl } from '../../support/assertions'
+
+const companyExport = exportFaker()
+
+const companyExportInteractionsEndpoint = '/api-proxy/v4/interaction'
+const queryParams = '&limit=10&offset=0'
+const requestUrl = `${companyExportInteractionsEndpoint}?company_export_id=${companyExport.id}`
+
+describe('Company Export Interactions Collections Sort', () => {
+  context('Default sort', () => {
+    beforeEach(() => {
+      cy.intercept('POST', `${requestUrl}${queryParams}&sortby=-created_on`).as(
+        'apiRequest'
+      )
+      cy.visit(urls.exportPipeline.interactions.index())
+      cy.visit(assertUrl)
+    })
+
+    it('should apply the default sort', () => {
+      cy.wait('@apiRequest').then(({ request }) => {
+        expect(request.body.sortby).to.equal('-created_on')
+      })
+    })
+
+    it('should have all sort options', () => {
+      cy.get('[data-test="sortby"] option').then((options) => {
+        const sortOptions = [...options].map((o) => ({
+          value: o.value,
+          name: o.label,
+        }))
+        expect(sortOptions).to.deep.eq([
+          { value: '-created_on', name: 'Recently created' },
+          { value: 'company__name', name: 'Company name A-Z' },
+          { value: 'subject', name: 'Subject A-Z' },
+        ])
+      })
+    })
+  })
+
+  context('User sort', () => {
+    const element = '[data-test="sortby"] select'
+
+    beforeEach(() => {
+      cy.intercept('POST', `${requestUrl}${queryParams}&sortby=-created_on`).as(
+        'apiRequest'
+      )
+      cy.visit(`${urls.exportPipeline.interactions.index()}`)
+      cy.wait('@apiRequest')
+    })
+
+    it('should sort by "Recently created"', () => {
+      cy.get(element).select('Recently created')
+      assertUrl('sortby=-created_on')
+    })
+
+    it('should sort by "Company name A-Z"', () => {
+      cy.get(element).select('Company name A-Z')
+      assertUrl('sortby=company__name')
+    })
+
+    it('should sort by "Subject A-Z"', () => {
+      cy.get(element).select('Subject A-Z')
+      assertUrl('sortby=subject')
+    })
+  })
+})

--- a/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
@@ -19,17 +19,13 @@ describe('Export project interaction collection list', () => {
         'contain',
         '1,233 interactions'
       )
-    })
-
-    it('should show the current and number of pages', () => {
+      // should show current and total pages
       cy.contains('Page 1 of 124').should('be.visible')
-    })
 
-    it('should display 10 interactions per page', () => {
+      // should display 10 interactions per page
       cy.get('[data-test="collection-item"]').should('have.length', 10)
-    })
 
-    it('should show the pagination', () => {
+      // should show the pagination
       cy.get('[data-test="pagination"]').should('be.visible')
       cy.get('[data-test="page-number-active"]').should('have.text', '1')
       cy.get('[data-test="page-number"]').should('contain', '124')
@@ -39,7 +35,9 @@ describe('Export project interaction collection list', () => {
 })
 
 describe('Export interaction collections filters "Sort by"', () => {
-  context('Default sort by "Recently created"', () => {
+  context('Sort by filters with default "Recently created"', () => {
+    const element = '[data-test="sortby"] select'
+
     beforeEach(() => {
       cy.intercept(
         'GET',
@@ -64,18 +62,6 @@ describe('Export interaction collections filters "Sort by"', () => {
           { value: 'subject', name: 'Subject A-Z' },
         ])
       })
-    })
-  })
-
-  context('Other sort by filters', () => {
-    const element = '[data-test="sortby"] select'
-
-    beforeEach(() => {
-      cy.intercept(
-        'GET',
-        `/api-proxy/v4/interaction?company_export_id=${companyExportProject.id}&sortby=-created_on${queryParams}`
-      ).as('apiRequest')
-      cy.visit(`/export/${companyExportProject.id}/interactions`)
     })
 
     it('should sort by "Company name A-Z"', () => {

--- a/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
@@ -1,20 +1,51 @@
-import urls from '../../../../../src/lib/urls'
 import fixtures from '../../fixtures'
 import { assertUrl } from '../../support/assertions'
 
 const companyExportProject = fixtures.export.exportProjectDetails
-
-const companyExportInteractionsEndpoint = '/api-proxy/v4/interaction'
 const queryParams = '&limit=10&offset=0'
-const requestUrl = `${companyExportInteractionsEndpoint}?company_export_id=${companyExportProject.id}`
 
-describe('Export project interaction collections "Sort by"', () => {
+describe('Export project interaction collection list', () => {
+  context('When export project render with multiple interaction linked', () => {
+    beforeEach(() => {
+      cy.intercept(
+        'GET',
+        `/api-proxy/v4/interaction?company_export_id=${companyExportProject.id}&sortby=-created_on${queryParams}`
+      ).as('apiRequest')
+      cy.visit(`/export/${companyExportProject.id}/interactions`)
+    })
+
+    it('should display the interactions list', () => {
+      cy.get('[data-test="collection-header-name').should(
+        'contain',
+        '1,233 interactions'
+      )
+    })
+
+    it('should show the current and number of pages', () => {
+      cy.contains('Page 1 of 124').should('be.visible')
+    })
+
+    it('should display 10 interactions per page', () => {
+      cy.get('[data-test="collection-item"]').should('have.length', 10)
+    })
+
+    it('should show the pagination', () => {
+      cy.get('[data-test="pagination"]').should('be.visible')
+      cy.get('[data-test="page-number-active"]').should('have.text', '1')
+      cy.get('[data-test="page-number"]').should('contain', '124')
+      cy.get('[data-test="next"]').should('have.text', 'Next page')
+    })
+  })
+})
+
+describe('Export interaction collections filters "Sort by"', () => {
   context('Default sort by "Recently created"', () => {
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}${queryParams}&sortby=-created_on`).as(
-        'apiRequest'
-      )
-      cy.visit(urls.exportPipeline.interactions.index(companyExportProject.id))
+      cy.intercept(
+        'GET',
+        `/api-proxy/v4/interaction?company_export_id=${companyExportProject.id}&sortby=-created_on${queryParams}`
+      ).as('apiRequest')
+      cy.visit(`/export/${companyExportProject.id}/interactions`)
     })
 
     it('should render "Sort by" label', () => {
@@ -36,14 +67,15 @@ describe('Export project interaction collections "Sort by"', () => {
     })
   })
 
-  context('User sort', () => {
+  context('Other sort by filters', () => {
     const element = '[data-test="sortby"] select'
 
     beforeEach(() => {
-      cy.intercept('GET', `${requestUrl}${queryParams}&sortby=-created_on`).as(
-        'apiRequest'
-      )
-      cy.visit(urls.exportPipeline.interactions.index(companyExportProject.id))
+      cy.intercept(
+        'GET',
+        `/api-proxy/v4/interaction?company_export_id=${companyExportProject.id}&sortby=-created_on${queryParams}`
+      ).as('apiRequest')
+      cy.visit(`/export/${companyExportProject.id}/interactions`)
     })
 
     it('should sort by "Company name A-Z"', () => {

--- a/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
@@ -1,30 +1,27 @@
 import urls from '../../../../../src/lib/urls'
-import { exportFaker } from '../../fakers/export'
+import fixtures from '../../fixtures'
 import { assertUrl } from '../../support/assertions'
 
-const companyExport = exportFaker()
+const companyExportProject = fixtures.export.exportProjectDetails
 
 const companyExportInteractionsEndpoint = '/api-proxy/v4/interaction'
 const queryParams = '&limit=10&offset=0'
-const requestUrl = `${companyExportInteractionsEndpoint}?company_export_id=${companyExport.id}`
+const requestUrl = `${companyExportInteractionsEndpoint}?company_export_id=${companyExportProject.id}`
 
-describe('Company Export Interactions Collections Sort', () => {
-  context('Default sort', () => {
+describe('Export project interaction collections "Sort by"', () => {
+  context('Default sort by "Recently created"', () => {
     beforeEach(() => {
-      cy.intercept('POST', `${requestUrl}${queryParams}&sortby=-created_on`).as(
+      cy.intercept('GET', `${requestUrl}${queryParams}&sortby=-created_on`).as(
         'apiRequest'
       )
-      cy.visit(urls.exportPipeline.interactions.index())
-      cy.visit(assertUrl)
+      cy.visit(urls.exportPipeline.interactions.index(companyExportProject.id))
     })
 
-    it('should apply the default sort', () => {
-      cy.wait('@apiRequest').then(({ request }) => {
-        expect(request.body.sortby).to.equal('-created_on')
-      })
+    it('should render "Sort by" label', () => {
+      cy.get('[data-test="sortby"]').should('contain', 'Sort by')
     })
 
-    it('should have all sort options', () => {
+    it('should have all sort by options', () => {
       cy.get('[data-test="sortby"] option').then((options) => {
         const sortOptions = [...options].map((o) => ({
           value: o.value,
@@ -43,16 +40,10 @@ describe('Company Export Interactions Collections Sort', () => {
     const element = '[data-test="sortby"] select'
 
     beforeEach(() => {
-      cy.intercept('POST', `${requestUrl}${queryParams}&sortby=-created_on`).as(
+      cy.intercept('GET', `${requestUrl}${queryParams}&sortby=-created_on`).as(
         'apiRequest'
       )
-      cy.visit(`${urls.exportPipeline.interactions.index()}`)
-      cy.wait('@apiRequest')
-    })
-
-    it('should sort by "Recently created"', () => {
-      cy.get(element).select('Recently created')
-      assertUrl('sortby=-created_on')
+      cy.visit(urls.exportPipeline.interactions.index(companyExportProject.id))
     })
 
     it('should sort by "Company name A-Z"', () => {

--- a/test/sandbox/fixtures/v4/company/company-with-export-project-details.json
+++ b/test/sandbox/fixtures/v4/company/company-with-export-project-details.json
@@ -1,0 +1,64 @@
+{
+    "id": "f5bc555e-0eba-4a7e-abe9-db89a78afc5c",
+    "company": {
+        "name": "Venus Ltd",
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611"
+    },
+    "owner": {
+        "name": "John Doe",
+        "first_name": "John",
+        "last_name": "Doe",
+        "dit_team": {
+            "name": "Agricultural Engineers Association Ltd",
+            "id": "d2f02898-9698-e211-a939-e4115bead28a"
+        },
+        "id": "c0e09068-ce3e-4798-9437-2d258d83881e"
+    },
+    "team_members": [
+        {
+            "name": "Puck Head",
+            "id": "e83a608e-84a4-11e6-ae22-56b6b6499611"
+        },
+        {
+            "name": "Jacob Webster",
+            "id": "b4848b30-f532-4cfc-a063-b064d8435b65"
+        }
+    ],
+    "contacts": [
+        {
+            "name": "Johnny Cakeman",
+            "email": "johnny@cakeman.com",
+            "id": "9b1138ab-ec7b-497f-b8c3-27fed21694ef"
+        }
+    ],
+    "destination_country": {
+        "name": "Åland Islands",
+        "id": "ff996375-8adf-459a-b2a6-a477b66c7c6a"
+    },
+    "sector": {
+        "name": "Advanced engineering : Metallurgical process plant",
+        "id": "a422c9d2-5f95-e211-a939-e4115bead28a"
+    },
+    "exporter_experience": {
+        "name": "Exported in the last 12 months, but has not won an export order by having an export plan",
+        "id": "8937c359-157e-41dd-8520-679383847ea0"
+    },
+    "estimated_win_date": "2025-03-01",
+    "estimated_export_value_amount": "500000",
+    "estimated_export_value_years": {
+        "name": "4 years",
+        "id": "3f289d56-aec1-4472-a046-10828cad4992"
+    },
+    "export_potential": "high",
+    "created_on": "2025-01-15T10:38:12.694291Z",
+    "modified_on": "2025-01-15T10:40:30.928565Z",
+    "archived": false,
+    "archived_on": null,
+    "archived_reason": "",
+    "title": "Export Project for Venus ltd - TEST",
+    "status": "active",
+    "notes": "",
+    "created_by": "c0e09068-ce3e-4798-9437-2d258d83881e",
+    "modified_by": "c0e09068-ce3e-4798-9437-2d258d83881e",
+    "archived_by": null
+}

--- a/test/sandbox/fixtures/v4/interaction/interaction-by-export-project.js
+++ b/test/sandbox/fixtures/v4/interaction/interaction-by-export-project.js
@@ -1,0 +1,39 @@
+import { faker } from '../../../utils/random.js'
+import interactionsFixture from './interactions.json' assert { type: 'json' }
+
+export const interactionByExportProject = (req) => {
+  const interactionsByExportProjectList = interactionsFixture.results.map(
+    (interaction) => ({
+      ...interaction,
+      company_export: {
+        id: req.query.company_export_id,
+        title: faker.word.sample(),
+      },
+      dit_participants: [
+        {
+          adviser: {
+            name: faker.person.fullName(),
+            first_name: faker.person.firstName(),
+            last_name: faker.person.lastName(),
+            id: faker.string.uuid(),
+          },
+          team: {
+            name: faker.company.name(),
+            id: faker.string.uuid(),
+          },
+        },
+      ],
+    })
+  )
+
+  const limit = parseInt(req.query.limit, 10)
+  const offset = parseInt(req.query.offset, 10)
+
+  return Object.assign(
+    {},
+    {
+      ...interactionsFixture,
+      results: interactionsByExportProjectList.slice(offset, offset + limit),
+    }
+  )
+}

--- a/test/sandbox/routes/v3/interaction/interaction.js
+++ b/test/sandbox/routes/v3/interaction/interaction.js
@@ -13,6 +13,7 @@ import interactionDraftPastMeeting from '../../../fixtures/v3/interaction/intera
 import interactionValidationError from '../../../fixtures/v3/interaction/interaction-validation-error.json' assert { type: 'json' }
 import interactionWithReferral from '../../../fixtures/v3/interaction/interaction-with-referral.json' assert { type: 'json' }
 import interactionWithoutTheme from '../../../fixtures/v3/interaction/interaction-without-theme.js'
+import { interactionByExportProject } from '../../../fixtures/v4/interaction/interaction-by-export-project.js'
 
 export const getInteractions = function (req, res) {
   if (req.query.contact_id) {
@@ -31,6 +32,10 @@ export const getInteractions = function (req, res) {
 
   if (req.query.event_id === 'b93d4273-36fe-4008-ac40-fbc197910791') {
     return res.json(noInteractions)
+  }
+
+  if (req.query.company_export_id === 'f5bc555e-0eba-4a7e-abe9-db89a78afc5c') {
+    return res.json(interactionByExportProject(req))
   }
 
   res.json(interactions)

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -248,14 +248,17 @@ export const exportDetail = function (req, res) {
   var companyId = req.params.companyId
   var exportId = req.params.exportId
 
+  var errorResponse = { non_field_errors: ['A 400 error message here'] }
+
   if (companyId === companyLambdaPlc.id) {
     res.status(500).send('')
   } else if (companyId === companyDnBCorp.id) {
-    res.status(400).json({ non_field_errors: ['A 400 error message here'] })
+    res.status(400).json(errorResponse)
   } else if (exportId === companyWithExportProjectDetails.id) {
     res.json(companyWithExportProjectDetails)
   } else {
-    res.send('')
+    //Throw error message
+    res.status(400).json(errorResponse)
   }
 }
 

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -257,7 +257,6 @@ export const exportDetail = function (req, res) {
   } else if (exportId === companyWithExportProjectDetails.id) {
     res.json(companyWithExportProjectDetails)
   } else {
-    //Throw error message
     res.status(400).json(errorResponse)
   }
 }

--- a/test/sandbox/routes/v4/company/company.js
+++ b/test/sandbox/routes/v4/company/company.js
@@ -26,6 +26,7 @@ import companyWithValidationError from '../../../fixtures/v4/company/company-val
 import companyAudit from '../../../fixtures/v4/company-audit/company-audit.json' assert { type: 'json' }
 import companyUsState from '../../../fixtures/v4/company/company-us-state.json' assert { type: 'json' }
 import companyCanadianProvince from '../../../fixtures/v4/company/company-canada-province.json' assert { type: 'json' }
+import companyWithExportProjectDetails from '../../../fixtures/v4/company/company-with-export-project-details.json' assert { type: 'json' }
 import exportWins from '../../../fixtures/v4/company-export-wins/export-wins.json' assert { type: 'json' }
 import exportWinsPage1 from '../../../fixtures/v4/company-export-wins/export-wins-page-1.json' assert { type: 'json' }
 import exportWinsPage2 from '../../../fixtures/v4/company-export-wins/export-wins-page-2.json' assert { type: 'json' }
@@ -245,11 +246,14 @@ export const getReferralDetails = function (req, res) {
 
 export const exportDetail = function (req, res) {
   var companyId = req.params.companyId
+  var exportId = req.params.exportId
 
   if (companyId === companyLambdaPlc.id) {
     res.status(500).send('')
   } else if (companyId === companyDnBCorp.id) {
     res.status(400).json({ non_field_errors: ['A 400 error message here'] })
+  } else if (exportId === companyWithExportProjectDetails.id) {
+    res.json(companyWithExportProjectDetails)
   } else {
     res.send('')
   }

--- a/test/sandbox/routes/v4/interaction/interaction.js
+++ b/test/sandbox/routes/v4/interaction/interaction.js
@@ -17,6 +17,8 @@ import interactionWithExportCountries from '../../../fixtures/v4/interaction/int
 import interactionWithoutExportCountries from '../../../fixtures/v4/interaction/interaction-with-no-countries-discussed.json' assert { type: 'json' }
 import interactionWithBusIntel from '../../../fixtures/v4/interaction/interaction-with-business-intelligence.json' assert { type: 'json' }
 
+import { interactionByExportProject } from '../../../fixtures/v4/interaction/interaction-by-export-project.js'
+
 export const getInteractions = function (req, res) {
   if (req.query.contact_id) {
     return res.json(interactionByContactId)
@@ -30,6 +32,10 @@ export const getInteractions = function (req, res) {
     req.query.investment_project_id === '5d341b34-1fc8-4638-b4b1-a0922ebf401e'
   ) {
     return res.json(interactionByInvestmentProjectId)
+  }
+
+  if (req.query.company_export_id === 'f5bc555e-0eba-4a7e-abe9-db89a78afc5c') {
+    return res.json(interactionByExportProject(req))
   }
 
   res.json(interactions)

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -892,7 +892,7 @@ app.get('/v4/task/:taskId', getTask)
 app.post('/v4/task', createTask)
 app.patch('/v4/task/:taskId', updateTask)
 
-app.get('/v4/export/', (req, res) => res.json({ count: 0, results: [] }))
+app.get('/v4/export', (req, res) => res.json({ count: 0, results: [] }))
 app.get('/v4/export/:exportId', (req, res) => exportDetail(req, res))
 
 app.get('/v4/export/owner', (req, res) =>

--- a/test/sandbox/server.js
+++ b/test/sandbox/server.js
@@ -892,7 +892,9 @@ app.get('/v4/task/:taskId', getTask)
 app.post('/v4/task', createTask)
 app.patch('/v4/task/:taskId', updateTask)
 
-app.get('/v4/export', (req, res) => res.json({ count: 0, results: [] }))
+app.get('/v4/export/', (req, res) => res.json({ count: 0, results: [] }))
+app.get('/v4/export/:exportId', (req, res) => exportDetail(req, res))
+
 app.get('/v4/export/owner', (req, res) =>
   res.json([
     {


### PR DESCRIPTION
## Description of change

Export project interaction list with `Sort by` functionality, it allows user to sort by `Recent created`, `Company A-Z` and `Subject A-Z`.

Note: 
This PR includes fixing some issue from feature branch `Export Project Interaction` https://github.com/uktrade/data-hub-frontend/pull/7433. Which includes:
- Export Pipeline TabNav component test issue.
- Export Interaction Details component and sandbox endpoint issue.
- Adding Export Interaction List and `Sort by` functional testing and sandbox endpoint.

## Test instructions
- From local Sandbox, navigate `http://localhost:3000/export/f5bc555e-0eba-4a7e-abe9-db89a78afc5c/interactions` then filter by `Sort by`. 


## Screenshots

### Before
- No side bar navigation
<img width="802" alt="image" src="https://github.com/user-attachments/assets/3c4c328d-53d1-4bb1-9109-0bd2d6aa380a" />

### After
- Export interaction `Sort by` filter

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/afbcb1bc-df16-498a-bf29-31a4ca42772e" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
