### PR TITLE
Add Export Project interaction flow

### DIFF
--- a/src/apps/dashboard/index.js
+++ b/src/apps/dashboard/index.js
@@ -1,19 +1,6 @@
-const router = require('express').Router()
-
-const urls = require('../../lib/urls')
-const { renderDashboard } = require('./controllers')
+const router = require('./router')
 
 module.exports = {
-  router: router.get(
-    // These paths are handled by react-router
-    [
-      urls.dashboard.index(),
-      urls.companyLists.index(),
-      urls.dashboard.investmentProjects(),
-      urls.companies.referrals.list(),
-      urls.exportPipeline.index(),
-      urls.dashboard.myTasks(),
-    ],
-    renderDashboard
-  ),
+  mountpath: '/',
+  router,
 }

--- a/src/apps/dashboard/middleware/interactions.js
+++ b/src/apps/dashboard/middleware/interactions.js
@@ -1,0 +1,11 @@
+const { getDitCompany } = require('../../companies/repos')
+
+async function setCompanyDetails(req, res, next) {
+  const { companyExport } = res.locals
+  res.locals.company = await getDitCompany(req, companyExport.company.id)
+  next()
+}
+
+module.exports = {
+  setCompanyDetails,
+}

--- a/src/apps/dashboard/middleware/params.js
+++ b/src/apps/dashboard/middleware/params.js
@@ -1,0 +1,16 @@
+const { getCompanyExport } = require('../repos')
+
+async function getCompanyExportParam(req, res, next, id) {
+  try {
+    const companyExport = await getCompanyExport(req, id)
+
+    res.locals.companyExport = companyExport
+    next()
+  } catch (error) {
+    next(error)
+  }
+}
+
+module.exports = {
+  getCompanyExportParam,
+}

--- a/src/apps/dashboard/repos.js
+++ b/src/apps/dashboard/repos.js
@@ -1,0 +1,11 @@
+/* eslint camelcase: 0, prefer-promise-reject-errors: 0 */
+const config = require('../../config')
+const { authorisedRequest } = require('../../lib/authorised-request')
+
+function getCompanyExport(req, id) {
+  return authorisedRequest(req, `${config.apiRoot}/v4/export/${id}`)
+}
+
+module.exports = {
+  getCompanyExport,
+}

--- a/src/apps/dashboard/router.js
+++ b/src/apps/dashboard/router.js
@@ -1,0 +1,33 @@
+const router = require('express').Router()
+
+const urls = require('../../lib/urls')
+const { renderDashboard } = require('./controllers')
+
+const interactionsRouter = require('../interactions/router.sub-app')
+const { setCompanyDetails } = require('./middleware/interactions')
+const { getCompanyExportParam } = require('./middleware/params')
+const { setHome } = require('../../middleware/breadcrumbs')
+
+router.param('exportId', getCompanyExportParam)
+
+router.use(
+  `${urls.exportPipeline.index.mountPoint}${urls.exportPipeline.interactions.index.route}`,
+  setHome({ href: '/export' }),
+  setCompanyDetails,
+  interactionsRouter
+)
+
+router.get(
+  // These paths are handled by react-router
+  [
+    urls.dashboard.index(),
+    urls.companyLists.index(),
+    urls.dashboard.investmentProjects(),
+    urls.companies.referrals.list(),
+    urls.exportPipeline.index(),
+    urls.dashboard.myTasks(),
+  ],
+  renderDashboard
+)
+
+module.exports = router

--- a/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
+++ b/src/apps/interactions/apps/details-form/client/InteractionDetailsForm.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import { useLocation } from 'react-router-dom'
 
 import StepInteractionType from './StepInteractionType'
+import StepCompanyExportInteractionType from './StepCompanyExportInteractionType'
 import StepInteractionDetails from './StepInteractionDetails'
 import Step from '../../../../../client/components/Form/elements/Step'
 import Task from '../../../../../client/components/Task'
@@ -23,6 +24,7 @@ const getReturnLink = (
   companyId,
   referralId,
   investmentId,
+  companyExportId,
   contactId,
   interactionId
 ) => {
@@ -39,6 +41,11 @@ const getReturnLink = (
     )
   } else if (contactId) {
     return urls.contacts.interactions.detail(contactId, interactionId)
+  } else if (companyExportId) {
+    return urls.exportPipeline.interactions.detail(
+      companyExportId,
+      interactionId
+    )
   }
 
   return urls.companies.interactions.detail(companyId, interactionId)
@@ -64,6 +71,7 @@ const getFlashMessage = (interactionId, wasPolicyFeedbackProvided) => {
 const InteractionDetailsForm = ({
   companyId,
   investmentId,
+  companyExportId,
   contactId,
   user,
   interactionId,
@@ -100,6 +108,7 @@ const InteractionDetailsForm = ({
                 companyId,
                 referral,
                 investmentId,
+                companyExportId,
                 contactId,
                 user,
                 interactionId,
@@ -116,6 +125,7 @@ const InteractionDetailsForm = ({
                   companyId,
                   referral?.id,
                   investmentId,
+                  companyExportId,
                   contactId,
                   data.id
                 )
@@ -133,7 +143,7 @@ const InteractionDetailsForm = ({
                 <>
                   {/* Step registered if creating the interaction
                   and haven't come from an investment project */}
-                  {!interactionId && !investmentId && (
+                  {!interactionId && !investmentId && !companyExportId && (
                     <Step
                       name="interaction_type"
                       cancelUrl={urls.companies.detail(companyId)}
@@ -141,7 +151,14 @@ const InteractionDetailsForm = ({
                       {() => <StepInteractionType />}
                     </Step>
                   )}
-
+                  {!interactionId && !investmentId && companyExportId && (
+                    <Step
+                      name="interaction_type"
+                      cancelUrl={urls.exportPipeline.details(companyExportId)}
+                    >
+                      {() => <StepCompanyExportInteractionType />}
+                    </Step>
+                  )}
                   <Step
                     name="interaction_details"
                     forwardButton={

--- a/src/apps/interactions/apps/details-form/client/StepCompanyExportInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepCompanyExportInteractionType.jsx
@@ -1,0 +1,56 @@
+import React, { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { omitBy, isUndefined } from 'lodash'
+
+import { useFormContext } from '../../../../../client/components/Form/hooks'
+import { FieldRadios } from '../../../../../client/components'
+import { KINDS } from '../../../constants'
+
+const StepCompanyExportInteractionType = () => {
+  const { resetFields, getFieldState } = useFormContext()
+  const location = useLocation()
+
+  useEffect(() => {
+    if (location.pathname.endsWith('/interactions/create')) {
+      // If we do not clean up, then the form values object contains keys and values
+      // relevant to the initial form interaction, as the user completes the form
+      // a second time some keys and values are overwritten, others are not, the
+      // latter causes problems with API validation when saving the form as the
+      // wrong keys are sent as part of the payload, which ultimately means the
+      // user cannot save the form (HTTP 400), meaning they have to start over.
+      // Therefore, the cleanest approach is to reset the fields within the form
+      // the moment the users lands on the "Add interaction ..." page:
+
+      const theme = 'export'
+      const kind = getFieldState('kind').value
+      const previousSelection = omitBy({ theme, kind }, isUndefined)
+
+      return resetFields(previousSelection)
+    }
+  }, [location.pathname])
+
+  return (
+    <>
+      <FieldRadios
+        label="What would you like to record?"
+        name="kind"
+        dataTestPrefix="export"
+        required="Select interaction type"
+        options={[
+          {
+            label: 'A standard interaction',
+            hint: 'For example, an email, phone call or meeting',
+            value: KINDS.INTERACTION,
+          },
+          {
+            label: 'A service you have provided',
+            hint: 'For example, a significant assist or event',
+            value: KINDS.SERVICE_DELIVERY,
+          },
+        ]}
+      />
+    </>
+  )
+}
+
+export default StepCompanyExportInteractionType

--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -65,7 +65,6 @@ const getServiceContext = (theme, kind, investmentProject) => {
       [KINDS.SERVICE_DELIVERY]: SERVICE_CONTEXTS.OTHER_SERVICE_DELIVERY,
     },
   }
-
   return kind && mapping[theme][kind] ? mapping[theme][kind] : mapping[theme]
 }
 

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -120,7 +120,12 @@ const transformValues = (interaction, callback, fieldNames) => {
     )
 }
 
-const transformInteractionToValues = (interaction, companyId, investmentId) => {
+const transformInteractionToValues = (
+  interaction,
+  companyId,
+  investmentId,
+  companyExportId
+) => {
   const advisers = interaction.dit_participants
     .filter((participant) => participant.adviser.name)
     .map((participant) => participant.adviser)
@@ -150,6 +155,7 @@ const transformInteractionToValues = (interaction, companyId, investmentId) => {
     },
     companies: [companyId],
     investment_project: investmentId,
+    company_export_id: companyExportId,
     helped_remove_export_barrier: interaction.helped_remove_export_barrier
       ? OPTION_YES
       : OPTION_NO,
@@ -195,6 +201,7 @@ export async function getInitialFormValues({
   companyId,
   referral,
   investmentId,
+  companyExportId,
   user,
   interactionId,
 }) {
@@ -241,6 +248,7 @@ export async function getInitialFormValues({
     return {
       companies: [companyId],
       investment_project: investmentId,
+      company_export: companyExportId,
       date: {
         day: formatDate(date, DATE_FORMAT_DAY),
         month: formatDate(date, DATE_FORMAT_MONTH),

--- a/src/client/modules/ExportPipeline/Export.jsx
+++ b/src/client/modules/ExportPipeline/Export.jsx
@@ -45,7 +45,6 @@ const Export = () => {
   const exportId = matchId ? matchId[1] : null
   const matchAspect = location.pathname.match(EXPORT_ASPECT_REGEX)
   const aspect = matchAspect ? matchAspect[1] : null // aspect will be either 'details' or 'interactions'
-
   return (
     <DefaultLayout
       superheading={<CompanyLink id={exportId} />}
@@ -54,6 +53,9 @@ const Export = () => {
       breadcrumbs={[
         { link: urls.exportPipeline.index(), text: 'Home' },
         { text: <ExportProjectTitle id={exportId} /> },
+        {
+          text: { interactions: 'Interactions' }[aspect],
+        },
       ]}
     >
       <TabNav

--- a/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
+++ b/src/client/modules/ExportPipeline/ExportInteractionsList/index.jsx
@@ -16,7 +16,7 @@ const ExportInteractionsList = ({ interactions = [] }) =>
         <CollectionItem
           key={item.id}
           headingText={item.subject}
-          headingUrl={urls.exportPipeline.interactions.details(
+          headingUrl={urls.exportPipeline.interactions.detail(
             item.company_export.id,
             item.id
           )}
@@ -32,7 +32,11 @@ const ExportInteractionsList = ({ interactions = [] }) =>
             {
               label: 'Adviser(s):',
               value: item.dit_participants
-                .map(({ adviser, team }) => `${adviser.name} - ${team.name}`)
+                .map(({ adviser, team }) =>
+                  team
+                    ? `${adviser.name} - ${team.name}`
+                    : `${adviser.name} - Not set`
+                )
                 .join(', '),
             },
             {
@@ -54,11 +58,12 @@ export default ({ exportId }) => (
     </p>
     <Interactions.Paginated
       id="export-interactions"
-      heading="interactions"
+      heading="interaction"
       shouldPluralize={true}
       noResults="You don't have any export interactions."
       payload={{ company_export_id: exportId }}
       sortOptions={SORT_OPTIONS_EXPORT_INTERACTION}
+      addItemUrl={urls.exportPipeline.interactions.create(exportId)}
     >
       {(page) => <ExportInteractionsList interactions={page} />}
     </Interactions.Paginated>

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -60,13 +60,17 @@ function url(mountPoint, subMountPoint, path) {
   return getUrl
 }
 
-function createInteractionsSubApp(mountPoint, pathPrefix = '') {
+function createInteractionsSubApp(
+  mountPoint,
+  pathPrefix = '',
+  pathPostfix = ''
+) {
   return {
     index:
       mountPoint === '/interactions'
         ? url(mountPoint, PRIMARY_LINK_PARAMS.interactions, pathPrefix)
         : url(mountPoint, pathPrefix),
-    detail: url(mountPoint, pathPrefix + '/:interactionId'),
+    detail: url(mountPoint, pathPrefix + '/:interactionId' + pathPostfix),
     create: url(mountPoint, pathPrefix + '/create'),
     createType: url(mountPoint, pathPrefix + '/create/:theme/:kind'),
     edit: url(mountPoint, pathPrefix + '/:interactionId/edit'),
@@ -762,10 +766,11 @@ module.exports = {
     index: url('/export'),
     create: url('/export/create?companyId=', ':companyId'),
     details: url('/export', '/:exportId/details'),
-    interactions: {
-      index: url('/export', '/:exportId/interactions'),
-      details: url('/export', '/:exportId/interactions/:interactionId/details'),
-    },
+    interactions: createInteractionsSubApp(
+      '/export',
+      '/:exportId/interactions',
+      '/details'
+    ),
     edit: url('/export', '/:exportId/edit'),
     delete: url('/export', '/:exportId/delete'),
   },

--- a/src/templates/_layouts/template.njk
+++ b/src/templates/_layouts/template.njk
@@ -96,8 +96,8 @@
 
   {% block local_header %}
     {% set pageTitle = getPageTitle() if getPageTitle %}
-    {% set heading = heading or pageTitle[0] %}
-    {{ LocalHeader({ heading: heading, subHeading: props.subHeading,  modifier: 'light-banner' }) }}
+    {% set heading = heading or props.heading or pageTitle[0] %}
+    {{ LocalHeader({ heading: heading, subHeading: props.subHeading, preHeading: props.preHeading, modifier: 'light-banner' }) }}
   {% endblock %}
 
 {% endblock %}

--- a/src/templates/_macros/common/local-header.njk
+++ b/src/templates/_macros/common/local-header.njk
@@ -46,6 +46,11 @@
               </div>
             {% endif %}
 
+            {% if props.preHeading %}
+              <div data-test="localHeaderPreHeading" class="c-local-header__subheading">
+                {{props.preHeading | safe}}
+              </div>
+            {% endif %}
             {% if props.heading %}
               <h1 class="c-local-header__heading">
                 {{ props.heading }} {{ props.headingSuffix | safe }}

--- a/test/sandbox/fixtures/v4/company/company-with-export-project-details.json
+++ b/test/sandbox/fixtures/v4/company/company-with-export-project-details.json
@@ -55,7 +55,7 @@
     "archived": false,
     "archived_on": null,
     "archived_reason": "",
-    "title": "Export Project for Venus ltd - TEST",
+    "title": "Export Project",
     "status": "active",
     "notes": "",
     "created_by": "c0e09068-ce3e-4798-9437-2d258d83881e",

--- a/test/sandbox/routes/v4/interaction/interaction.js
+++ b/test/sandbox/routes/v4/interaction/interaction.js
@@ -17,7 +17,6 @@ import interactionWithExportCountries from '../../../fixtures/v4/interaction/int
 import interactionWithoutExportCountries from '../../../fixtures/v4/interaction/interaction-with-no-countries-discussed.json' with { type: 'json' }
 import interactionWithBusIntel from '../../../fixtures/v4/interaction/interaction-with-business-intelligence.json' with { type: 'json' }
 import interactionStovaEvent from '../../../fixtures/v4/interaction/interaction-with-stova-event.json' with { type: 'json' }
-
 import { interactionByExportProject } from '../../../fixtures/v4/interaction/interaction-by-export-project.js'
 
 export const getInteractions = function (req, res) {


### PR DESCRIPTION
## Description of change

This adds a new flow to add export project interaction for export project interactions section.
It adds "Add interaction" button.
It updates the header to include company name and link to company and also export project title.
It adds new component that only allows user to select kind of interaction.

## Test instructions

Go to any Export project. Got to Interactions section. Click "Add interaction". Add interaction by filling the form.

## Screenshots

### Before

<img width="1010" alt="Screenshot 2025-03-19 at 16 54 48" src="https://github.com/user-attachments/assets/044806f3-aed2-4881-801a-9ad7e1e4f71f" />


### After
<img width="986" alt="Screenshot 2025-03-19 at 16 56 26" src="https://github.com/user-attachments/assets/ee41f060-9744-45e6-a775-3be694b28aa8" />

<img width="1005" alt="Screenshot 2025-03-19 at 16 58 39" src="https://github.com/user-attachments/assets/ac05c9cd-dff8-4cd7-be92-99fabc5ef9f3" />
<img width="994" alt="Screenshot 2025-03-19 at 16 59 13" src="https://github.com/user-attachments/assets/028cfdbd-1369-4412-80e5-2e1edd8c3bf5" />
<img width="1018" alt="Screenshot 2025-03-19 at 17 01 43" src="https://github.com/user-attachments/assets/01194bd8-57ff-4cb0-942e-f40bb798a9a3" />


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
