### PR TITLE
CLS2-1195 management of core team access

### DIFF
--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -26,6 +26,7 @@ import { isItaTierDAccount } from '../utils'
 import { ONE_LIST_EMAIL } from './constants'
 import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
 import { state2propsMainTab } from './state'
+import { canEditOneList } from '../CompanyBusinessDetails/utils'
 
 const LastUpdatedHeading = styled.div`
   color: ${DARK_GREY};
@@ -60,14 +61,6 @@ const AddObjectiveButton = styled(GridCol)`
 const ArchivedObjectivesLink = styled(GridCol)`
   padding-top: 7px;
 `
-
-const canEditOneList = (permissions) =>
-  permissions &&
-  permissions.includes('company.change_company') &&
-  (permissions.includes('company.change_one_list_core_team_member') ||
-    permissions.includes(
-      'company.change_one_list_tier_and_global_account_manager'
-    ))
 
 const DataWorkspaceAccountPlan = ({ company }) => (
   <SectionGridRow data-test="account-plan-row">

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -64,10 +64,10 @@ const ArchivedObjectivesLink = styled(GridCol)`
 const canEditOneList = (permissions) =>
   permissions &&
   permissions.includes('company.change_company') &&
-  permissions.includes('company.change_one_list_core_team_member') &&
-  permissions.includes(
-    'company.change_one_list_tier_and_global_account_manager'
-  )
+  (permissions.includes('company.change_one_list_core_team_member') ||
+    permissions.includes(
+      'company.change_one_list_tier_and_global_account_manager'
+    ))
 
 const DataWorkspaceAccountPlan = ({ company }) => (
   <SectionGridRow data-test="account-plan-row">

--- a/src/client/modules/Companies/CompanyBusinessDetails/CompanyBusinessDetails.jsx
+++ b/src/client/modules/Companies/CompanyBusinessDetails/CompanyBusinessDetails.jsx
@@ -24,7 +24,10 @@ import CompanyLayout from '../../../components/Layout/CompanyLayout'
 import Task from '../../../components/Task'
 import urls from '../../../../lib/urls'
 import { formatDate, DATE_FORMAT_COMPACT } from '../../../utils/date-utils'
-import { canEditOneList, isOneListAccountOwner } from './utils'
+import {
+  canEditOneListTierAndGlobalAccountManager,
+  isOneListAccountOwner,
+} from './utils'
 
 import {
   ID,
@@ -195,7 +198,7 @@ const CompanyBusinessDetails = ({
                 }
               </Task.Status>
               {(isOneListAccountOwner(company, currentAdviserId) ||
-                canEditOneList(userPermissions)) && (
+                canEditOneListTierAndGlobalAccountManager(userPermissions)) && (
                 <Button
                   as={'a'}
                   href={urls.companies.editOneList(companyId)}

--- a/src/client/modules/Companies/CompanyBusinessDetails/utils.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/utils.js
@@ -4,7 +4,14 @@ export const isOneListAccountOwner = (company, currentAdviserId) =>
 export const canEditOneList = (permissions) =>
   permissions &&
   permissions.includes('company.change_company') &&
-  permissions.includes('company.change_one_list_core_team_member') &&
+  (permissions.includes('company.change_one_list_core_team_member') ||
+    permissions.includes(
+      'company.change_one_list_tier_and_global_account_manager'
+    ))
+
+export const canEditOneListTierAndGlobalAccountManager = (permissions) =>
+  permissions &&
+  permissions.includes('company.change_company') &&
   permissions.includes(
     'company.change_one_list_tier_and_global_account_manager'
   )

--- a/src/client/modules/Companies/CoreTeam/EditOneList.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneList.jsx
@@ -26,7 +26,6 @@ const EditOneList = ({
   company,
   oneListTiers,
   globalAccountManager,
-  userPermissions,
 }) => {
   const { companyId } = useParams()
   const query = useQuery()
@@ -69,7 +68,6 @@ const EditOneList = ({
           oneListTiers && (
             <EditOneListForm
               company={company}
-              userPermissions={userPermissions}
               returnUrl={returnUrl}
               oneListTiers={oneListTiers}
               formInitialValues={{

--- a/src/client/modules/Companies/CoreTeam/EditOneList.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneList.jsx
@@ -26,6 +26,7 @@ const EditOneList = ({
   company,
   oneListTiers,
   globalAccountManager,
+  userPermissions,
 }) => {
   const { companyId } = useParams()
   const query = useQuery()
@@ -70,6 +71,7 @@ const EditOneList = ({
               company={company}
               returnUrl={returnUrl}
               oneListTiers={oneListTiers}
+              userPermissions={userPermissions}
               formInitialValues={{
                 [TIER_FIELD_NAME]: company.one_list_group_tier?.id,
                 [ACCOUNT_MANAGER_FIELD_NAME]: globalAccountManager,

--- a/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
@@ -39,7 +39,7 @@ const EditOneListForm = ({
     flashMessage={() => 'Core team has been updated.'}
     showStepInUrl={true}
   >
-    {({ values, currentStep, goToStep }) => (
+    {({ values, currentStep, goToStep, permissions }) => (
       <>
         <Step name="oneListTier">
           <FieldRadios
@@ -53,11 +53,17 @@ const EditOneListForm = ({
         {values.one_list_tier !== NONE && (
           <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
             <Step name="oneListAdvisers">
-              <FieldAdvisersTypeahead
-                name={ACCOUNT_MANAGER_FIELD_NAME}
-                label="Global Account Manager"
-                required="Select at least one adviser"
-              />
+              {permissions &&
+                permissions.includes('company.change_company') &&
+                permissions.includes(
+                  'company.change_one_list_tier_and_global_account_manager'
+                ) && (
+                  <FieldAdvisersTypeahead
+                    name={ACCOUNT_MANAGER_FIELD_NAME}
+                    label="Global Account Manager"
+                    required="Select at least one adviser"
+                  />
+                )}
               <FieldAdvisersTypeahead
                 name={ONE_LIST_TEAM_FIELD_NAME}
                 label="Advisers on the core team (optional)"

--- a/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
@@ -22,6 +22,7 @@ const EditOneListForm = ({
   oneListTiers,
   formInitialValues,
   returnUrl,
+  userPermissions,
 }) => (
   <Form
     id="edit-one-list"
@@ -29,7 +30,11 @@ const EditOneListForm = ({
     initialValues={formInitialValues}
     submissionTaskName={TASK_SAVE_ONE_LIST_DETAILS}
     analyticsFormName="editOneList"
-    transformPayload={(values) => ({ values, companyId: company.id })}
+    transformPayload={(values) => ({
+      values,
+      companyId: company.id,
+      userPermissions,
+    })}
     redirectTo={() =>
       returnUrl ? returnUrl : urls.companies.businessDetails(company.id)
     }

--- a/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
@@ -44,7 +44,7 @@ const EditOneListForm = ({
     flashMessage={() => 'Core team has been updated.'}
     showStepInUrl={true}
   >
-    {({ values, currentStep, goToStep, permissions }) => (
+    {({ values, currentStep, goToStep }) => (
       <>
         <Step name="oneListTier">
           <FieldRadios
@@ -58,9 +58,9 @@ const EditOneListForm = ({
         {values.one_list_tier !== NONE && (
           <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
             <Step name="oneListAdvisers">
-              {permissions &&
-                permissions.includes('company.change_company') &&
-                permissions.includes(
+              {userPermissions &&
+                userPermissions.includes('company.change_company') &&
+                userPermissions.includes(
                   'company.change_one_list_tier_and_global_account_manager'
                 ) && (
                   <FieldAdvisersTypeahead

--- a/src/client/modules/Companies/CoreTeam/state.js
+++ b/src/client/modules/Companies/CoreTeam/state.js
@@ -17,5 +17,6 @@ export const state2props = (state) => {
     ),
     oneListTiers: transformOneListTiers(state[ID].oneListTiers),
     oneListTeam: transformTeamMembers(state[ID].oneListTeam),
+    userPermissions: state.userPermissions,
   }
 }

--- a/src/client/modules/Companies/CoreTeam/tasks.js
+++ b/src/client/modules/Companies/CoreTeam/tasks.js
@@ -1,4 +1,5 @@
 import { apiProxyAxios } from '../../../components/Task/utils'
+import { canEditOneListTierAndGlobalAccountManager } from '../CompanyBusinessDetails/utils'
 import {
   NONE,
   ACCOUNT_MANAGER_FIELD_NAME,
@@ -20,14 +21,20 @@ export async function getOneListDetails(companyId) {
   )
 }
 
-async function assignOneListTierandGlobalManagerRequest({ companyId, values }) {
-  return await apiProxyAxios.post(
-    `v4/company/${companyId}/assign-one-list-tier-and-global-account-manager`,
-    {
-      [ACCOUNT_MANAGER_FIELD_NAME]: values[ACCOUNT_MANAGER_FIELD_NAME].value,
-      [TIER_FIELD_NAME]: values[TIER_FIELD_NAME],
-    }
-  )
+async function assignOneListTierandGlobalManagerRequest({
+  companyId,
+  values,
+  userPermissions,
+}) {
+  if (canEditOneListTierAndGlobalAccountManager(userPermissions)) {
+    return await apiProxyAxios.post(
+      `v4/company/${companyId}/assign-one-list-tier-and-global-account-manager`,
+      {
+        [ACCOUNT_MANAGER_FIELD_NAME]: values[ACCOUNT_MANAGER_FIELD_NAME].value,
+        [TIER_FIELD_NAME]: values[TIER_FIELD_NAME],
+      }
+    )
+  }
 }
 
 async function removeFromOneList({ companyId }) {
@@ -58,7 +65,11 @@ async function removeCoreTeamRequest({ companyId }) {
   )
 }
 
-export async function saveOneListDetails({ values, companyId }) {
+export async function saveOneListDetails({
+  values,
+  companyId,
+  userPermissions = NONE,
+}) {
   let request
 
   if (values[TIER_FIELD_NAME] === NONE) {
@@ -67,12 +78,20 @@ export async function saveOneListDetails({ values, companyId }) {
     )
   } else if (!values[ONE_LIST_TEAM_FIELD_NAME]) {
     request = Promise.all([
-      assignOneListTierandGlobalManagerRequest({ companyId, values }),
+      assignOneListTierandGlobalManagerRequest({
+        companyId,
+        values,
+        userPermissions,
+      }),
       removeCoreTeamRequest({ companyId }),
     ])
   } else {
     request = Promise.all([
-      assignOneListTierandGlobalManagerRequest({ companyId, values }),
+      assignOneListTierandGlobalManagerRequest({
+        companyId,
+        values,
+        userPermissions,
+      }),
       assignCoreTeamRequest({ companyId, values }),
     ])
   }

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -359,6 +359,61 @@ describe('One List core team', () => {
   })
 })
 
+describe('Edit One List core team permissions', () => {
+  context('when viewing a One List Tier company', () => {
+    after(() => {
+      cy.resetUser()
+    })
+
+    it('should not render the edit core team button for view only account', () => {
+      cy.setModulePermissions(['company.view_company'])
+      cy.visit(urls.companies.accountManagement.index(company.id))
+    })
+    ;[
+      {
+        permissions: [
+          'company.view_company',
+          'company.change_company',
+          'company.change_one_list_core_team_member',
+        ],
+        globalAccountManagerFieldVisible: false,
+      },
+      {
+        permissions: [
+          'company.view_company',
+          'company.change_company',
+          'company.change_one_list_tier_and_global_account_manager',
+        ],
+        globalAccountManagerFieldVisibility: true,
+      },
+    ].forEach(({ permissions, globalAccountManagerFieldVisibility }) =>
+      it('should render the edit core team button and form', () => {
+        cy.setModulePermissions(permissions)
+        cy.visit(urls.companies.accountManagement.index(company.id))
+
+        cy.intercept('GET', urls.companies.editVirtualTeam(company.id)).as(
+          'edit-one-list'
+        )
+
+        cy.get('[data-test="edit-core-team-button"]')
+          .should('exist')
+          .should(
+            'have.attr',
+            'href',
+            urls.companies.editVirtualTeam(company.id)
+          )
+          .click()
+
+        cy.wait('@edit-one-list')
+        if (globalAccountManagerFieldVisibility)
+          cy.get('#global_account_manager').should('exist')
+        else cy.get('#global_account_manager').should('not.exist')
+        cy.get('#core_team_members').should('exist')
+      })
+    )
+  })
+})
+
 describe('One List core Tier D team', () => {
   context('when viewing a One List Tier D company', () => {
     beforeEach(() => {

--- a/test/functional/cypress/specs/companies/business-details-spec.js
+++ b/test/functional/cypress/specs/companies/business-details-spec.js
@@ -202,7 +202,10 @@ describe('Companies business details', () => {
       })
 
       it('should display the not set text for a company without an address', () => {
-        const companyWithoutAddress = companyFaker({ address: null })
+        const companyWithoutAddress = companyFaker({
+          address: null,
+          dunsNumber: false,
+        })
         cy.intercept(
           'GET',
           `/api-proxy/v4/company/${companyWithoutAddress.id}`,

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -10,8 +10,6 @@ const selectors = require('../../../../selectors')
 const metadataTiers = require('../../../../sandbox/fixtures/metadata/one-list-tier.json')
 const urls = require('../../../../../src/lib/urls')
 
-const whoAmIUri = '/api-proxy/whoami/?format=json'
-
 describe('Edit One List', () => {
   const visitWithWait = (companyId, url) => {
     cy.intercept(
@@ -49,15 +47,15 @@ describe('Edit One List', () => {
     const testCompany = fixtures.company.oneListCorp
 
     beforeEach(() => {
-      cy.request('PUT', whoAmIUri, {
-        permissions: [
-          'company.view_company',
-          'company.change_company',
-          'company.change_one_list_tier_and_global_account_manager',
-        ],
-      })
-
+      cy.setModulePermissions([
+        'company.view_company',
+        'company.change_company',
+        'company.change_one_list_tier_and_global_account_manager',
+      ])
       visitWithWait(testCompany.id, urls.companies.editOneList(testCompany.id))
+    })
+    after(() => {
+      cy.resetUser()
     })
 
     it('should render One List tier options with tier pre-selected', () => {
@@ -266,11 +264,14 @@ describe('Edit One List', () => {
     const testCompany = fixtures.company.oneListCorp
 
     beforeEach(() => {
-      cy.request('PUT', whoAmIUri, {
-        permissions: ['company.view_company', 'company.change_company'],
-      })
-
+      cy.setModulePermissions([
+        'company.view_company',
+        'company.change_company',
+      ])
       visitWithWait(testCompany.id, urls.companies.editOneList(testCompany.id))
+    })
+    after(() => {
+      cy.resetUser()
     })
 
     it('should not have account manager field', () => {

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -10,6 +10,8 @@ const selectors = require('../../../../selectors')
 const metadataTiers = require('../../../../sandbox/fixtures/metadata/one-list-tier.json')
 const urls = require('../../../../../src/lib/urls')
 
+const whoAmIUri = '/api-proxy/whoami/?format=json'
+
 describe('Edit One List', () => {
   const visitWithWait = (companyId, url) => {
     cy.intercept(
@@ -47,6 +49,14 @@ describe('Edit One List', () => {
     const testCompany = fixtures.company.oneListCorp
 
     beforeEach(() => {
+      cy.request('PUT', whoAmIUri, {
+        permissions: [
+          'company.view_company',
+          'company.change_company',
+          'company.change_one_list_tier_and_global_account_manager',
+        ],
+      })
+
       visitWithWait(testCompany.id, urls.companies.editOneList(testCompany.id))
     })
 
@@ -71,6 +81,7 @@ describe('Edit One List', () => {
 
     it('should have the account manager pre-selected', () => {
       cy.contains('Continue').click()
+      cy.get('#global_account_manager').should('exist')
 
       cy.get(selectors.companyEditOneList.globalAccountManagerField)
         .find('input')
@@ -247,6 +258,38 @@ describe('Edit One List', () => {
       cy.location('pathname').should(
         'eq',
         urls.companies.accountManagement.index(testCompany.id)
+      )
+    })
+  })
+
+  context('non Account managers when editing One list', () => {
+    const testCompany = fixtures.company.oneListCorp
+
+    beforeEach(() => {
+      cy.request('PUT', whoAmIUri, {
+        permissions: ['company.view_company', 'company.change_company'],
+      })
+
+      visitWithWait(testCompany.id, urls.companies.editOneList(testCompany.id))
+    })
+
+    it('should not have account manager field', () => {
+      cy.contains('Continue').click()
+      cy.get('#global_account_manager').should('not.exist')
+    })
+
+    it('should submit updated data', () => {
+      cy.contains('Continue').click()
+
+      cy.get(
+        selectors.companyEditOneList.coreTeamField
+      ).selectTypeaheadOptionInFieldset('leroy')
+
+      cy.contains('Submit').click()
+
+      cy.location('pathname').should(
+        'eq',
+        urls.companies.businessDetails(testCompany.id)
       )
     })
   })


### PR DESCRIPTION
## Description of change

Enable all users to Edit the Core Team via Data Hub (excluding assigning the Global Account Manager role)

Users that are not super users nor account managers should not see the Global account manager field when editing Core Team.

## Test instructions

To create a user without super or global account manager permissions:

- Add the `company | company | Can change one list core team member associated with company` to the `DIT_staff` group in Data Hub API.
- <img width="1019" alt="image" src="https://github.com/user-attachments/assets/7e705c5b-3c13-4b27-ba12-c22880c6e1ce" />
- Login to front end with the user that is a member of the `DIT_staff` group and only has the Active permission.

Tip: for testing purposes I've created a new Data Hub API account with super user permissions so I can easily toggle the permissions on the SSO account that I use on the front end.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/dcab2f2e-9640-453f-9bab-edc880312f85)

### After

![image](https://github.com/user-attachments/assets/442ea077-03ef-4596-bd6e-8de9011fab3b)

Users *without* super user or global account manager permissions should see the following after clicking the Edit core team button:

<img width="949" alt="image" src="https://github.com/user-attachments/assets/a379b4f1-f164-4b25-99da-533b2f720e0b" />

There are no changes for users *with* super user or global account manager permissions. They should see the Global Account Manager and Advisers on the core team fields.

<img width="948" alt="image" src="https://github.com/user-attachments/assets/89e5c998-5966-4fd4-8c1e-a9a5066c6992" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
