### PR TITLE
Update project status

### DIFF
--- a/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
+++ b/src/client/modules/ExportPipeline/ExportForm/ExportFormFields.jsx
@@ -153,6 +153,7 @@ const ExportFormFields = ({
                 <FieldRadios
                   name="status"
                   label="Export status"
+                  hint="Marking a project as won does not create an export win. To create an export win, first save your changes then on the next page click on 'Convert to export win'."
                   required={ERROR_MESSAGES.status}
                   field={FieldRadios}
                   options={STATUS_OPTIONS}

--- a/test/functional/cypress/specs/export-pipeline/add-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/add-export-spec.js
@@ -14,6 +14,7 @@ import {
   assertPayload,
   assertFieldTypeahead,
   assertFieldError,
+  assertFieldErrorMessage,
   assertLocalHeader,
   assertBreadcrumbs,
   assertFieldEmpty,
@@ -184,7 +185,7 @@ describe('Export pipeline create', () => {
           ERROR_MESSAGES.destination_country,
           false
         )
-        assertFieldError(
+        assertFieldErrorMessage(
           cy.get('[data-test="field-status"]'),
           ERROR_MESSAGES.status
         )
@@ -192,7 +193,7 @@ describe('Export pipeline create', () => {
           cy.get('[data-test="field-sector"]'),
           ERROR_MESSAGES.sector
         )
-        assertFieldError(
+        assertFieldErrorMessage(
           cy.get('[data-test="field-status"]'),
           ERROR_MESSAGES.status
         )

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -1049,6 +1049,14 @@ const assertFieldError = (element, errorMessage, hasHint = true) =>
     .eq(hasHint ? 1 : 0)
     .should('have.text', errorMessage)
 
+const assertFieldErrorMessage = (element, errorMessage) =>
+  element
+    .find('span')
+    .filter((_, s) => Cypress.$(s).text().includes(errorMessage))
+    .should('have.length.greaterThan', 0)
+    .first()
+    .should('contain.text', errorMessage)
+
 const assertFieldErrorStrict = ({ inputName, errorMessage }) =>
   cy
     .get(`[data-test="field-${inputName}"]`)
@@ -1160,6 +1168,7 @@ module.exports = {
   assertAPIRequest,
   assertExactUrl,
   assertFieldError,
+  assertFieldErrorMessage,
   assertFieldErrorStrict,
   assertTypeaheadValues,
   assertLink,


### PR DESCRIPTION
## Description of change

This is about adding project status hints in add project forms. 

## Test instructions

as per video recorded

https://github.com/user-attachments/assets/ab07ce77-e9a3-406d-b5a3-8e9ceb1c40a5

## Screenshots

### Before

No project status hints
<img width="1280" alt="Current" src="https://github.com/user-attachments/assets/95e43f7e-6e79-4625-893c-0b4c48aaf3a8" />


### After

See highlighted area in the image below
![Screenshot 2025-02-04 at 16 08 01](https://github.com/user-attachments/assets/23ff4fc3-6fef-4ca0-8fdd-78dec3a480f0)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
