### PR TITLE
Show 'Not set' for contact details page when company has no address

### DIFF
--- a/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
+++ b/src/client/modules/Contacts/ContactDetails/ContactDetails.jsx
@@ -17,6 +17,9 @@ import ContactLayout from '../../../components/Layout/ContactLayout'
 import ConsentDetails from './ConsentDetails'
 
 const getAddress = (contact, companyAddress) => {
+  if (!companyAddress) {
+    return 'Not set'
+  }
   const address = contact.addressSameAsCompany
     ? {
         line1: companyAddress.line1,

--- a/test/functional/cypress/specs/contacts/details-spec.js
+++ b/test/functional/cypress/specs/contacts/details-spec.js
@@ -6,6 +6,7 @@ const companyAddresscontact = require('../../../../sandbox/fixtures/v3/contact/c
 const usContact = require('../../../../sandbox/fixtures/v3/contact/contact-with-us-address.json')
 const archiveContact = require('../../../../sandbox/fixtures/v3/contact/contact-archived.json')
 const invalidEmailContact = require('../../../../sandbox/fixtures/v3/contact/contact-invalid-email.json')
+const company = require('../../../../sandbox/fixtures/v4/company/company.json')
 
 const ARCHIVE_INTERCEPT = 'archiveHttpRequest'
 
@@ -156,6 +157,31 @@ describe('View contact details', () => {
             '123 Test Boulevard, Basney, US State, 9416875, United States',
           Email: usContact.email,
           'More details': usContact.notes,
+        })
+      })
+    })
+
+    context('Company has no address', () => {
+      beforeEach(() => {
+        company.address = null
+        cy.intercept(
+          'GET',
+          '/api-proxy/v4/company/4cd4128b-1bad-4f1e-9146-5d4678c6a018',
+          {
+            body: {
+              company,
+            },
+          }
+        )
+        cy.visit('/contacts/a55af9e5-c53c-4696-9647-065b28ea02de')
+      })
+
+      it('should display "Not set" when company address is empty', () => {
+        assertKeyValueTable('contact-details-table', {
+          'Job title': usContact.job_title,
+          'Phone number': usContact.full_telephone_number,
+          Address: 'Not set',
+          Email: usContact.email,
         })
       })
     })


### PR DESCRIPTION
## Description of change

The company address is not required by the backend.

Specifically not setting an address country on the backend causes the contact details page to break when the contacts address is set to be the same as the company address.

JIRA: https://uktrade.atlassian.net/browse/CPS-695

Fixes:
https://sentry.ci.uktrade.digital/organizations/dit/issues/155242/?project=235&project=238&query=is%3Aunresolved&statsPeriod=24h
https://sentry.ci.uktrade.digital/organizations/dit/issues/155241/?project=235&project=238&query=is%3Aunresolved&statsPeriod=24h

## Test instructions

Set a company to have no address_country in the shell.
Set a contact to have the same address as that company
View that contact in the frontend and see an error (dev, staging, prod)
Check out this branch and do the same and see 'Not set' for the address field.

## Screenshots

### Before

<img width="1507" alt="Screenshot 2025-03-17 at 12 13 03" src="https://github.com/user-attachments/assets/563cb3a8-c100-4501-b54a-71f07f50d0d4" />

### After

<img width="757" alt="Screenshot 2025-03-17 at 12 13 12" src="https://github.com/user-attachments/assets/63ca3e90-28fc-43dd-8ffc-f7464f952fc8" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
