### PR TITLE
Fix node version for release-storybook

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ jobs:
 
   release-storybook:
     docker:
-      - image: node:22-bullseye
+      - image: node:22.12.0-bullseye
     steps:
       - checkout
       - add_ssh_keys:


### PR DESCRIPTION
## Description of change

Once a PR is merged, CircleCI runs the `release-storybook` job. This job uses the image `node:22-bullseye`, which at the time of writing, installs node 22.14.0. Unfortunately, this is incompatible when running `npm install storybook` as we require 22.12.0.

```
npm install storybook

npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: undefined
npm error notsup Not compatible with your version of node/npm: undefined
npm error notsup Required: {"node":"22.12.0"}
npm error notsup Actual:   {"npm":"10.9.2","node":"v22.14.0"}

Exited with code exit status 1
``` 

This PR fixes the node version used in this job.

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
