### PR TITLE
Reduced summary table header left padding

### DIFF
--- a/src/client/components/SummaryTable/index.jsx
+++ b/src/client/components/SummaryTable/index.jsx
@@ -68,6 +68,14 @@ const StyledTableRow = styled(Table.Row)`
     `}
 `
 
+const StyledTableHeaderCell = styled(Table.CellHeader)({
+  padding: '10px 0px',
+})
+
+const StyledTableCell = styled(Table.Cell)({
+  padding: '10px',
+})
+
 SummaryTable.Row = ({ heading, children, hideWhenEmpty, flag, ...props }) => {
   if (hideWhenEmpty && isEmpty(children)) {
     return null
@@ -91,8 +99,8 @@ SummaryTable.Row = ({ heading, children, hideWhenEmpty, flag, ...props }) => {
 
   return (
     <StyledTableRow invalid={flag} {...props}>
-      {heading && <Table.CellHeader>{heading}</Table.CellHeader>}
-      <Table.Cell>{renderChildren()}</Table.Cell>
+      {heading && <StyledTableHeaderCell>{heading}</StyledTableHeaderCell>}
+      <StyledTableCell>{renderChildren()}</StyledTableCell>
     </StyledTableRow>
   )
 }


### PR DESCRIPTION
## Description of change

Reduced summary table header left padding to accommodate long string title to make one line as requested by designer.

Reference jira ticket: https://uktrade.atlassian.net/browse/EGTB-1740

## Test instructions

Navigate into Export Project Interactions then project details.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/cb6b3178-9212-428a-abbe-62f297635847)

### After

![image](https://github.com/user-attachments/assets/98bf9b20-39df-42cd-bd55-a63b8078ec32)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
