### PR TITLE
Removing modified as default sort for EYB leads

### DIFF
--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -117,7 +117,7 @@ const EYBLeadCollection = ({
         entityName="eybLead"
         defaultQueryParams={{
           page: 1,
-          sortby: '-triage_modified',
+          sortby: '-triage_created',
         }}
         selectedFilters={selectedFilters}
       >

--- a/src/client/modules/Investments/EYBLeads/constants.js
+++ b/src/client/modules/Investments/EYBLeads/constants.js
@@ -26,12 +26,12 @@ export const VALUE_OPTIONS = [
 
 export const SORT_OPTIONS = [
   {
-    name: 'Recently modified',
-    value: '-triage_modified',
-  },
-  {
     name: 'Recently created',
     value: '-triage_created',
+  },
+  {
+    name: 'Recently modified',
+    value: '-triage_modified',
   },
   {
     name: 'Company A-Z',

--- a/src/client/modules/Investments/EYBLeads/tasks.js
+++ b/src/client/modules/Investments/EYBLeads/tasks.js
@@ -19,7 +19,7 @@ export const getEYBLeads = ({
     limit,
     offset: limit * (parseInt(page, 10) - 1) || 0,
     ...(company ? { company } : null),
-    sortby: sortby ? sortby : '-triage_modified',
+    sortby: sortby ? sortby : '-triage_created',
   })
   overseas_region.forEach((overseasRegionId) =>
     params.append('overseas_region', overseasRegionId)

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -108,15 +108,15 @@ const EYB_LEAD_LIST = Array(
 )
 
 const PAYLOADS = {
-  minimum: { limit: '10', offset: '0', sortby: '-triage_modified' },
+  minimum: { limit: '10', offset: '0', sortby: '-triage_created' },
   companyFilter: { company: COMPANY_NAME },
   sectorFilter: { sector: SECTOR_ID },
   highValueFilter: { value: HIGH_VALUE },
   lowValueFilter: { value: LOW_VALUE },
   unknownValueFilter: { value: UNKNOWN_VALUE },
   countryFilter: { country: COUNTRY_ID_1 },
-  sortByModified: { sortby: '-triage_modified' },
   sortByCreated: { sortby: '-triage_created' },
+  sortByModified: { sortby: '-triage_modified' },
   sortByCompanyAZ: { sortby: 'company__name' },
 }
 
@@ -596,29 +596,29 @@ describe('EYB leads collection page', () => {
       cy.get('[data-test="sortby"] select option').then((options) => {
         const actual = [...options].map((o) => o.value)
         expect(actual).to.deep.eq([
-          '-triage_modified',
           '-triage_created',
+          '-triage_modified',
           'company__name',
         ])
       })
     })
 
-    it('should sort by most recently modified by default', () => {
-      assertQueryParams('sortby', '-triage_modified')
+    it('should sort by most recently created by default', () => {
+      assertQueryParams('sortby', '-triage_created')
       cy.wait('@apiRequest')
         .its('request.query')
-        .should('include', PAYLOADS.sortByModified)
+        .should('include', PAYLOADS.sortByCreated)
     })
 
-    it('should sort by recently created', () => {
+    it('should sort by recently modified', () => {
       cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
-        if (req.query.sortby === '-triage_created') req.alias = 'sortedRequest'
+        if (req.query.sortby === '-triage_modified') req.alias = 'sortedRequest'
       })
-      cy.get('[data-test="sortby"] select').select('-triage_created')
-      assertQueryParams('sortby', '-triage_created')
+      cy.get('[data-test="sortby"] select').select('-triage_modified')
+      assertQueryParams('sortby', '-triage_modified')
       cy.wait('@sortedRequest')
         .its('request.query')
-        .should('include', PAYLOADS.sortByCreated)
+        .should('include', PAYLOADS.sortByModified)
     })
 
     it('should sort by company name A-Z', () => {
@@ -635,13 +635,13 @@ describe('EYB leads collection page', () => {
     it('should sort by most recently created when another sort option is selected', () => {
       cy.get('[data-test="sortby"] select').select('company__name')
       cy.intercept('GET', `${EYB_RETRIEVE_API_ROUTE}?*`, (req) => {
-        if (req.query.sortby === '-triage_modified') req.alias = 'sortedRequest'
+        if (req.query.sortby === '-triage_created') req.alias = 'sortedRequest'
       })
-      cy.get('[data-test="sortby"] select').select('-triage_modified')
-      assertQueryParams('sortby', '-triage_modified')
+      cy.get('[data-test="sortby"] select').select('-triage_created')
+      assertQueryParams('sortby', '-triage_created')
       cy.wait('@sortedRequest')
         .its('request.query')
-        .should('include', PAYLOADS.sortByModified)
+        .should('include', PAYLOADS.sortByCreated)
     })
   })
 })


### PR DESCRIPTION
## Description of change

Removing modified as default sort for EYB leads as it should be created date

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
