### PR TITLE
one list adviser core team to Lead ITA

### DIFF
--- a/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
+++ b/src/client/modules/Companies/CoreTeam/CoreTeam.jsx
@@ -51,9 +51,7 @@ export const CoreTeamAdvisers = ({ company }) => (
           <Table.Row>
             <Table.CellHeader setWidth="25%">Team</Table.CellHeader>
             <Table.CellHeader setWidth="15%">Location</Table.CellHeader>
-            <Table.CellHeader setWidth="25%">
-              Global Account Manager
-            </Table.CellHeader>
+            <Table.CellHeader setWidth="25%">Lead ITA</Table.CellHeader>
             <Table.CellHeader setWidth="35%">Email</Table.CellHeader>
           </Table.Row>
           {buildGAMRow(oneListTeam)}

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -282,7 +282,7 @@ describe('One List core team', () => {
       assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager', 'Email'],
+          ['Team', 'Location', 'Lead ITA', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
@@ -347,7 +347,7 @@ describe('One List core team', () => {
       assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager', 'Email'],
+          ['Team', 'Location', 'Lead ITA', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,

--- a/test/functional/cypress/specs/companies/core-team-spec.js
+++ b/test/functional/cypress/specs/companies/core-team-spec.js
@@ -46,7 +46,7 @@ describe('One List core team', () => {
       assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager', 'Email'],
+          ['Team', 'Location', 'Lead ITA', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,
@@ -105,7 +105,7 @@ describe('One List core team', () => {
       assertGovReactTable({
         element: '[data-test="global-acc-manager-table"]',
         rows: [
-          ['Team', 'Location', 'Global Account Manager', 'Email'],
+          ['Team', 'Location', 'Lead ITA', 'Email'],
           [
             globalAccountManager.dit_team.name,
             globalAccountManager.dit_team.uk_region.name,


### PR DESCRIPTION
## Description of change

This PR addresses the One List Tier D - International Trade Adviser Accounts --Account management table header should be "Lead ITA"

## Test instructions

Updated Lead ITA

## Screenshots

![image](https://github.com/user-attachments/assets/8b2678f1-3d17-4265-b35b-d05626c33f97)


_Add a screenshot_

<img width="1643" alt="image" src="https://github.com/user-attachments/assets/fbf39ec8-1bb2-460c-aa70-2ef93e979a33" />

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
