### PR TITLE
EYB leads sorted by modified feature

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -117,7 +117,7 @@ const EYBLeadCollection = ({
         entityName="eybLead"
         defaultQueryParams={{
           page: 1,
-          sortby: '-triage_created',
+          sortby: '-triage_modified',
         }}
         selectedFilters={selectedFilters}
       >

--- a/src/client/modules/Investments/EYBLeads/constants.js
+++ b/src/client/modules/Investments/EYBLeads/constants.js
@@ -26,6 +26,10 @@ export const VALUE_OPTIONS = [
 
 export const SORT_OPTIONS = [
   {
+    name: 'Recently modified',
+    value: '-triage_modified',
+  },
+  {
     name: 'Recently created',
     value: '-triage_created',
   },

--- a/src/client/modules/Investments/EYBLeads/tasks.js
+++ b/src/client/modules/Investments/EYBLeads/tasks.js
@@ -19,7 +19,7 @@ export const getEYBLeads = ({
     limit,
     offset: limit * (parseInt(page, 10) - 1) || 0,
     ...(company ? { company } : null),
-    sortby: sortby ? sortby : '-triage_created',
+    sortby: sortby ? sortby : '-triage_modified',
   })
   overseas_region.forEach((overseasRegionId) =>
     params.append('overseas_region', overseasRegionId)

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -97,13 +97,14 @@ const EYB_LEAD_LIST = Array(
 )
 
 const PAYLOADS = {
-  minimum: { limit: '10', offset: '0', sortby: '-triage_created' },
+  minimum: { limit: '10', offset: '0', sortby: '-triage_modified' },
   companyFilter: { company: COMPANY_NAME },
   sectorFilter: { sector: SECTOR_ID },
   highValueFilter: { value: HIGH_VALUE },
   lowValueFilter: { value: LOW_VALUE },
   unknownValueFilter: { value: UNKNOWN_VALUE },
   countryFilter: { country: COUNTRY_ID_1 },
+  sortByModified: { sortby: '-triage_modified' },
   sortByCreated: { sortby: '-triage_created' },
   sortByCompanyAZ: { sortby: 'company__name' },
 }
@@ -587,9 +588,20 @@ describe('EYB leads collection page', () => {
       })
     })
 
-    it('should sort by most recently created by default', () => {
-      assertQueryParams('sortby', '-triage_created')
+    it('should sort by most recently modified by default', () => {
+      assertQueryParams('sortby', '-triage_modified')
       cy.wait('@apiRequest')
+        .its('request.query')
+        .should('include', PAYLOADS.sortByModified)
+    })
+
+    it('should sort by recently created', () => {
+      cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
+        if (req.query.sortby === '-triage_created') req.alias = 'sortedRequest'
+      })
+      cy.get('[data-test="sortby"] select').select('-triage_created')
+      assertQueryParams('sortby', '-triage_created')
+      cy.wait('@sortedRequest')
         .its('request.query')
         .should('include', PAYLOADS.sortByCreated)
     })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -635,13 +635,13 @@ describe('EYB leads collection page', () => {
     it('should sort by most recently created when another sort option is selected', () => {
       cy.get('[data-test="sortby"] select').select('company__name')
       cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
-        if (req.query.sortby === '-triage_created') req.alias = 'sortedRequest'
+        if (req.query.sortby === '-triage_modified') req.alias = 'sortedRequest'
       })
-      cy.get('[data-test="sortby"] select').select('-triage_created')
-      assertQueryParams('sortby', '-triage_created')
+      cy.get('[data-test="sortby"] select').select('-triage_modified')
+      assertQueryParams('sortby', '-triage_modified')
       cy.wait('@sortedRequest')
         .its('request.query')
-        .should('include', PAYLOADS.sortByCreated)
+        .should('include', PAYLOADS.sortByModified)
     })
   })
 })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -53,6 +53,7 @@ const OVERSEAS_REGION_ID_2 = '5616ccf5-ab4a-4c2c-9624-13c69be3c46b'
 
 const EYB_LEAD_LIST = Array(
   eybLeadFaker({
+    triage_modified: DATE_TIME_STRING,
     triage_created: DATE_TIME_STRING,
     company: { name: `${COMPANY_NAME} and Co` },
     is_high_value: true,
@@ -66,6 +67,7 @@ const EYB_LEAD_LIST = Array(
     },
   }),
   eybLeadFaker({
+    triage_modified: DATE_TIME_STRING,
     triage_created: DATE_TIME_STRING,
     sector: { name: SECTOR_NAME, id: SECTOR_ID },
     is_high_value: false,
@@ -78,9 +80,18 @@ const EYB_LEAD_LIST = Array(
       },
     },
   }),
-  eybLeadFaker({ triage_created: DATE_TIME_STRING, is_high_value: null }),
-  eybLeadFaker({ triage_created: DATE_TIME_STRING, is_high_value: false }),
   eybLeadFaker({
+    triage_modified: DATE_TIME_STRING,
+    triage_created: DATE_TIME_STRING,
+    is_high_value: null,
+  }),
+  eybLeadFaker({
+    triage_modified: DATE_TIME_STRING,
+    triage_created: DATE_TIME_STRING,
+    is_high_value: false,
+  }),
+  eybLeadFaker({
+    triage_modified: DATE_TIME_STRING,
     triage_created: DATE_TIME_STRING,
     is_high_value: false,
     company: null,
@@ -584,7 +595,11 @@ describe('EYB leads collection page', () => {
     it('should load sort by dropdown', () => {
       cy.get('[data-test="sortby"] select option').then((options) => {
         const actual = [...options].map((o) => o.value)
-        expect(actual).to.deep.eq(['-triage_created', 'company__name'])
+        expect(actual).to.deep.eq([
+          '-triage_modified',
+          '-triage_created',
+          'company__name',
+        ])
       })
     })
 


### PR DESCRIPTION
## Description of change

Change to the EYB leads page to allow sort by modified date and set by default on page load.

## Test instructions

The functional test when run should prove that when the page loads the selected sort option is triage_modified by default. 

## Screenshots

### Before

_Add a screenshot_

### After

<img width="676" alt="image" src="https://github.com/user-attachments/assets/ef93921c-ddd1-4eb9-a216-0fa28a0e99c0" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
