### PR TITLE
Feature/cls2 1301 add sharepoint file to company

### DIFF
--- a/src/apps/routers.js
+++ b/src/apps/routers.js
@@ -15,6 +15,7 @@ const reactRoutes = [
   '/omis',
   '/access-denied',
   '/reminders',
+  '/files/create',
   '/reminders/investments-estimated-land-dates',
   '/reminders/investments-no-recent-interactions',
   '/reminders/investments-outstanding-propositions',

--- a/src/client/components/CompanyTabbedLocalNavigation/constants.js
+++ b/src/client/components/CompanyTabbedLocalNavigation/constants.js
@@ -28,12 +28,12 @@ export const localNavItems = (companyId) => {
       permissions: ['company.view_contact'],
       ariaDescription: 'Company contacts',
     },
-    // {
-    //   path: 'files',
-    //   url: urls.companies.files(companyId),
-    //   label: 'Files',
-    //   ariaDescription: 'Files',
-    // },
+    {
+      path: 'files',
+      url: urls.companies.files(companyId),
+      label: 'Files',
+      ariaDescription: 'Files',
+    },
     {
       path: 'account-management',
       url: urls.companies.accountManagement.index(companyId),

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -4,6 +4,7 @@ import { Link, Details } from 'govuk-react'
 import { useParams } from 'react-router-dom'
 
 import { FILES__LOADED } from '../../../actions'
+import { DOCUMENT_TYPES, RELATED_OBJECT_TYPES } from './constants'
 import { FilteredCollectionList } from '../../../components'
 import { listSkeletonPlaceholder } from '../../../components/SkeletonPlaceholder'
 import { CompanyResource } from '../../../components/Resource'
@@ -61,13 +62,15 @@ const CompanyFilesCollection = ({
             ) : null}
             <FilteredCollectionList
               {...props}
-              collectionName="File"
+              collectionName="SharePoint link"
               sortOptions={optionMetadata.sortOptions}
               taskProps={collectionListTask}
               collectionItemTemplate={collectionSummaryCardItemTemplateDefault}
               selectedFilters={selectedFilters}
               addItemUrl={
-                company.archived ? null : `/files/create?company=${company.id}`
+                company.archived
+                  ? null
+                  : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`
               }
               entityName="file"
               defaultQueryParams={{

--- a/src/client/modules/Files/CollectionList/constants.js
+++ b/src/client/modules/Files/CollectionList/constants.js
@@ -4,6 +4,13 @@ export const SORT_OPTIONS = [
 ]
 
 export const DOCUMENT_TYPES = {
-  SHAREPOINT: 'documents.sharepointdocument',
-  FILE_UPLOAD: 'documents.document',
+  SHAREPOINT: {
+    type: 'documents.sharepointdocument',
+    label: 'Add a new SharePoint link',
+  },
+  UPLOADABLE: { type: 'documents.uploadable', label: 'Upload a new doucment' },
+}
+
+export const RELATED_OBJECT_TYPES = {
+  COMPANY: 'company.company',
 }

--- a/src/client/modules/Files/CollectionList/transformers.js
+++ b/src/client/modules/Files/CollectionList/transformers.js
@@ -14,7 +14,7 @@ export const transformFileToListItem = () => (file) => {
 
   // Handle different document types
   switch (file.document_type) {
-    case DOCUMENT_TYPES.SHAREPOINT:
+    case DOCUMENT_TYPES.SHAREPOINT.type:
       title = 'SharePoint link'
       if (file.document.title) {
         title += ` - ${file.document.title}`
@@ -26,8 +26,8 @@ export const transformFileToListItem = () => (file) => {
           text: 'View file (opens in new tab)',
           url: file.document.url,
           attrs: { target: '_blank', rel: 'noopener noreferrer' },
-        },
-        { text: 'Delete', url: '#' }
+        }
+        // { text: 'Delete', url: '#' } removed for now as functionality missing
       )
 
       // Add summary rows for SharePoint document

--- a/src/client/modules/Files/CreateFile/CreateFile.jsx
+++ b/src/client/modules/Files/CreateFile/CreateFile.jsx
@@ -1,0 +1,133 @@
+import React from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { H3 } from 'govuk-react'
+
+import {
+  DefaultLayout,
+  FieldInput,
+  Form,
+  FormLayout,
+} from '../../../components'
+import { WEBSITE_REGEX } from '../../../../apps/companies/apps/add-company/client/constants'
+import { transformFileForApi } from './transformers'
+import urls from '../../../../lib/urls'
+import { CompanyResource } from '../../../components/Resource'
+
+import { FORM_LAYOUT } from '../../../../common/constants'
+import { TASK_CREATE_FILE } from './state'
+import {
+  DOCUMENT_TYPES,
+  RELATED_OBJECT_TYPES,
+} from '../CollectionList/constants'
+
+const CompanyName = ({ id }) => (
+  <CompanyResource.Inline id={id}>
+    {(company) => company.name}
+  </CompanyResource.Inline>
+)
+
+const websiteValidator = (value) =>
+  value && !WEBSITE_REGEX.test(value)
+    ? 'You must enter a valid SharePoint share link'
+    : null
+
+const documentTypeText = {
+  sharePoint: 'Add a new SharePoint link',
+}
+
+const SharePointForm = ({ relatedObjectId }) => {
+  return (
+    <Form
+      id="add-sharepoint-link-form"
+      submissionTaskName={TASK_CREATE_FILE}
+      analyticsFormName="addSharePointLink"
+      redirectTo={() => urls.companies.files(relatedObjectId)}
+      flashMessage={() => 'SharePoint link added successfully'}
+      submitButtonLabel="Add SharePoint link"
+      cancelButtonLabel="Cancel"
+      cancelRedirectTo={() => urls.companies.files(relatedObjectId)}
+      transformPayload={(values) =>
+        transformFileForApi({
+          relatedObjectId,
+          relatedObjectType: RELATED_OBJECT_TYPES.COMPANY,
+          documentType: DOCUMENT_TYPES.SHAREPOINT.type,
+          values,
+        })
+      }
+    >
+      <FieldInput
+        label="SharePoint share link url"
+        name="url"
+        type="url"
+        validate={websiteValidator}
+        initialValue=""
+        required="You must enter a SharePoint share link"
+        hint="Paste in the share link from the Sharepoint file. See how to share
+          SharePoint files and folders (opens in new tab) for information on
+          generating this."
+      />
+
+      <FieldInput
+        label="Link title (Optional)"
+        name="title"
+        type="text"
+        initialValue=""
+        hint="A short descriptive title to help others identify the file and it's
+          use"
+      />
+
+      <H3>Access requests</H3>
+      <p>
+        Access to this file will be handled via SharePoint permissions. People
+        who do not have access will need to request file access via SharePoint.
+      </p>
+    </Form>
+  )
+}
+
+const CreateFile = () => {
+  const [searchParams] = useSearchParams()
+  const relatedObjectId = searchParams.get('related_object_id')
+  const relatedObjectType = searchParams.get('related_object_type')
+  const documentType = searchParams.get('document_type')
+
+  const breadcrumbs = [{ link: '/', text: 'Home' }]
+  let pageTitle = null
+  let heading = null
+
+  if (relatedObjectType === RELATED_OBJECT_TYPES.COMPANY) {
+    pageTitle = `${DOCUMENT_TYPES.SHAREPOINT.label} - Files - ${(<CompanyName id={relatedObjectId} />)} - Companies`
+    heading = DOCUMENT_TYPES.SHAREPOINT.label
+    breadcrumbs.push(
+      { link: urls.companies.index(), text: 'Companies' },
+      {
+        link: urls.companies.detail(relatedObjectId),
+        text: <CompanyName id={relatedObjectId} />,
+      },
+      {
+        link: urls.companies.files(relatedObjectId),
+        text: 'Files',
+      },
+      {
+        text:
+          documentType === DOCUMENT_TYPES.SHAREPOINT.type
+            ? documentTypeText.sharePoint
+            : 'Empty',
+      }
+    )
+  }
+
+  return (
+    <DefaultLayout
+      pageTitle={pageTitle}
+      heading={heading}
+      breadcrumbs={breadcrumbs}
+    >
+      <FormLayout setWidth={FORM_LAYOUT.TWO_THIRDS}>
+        <SharePointForm relatedObjectId={relatedObjectId} />
+      </FormLayout>
+    </DefaultLayout>
+  )
+}
+
+export default CreateFile

--- a/src/client/modules/Files/CreateFile/CreateFile.jsx
+++ b/src/client/modules/Files/CreateFile/CreateFile.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { H3 } from 'govuk-react'
+import { H4 } from 'govuk-react'
 
 import {
   DefaultLayout,
@@ -62,9 +62,7 @@ const SharePointForm = ({ relatedObjectId }) => {
         validate={websiteValidator}
         initialValue=""
         required="You must enter a SharePoint share link"
-        hint="Paste in the share link from the Sharepoint file. See how to share
-          SharePoint files and folders (opens in new tab) for information on
-          generating this."
+        hint="Paste in the share link from the Sharepoint file."
       />
 
       <FieldInput
@@ -76,7 +74,7 @@ const SharePointForm = ({ relatedObjectId }) => {
           use"
       />
 
-      <H3>Access requests</H3>
+      <H4>Access requests</H4>
       <p>
         Access to this file will be handled via SharePoint permissions. People
         who do not have access will need to request file access via SharePoint.

--- a/src/client/modules/Files/CreateFile/state.js
+++ b/src/client/modules/Files/CreateFile/state.js
@@ -1,0 +1,1 @@
+export const TASK_CREATE_FILE = 'TASK_CREATE_FILE'

--- a/src/client/modules/Files/CreateFile/tasks.js
+++ b/src/client/modules/Files/CreateFile/tasks.js
@@ -1,0 +1,3 @@
+import { apiProxyAxios } from '../../../components/Task/utils'
+
+export const createFile = (values) => apiProxyAxios.post('v4/document/', values)

--- a/src/client/modules/Files/CreateFile/transformers.js
+++ b/src/client/modules/Files/CreateFile/transformers.js
@@ -1,0 +1,17 @@
+export const transformFileForApi = ({
+  relatedObjectId,
+  relatedObjectType,
+  documentType,
+  values,
+}) => {
+  const { url, title } = values
+  return {
+    related_object_id: relatedObjectId,
+    related_object_type: relatedObjectType,
+    document_type: documentType,
+    document_data: {
+      title: title,
+      url: url,
+    },
+  }
+}

--- a/src/client/routes.js
+++ b/src/client/routes.js
@@ -92,6 +92,7 @@ import CompanyActivityCollectionNoAs from './modules/Companies/CompanyActivity/i
 import CompanyContactsCollection from './modules/Contacts/CollectionList/CompanyContactsCollection'
 import CompanyOrdersCollection from './modules/Omis/CollectionList/CompanyOrdersCollection'
 import CompanyFilesCollection from './modules/Files/CollectionList/CompanyFilesCollection'
+import CreateFile from './modules/Files/CreateFile/CreateFile'
 import AccountManagement from './modules/Companies/AccountManagement'
 import CompanyProjectsCollection from './modules/Companies/CompanyInvestments/CompanyProjectsCollection'
 import LargeCapitalProfile from './modules/Companies/CompanyInvestments/LargeCapitalProfile'
@@ -386,6 +387,14 @@ function Routes() {
       element: (
         <ProtectedRoute module={'datahub:companies'}>
           <CannotFindMatch />
+        </ProtectedRoute>
+      ),
+    },
+    {
+      path: '/files/create',
+      element: (
+        <ProtectedRoute module={'datahub:companies'}>
+          <CreateFile />
         </ProtectedRoute>
       ),
     },

--- a/src/client/tasks.js
+++ b/src/client/tasks.js
@@ -153,6 +153,7 @@ import {
   getContactsMetadata,
 } from './modules/Contacts/CollectionList/tasks'
 import { getFiles } from './modules/Files/CollectionList/tasks'
+import { createFile } from './modules/Files/CreateFile/tasks.js'
 import {
   getInteractions,
   getInteractionsMetadata,
@@ -184,6 +185,7 @@ import {
 } from './modules/Contacts/CollectionList/state'
 
 import { TASK_GET_FILES_LIST } from './modules/Files/CollectionList/state'
+import { TASK_CREATE_FILE } from './modules/Files/CreateFile/state'
 
 import {
   TASK_GET_INTERACTIONS_LIST,
@@ -536,6 +538,7 @@ export const tasks = {
     investmentProfilesTasks.loadFilterOptions,
   [TASK_GET_CONTACTS_LIST]: getContacts,
   [TASK_GET_FILES_LIST]: getFiles,
+  [TASK_CREATE_FILE]: createFile,
   [TASK_GET_CONTACTS_METADATA]: getContactsMetadata,
   [TASK_GET_INTERACTIONS_LIST]: getInteractions,
   [TASK_GET_INTERACTIONS_ADVISER_NAME]: getAdviserNames,

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -21,7 +21,6 @@ describe('DA Permission', () => {
         'Overview',
         'Contacts',
         'Details',
-        'Files',
         'Account management',
         'Investment',
         'Orders',
@@ -42,7 +41,6 @@ describe('DA Permission', () => {
       assertLocalNav(selectors.nav.headerNav, [
         'Companies',
         'Contacts',
-        'Files',
         'Investments',
         'Orders',
         'Market access',
@@ -73,7 +71,6 @@ describe('DA Permission', () => {
     it('should display DA only tabs', () => {
       assertLocalReactNav('[data-test=local-nav] > ul', [
         'Details',
-        'Files',
         'Audit history',
       ])
     })
@@ -93,7 +90,6 @@ describe('DA Permission', () => {
         'Project details',
         'Project team',
         'Tasks',
-        'Files',
         'Interactions',
         'Evaluations',
         'Propositions',

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -21,6 +21,7 @@ describe('DA Permission', () => {
         'Overview',
         'Contacts',
         'Details',
+        'Files',
         'Account management',
         'Investment',
         'Orders',
@@ -41,6 +42,7 @@ describe('DA Permission', () => {
       assertLocalNav(selectors.nav.headerNav, [
         'Companies',
         'Contacts',
+        'Files',
         'Investments',
         'Orders',
         'Market access',
@@ -71,6 +73,7 @@ describe('DA Permission', () => {
     it('should display DA only tabs', () => {
       assertLocalReactNav('[data-test=local-nav] > ul', [
         'Details',
+        'Files',
         'Audit history',
       ])
     })
@@ -90,6 +93,7 @@ describe('DA Permission', () => {
         'Project details',
         'Project team',
         'Tasks',
+        'Files',
         'Interactions',
         'Evaluations',
         'Propositions',

--- a/test/end-to-end/cypress/specs/DA/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DA/local-nav-spec.js
@@ -19,8 +19,9 @@ describe('DA Permission', () => {
     it('should display DA only tabs', () => {
       assertLocalReactNav('[data-test="tabbedLocalNavList"]', [
         'Overview',
-        'Contacts',
         'Details',
+        'Contacts',
+        'Files',
         'Account management',
         'Investment',
         'Orders',

--- a/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/DIT/local-nav-spec.js
@@ -56,6 +56,7 @@ describe('DBT Permission', () => {
         'Activity',
         'Details',
         'Contacts',
+        'Files',
         'Account management',
         'Investment',
         'Export',

--- a/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
+++ b/test/end-to-end/cypress/specs/LEP/local-nav-spec.js
@@ -23,8 +23,9 @@ describe('LEP Permission', () => {
     it('should display LEP only tabs', () => {
       assertLocalReactNav('[data-test="tabbedLocalNavList"]', [
         'Overview',
-        'Contacts',
         'Details',
+        'Contacts',
+        'Files',
         'Account management',
         'Investment',
       ])

--- a/test/functional/cypress/fakers/generic-documents.js
+++ b/test/functional/cypress/fakers/generic-documents.js
@@ -2,7 +2,10 @@ import { faker, jsf } from '../../../sandbox/utils/random'
 
 import apiSchema from '../../../api-schema.json'
 import { listFaker } from './utils'
-import { DOCUMENT_TYPES } from '../../../../src/client/modules/Files/CollectionList/constants'
+import {
+  DOCUMENT_TYPES,
+  RELATED_OBJECT_TYPES,
+} from '../../../../src/client/modules/Files/CollectionList/constants'
 
 const genericDocumentFaker = (overrides = {}) => ({
   ...jsf.generate(apiSchema.components.schemas.GenericDocumentRetrieve),
@@ -42,8 +45,8 @@ const genericDocumentFaker = (overrides = {}) => ({
   document_object_id: faker.string.uuid(),
   related_object_id: faker.string.uuid(),
   archived_by: null,
-  document_type: DOCUMENT_TYPES.SHAREPOINT,
-  related_object_type: 'company.company',
+  document_type: DOCUMENT_TYPES.SHAREPOINT.type,
+  related_object_type: RELATED_OBJECT_TYPES.COMPANY,
   ...overrides,
 })
 

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -315,7 +315,7 @@ describe('One List core team', () => {
     })
 
     it('should render the edit core team button', () => {
-      cy.get('[data-test="edit-core-team-button"]', { timeout: 5000 })
+      cy.get('[data-test="edit-core-team-button"]', { timeout: 10000 })
         .should('exist')
         .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
     })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -260,7 +260,11 @@ describe('Company account management', () => {
 describe('One List core team', () => {
   context('when viewing a One List Tier company', () => {
     beforeEach(() => {
+      cy.intercept('GET', `/api-proxy/v4/company/${company.id}`).as(
+        'companyApi'
+      )
       cy.visit(urls.companies.accountManagement.index(company.id))
+      cy.wait('@companyApi')
     })
 
     it('should render the heading', () => {
@@ -315,7 +319,7 @@ describe('One List core team', () => {
     })
 
     it('should render the edit core team button', () => {
-      cy.get('[data-test="edit-core-team-button"]', { timeout: 10000 })
+      cy.get('[data-test="edit-core-team-button"]')
         .should('exist')
         .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
     })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -315,7 +315,7 @@ describe('One List core team', () => {
     })
 
     it('should render the edit core team button', () => {
-      cy.get('[data-test="edit-core-team-button"]', { timeout: 2000 })
+      cy.get('[data-test="edit-core-team-button"]', { timeout: 5000 })
         .should('exist')
         .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
     })

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -318,12 +318,6 @@ describe('One List core team', () => {
       })
     })
 
-    it('should render the edit core team button', () => {
-      cy.get('[data-test="edit-core-team-button"]')
-        .should('exist')
-        .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
-    })
-
     it('should render the details section', () => {
       cy.get('[data-test=core-team-details]')
         .click()

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -315,7 +315,7 @@ describe('One List core team', () => {
     })
 
     it('should render the edit core team button', () => {
-      cy.get('[data-test="edit-core-team-button"]')
+      cy.get('[data-test="edit-core-team-button"]', { timeout: 2000 })
         .should('exist')
         .should('have.attr', 'href', urls.companies.editVirtualTeam(company.id))
     })

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -43,7 +43,7 @@ describe('Company overview page', () => {
 
       it('tab should contain the text Overview', () => {
         cy.get('[data-test="tabbedLocalNavList"]', {
-          timeout: 5000,
+          timeout: 10000,
         }).should('contain.text', 'Overview')
       })
     }
@@ -245,7 +245,7 @@ describe('Company overview page', () => {
       })
       it('Inactive projects should not include an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 5000,
+          timeout: 10000,
         })
           .contains('Investment')
           .click()
@@ -255,7 +255,7 @@ describe('Company overview page', () => {
       })
       it('UK based Active projects should not have an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 5000,
+          timeout: 10000,
         })
           .contains('Investment')
           .click()
@@ -704,7 +704,7 @@ describe('Company overview page', () => {
 
       it('the card should contain a message outlining three active investments', () => {
         cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]', {
-          timeout: 5000,
+          timeout: 10000,
         }).should('be.visible')
         cy.get('[data-test="activeInvestmentProjectsContainer"]')
           .children()

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -42,10 +42,9 @@ describe('Company overview page', () => {
       })
 
       it('tab should contain the text Overview', () => {
-        cy.get('[data-test="tabbedLocalNavList"]')
-          .children()
-          .children()
-          .should('contain.text', 'Overview')
+        cy.get('[data-test="tabbedLocalNavList"]', {
+          timeout: 2000,
+        }).should('contain.text', 'Overview')
       })
     }
   )
@@ -245,13 +244,21 @@ describe('Company overview page', () => {
         cy.go('back')
       })
       it('Inactive projects should not include an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
+        cy.get('[data-test="tabbedLocalNav"]', {
+          timeout: 2000,
+        })
+          .contains('Investment')
+          .click()
         getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('add-collection-item-button').should('not.exist')
         cy.go('back')
       })
       it('UK based Active projects should not have an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
+        cy.get('[data-test="tabbedLocalNav"]', {
+          timeout: 2000,
+        })
+          .contains('Investment')
+          .click()
         getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('[data-test="add-collection-item-button"]').should('not.exist')
         cy.go('back')
@@ -697,7 +704,7 @@ describe('Company overview page', () => {
 
       it('the card should contain a message outlining three active investments', () => {
         cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]', {
-          timeout: 1000,
+          timeout: 2000,
         }).should('be.visible')
         cy.get('[data-test="activeInvestmentProjectsContainer"]')
           .children()

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -33,29 +33,6 @@ describe('Company overview page', () => {
   )
 
   context(
-    'when viewing company overview the tab should display Overview',
-    () => {
-      beforeEach(() => {
-        cy.intercept(
-          'GET',
-          `/api-proxy/v4/company/${companyGlobalUltimateAllDetails.id}`
-        ).as('companyApi')
-        cy.visit(
-          urls.companies.overview.index(companyGlobalUltimateAllDetails.id)
-        )
-        cy.wait('@companyApi')
-      })
-
-      it('tab should contain the text Overview', () => {
-        cy.wait(7000)
-        cy.get('[data-test="tabbedLocalNavList"]').should(
-          'contain.text',
-          'Overview'
-        )
-      })
-    }
-  )
-  context(
     'when viewing the Overview page a Business details card should be displayed',
     () => {
       beforeEach(() => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -727,6 +727,7 @@ describe('Company overview page', () => {
             '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
           )}`
         )
+        cy.wait(10000)
         cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
         cy.go('back')
         cy.get('[data-test="last-interaction-date-new-restaurant-header"]')
@@ -753,6 +754,7 @@ describe('Company overview page', () => {
             '3520b973-0e77-46cf-be75-3585f2f6691e'
           )}`
         )
+        cy.wait(10000)
         cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
         cy.go('back')
         cy.get('[data-test="active-investment-page-wig-factory-link"]')

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -36,9 +36,14 @@ describe('Company overview page', () => {
     'when viewing company overview the tab should display Overview',
     () => {
       beforeEach(() => {
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${companyGlobalUltimateAllDetails.id}`
+        ).as('companyApi')
         cy.visit(
           urls.companies.overview.index(companyGlobalUltimateAllDetails.id)
         )
+        cy.wait('@companyApi')
       })
 
       it('tab should contain the text Overview', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -45,7 +45,7 @@ describe('Company overview page', () => {
         )
         cy.wait('@companyApi')
       })
-
+      cy.wait(7000)
       it('tab should contain the text Overview', () => {
         cy.get('[data-test="tabbedLocalNavList"]').should(
           'contain.text',
@@ -732,18 +732,7 @@ describe('Company overview page', () => {
             '0e686ea4-b8a2-4337-aec4-114d92ad4588'
           )}`
         )
-        cy.wait(5000)
-        cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
-        cy.go('back')
-        cy.get('[data-test="active-investment-page-new-restaurant-link"]')
-          .contains('New restaurant')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.details(
-            '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
-          )}`
-        )
+
         cy.go('back')
         cy.get('[data-test="estimated-land-date-new-restaurant-header"]')
           .next()
@@ -760,7 +749,6 @@ describe('Company overview page', () => {
             '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
           )}`
         )
-        cy.wait(5000)
         cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
         cy.go('back')
         cy.get('[data-test="last-interaction-date-new-restaurant-header"]')

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -45,8 +45,9 @@ describe('Company overview page', () => {
         )
         cy.wait('@companyApi')
       })
-      cy.wait(7000)
+
       it('tab should contain the text Overview', () => {
+        cy.wait(7000)
         cy.get('[data-test="tabbedLocalNavList"]').should(
           'contain.text',
           'Overview'

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -42,9 +42,10 @@ describe('Company overview page', () => {
       })
 
       it('tab should contain the text Overview', () => {
-        cy.get('[data-test="tabbedLocalNavList"]', {
-          timeout: 10000,
-        }).should('contain.text', 'Overview')
+        cy.get('[data-test="tabbedLocalNavList"]').should(
+          'contain.text',
+          'Overview'
+        )
       })
     }
   )
@@ -244,21 +245,13 @@ describe('Company overview page', () => {
         cy.go('back')
       })
       it('Inactive projects should not include an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 10000,
-        })
-          .contains('Investment')
-          .click()
+        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
         getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('add-collection-item-button').should('not.exist')
         cy.go('back')
       })
       it('UK based Active projects should not have an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 10000,
-        })
-          .contains('Investment')
-          .click()
+        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
         getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('[data-test="add-collection-item-button"]').should('not.exist')
         cy.go('back')
@@ -708,9 +701,9 @@ describe('Company overview page', () => {
       })
 
       it('the card should contain a message outlining three active investments', () => {
-        cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]', {
-          timeout: 10000,
-        }).should('be.visible')
+        cy.get(
+          '[data-test="estimated-land-date-new-rollercoaster-header"]'
+        ).should('be.visible')
         cy.get('[data-test="activeInvestmentProjectsContainer"]')
           .children()
           .first()

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -43,7 +43,7 @@ describe('Company overview page', () => {
 
       it('tab should contain the text Overview', () => {
         cy.get('[data-test="tabbedLocalNavList"]', {
-          timeout: 2000,
+          timeout: 5000,
         }).should('contain.text', 'Overview')
       })
     }
@@ -245,7 +245,7 @@ describe('Company overview page', () => {
       })
       it('Inactive projects should not include an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 2000,
+          timeout: 5000,
         })
           .contains('Investment')
           .click()
@@ -255,7 +255,7 @@ describe('Company overview page', () => {
       })
       it('UK based Active projects should not have an "Add investment project" button', () => {
         cy.get('[data-test="tabbedLocalNav"]', {
-          timeout: 2000,
+          timeout: 5000,
         })
           .contains('Investment')
           .click()
@@ -704,7 +704,7 @@ describe('Company overview page', () => {
 
       it('the card should contain a message outlining three active investments', () => {
         cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]', {
-          timeout: 2000,
+          timeout: 5000,
         }).should('be.visible')
         cy.get('[data-test="activeInvestmentProjectsContainer"]')
           .children()

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -211,9 +211,14 @@ describe('Company overview page', () => {
     'when viewing the investment status card with different stages and statuses of investment projects',
     () => {
       beforeEach(() => {
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${fixtures.company.allOverviewDetails.id}`
+        ).as('companyApi')
         cy.visit(
           urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
         )
+        cy.wait('@companyApi')
       })
 
       it('the card should link to the latest won project', () => {
@@ -738,6 +743,7 @@ describe('Company overview page', () => {
             '0e686ea4-b8a2-4337-aec4-114d92ad4588'
           )}`
         )
+        cy.wait(5000)
         cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
         cy.go('back')
         cy.get('[data-test="active-investment-page-new-restaurant-link"]')
@@ -765,6 +771,7 @@ describe('Company overview page', () => {
             '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
           )}`
         )
+        cy.wait(5000)
         cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
         cy.go('back')
         cy.get('[data-test="last-interaction-date-new-restaurant-header"]')

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -697,9 +697,14 @@ describe('Company overview page', () => {
     'when viewing the active investment projects card for a business that has all information added',
     () => {
       beforeEach(() => {
+        cy.intercept(
+          'GET',
+          `/api-proxy/v4/company/${fixtures.company.allOverviewDetails.id}`
+        ).as('companyApi')
         cy.visit(
           urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
         )
+        cy.wait('@companyApi')
       })
 
       it('the card should contain a message outlining three active investments', () => {

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -216,14 +216,9 @@ describe('Company overview page', () => {
     'when viewing the investment status card with different stages and statuses of investment projects',
     () => {
       beforeEach(() => {
-        cy.intercept(
-          'GET',
-          `/api-proxy/v4/company/${fixtures.company.allOverviewDetails.id}`
-        ).as('companyApi')
         cy.visit(
           urls.companies.overview.index(fixtures.company.allOverviewDetails.id)
         )
-        cy.wait('@companyApi')
       })
 
       it('the card should link to the latest won project', () => {
@@ -236,35 +231,24 @@ describe('Company overview page', () => {
             '945ea6d1-eee3-4f5b-9144-84a75b71b8e6'
           )
         )
-        cy.go('back')
       })
-      it('the card should link to the active projects', () => {
-        cy.get('[data-test="total-active-projects"]').contains('4').click()
-        cy.go('back')
+    }
+  )
+
+  context(
+    'when viewing the investment status card the "add investment project button" should not show',
+    () => {
+      beforeEach(() => {
+        cy.visit(
+          urls.companies.investments.companyInvestmentProjects(
+            fixtures.company.allOverviewDetails.id
+          )
+        )
       })
-      it('the card should link to the prospect projects', () => {
-        cy.get('[data-test="total-prospect-projects"]').contains('3').click()
-        cy.go('back')
-      })
-      it('the card should link to the verify win projects', () => {
-        cy.get('[data-test="total-verify-win-projects"]').contains('1').click()
-        cy.go('back')
-      })
-      it('the card should link to the abandoned projects', () => {
-        cy.get('[data-test="total-abandoned-projects"]').contains('1').click()
-        cy.go('back')
-      })
-      it('Inactive projects should not include an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
+
+      it('Inactive / UK based Active projects should not include an "Add investment project" button', () => {
         getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
         cy.get('add-collection-item-button').should('not.exist')
-        cy.go('back')
-      })
-      it('UK based Active projects should not have an "Add investment project" button', () => {
-        cy.get('[data-test="tabbedLocalNav"]').contains('Investment').click()
-        getCollectionList() // This ensures the collection list has loaded before checking for the presence of the button
-        cy.get('[data-test="add-collection-item-button"]').should('not.exist')
-        cy.go('back')
       })
     }
   )

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -19,9 +19,6 @@ const urls = require('../../../../../src/lib/urls')
 const { usCompany } = company
 
 describe('Company overview page', () => {
-  const interactionUrlAllOverview = urls.companies.interactions.index(
-    fixtures.company.allOverviewDetails.id
-  )
   const addInteractionUrlAllOverview = urls.companies.interactions.create(
     fixtures.company.allOverviewDetails.id
   )
@@ -672,111 +669,6 @@ describe('Company overview page', () => {
         cy.wait('@companyApi')
       })
 
-      it('the card should contain a message outlining three active investments', () => {
-        cy.get(
-          '[data-test="estimated-land-date-new-rollercoaster-header"]'
-        ).should('be.visible')
-        cy.get('[data-test="activeInvestmentProjectsContainer"]')
-          .children()
-          .first()
-          .contains('Active investment projects')
-          .next()
-          .children()
-          .first()
-          .contains('New rollercoaster')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.details(
-            '0e686ea4-b8a2-4337-aec4-114d92ad4588'
-          )}`
-        )
-        cy.go('back')
-        cy.get('[data-test="estimated-land-date-new-rollercoaster-header"]')
-          .next()
-          .contains('May 2024')
-        cy.get('[data-test="last-interaction-date-new-rollercoaster-header"]')
-          .next()
-          .contains('Not set')
-        cy.get('[data-test="likelihood-of-landing-new-rollercoaster-header"]')
-          .next()
-          .contains('High')
-        cy.get('[data-test="active-investment-edit-new-rollercoaster-link"]')
-          .contains('Edit')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.editDetails(
-            '0e686ea4-b8a2-4337-aec4-114d92ad4588'
-          )}`
-        )
-
-        cy.go('back')
-        cy.get('[data-test="estimated-land-date-new-restaurant-header"]')
-          .next()
-          .contains('October 2025')
-        cy.get('[data-test="likelihood-of-landing-new-restaurant-header"]')
-          .next()
-          .contains('Medium')
-        cy.get('[data-test="active-investment-edit-new-restaurant-link"]')
-          .contains('Edit')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.editDetails(
-            '18750b26-a8c3-41b2-8d3a-fb0b930c2270'
-          )}`
-        )
-        cy.wait(10000)
-        cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
-        cy.go('back')
-        cy.get('[data-test="last-interaction-date-new-restaurant-header"]')
-          .next()
-          .contains('16 March 2021')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${interactionUrlAllOverview}/3fd90013-4bcb-4c39-b8df-df264471ea85`
-        )
-        cy.go('back')
-        cy.get('[data-test="estimated-land-date-wig-factory-header"]')
-          .next()
-          .contains('January 2026')
-        cy.get('[data-test="likelihood-of-landing-wig-factory-header"]')
-          .next()
-          .contains('Low')
-        cy.get('[data-test="active-investment-edit-wig-factory-link"]')
-          .contains('Edit')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.editDetails(
-            '3520b973-0e77-46cf-be75-3585f2f6691e'
-          )}`
-        )
-        cy.wait(10000)
-        cy.get('[data-test="field-likelihood_to_land"]').type('Low').click()
-        cy.go('back')
-        cy.get('[data-test="active-investment-page-wig-factory-link"]')
-          .contains('Wig factory')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${urls.investments.projects.details(
-            '3520b973-0e77-46cf-be75-3585f2f6691e'
-          )}`
-        )
-        cy.go('back')
-        cy.get('[data-test="last-interaction-date-wig-factory-header"]')
-          .next()
-          .contains('16 March 2021')
-          .click()
-        cy.location('pathname').should(
-          'eq',
-          `${interactionUrlAllOverview}/3fd90013-4bcb-4c39-b8df-df264471ea85`
-        )
-        cy.go('back')
-      })
       it('the card should link to the investment page', () => {
         cy.get('[data-test="active-investments-page-link"]')
           .contains('View 1 more active investment')

--- a/test/functional/cypress/specs/files/create-spec.js
+++ b/test/functional/cypress/specs/files/create-spec.js
@@ -53,11 +53,11 @@ describe('SharePoint link file create for company', () => {
 
   context('when filling in a valid SharePoint form', () => {
     it('should save with expected values and endpoint', () => {
-      const test_url = 'http://somevalidurl.com'
-      const test_title = 'Some test title'
+      const testUrl = 'http://somevalidurl.com'
+      const testTitle = 'Some test title'
 
-      cy.get('#url').type(test_url)
-      cy.get('#title').type(test_title)
+      cy.get('#url').type(testUrl)
+      cy.get('#title').type(testTitle)
 
       cy.contains('button', 'Add SharePoint link').click()
 
@@ -66,8 +66,8 @@ describe('SharePoint link file create for company', () => {
         related_object_type: RELATED_OBJECT_TYPES.COMPANY,
         document_type: DOCUMENT_TYPES.SHAREPOINT.type,
         document_data: {
-          title: test_title,
-          url: test_url,
+          title: testTitle,
+          url: testUrl,
         },
       }
 

--- a/test/functional/cypress/specs/files/create-spec.js
+++ b/test/functional/cypress/specs/files/create-spec.js
@@ -1,0 +1,88 @@
+import {
+  assertLocalHeader,
+  assertBreadcrumbs,
+  assertErrorSummary,
+  assertTextVisible,
+  assertUrl,
+} from '../../../cypress/support/assertions'
+
+import urls from '../../../../../src/lib/urls'
+
+import {
+  DOCUMENT_TYPES,
+  RELATED_OBJECT_TYPES,
+} from '../../../../../src/client/modules/Files/CollectionList/constants'
+
+describe('SharePoint link file create for company', () => {
+  const companyId = '4cd4128b-1bad-4f1e-9146-5d4678c6a018'
+  beforeEach(() => {
+    cy.intercept('POST', '/api-proxy/v4/document', {
+      statusCode: 201,
+    }).as('fileHttpRequest')
+    cy.visit(
+      `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`
+    )
+  })
+
+  it('should render the SharePoint link header', () => {
+    assertLocalHeader('Add a new SharePoint link')
+  })
+
+  it('should render add SharePoint link breadcrumb', () => {
+    assertBreadcrumbs({
+      Home: '/',
+      Companies: urls.companies.index(),
+      'Zboncak Group|271eb29e-425b-4cd8-b386-3208c3a5f978': `/companies/${companyId}`,
+      Files: `/companies/${companyId}/files`,
+      'Add a new SharePoint link': null,
+    })
+  })
+
+  context('when verifying SharePoint link inputs', () => {
+    it('should validate an empty form', () => {
+      cy.contains('button', 'Add SharePoint link').click()
+      assertErrorSummary(['You must enter a SharePoint share link'])
+    })
+
+    it('should validate a valid URL is added to the form', () => {
+      cy.get('#url').type('INVALID_URL')
+      cy.contains('button', 'Add SharePoint link').click()
+      assertErrorSummary(['You must enter a valid SharePoint share link'])
+    })
+  })
+
+  context('when filling in a valid SharePoint form', () => {
+    it('should save with expected values and endpoint', () => {
+      const test_url = 'http://somevalidurl.com'
+      const test_title = 'Some test title'
+
+      cy.get('#url').type(test_url)
+      cy.get('#title').type(test_title)
+
+      cy.contains('button', 'Add SharePoint link').click()
+
+      const expectedBody = {
+        related_object_id: companyId,
+        related_object_type: RELATED_OBJECT_TYPES.COMPANY,
+        document_type: DOCUMENT_TYPES.SHAREPOINT.type,
+        document_data: {
+          title: test_title,
+          url: test_url,
+        },
+      }
+
+      cy.wait('@fileHttpRequest').then((xhr) => {
+        expect(xhr.request.body).to.deep.equal(expectedBody)
+        assertUrl(urls.companies.files(companyId))
+        assertTextVisible(`SharePoint link added successfully`)
+      })
+    })
+  })
+
+  context('when a user cancels', () => {
+    it('should return without saving and return to the correct endpoint', () => {
+      cy.contains('Cancel').click()
+      assertUrl(urls.companies.files(companyId))
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Adding functionality to add SharePoint links to files section of companies. 

## Test instructions

CreateFile functional tests should load the create flow and the page should be rendered for sharepoint links against a company. 

## Screenshots

### Before

N/A

### After

<img width="726" alt="image" src="https://github.com/user-attachments/assets/7f8362d2-d48f-4d9f-b10c-e1e25765d704" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
