### PR TITLE
Add business intelligence filter

### DIFF
--- a/src/client/modules/Companies/CompanyActivity/constants.js
+++ b/src/client/modules/Companies/CompanyActivity/constants.js
@@ -61,6 +61,13 @@ export const SORT_OPTIONS = [
   { value: 'subject', name: 'Subject A-Z (interaction)' },
 ]
 
+export const BUSINESS_INTELLIGENCE_OPTION = [
+  {
+    label: 'Includes business intelligence',
+    value: 'true',
+  },
+]
+
 export const NEW_PROJECT_TAG = {
   text: 'New Investment Project',
   colour: 'grey',

--- a/src/client/modules/Companies/CompanyActivity/index.jsx
+++ b/src/client/modules/Companies/CompanyActivity/index.jsx
@@ -191,7 +191,7 @@ const CompanyActivityCollectionNoAS = ({
                 />
                 <FilterToggleSection
                   id="CompanyActivityCollection.interaction-details-filters"
-                  label="Interaction detailsm"
+                  label="Interaction details"
                   isOpen={true}
                 >
                   <Filters.Input

--- a/src/client/modules/Companies/CompanyActivity/index.jsx
+++ b/src/client/modules/Companies/CompanyActivity/index.jsx
@@ -9,7 +9,7 @@ import {
   COMPANY_ACTIVITIES__METADATA_LOADED,
 } from '../../../actions'
 
-import { LABELS } from './constants'
+import { LABELS, BUSINESS_INTELLIGENCE_OPTION } from './constants'
 
 import {
   CollectionFilters,
@@ -191,7 +191,7 @@ const CompanyActivityCollectionNoAS = ({
                 />
                 <FilterToggleSection
                   id="CompanyActivityCollection.interaction-details-filters"
-                  label="Interaction details"
+                  label="Interaction detailsm"
                   isOpen={true}
                 >
                   <Filters.Input
@@ -213,6 +213,16 @@ const CompanyActivityCollectionNoAS = ({
                     noOptionsMessage="No advisers found"
                     selectedOptions={selectedFilters.advisers.options}
                     data-test="adviser-filter"
+                  />
+                  <Filters.CheckboxGroup
+                    legend={LABELS.businessIntelligence}
+                    name="was_policy_feedback_provided"
+                    qsParam="was_policy_feedback_provided"
+                    options={BUSINESS_INTELLIGENCE_OPTION}
+                    selectedOptions={
+                      selectedFilters.businessIntelligence.options
+                    }
+                    data-test="business-intelligence-filter"
                   />
                 </FilterToggleSection>
                 {/* TODO - reinstate this once we have initial DAGs in place for external items */}


### PR DESCRIPTION
## Description of change

This PR addresses to add Business intelligence filter on the company activity page 

## Test instructions

New Fillter Checkbox

## Screenshots

### Before

<img width="1409" alt="image" src="https://github.com/user-attachments/assets/4be90eb7-86a5-4ea8-bf8e-64ade8cda0da" />

### After

<img width="1462" alt="image" src="https://github.com/user-attachments/assets/38c059bd-d4cd-4106-80cf-87751a3809df" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
