### PR TITLE
Handle adding investment project to company with no address

### DIFF
--- a/src/apps/investments/client/projects/create/CompanySummaryTable.jsx
+++ b/src/apps/investments/client/projects/create/CompanySummaryTable.jsx
@@ -14,6 +14,7 @@ import {
   TASK_GET_COMPANY_INVESTMENT_COUNT,
   companyInvestmentCountState2props,
 } from './state'
+import { NOT_SET_TEXT } from '../../../../companies/constants'
 
 const StyledSummaryTable = styled(SummaryTable)({
   marginTop: 0,
@@ -40,7 +41,7 @@ const CompanySummaryTable = ({ company, companyInvestmentCount }) => (
       {company.name}
     </SummaryTable.Row>
     <SummaryTable.Row heading="Country" hideWhenEmpty={true}>
-      {company.address.country.name}
+      {company.address ? company.address.country.name : NOT_SET_TEXT}
     </SummaryTable.Row>
     <SummaryTable.Row heading="Company investments">
       <Task.Status

--- a/src/client/modules/Investments/Projects/ProjectsCollection.jsx
+++ b/src/client/modules/Investments/Projects/ProjectsCollection.jsx
@@ -126,7 +126,7 @@ const ProjectsCollection = ({
         addItemUrl={
           !company
             ? `/investments/projects/create`
-            : company.archived || company.ukBased
+            : company.archived || company.ukBased || !company.address
               ? null
               : `/investments/projects/create/${company.id}`
         }

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -22,6 +22,7 @@ const {
 const { companies, investments } = require('../../../../../../src/lib/urls')
 const fixtures = require('../../../fixtures')
 const urls = require('../../../../../../src/lib/urls')
+const { companyFaker } = require('../../../fakers/companies')
 
 const { dnbCorp, archivedLtd } = fixtures.company
 
@@ -208,6 +209,29 @@ describe('Company Investments Collection Page', () => {
       assertAddItemButtonNotPresent()
     })
   })
+
+  context(
+    'when viewing investments projects for a company without an address',
+    () => {
+      beforeEach(() => {
+        const companyWithoutAddress = companyFaker({ address: null })
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${companyWithoutAddress.id}`,
+          companyWithoutAddress
+        ).as('companyOverview')
+        cy.visit(
+          companies.investments.companyInvestmentProjects(
+            companyWithoutAddress.id
+          )
+        )
+        cy.wait('@companyOverview')
+      })
+      it('should not render an "Add investment project" button', () => {
+        assertAddItemButtonNotPresent()
+      })
+    }
+  )
 
   context('API payload', () => {
     it('should have the correct payload', () => {


### PR DESCRIPTION
## Description of change

Upon fixing #7603, it was found that attempting to add investment projects to a similar company (one without an address), raised an error - the form could not read properties of `company.address`.

This PR adds a rule to hide the "Add investment project" button from the investment project collection (on the company overview investment tab) if the company has no address. 

> [!NOTE]
> There is already a business rule that hides the button if the company is UK based. Without an address, we cannot differentiate between a domestic or international company, so this change aligns with existing requirements.

Additionally, in the event users navigate to the form via direct URL, the text `'Not set'` will appear in the company summary table if the object is missing, instead of raising an error.

This also fixes the sentry alert: https://sentry.ci.uktrade.digital/organizations/dit/issues/154823/; although this is only originating from the dev environment (i.e. me causing it) so far. There probably aren't many live users being affected. 

## Test instructions

1. Navigate to the investment tab on the overview page of a company without an address.
2. The investment project collection should **not** have an "Add investment project" button.
3. Navigate to the `investments/projects/create/<uuid of company without an address>` and the form should load with the text `'Not set'` in the company summary table.

This also fixes the sentry alert: https://sentry.ci.uktrade.digital/organizations/dit/issues/154823/

## Screenshots

### Before

<img width="986" alt="image" src="https://github.com/user-attachments/assets/3e34f58b-be24-440f-83af-4ccfebf4939a" />

<img width="986" alt="image" src="https://github.com/user-attachments/assets/dbb50541-82c3-43dd-b7ac-cec756859800" />

### After

<img width="986" alt="image" src="https://github.com/user-attachments/assets/ebb7b66b-a11d-4a61-9a15-c1be1017e278" />

<img width="986" alt="image" src="https://github.com/user-attachments/assets/2b376bb7-93b9-48a7-86e3-ea7a68718c99" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
