### PR TITLE
Bug fix EYB lead audit log is_high_value null to boolean

### DIFF
--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -37,7 +37,11 @@ export const transformLeadToListItem = ({
   }
 
   const getLatestIsHighValueChange = (auditLog) => {
-    const highValueChanges = getLowHighValueAuditLog(auditLog)
+    const highValueChanges = getLowHighValueAuditLog(auditLog).filter(
+      (entry) =>
+        entry.changes.is_high_value[0] !== null &&
+        entry.changes.is_high_value[1] !== null
+    ) // Exclude null values
     if (highValueChanges.length === 0) return null
 
     const latestChange = highValueChanges.reduce((latest, entry) =>

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -91,6 +91,13 @@ const EYB_LEAD_LIST = Array(
     is_high_value: false,
     audit_log: [
       {
+        id: 356,
+        timestamp: '2025-02-18T09:00:20.773368Z',
+        changes: {
+          is_high_value: [null, false],
+        },
+      },
+      {
         id: 777,
         timestamp: '2025-02-17T09:00:20.773368Z',
         changes: {
@@ -284,7 +291,7 @@ describe('EYB leads collection page', () => {
         .eq(3)
         .should(
           'contain',
-          `Value modified on ${formatDate(eybLeadWithAuditDataHighToLowValue.audit_log[0].timestamp, DATE_FORMAT_COMPACT)}`
+          `Value modified on ${formatDate(eybLeadWithAuditDataHighToLowValue.audit_log[1].timestamp, DATE_FORMAT_COMPACT)}`
         )
         .should('contain', `Value change High to Low`)
 


### PR DESCRIPTION
Bug fix EYB lead audit log is_high_value null to boolean

## Description of change

EYB lead is_high_value can sometimes be null and when the value is changed to true or false and audit log is added. Users do not care for these changes so adding logic to filter these out.

## Test instructions

Added test data and check to ensure the row renders correctly when thrown a null to boolean change log.

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
