### PR TITLE
Add heading for one list tier D to  adviser core team 

### DIFF
--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -66,51 +66,47 @@ const RenderHasAccountManager = ({
   </div>
 )
 
-export const LeadITA = ({ company, permissions }) => {
-  const getLeadIta =
-    company.oneListGroupTier.name ==
-    'Tier D - International Trade Adviser Accounts'
-      ? 'Advisers on core team'
-      : 'Lead ITA'
-  return (
-    <>
-      <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
-        {getLeadIta}
-      </H2>
-      {!!company.oneListGroupGlobalAccountManager ? (
-        <RenderHasAccountManager
-          leadITA={company.oneListGroupGlobalAccountManager}
-          companyId={company.id}
-          permissions={permissions}
-          addUrl={urls.companies.accountManagement.advisers.assign(company.id)}
-        />
-      ) : (
-        <>
-          <p>
-            This company record has no Lead International Trade Adviser (ITA).
-          </p>
-          {hasPermissionToAddIta(permissions) && (
-            <>
-              <p>
-                You can add a Lead ITA. This will be visible to all Data Hub
-                users.
-              </p>
-              <Button
-                as={'a'}
-                href={urls.companies.accountManagement.advisers.assign(
-                  company.id
-                )}
-                data-test="add-ita-button"
-              >
-                Add a Lead ITA
-              </Button>
-            </>
-          )}
-        </>
-      )}
-    </>
-  )
-}
+export const LeadITA = ({ company, permissions }) => (
+  <>
+    <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
+      {company.oneListGroupTier?.name ==
+      'Tier D - International Trade Adviser Accounts'
+        ? 'Advisers on core team'
+        : 'Lead ITA'}
+    </H2>
+    {!!company.oneListGroupGlobalAccountManager ? (
+      <RenderHasAccountManager
+        leadITA={company.oneListGroupGlobalAccountManager}
+        companyId={company.id}
+        permissions={permissions}
+        addUrl={urls.companies.accountManagement.advisers.assign(company.id)}
+      />
+    ) : (
+      <>
+        <p>
+          This company record has no Lead International Trade Adviser (ITA).
+        </p>
+        {hasPermissionToAddIta(permissions) && (
+          <>
+            <p>
+              You can add a Lead ITA. This will be visible to all Data Hub
+              users.
+            </p>
+            <Button
+              as={'a'}
+              href={urls.companies.accountManagement.advisers.assign(
+                company.id
+              )}
+              data-test="add-ita-button"
+            >
+              Add a Lead ITA
+            </Button>
+          </>
+        )}
+      </>
+    )}
+  </>
+)
 
 LeadITA.propTypes = {
   company: PropTypes.object.isRequired,

--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -69,8 +69,7 @@ const RenderHasAccountManager = ({
 export const LeadITA = ({ company, permissions }) => (
   <>
     <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
-      {company.oneListGroupTier?.name ==
-      'Tier D - International Trade Adviser Accounts'
+      {company.oneListGroupTier?.id == '1929c808-99b4-4abf-a891-45f2e187b410'
         ? 'Advisers on core team'
         : `Lead ITA for ${company.name}`}
     </H2>

--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -66,44 +66,51 @@ const RenderHasAccountManager = ({
   </div>
 )
 
-export const LeadITA = ({ company, permissions }) => (
-  <>
-    <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
-      Lead ITA for {company.name}
-    </H2>
-    {!!company.oneListGroupGlobalAccountManager ? (
-      <RenderHasAccountManager
-        leadITA={company.oneListGroupGlobalAccountManager}
-        companyId={company.id}
-        permissions={permissions}
-        addUrl={urls.companies.accountManagement.advisers.assign(company.id)}
-      />
-    ) : (
-      <>
-        <p>
-          This company record has no Lead International Trade Adviser (ITA).
-        </p>
-        {hasPermissionToAddIta(permissions) && (
-          <>
-            <p>
-              You can add a Lead ITA. This will be visible to all Data Hub
-              users.
-            </p>
-            <Button
-              as={'a'}
-              href={urls.companies.accountManagement.advisers.assign(
-                company.id
-              )}
-              data-test="add-ita-button"
-            >
-              Add a Lead ITA
-            </Button>
-          </>
-        )}
-      </>
-    )}
-  </>
-)
+export const LeadITA = ({ company, permissions }) => {
+  const getLeadIta =
+    company.oneListGroupTier.name ==
+    'Tier D - International Trade Adviser Accounts'
+      ? 'Advisers on core team'
+      : 'Lead ITA'
+  return (
+    <>
+      <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
+        {getLeadIta}
+      </H2>
+      {!!company.oneListGroupGlobalAccountManager ? (
+        <RenderHasAccountManager
+          leadITA={company.oneListGroupGlobalAccountManager}
+          companyId={company.id}
+          permissions={permissions}
+          addUrl={urls.companies.accountManagement.advisers.assign(company.id)}
+        />
+      ) : (
+        <>
+          <p>
+            This company record has no Lead International Trade Adviser (ITA).
+          </p>
+          {hasPermissionToAddIta(permissions) && (
+            <>
+              <p>
+                You can add a Lead ITA. This will be visible to all Data Hub
+                users.
+              </p>
+              <Button
+                as={'a'}
+                href={urls.companies.accountManagement.advisers.assign(
+                  company.id
+                )}
+                data-test="add-ita-button"
+              >
+                Add a Lead ITA
+              </Button>
+            </>
+          )}
+        </>
+      )}
+    </>
+  )
+}
 
 LeadITA.propTypes = {
   company: PropTypes.object.isRequired,

--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -72,7 +72,7 @@ export const LeadITA = ({ company, permissions }) => (
       {company.oneListGroupTier?.name ==
       'Tier D - International Trade Adviser Accounts'
         ? 'Advisers on core team'
-        : 'Lead ITA'}
+        : `Lead ITA for ${company.name}`}
     </H2>
     {!!company.oneListGroupGlobalAccountManager ? (
       <RenderHasAccountManager

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -370,7 +370,7 @@ describe('One List core Tier D team', () => {
     it('should render the heading', () => {
       cy.get('[data-test=lead-ita-heading]')
         .should('exist')
-        .should('have.text', "Lead ITA for Ian's Camper Vans Ltd")
+        .should('have.text', 'Advisers on core team')
     })
 
     it('should render the Lead ITA table', () => {
@@ -398,7 +398,10 @@ describe('One List core Tier D team', () => {
         one_list_group_global_account_manager: adviserFaker({
           dit_team: undefined,
         }),
-        one_list_group_tier: { id: '1929c808-99b4-4abf-a891-45f2e187b410' },
+        one_list_group_tier: {
+          id: '1929c808-99b4-4abf-a891-45f2e187b410',
+          name: 'Tier D - International Trade Adviser Accounts',
+        },
         id: companyTierD.id,
       })
 
@@ -415,7 +418,7 @@ describe('One List core Tier D team', () => {
       it('should render the heading', () => {
         cy.get('[data-test=lead-ita-heading]')
           .should('exist')
-          .should('have.text', `Lead ITA for ${companyTierDNoTeam.name}`)
+          .should('have.text', `Advisers on core team`)
       })
 
       it('should render the Lead ITA table', () => {

--- a/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
+++ b/test/functional/cypress/specs/companies/lead-advisers/company-page-spec.js
@@ -56,7 +56,7 @@ describe('Lead advisers', () => {
         fixtures.company.oneListTierDita.one_list_group_global_account_manager
 
       it('should display a header with the company name', () => {
-        cy.contains("Lead ITA for Ian's Camper Vans Ltd")
+        cy.contains('Advisers on core team')
       })
       it('should render the global account manager table', () => {
         assertGovReactTable({

--- a/test/sandbox/fixtures/v4/company/company-one-list-tier-d-ita.json
+++ b/test/sandbox/fixtures/v4/company/company-one-list-tier-d-ita.json
@@ -25,6 +25,7 @@
     "id": "98d14e94-5d95-e211-a939-e4115bead28a"
   },
   "one_list_group_tier": {
+    "name": "Tier D - International Trade Adviser Accounts",
     "id": "1929c808-99b4-4abf-a891-45f2e187b410"
   },
   "contacts": [


### PR DESCRIPTION
## Description of change

This PR addresses the One List Tier D - International Trade Adviser Accounts  heading should be "Adviser core on team" and its association to be  "Lead ITA"
## Test instructions

Updated "Adviser core on team"

## Screenshots

![image](https://github.com/user-attachments/assets/efd384c6-6304-4f62-a2e7-0854159878bd)

_Add a screenshot_

![Uploading image.png…]()

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
