### PR TITLE
Commented  `onBlur` from input tag that causes looping issue when loading company list

### DIFF
--- a/src/client/components/RoutedInput/index.jsx
+++ b/src/client/components/RoutedInput/index.jsx
@@ -66,7 +66,6 @@ const RoutedInput = ({
           writeQs()
         }
       }}
-      onBlur={writeQs}
     />
   )
 }


### PR DESCRIPTION
## Description of change

Fix issue for company list rendering in loop mode for Safari browser and mobile device.

## Test instructions

Use Safari browser, then navigate into Datahub main and Company menu.



## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
