### PR TITLE
Reapply site address question changes with some modifications

### DIFF
--- a/src/client/components/MyInvestmentProjects/constants.js
+++ b/src/client/components/MyInvestmentProjects/constants.js
@@ -48,7 +48,7 @@ export const GET_REQUIRED_FIELDS_AFTER_STAGE = {
   ['non_fdi_r_and_d_budget']: STAGE.VERIFY_WIN_ID,
   ['new_tech_to_uk']: STAGE.VERIFY_WIN_ID,
   ['export_revenue']: STAGE.VERIFY_WIN_ID,
-  ['site_decided']: STAGE.VERIFY_WIN_ID,
+  ['site_address_is_company_address']: STAGE.VERIFY_WIN_ID,
   ['actual_uk_regions']: STAGE.VERIFY_WIN_ID,
   ['delivery_partners']: STAGE.VERIFY_WIN_ID,
   ['actual_land_date']: STAGE.VERIFY_WIN_ID,
@@ -136,6 +136,8 @@ export const INCOMPLETE_FIELDS = {
     'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?',
   export_revenue:
     'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
+  site_address_is_company_address:
+    "Is the site address the same as the UK recipient company's address?",
   address_1: 'Street',
   address_town: 'Town',
   address_postcode: 'Postcode',

--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -253,14 +253,14 @@ const EditProjectRequirements = () => {
                 )}
                 placeholder="Select a UK region"
                 isMulti={true}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
+                validate={(values, field, formFields) =>
+                  validateFieldForStage(
                     field,
                     formFields,
                     project,
                     'Select a UK region'
                   )
-                }}
+                }
               />
               <ResourceOptionsField
                 name="delivery_partners"

--- a/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectRequirements.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { H2 } from 'govuk-react'
 import { LEVEL_SIZE } from '@govuk-react/constants'
 import { useParams } from 'react-router-dom'
+import InsetText from '@govuk-react/inset-text'
 
 import {
   FieldAddress,
@@ -28,6 +29,7 @@ import {
 import {
   OPTIONS_YES_NO,
   OPTION_YES,
+  OPTION_NO,
   UNITED_KINGDOM_ID,
 } from '../../../../../common/constants'
 
@@ -38,7 +40,7 @@ import {
   isFieldOptionalForStageLabel,
   validateFieldForStage,
 } from '../validators'
-import { siteDecidedValidator } from './validators'
+import { siteAddressIsCompanyAddressValidator } from './validators'
 
 const ukObject = {
   name: 'United Kingdom',
@@ -78,6 +80,7 @@ const EditProjectRequirements = () => {
                 transformProjectRequirementsForApi({
                   projectId,
                   values,
+                  ukCompany: project.ukCompany,
                 })
               }
             >
@@ -177,58 +180,86 @@ const EditProjectRequirements = () => {
                 }}
               />
               <FieldRadios
-                name="site_decided"
-                label="Has the UK location (site address) for this investment been decided yet?"
+                name="site_address_is_company_address"
+                label={
+                  "Is the site address the same as the UK recipient company's address?" +
+                  isFieldOptionalForStageLabel(
+                    'site_address_is_company_address',
+                    project
+                  )
+                }
                 initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.siteDecided
+                  project.siteAddressIsCompanyAddress
                 )}
                 options={OPTIONS_YES_NO.map((option) => ({
                   ...option,
                   ...(option.value === OPTION_YES && {
                     children: (
                       <>
-                        <FieldAddress
-                          legend="Address"
-                          name="address"
-                          country={ukObject}
-                          hideCountyField={true}
-                          useStaticPostcodeField={true}
-                          initialValue={{
-                            address1: project.address1 || '',
-                            address2: project.address2 || '',
-                            town: project.addressTown || '',
-                            postcode: project.addressPostcode || '',
-                          }}
-                        />
-                        <FieldUKRegionTypeahead
-                          name="actual_uk_regions"
-                          label={
-                            'UK regions landed' +
-                            isFieldOptionalForStageLabel(
-                              'actual_uk_regions',
-                              project
-                            )
-                          }
-                          initialValue={transformArrayForTypeahead(
-                            project.actualUkRegions
-                          )}
-                          placeholder="Select a UK region"
-                          isMulti={true}
-                          validate={(values, field, formFields) => {
-                            return validateFieldForStage(
-                              field,
-                              formFields,
-                              project,
-                              'Select a UK region'
-                            )
-                          }}
-                        />
+                        <InsetText className="govuk-!-margin-bottom-3">
+                          The address will appear on this form once you have
+                          selected the recipient company
+                        </InsetText>
                       </>
+                    ),
+                  }),
+                  ...(option.value === OPTION_YES &&
+                    project.ukCompany && {
+                      children: (
+                        <>
+                          <InsetText className="govuk-!-margin-bottom-3">
+                            <p>{project.ukCompany.address1}</p>
+                            <p>{project.ukCompany.address2}</p>
+                            <p>{project.ukCompany.addressTown}</p>
+                            <p>{project.ukCompany.addressPostcode}</p>
+                          </InsetText>
+                        </>
+                      ),
+                    }),
+                  ...(option.value === OPTION_NO && {
+                    children: (
+                      <FieldAddress
+                        legend="What is the site address?"
+                        name="address"
+                        country={ukObject}
+                        hideCountyField={true}
+                        useStaticPostcodeField={true}
+                        initialValue={{
+                          address1: project.address1 || '',
+                          address2: project.address2 || '',
+                          town: project.addressTown || '',
+                          postcode: project.addressPostcode || '',
+                        }}
+                      />
                     ),
                   }),
                 }))}
                 validate={(values, field, formFields) => {
-                  return siteDecidedValidator(field, formFields, project)
+                  return siteAddressIsCompanyAddressValidator(
+                    field,
+                    formFields,
+                    project
+                  )
+                }}
+              />
+              <FieldUKRegionTypeahead
+                name="actual_uk_regions"
+                label={
+                  'UK regions landed' +
+                  isFieldOptionalForStageLabel('actual_uk_regions', project)
+                }
+                initialValue={transformArrayForTypeahead(
+                  project.actualUkRegions
+                )}
+                placeholder="Select a UK region"
+                isMulti={true}
+                validate={(values, field, formFields) => {
+                  return validateFieldForStage(
+                    field,
+                    formFields,
+                    project,
+                    'Select a UK region'
+                  )
                 }}
               />
               <ResourceOptionsField

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -15,26 +15,33 @@ const checkIfItemHasValueOrZero = (value) =>
 const setConditionalArrayValue = (radioValue, array) =>
   transformRadioOptionToBool(radioValue) ? array.map((x) => x.value) : []
 
-const setSiteDecidedSubValues = (
-  site_decided,
+const setSiteAddressValues = (
+  siteAddressIsCompanyAddress,
+  ukCompany,
   address1,
   address2,
   city,
   postcode
 ) => {
-  return transformRadioOptionToBool(site_decided)
-    ? {
-        address_1: address1,
-        address_2: address2,
-        address_town: city,
-        address_postcode: postcode,
-      }
-    : {
-        address_1: '',
-        address_2: '',
-        address_town: '',
-        address_postcode: '',
-      }
+  const siteAddressIsCompanyAddressBool = transformRadioOptionToBool(
+    siteAddressIsCompanyAddress
+  )
+  if (siteAddressIsCompanyAddressBool === true && ukCompany) {
+    return {
+      address_1: ukCompany.address1,
+      address_2: ukCompany.address2,
+      address_town: ukCompany.addressTown,
+      address_postcode: ukCompany.addressPostcode,
+    }
+  } else {
+    // return entered/existing values if not empty to ensure data is NOT overwritten
+    return {
+      address_1: address1 ? address1 : null,
+      address_2: address2 ? address2 : null,
+      address_town: city ? city : null,
+      address_postcode: postcode ? postcode : null,
+    }
+  }
 }
 
 const checkLandDate = (estimatedLandDate) => {
@@ -73,7 +80,11 @@ export const transformBoolToRadioOptionWithNullCheck = (boolean) =>
 export const transformBoolToInvertedRadioOptionWithNullCheck = (boolean) =>
   boolean === null ? null : transformBoolToInvertedRadioOption(boolean)
 
-export const transformProjectRequirementsForApi = ({ projectId, values }) => {
+export const transformProjectRequirementsForApi = ({
+  projectId,
+  values,
+  ukCompany,
+}) => {
   const {
     actual_uk_regions,
     address1,
@@ -84,13 +95,14 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
     competitor_countries,
     delivery_partners,
     postcode,
-    site_decided,
+    site_address_is_company_address,
     strategic_drivers,
     uk_region_locations,
   } = values
 
-  const siteDecidedObject = setSiteDecidedSubValues(
-    site_decided,
+  const siteAddressObject = setSiteAddressValues(
+    site_address_is_company_address,
+    ukCompany,
     address1,
     address2,
     city,
@@ -99,10 +111,9 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
 
   const requirementsValues = {
     id: projectId,
-    actual_uk_regions: setConditionalArrayValue(
-      site_decided,
-      actual_uk_regions
-    ),
+    actual_uk_regions: actual_uk_regions
+      ? actual_uk_regions.map((x) => x.value)
+      : [],
     client_considering_other_countries: transformRadioOptionToBoolWithNullCheck(
       client_considering_other_countries
     ),
@@ -114,7 +125,9 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
     delivery_partners: delivery_partners
       ? delivery_partners.map((x) => x.value)
       : [],
-    site_decided: transformRadioOptionToBoolWithNullCheck(site_decided),
+    site_address_is_company_address: transformRadioOptionToBoolWithNullCheck(
+      site_address_is_company_address
+    ),
     strategic_drivers: strategic_drivers
       ? strategic_drivers.map((x) => x.value)
       : [],
@@ -123,7 +136,7 @@ export const transformProjectRequirementsForApi = ({ projectId, values }) => {
       : [],
   }
 
-  return { ...siteDecidedObject, ...requirementsValues }
+  return { ...siteAddressObject, ...requirementsValues }
 }
 
 export const transformProjectSummaryForApi = ({

--- a/src/client/modules/Investments/Projects/Details/validators.js
+++ b/src/client/modules/Investments/Projects/Details/validators.js
@@ -1,8 +1,6 @@
 import { STAGE } from '../../../../components/MyInvestmentProjects/constants'
 import { isFieldRequiredForStage } from '../validators'
 
-const { OPTION_YES } = require('../../../../../common/constants')
-
 export const totalInvestmentValidator = (value, foreignEquityInvestment) => {
   if (parseInt(value) < parseInt(foreignEquityInvestment)) {
     return 'Total investment must be >= to capital expenditure'
@@ -18,13 +16,14 @@ export const capitalExpenditureValidator = (value) => {
   return null
 }
 
-export const siteDecidedValidator = (field, formFields, project) => {
-  if (project?.stage?.id == STAGE.ACTIVE_ID && !formFields.values[field.name]) {
-    return 'Select a value for UK location decision'
-  }
+export const siteAddressIsCompanyAddressValidator = (
+  field,
+  formFields,
+  project
+) => {
   return isFieldRequiredForStage(field.name, project) &&
-    formFields.values[field.name] != OPTION_YES
-    ? 'A UK region is required'
+    !formFields.values[field.name]
+    ? "Select if the site address the same as the UK recipient company's address?"
     : null
 }
 

--- a/src/client/modules/Investments/Projects/transformers.js
+++ b/src/client/modules/Investments/Projects/transformers.js
@@ -101,6 +101,7 @@ export const mapFieldToUrl = (field, projectId) => {
     'Delivery partners',
     'Strategic drivers behind this investment',
     'Possible UK locations for this investment',
+    "Is the site address the same as the UK recipient company's address?",
     'Street',
     'Town',
     'Postcode',

--- a/test/api-schema.json
+++ b/test/api-schema.json
@@ -7506,7 +7506,7 @@
             "type": "string",
             "nullable": true
           },
-          "site_decided": {
+          "site_address_is_company_address": {
             "type": "boolean",
             "nullable": true
           },
@@ -9526,13 +9526,7 @@
             "nullable": true
           },
           "hiring": {
-            "enum": [
-              "1-5",
-              "6-50",
-              "51-100",
-              "101+",
-              "NO_PLANS_TO_HIRE_YET"
-            ],
+            "enum": ["1-5", "6-50", "51-100", "101+", "NO_PLANS_TO_HIRE_YET"],
             "type": "string"
           },
           "spend": {

--- a/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
+++ b/test/component/cypress/specs/Investments/Projects/ProjectIncompleteFields.cy.jsx
@@ -49,10 +49,7 @@ const activeIncompleteFields = [
   'non_fdi_r_and_d_budget',
   'new_tech_to_uk',
   'export_revenue',
-  'address_1',
-  'address_town',
-  'address_postcode',
-  'actual_uk_regions',
+  'site_address_is_company_address',
   'delivery_partners',
   'actual_land_date',
   'foreign_equity_investment',
@@ -226,10 +223,10 @@ describe('ProjectIncompleteFields', () => {
           'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?',
           valueLink
         )
-        assertLink('Street', requirementsLink)
-        assertLink('Town', requirementsLink)
-        assertLink('Postcode', requirementsLink)
-        assertLink('UK regions landed', requirementsLink)
+        assertLink(
+          "Is the site address the same as the UK recipient company's address?",
+          requirementsLink
+        )
         assertLink('Delivery partners', requirementsLink)
         assertLink('Actual land date', detailsLink)
         assertLink('Foreign equity investment', valueLink)

--- a/test/functional/cypress/fakers/investment-projects.js
+++ b/test/functional/cypress/fakers/investment-projects.js
@@ -83,6 +83,7 @@ const investmentProjectFaker = (overrides = {}) => ({
     sector_classification_gva_multiplier: 'labour',
     id: faker.string.uuid(),
   },
+  specific_programmes: [],
   ...overrides,
 })
 
@@ -120,7 +121,7 @@ const investmentProjectEmptyFaker = (overrides = {}) =>
     non_fdi_r_and_d_budget: null,
     new_tech_to_uk: null,
     export_revenue: null,
-    site_decided: null,
+    site_address_is_company_address: null,
     address_1: null,
     address_town: null,
     address_postcode: null,

--- a/test/functional/cypress/fixtures/investment/investment-has-existing-requirements.json
+++ b/test/functional/cypress/fixtures/investment/investment-has-existing-requirements.json
@@ -122,7 +122,7 @@
   "client_cannot_provide_total_investment": false,
   "client_cannot_provide_foreign_investment": false,
   "client_requirements": "Anywhere",
-  "site_decided": true,
+  "site_address_is_company_address": false,
   "address_1": "10 Eastings Road",
   "address_2": null,
   "address_town": "London",

--- a/test/functional/cypress/fixtures/investment/investment-no-existing-requirements.json
+++ b/test/functional/cypress/fixtures/investment/investment-no-existing-requirements.json
@@ -124,7 +124,7 @@
   "client_cannot_provide_total_investment": null,
   "client_cannot_provide_foreign_investment": null,
   "client_requirements": null,
-  "site_decided": null,
+  "site_address_is_company_address": null,
   "address_1": null,
   "address_2": null,
   "address_town": null,

--- a/test/functional/cypress/specs/investments/constants.js
+++ b/test/functional/cypress/specs/investments/constants.js
@@ -89,10 +89,18 @@ export const FIELDS = {
     name: 'uk_region_locations',
     message: 'Select a possible UK location',
   },
-
+  SITE_ADDRESS_IS_COMPANY_ADDRESS: {
+    name: 'site_address_is_company_address',
+    message:
+      "Select if the site address the same as the UK recipient company's address",
+  },
   ADDRESS1: { name: 'address1', message: 'Enter an address' },
   CITY: { name: 'city', message: 'Enter a town or city' },
   POSTCODE: { name: 'postcode', message: 'Enter a postcode' },
+  ACTUAL_UK_REGIONS: {
+    name: 'actual_uk_regions',
+    message: 'Select a UK region',
+  },
 
   // Edit value
   CLIENT_CANNOT_PROVIDE_FOREIGN_INVESTMENT: {
@@ -169,7 +177,8 @@ export const EDIT_REQUIREMENTS_BASE_FIELDS = [
 export const EDIT_REQUIREMENTS_ADDITIONAL_FIELDS = [
   ...EDIT_REQUIREMENTS_BASE_FIELDS,
   FIELDS.DELIVERY_PARTNERS,
-  { name: 'site_decided', message: 'A UK region is required' },
+  FIELDS.SITE_ADDRESS_IS_COMPANY_ADDRESS,
+  FIELDS.ACTUAL_UK_REGIONS,
 ]
 
 export const EDIT_VALUE_BASE_FIELDS = [

--- a/test/functional/cypress/specs/investments/project-edit-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-details-spec.js
@@ -41,6 +41,12 @@ const setupProjectFaker = (overrides) =>
         id: '952232d2-1d25-4c3a-bcac-2f3a30a94da9',
       },
     ],
+    business_activities: [
+      {
+        name: 'Retail',
+        id: 'a2dbd807-ae52-421c-8d1d-88adfc7a506b',
+      },
+    ],
     referral_source_adviser: {
       name: 'Puck Head',
       first_name: 'Puck',

--- a/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
@@ -1,28 +1,147 @@
+import { INVESTMENT_PROJECT_STAGES } from '../../fakers/constants'
+
 const {
   assertLocalHeader,
   assertBreadcrumbs,
+  assertErrorSummary,
   assertFieldTextarea,
   assertFieldRadios,
+  assertFieldRadiosNotSelected,
+  assertFieldRadioSelected,
   assertFieldTypeahead,
   assertFieldInput,
   assertFieldUneditable,
 } = require('../../support/assertions')
 const { investments } = require('../../../../../src/lib/urls')
-
+const { investmentProjectFaker } = require('../../fakers/investment-projects')
 const projectNoExistingRequirements = require('../../fixtures/investment/investment-no-existing-requirements.json')
 const projectHasExistingRequirements = require('../../fixtures/investment/investment-has-existing-requirements.json')
 const ukRegions = require('../../../../sandbox/fixtures/metadata/uk-region.json')
 
+const ukCompany = {
+  name: 'Mars Components Ltd',
+  address_1: '12 Alpha Street',
+  address_2: '',
+  address_town: 'Volcanus',
+  address_postcode: 'NE28 5AQ',
+  id: '731bdcc1-f685-4c8e-bd66-b356b2c16995',
+}
+
 const navigateToForm = ({ project }, dataTest = 'edit') => {
+  cy.intercept('GET', `/api-proxy/v3/investment/${project.id}`, {
+    statusCode: 200,
+    body: project,
+  }).as('getProjectDetails')
   cy.visit(investments.projects.details(project.id))
   cy.get(`[data-test="${dataTest}-requirements-button"]`).click()
 }
 
 const checkIfClientConsidering = (valueToCheck) => (valueToCheck ? 3 : 2)
-const checkIfSiteDecided = (valueToCheck) => (valueToCheck ? 7 : 2)
+const checkIfSiteAddressIsCompanyAddress = (valueToCheck) => {
+  if (valueToCheck === null) {
+    return 2
+  } else if (valueToCheck === true) {
+    return 3
+  } else if (valueToCheck === false) {
+    return 6
+  }
+}
 const convertBoolToYesNo = (valueToCheck) => (valueToCheck ? 'Yes' : 'No')
 const convertBoolToYesNoWithNullCheck = (valueToCheck) =>
   valueToCheck === null ? null : convertBoolToYesNo(valueToCheck)
+
+const assertSiteAddressIsCompanyAddressField = (project) => {
+  it('should display the site address is company address field', () => {
+    cy.get('[data-test="field-site_address_is_company_address"]').then(
+      (element) => {
+        assertFieldRadios({
+          element,
+          label:
+            "Is the site address the same as the UK recipient company's address?",
+          optionsCount: checkIfSiteAddressIsCompanyAddress(
+            project.site_address_is_company_address
+          ),
+          value: convertBoolToYesNoWithNullCheck(
+            project.site_address_is_company_address
+          ),
+        })
+      }
+    )
+  })
+  if (project.site_address_is_company_address === null) {
+    it('should display the site address is company address field unselected', () => {
+      assertFieldRadiosNotSelected({
+        inputName: 'site_address_is_company_address',
+      })
+    })
+  } else if (
+    project.site_address_is_company_address === true &&
+    project.uk_company === null
+  ) {
+    it('should display the inset text below the yes option', () => {
+      assertFieldRadioSelected({
+        inputName: 'site_address_is_company_address',
+        selectedIndex: 0,
+      })
+      cy.get('[data-test="site_address_is_company_address"]').contains(
+        'The address will appear on this form once you have selected the recipient company'
+      )
+    })
+  } else if (
+    project.site_address_is_company_address === true &&
+    project.uk_company !== null
+  ) {
+    it('should display the inset text below the yes option', () => {
+      assertFieldRadioSelected({
+        inputName: 'site_address_is_company_address',
+        selectedIndex: 0,
+      })
+      cy.get('[data-test="site_address_is_company_address"]')
+        .contains(`${project.uk_company.address_1}`)
+        .contains(`${project.uk_company.address_2}`)
+        .contains(`${project.uk_company.address_town}`)
+        .contains(`${project.uk_company.address_postcode}`)
+    })
+  } else if (project.site_address_is_company_address === false) {
+    it('should display the address field', () => {
+      cy.get('[data-test="field-country"]').then((element) => {
+        assertFieldUneditable({
+          element,
+          label: 'Country',
+          value: 'United Kingdom',
+        })
+      })
+      cy.get('[data-test="field-address1"]').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Address line 1',
+          value: project.address_1,
+        })
+      })
+      cy.get('[data-test="field-address2"]').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Address line 2 (optional)',
+          value: project.address_2,
+        })
+      })
+      cy.get('[data-test="field-city"]').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Town or city',
+          value: project.address_town,
+        })
+      })
+      cy.get('[data-test="field-postcode"]').then((element) => {
+        assertFieldInput({
+          element,
+          label: 'Postcode',
+          value: project.address_postcode,
+        })
+      })
+    })
+  }
+}
 
 const testProjectRequirementsForm = ({ project }, dataTest) => {
   beforeEach(() => {
@@ -117,87 +236,20 @@ const testProjectRequirementsForm = ({ project }, dataTest) => {
     )
   })
 
-  it('should display the site decided field', () => {
-    cy.get('[data-test="field-site_decided"]').then((element) => {
-      assertFieldRadios({
-        element,
-        label:
-          'Has the UK location (site address) for this investment been decided yet?',
-        optionsCount: checkIfSiteDecided(project.site_decided),
-        value: convertBoolToYesNoWithNullCheck(project.site_decided),
-      })
-    })
+  it('should correctly display the site address is company address field', () => {
+    assertSiteAddressIsCompanyAddressField(project)
   })
 
-  project.site_decided
-    ? it('should display the address field', () => {
-        cy.get('[data-test="field-country"]').then((element) => {
-          assertFieldUneditable({
-            element,
-            label: 'Country',
-            value: 'United Kingdom',
-          })
-        })
-        cy.get('[data-test="field-address1"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Address line 1',
-            value: project.address_1,
-          })
-        })
-        cy.get('[data-test="field-address2"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Address line 2 (optional)',
-            value: project.address_2,
-          })
-        })
-        cy.get('[data-test="field-city"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Town or city',
-            value: project.address_town,
-          })
-        })
-        cy.get('[data-test="field-postcode"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Postcode',
-            value: project.address_postcode,
-          })
-        })
-      })
-    : it('should not display the address field', () => {
-        cy.get('[data-test="field-address"]').should('not.exist')
-      })
-
-  if (project.site_decided) {
-    it('should render the landed regions field', () => {
-      cy.get('[data-test="field-actual_uk_regions"]').then((element) => {
-        assertFieldTypeahead({
-          element,
-          label: 'UK regions landed',
-          placeholder: 'Select a UK region',
-          values: project.actual_uk_regions,
-        })
-      })
-    })
-
-    it('should only display active UK regions when the landed regions field is selected', () => {
-      const activeUkRegions = ukRegions.filter((region) => !region.disabled_on)
-      cy.get('[data-test="field-actual_uk_regions"]').as('typeaheadField')
-      cy.get('@typeaheadField').find('input').first().click()
-      cy.get('[data-test="typeahead-menu-option"]').should('be.visible')
-      cy.get('[data-test="typeahead-menu-option"]').should(
-        'have.length',
-        activeUkRegions.length
-      )
-    })
-  } else {
-    it('should not display the landed regions field', () => {
-      cy.get('[data-test="field-actual_uk_regions"]').should('not.exist')
-    })
-  }
+  it('should render the active UK regions field', () => {
+    const activeUkRegions = ukRegions.filter((region) => !region.disabled_on)
+    cy.get('[data-test="field-actual_uk_regions"]').as('typeaheadField')
+    cy.get('@typeaheadField').find('input').first().click()
+    cy.get('[data-test="typeahead-menu-option"]').should('be.visible')
+    cy.get('[data-test="typeahead-menu-option"]').should(
+      'have.length',
+      activeUkRegions.length
+    )
+  })
 
   it('should render the delivery partners field', () => {
     cy.get('[data-test="field-delivery_partners"]').then((element) => {
@@ -249,7 +301,7 @@ describe('Edit the requirements of a project', () => {
         .selectTypeaheadOption('East Midlands')
         .selectTypeaheadOption('East of England')
 
-      cy.get('[data-test="site-decided-yes"]').click()
+      cy.get('[data-test="site-address-is-company-address-no"]').click()
       cy.get('[data-test="field-address1"]').type('Street address')
       cy.get('[data-test="field-address2"]').type('Street address 2')
       cy.get('[data-test="field-city"]').type('Town')
@@ -272,6 +324,148 @@ describe('Edit the requirements of a project', () => {
       cy.url().should('not.include', 'edit-requirements')
 
       cy.get('[data-test="flash"]').contains('Investment requirements updated')
+    })
+  })
+})
+
+describe('Site address fields', () => {
+  const siteAddressProject = (overrides) => {
+    return investmentProjectFaker({
+      stage: INVESTMENT_PROJECT_STAGES.prospect, // ensures all fields are optional at stage
+      strategic_drivers: [
+        {
+          name: 'Access to market',
+          id: '382aa6d1-a362-4166-a09d-f579d9f3be75',
+        },
+      ], // populating this field forces the `edit requirements` button to appear
+      uk_company: null,
+      site_address_is_company_address: null,
+      address_1: null,
+      address_2: null,
+      address_town: null,
+      address_postcode: null,
+      ...overrides,
+    })
+  }
+
+  context('When viewing the site address fields', () => {
+    it('should show unselected radios when site address is company address is null', () => {
+      const project = siteAddressProject()
+      navigateToForm({ project: project })
+      assertSiteAddressIsCompanyAddressField(project)
+    })
+
+    it('should show the inset text when site address is company is true and uk company is not set', () => {
+      const project = siteAddressProject({
+        site_address_is_company_address: true,
+      })
+      navigateToForm({ project: project })
+      assertSiteAddressIsCompanyAddressField(project)
+    })
+
+    it('should show the company address fields when the site address is company address is true and uk company is set', () => {
+      const project = siteAddressProject({
+        uk_company: ukCompany,
+        site_address_is_company_address: true,
+      })
+      navigateToForm({ project: project })
+      assertSiteAddressIsCompanyAddressField(project)
+    })
+
+    it('should show the address input fields when site address is company address is false', () => {
+      const project = siteAddressProject({
+        site_address_is_company_address: false,
+      })
+      navigateToForm({ project: project })
+      assertSiteAddressIsCompanyAddressField(project)
+    })
+  })
+  context('When editing the site address fields and clicking submit', () => {
+    it('should submit site address is company address is null when user does not modify field', () => {
+      const project = siteAddressProject()
+      navigateToForm({ project: project })
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body')
+        .should('include', {
+          site_address_is_company_address: null,
+        })
+    })
+    it('should submit site address is company address is true and existing site address values when user selects yes and uk company is null', () => {
+      const project = siteAddressProject()
+      navigateToForm({ project: project })
+      cy.get('[data-test="site-address-is-company-address-yes"]').click()
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body')
+        .should('include', {
+          site_address_is_company_address: true,
+          address_1: project.address_1,
+          address_2: project.address_2,
+          address_town: project.address_town,
+          address_postcode: project.address_postcode,
+        })
+    })
+    it('should submit site address is company address is true and populate address fields when user selects yes and project has uk company', () => {
+      const project = siteAddressProject({ uk_company: ukCompany })
+      navigateToForm({ project: project })
+      cy.get('[data-test="site-address-is-company-address-yes"]').click()
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body')
+        .should('include', {
+          site_address_is_company_address: true,
+          address_1: ukCompany.address_1,
+          address_2: ukCompany.address_2,
+          address_town: ukCompany.address_town,
+          address_postcode: ukCompany.address_postcode,
+        })
+    })
+    it('should raise validation errors when site address is company address is false and address fields have not been populated', () => {
+      const project = siteAddressProject()
+      navigateToForm({ project: project })
+      cy.get('[data-test="site-address-is-company-address-no"]').click()
+      cy.get('[data-test="submit-button"]').click()
+      assertErrorSummary([
+        'Enter an address',
+        'Enter a town or city',
+        'Enter a postcode',
+      ])
+    })
+    it('should submit site address is company address is false and address fields when user selects no and enters address fields', () => {
+      const project = siteAddressProject()
+      const address1 = 'Address line 1'
+      const address2 = 'Address line 2'
+      const city = 'City'
+      const postcode = 'ABC 123'
+      navigateToForm({ project: project })
+      cy.get('[data-test="site-address-is-company-address-no"]').click()
+      cy.get('[data-test="field-address1"]').type(address1)
+      cy.get('[data-test="field-address2"]').type(address2)
+      cy.get('[data-test="field-city"]').type(city)
+      cy.get('[data-test="field-postcode"]').type(postcode)
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body')
+        .should('include', {
+          site_address_is_company_address: false,
+          address_1: address1,
+          address_2: address2,
+          address_town: city,
+          address_postcode: postcode,
+        })
     })
   })
 })

--- a/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-requirements-spec.js
@@ -468,4 +468,31 @@ describe('Site address fields', () => {
         })
     })
   })
+  context('When editing and submitting the landed uk regions field', () => {
+    it('should submit an empty list if no regions are selected', () => {
+      const project = siteAddressProject({ actual_uk_regions: [] })
+      navigateToForm({ project: project })
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body.actual_uk_regions')
+        .should('be.empty')
+    })
+    it('should submit a list if one or more regions are selected', () => {
+      const project = siteAddressProject({ actual_uk_regions: [] })
+      navigateToForm({ project: project })
+      cy.get('[data-test="field-actual_uk_regions"]')
+        .selectTypeaheadOption('East Midlands')
+        .selectTypeaheadOption('East of England')
+      cy.intercept('PATCH', `/api-proxy/v3/investment/${project.id}`, {
+        statusCode: 200,
+      }).as('patchProjectRequirements')
+      cy.get('[data-test="submit-button"]').click()
+      cy.wait('@patchProjectRequirements')
+        .its('request.body.actual_uk_regions')
+        .should('have.lengthOf', 2)
+    })
+  })
 })

--- a/test/functional/cypress/specs/investments/project-edit-stages-specs.js
+++ b/test/functional/cypress/specs/investments/project-edit-stages-specs.js
@@ -31,7 +31,7 @@ function assertRequiredFieldsForStages(
   buttonName
 ) {
   stageRequiredFields.forEach((stageRequiredField) => {
-    const [stage, requiredFields, ukLocationRequired = false] =
+    const [stage, requiredFields, siteAddressIsCompanyAddress = false] =
       stageRequiredField
 
     context(`In the ${stage.name} stage `, () => {
@@ -59,13 +59,12 @@ function assertRequiredFieldsForStages(
         )
       })
 
-      if (ukLocationRequired) {
-        it('submitting an empty form with site_decide set to Yes should show address validation errors', () => {
-          cy.get('[data-test="site-decided-yes"]').click()
+      if (siteAddressIsCompanyAddress) {
+        it('submitting an empty form with site_address_is_company_address set to No should show address validation errors', () => {
+          cy.get('[data-test="site-address-is-company-address-no"]').click()
           cy.get('[data-test="submit-button"]').click()
 
           assertValidationMessages([
-            FIELDS.SITE_DECIDED,
             FIELDS.ADDRESS1,
             FIELDS.CITY,
             FIELDS.POSTCODE,
@@ -102,17 +101,7 @@ describe('Field validation for each stage', () => {
         EDIT_REQUIREMENTS_BASE_FIELDS,
         false,
       ],
-      [
-        INVESTMENT_PROJECT_STAGES.active,
-        [
-          ...EDIT_REQUIREMENTS_BASE_FIELDS,
-          {
-            name: 'site_decided',
-            message: 'Select a value for UK location decision',
-          },
-        ],
-        false,
-      ],
+      [INVESTMENT_PROJECT_STAGES.active, EDIT_REQUIREMENTS_BASE_FIELDS, false],
       [
         INVESTMENT_PROJECT_STAGES.verifyWin,
         EDIT_REQUIREMENTS_ADDITIONAL_FIELDS,


### PR DESCRIPTION
## Description of change

Reapplies PR #7486 (commit 382debc6b39c30c5088474c7e2e4980a496f4229) with some modifications. These include:
- keeping the `actual_uk_regions` question and unnesting it
- setting the address fields to the existing/entered values when `(site_address_is_company_address == True && uk_company is not None)` is False

Updated API PR can be found [here](https://github.com/uktrade/data-hub-api/pull/5939).

## Test instructions

For projects that have:
- `site_address_is_company_address === null`: the radio buttons should be unselected. If no modifications are made, the frontend will set the address fields to existing values upon submission.
- `site_address_is_company_address === true && !uk_company)`: the yes option will be selected and show some help text prompting users to select a UK recipient company. Upon submission, the frontend will set `site_address_is_company_address === true` the address fields to existing values.
-  `site_address_is_company_address === true && uk_company)`: the yes option will be selected and show the UK recipient company address fields. Upon submission, the frontend will set `site_address_is_company_address === true` the address fields to the UK company address.
- `site_address_is_company_address === false`: the no option will be selected and address fields will appear for manual entry. Upon submission, the frontend will set `site_address_is_company_address === false` and the address fields to the values entered.

The `actual_uk_regions` field is now separate/unnested and should behave as usual.

## Screenshots

<img width="766" alt="image" src="https://github.com/user-attachments/assets/b0b641ff-0d8d-4e38-9fb4-b5245a8e8143" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
