### PR TITLE
Show 'Not set' in details page when company has no address

### DIFF
--- a/src/client/modules/Companies/CompanyBusinessDetails/SectionAddresses.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/SectionAddresses.jsx
@@ -7,6 +7,7 @@ import { SPACING_POINTS } from '@govuk-react/constants'
 
 import { Badge, SummaryTable } from '../../../components'
 import urls from '../../../../lib/urls'
+import { NOT_SET_TEXT } from '../../../../apps/companies/constants'
 
 const StyledAddressList = styled('ul')`
   margin-top: ${SPACING_POINTS[2]}px;
@@ -59,13 +60,16 @@ const SectionAddresses = ({ company, isDnbCompany, isArchived }) => {
         )
       }
     >
-      <Table.Row>
-        {!hasOnlyOneAddress && (
-          <Address address={company.registeredAddress} isRegistered={true} />
-        )}
-
-        <Address address={company.address} isRegistered={hasOnlyOneAddress} />
-      </Table.Row>
+      {company.address ? (
+        <Table.Row>
+          {!hasOnlyOneAddress && (
+            <Address address={company.registeredAddress} isRegistered={true} />
+          )}
+          <Address address={company.address} isRegistered={hasOnlyOneAddress} />
+        </Table.Row>
+      ) : (
+        <SummaryTable.Row>{NOT_SET_TEXT}</SummaryTable.Row>
+      )}
     </SummaryTable>
   )
 }


### PR DESCRIPTION
## Description of change

This PR fixes a bug in the details tab where if a company had no address, the application would raise an error due to the page being unable to read properties of the `company.address` object. Now, the code checks for an address first. If a company does not have one, it displays `'Not set'` under the Addresses summary table. 

This fixes various recent sentry alerts:
- https://sentry.ci.uktrade.digital/organizations/dit/issues/154164/
- https://sentry.ci.uktrade.digital/organizations/dit/issues/154419/
- https://sentry.ci.uktrade.digital/organizations/dit/issues/154418/

## Test instructions

The text `'Not set'` displaying under the Addresses summary table on the details (formerly business details) tab.

## Screenshots

### Before

<img width="1475" alt="image" src="https://github.com/user-attachments/assets/3226e20e-1532-4c56-b7f4-d39bfb2bfca4" />

### After

<img width="1475" alt="image" src="https://github.com/user-attachments/assets/cdf96792-50dd-471d-b28b-8b5a30d3fd0b" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
