### PR TITLE
CLS2-1277 Adding address to investment project requirements section

### DIFF
--- a/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
@@ -289,6 +289,29 @@ const ProjectDetails = ({ currentAdviserId }) => {
                   )
                 }
               />
+              <SummaryTable.TextRow
+                heading="UK location (site address)"
+                value={
+                  project.address1 ? (
+                    <>
+                      {project.address1} <br />
+                      {project.address2 && (
+                        <>
+                          {project.address2} <br />
+                        </>
+                      )}
+                      {project.addressTown && (
+                        <>
+                          {project.addressTown} <br />
+                        </>
+                      )}
+                      {project.addressPostcode}
+                    </>
+                  ) : (
+                    'Not set'
+                  )
+                }
+              />
               {project.deliveryPartners &&
                 project.deliveryPartners.length > 0 && (
                   <SummaryTable.TextRow

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -108,6 +108,7 @@ describe('Investment project details', () => {
           'Possible UK locations': 'North East',
           'UK regions landed': 'North East',
           'UK recipient company': 'Mercury LtdEdit companyRemove company',
+          'UK location (site address)': '10 Eastings Road London W1 2AA',
           'Delivery partners': 'New Anglia LEP, North Eastern LEP',
         },
       })
@@ -289,6 +290,7 @@ describe('Investment project details', () => {
         dataTest: 'project-requirements-table',
         content: {
           'UK recipient company': 'Find company',
+          'UK location (site address)': 'Not set',
         },
       })
       cy.get('[data-test="find-company-link"]')


### PR DESCRIPTION
CLS2-1277 Adding address to investment project requirements section

## Description of change

Ask to show the address fields on the investment project requirements section so that users do not need to click into the record to verify if the information has been added.

## Test instructions

Tests will check that the new row renders showing the address information if present or will show 'not set'.

## Screenshots

### Before

_Add a screenshot_

### After

<img width="748" alt="image" src="https://github.com/user-attachments/assets/4417f8a4-132a-4e86-ace1-2439bf56d44f" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
