### PR TITLE
add company head quarters location to eyb lead preview

### DIFF
--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -79,7 +79,7 @@ export const transformLeadToListItem = ({
     { label: 'Estimated spend', value: spend },
     {
       label: 'Location of company headquarters',
-      value: address.country.name ? address.country.name : '',
+      value: address?.country?.name ? address?.country?.name : '',
     },
     { label: 'Sector', value: sector ? sector.name : '' },
     {

--- a/src/client/modules/Investments/EYBLeads/transformers.js
+++ b/src/client/modules/Investments/EYBLeads/transformers.js
@@ -15,6 +15,7 @@ export const transformLeadToListItem = ({
   proposed_investment_region,
   is_high_value,
   audit_log,
+  address,
 }) => {
   const tags = [
     {
@@ -76,6 +77,10 @@ export const transformLeadToListItem = ({
 
   metadata.push(
     { label: 'Estimated spend', value: spend },
+    {
+      label: 'Location of company headquarters',
+      value: address.country.name ? address.country.name : '',
+    },
     { label: 'Sector', value: sector ? sector.name : '' },
     {
       label: 'Estimated land date',

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -267,6 +267,10 @@ describe('EYB leads collection page', () => {
           `Submitted to EYB ${formatDate(eybLead.triage_created, DATE_FORMAT_COMPACT)}`
         )
         .should('contain', `Estimated spend ${eybLead.spend}`)
+        .should(
+          'contain',
+          `Location of company headquarters ${eybLead.address.country.name}`
+        )
         .should('contain', `Sector ${eybLead.sector.name}`)
         .should(
           'contain',


### PR DESCRIPTION
## Description of change

This PR addresses adding Location of Company Headquarters on EYB lead preview


## Screenshots

### Before

<img width="1020" alt="image" src="https://github.com/user-attachments/assets/08a16553-0978-402b-8188-88ee28c26a25" />


### After

<img width="1002" alt="image" src="https://github.com/user-attachments/assets/611b671c-641f-4f47-8964-3ec62c3c0f72" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
