### PR TITLE
Add upload file button

### DIFF
--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -41,13 +41,14 @@ const CollectionHeaderRow = ({
   children,
   ...rest
 }) => {
+  //
   return (
     <StyledRowWrapper primary={primary} {...rest}>
       {children}
-      {actions && (
-        <StyledActions>
-          {actionsList?.length ? actionsList : actions}
-        </StyledActions>
+      {actionsList?.length ? (
+        <StyledActions> {actionsList} </StyledActions>
+      ) : (
+        actions && <StyledActions> {actions} </StyledActions>
       )}
     </StyledRowWrapper>
   )

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -36,16 +36,24 @@ const CollectionHeaderRow = ({
   children,
   ...rest
 }) => {
-  // if (!actionsList) {
-  return (
-    <StyledRowWrapper primary={primary} {...rest}>
-      {children}
+  if (!actionsList) {
+    return (
+      <StyledRowWrapper primary={primary} {...rest}>
+        {children}
 
-      {actionsList && <StyledActions>{actionsList}</StyledActions>}
-      {actions && <StyledActions>{actions}</StyledActions>}
-    </StyledRowWrapper>
-  )
-  // }
+        {actions && <StyledActions>{actions}</StyledActions>}
+      </StyledRowWrapper>
+    )
+  } else {
+    return (
+      <StyledRowWrapper primary={primary} {...rest}>
+        {children}
+
+        {actionsList && <StyledActions>{actionsList[0]}</StyledActions>}
+        {actionsList && <StyledActions>{actionsList[1]}</StyledActions>}
+      </StyledRowWrapper>
+    )
+  }
 }
 
 CollectionHeaderRow.propTypes = {

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -29,14 +29,23 @@ const StyledActions = styled('div')`
   }
 `
 
-const CollectionHeaderRow = ({ primary, actions, children, ...rest }) => {
+const CollectionHeaderRow = ({
+  primary,
+  actions,
+  actionsList,
+  children,
+  ...rest
+}) => {
+  // if (!actionsList) {
   return (
     <StyledRowWrapper primary={primary} {...rest}>
       {children}
 
+      {actionsList && <StyledActions>{actionsList}</StyledActions>}
       {actions && <StyledActions>{actions}</StyledActions>}
     </StyledRowWrapper>
   )
+  // }
 }
 
 CollectionHeaderRow.propTypes = {

--- a/src/client/components/CollectionList/CollectionHeaderRow.jsx
+++ b/src/client/components/CollectionList/CollectionHeaderRow.jsx
@@ -19,6 +19,11 @@ const StyledActions = styled('div')`
   width: 100%;
   margin-top: ${SPACING.SCALE_2};
 
+  a {
+    margin-left: 10px;
+    white-space: nowrap;
+  }
+
   ${MEDIA_QUERIES.TABLET} {
     margin-top: 0;
     margin-left: ${SPACING.SCALE_1};
@@ -36,24 +41,16 @@ const CollectionHeaderRow = ({
   children,
   ...rest
 }) => {
-  if (!actionsList) {
-    return (
-      <StyledRowWrapper primary={primary} {...rest}>
-        {children}
-
-        {actions && <StyledActions>{actions}</StyledActions>}
-      </StyledRowWrapper>
-    )
-  } else {
-    return (
-      <StyledRowWrapper primary={primary} {...rest}>
-        {children}
-
-        {actionsList && <StyledActions>{actionsList[0]}</StyledActions>}
-        {actionsList && <StyledActions>{actionsList[1]}</StyledActions>}
-      </StyledRowWrapper>
-    )
-  }
+  return (
+    <StyledRowWrapper primary={primary} {...rest}>
+      {children}
+      {actions && (
+        <StyledActions>
+          {actionsList?.length ? actionsList : actions}
+        </StyledActions>
+      )}
+    </StyledRowWrapper>
+  )
 }
 
 CollectionHeaderRow.propTypes = {

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -98,7 +98,19 @@ function FilteredCollectionHeader({
   selectedFilters,
   hasFilters,
   useReactRouter = false,
+  addItemButtons = [],
 }) {
+  const actionsList = addItemButtons?.length > 0 && (
+    <Button
+      as={StyledReactRouterLink}
+      to={addItemButtons}
+      buttonColour={GREY_3}
+      buttonTextColour={BLACK}
+      data-test="add-collection-item-button"
+    >
+      Upload file
+    </Button>
+  )
   const formattedTotal = decimal(totalItems)
   const counterSuffix = pluralize(collectionName, totalItems)
   const actions =
@@ -129,7 +141,7 @@ function FilteredCollectionHeader({
 
   return (
     <CollectionHeaderRowContainer>
-      <CollectionHeaderRow actions={actions}>
+      <CollectionHeaderRow actions={actions} actionsList={actionsList}>
         <StyledDiv role="status">
           <StyledHeaderText>
             <StyledResultCount data-test="collectionCount">

--- a/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
+++ b/src/client/components/FilteredCollectionList/FilteredCollectionHeader.jsx
@@ -100,17 +100,21 @@ function FilteredCollectionHeader({
   useReactRouter = false,
   addItemButtons = [],
 }) {
-  const actionsList = addItemButtons?.length > 0 && (
-    <Button
-      as={StyledReactRouterLink}
-      to={addItemButtons}
-      buttonColour={GREY_3}
-      buttonTextColour={BLACK}
-      data-test="add-collection-item-button"
-    >
-      Upload file
-    </Button>
-  )
+  let actionsList = []
+  for (const actionsItem of addItemButtons) {
+    actionsList.push(
+      <Button
+        id={Math.random()}
+        as={StyledReactRouterLink}
+        to={actionsItem.url}
+        buttonColour={GREY_3}
+        buttonTextColour={BLACK}
+        data-test="add-collection-item-button"
+      >
+        {actionsItem.text}
+      </Button>
+    )
+  }
   const formattedTotal = decimal(totalItems)
   const counterSuffix = pluralize(collectionName, totalItems)
   const actions =

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -85,6 +85,7 @@ const FilteredCollectionList = ({
   entityName,
   entityNamePlural,
   addItemUrl,
+  addItemsButtons,
   defaultQueryParams,
   titleRenderer = null,
   sanitizeFiltersForAnalytics = null,
@@ -124,6 +125,7 @@ const FilteredCollectionList = ({
               selectedFilters={selectedFilters}
               addItemUrl={addItemUrl}
               useReactRouter={useReactRouter}
+              addItemsButtons={addItemsButtons}
             />
           )}
           {sortOptions && (

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -85,7 +85,7 @@ const FilteredCollectionList = ({
   entityName,
   entityNamePlural,
   addItemUrl,
-  addItemsButtons,
+  addItemButtons = [],
   defaultQueryParams,
   titleRenderer = null,
   sanitizeFiltersForAnalytics = null,
@@ -125,7 +125,7 @@ const FilteredCollectionList = ({
               selectedFilters={selectedFilters}
               addItemUrl={addItemUrl}
               useReactRouter={useReactRouter}
-              addItemsButtons={addItemsButtons}
+              addItemButtons={addItemButtons}
             />
           )}
           {sortOptions && (

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -72,6 +72,20 @@ const CompanyFilesCollection = ({
                   ? null
                   : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`
               }
+              addItemButtons={[
+                {
+                  text: 'Add SharePoint link',
+                  url: company.archived
+                    ? null
+                    : `/files/create?company=${company.id}`,
+                },
+                {
+                  text: 'Upload file',
+                  url: company.archived
+                    ? null
+                    : `/files/create?company=${company.id}`,
+                },
+              ]}
               entityName="file"
               defaultQueryParams={{
                 sortby: '-created_on',

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -73,12 +73,15 @@ const CompanyFilesCollection = ({
                   : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`
               }
               addItemButtons={[
-                {
-                  text: 'Upload file',
-                  url: company.archived
-                    ? null
-                    : `/files/create?company=${company.id}`,
-                },
+                // Un-comment when upload file screen has been implemented
+                /* eslint-disable */
+                // {
+                //   text: 'Upload file',
+                //   url: company.archived
+                //     ? null
+                //     : `/files/create?company=${company.id}`,
+                // },
+                /* eslint-enable */
                 {
                   text: 'Add SharePoint link',
                   url: company.archived

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -74,16 +74,16 @@ const CompanyFilesCollection = ({
               }
               addItemButtons={[
                 {
-                  text: 'Add SharePoint link',
-                  url: company.archived
-                    ? null
-                    : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`,
-                },
-                {
                   text: 'Upload file',
                   url: company.archived
                     ? null
                     : `/files/create?company=${company.id}`,
+                },
+                {
+                  text: 'Add SharePoint link',
+                  url: company.archived
+                    ? null
+                    : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`,
                 },
               ]}
               entityName="file"

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -77,7 +77,7 @@ const CompanyFilesCollection = ({
                   text: 'Add SharePoint link',
                   url: company.archived
                     ? null
-                    : `/files/create?company=${company.id}`,
+                    : `/files/create?related_object_id=${companyId}&related_object_type=${RELATED_OBJECT_TYPES.COMPANY}&document_type=${DOCUMENT_TYPES.SHAREPOINT.type}`,
                 },
                 {
                   text: 'Upload file',

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -22,7 +22,7 @@ describe('Generic Documents / Files Collections for company', () => {
   const apiUrl = `/api-proxy/v4/document/?related_object_id=${company.id}&limit=10&offset=0&sortby=-created_on`
 
   const company = companyFaker({
-    id: relatedObjectId,
+    id: '4cd4128b-1bad-4f1e-9146-5d4678c6a018',
     archived: true,
     archived_on: '2017-03-14T14:49:17',
     archived_by: 'Sam Smith',
@@ -57,10 +57,7 @@ describe('Generic Documents / Files Collections for company', () => {
   context('SharePoint header buttons', () => {
     it('if url not set, return page url', () => {
       // Should button not be shown if no url is set?
-      assertAddItemButton(
-        'Add SharePoint link',
-        companies.files(relatedObjectId)
-      )
+      assertAddItemButton('Add SharePoint link', companies.files(company.id))
     })
 
     it('should render the correct amount of buttons', () => {

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -4,6 +4,7 @@ import {
   assertSummaryCardTitle,
   assertSummaryCardLinks,
   assertSummaryCardList,
+  assertMultipleAddItemButtons,
 } from '../../support/collection-list-assertions'
 import { companies } from '../../../../../src/lib/urls'
 import {
@@ -39,6 +40,10 @@ describe('Generic Documents / Files Collections for company', () => {
 
   it('should display a list of generic documents / files', () => {
     assertListLength(genericDocumentsList)
+  })
+
+  it('should display multiple buttons', () => {
+    assertMultipleAddItemButtons('Upload file', 'Add SharePoint link')
   })
 
   context('SharePoint type documents / files', () => {

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -43,7 +43,7 @@ describe('Generic Documents / Files Collections for company', () => {
   })
 
   it('should display multiple buttons', () => {
-    assertMultipleAddItemButtons('Upload file', 'Add SharePoint link')
+    assertMultipleAddItemButtons(1)
   })
 
   context('SharePoint type documents / files', () => {

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -5,6 +5,7 @@ import {
   assertSummaryCardLinks,
   assertSummaryCardList,
   assertMultipleAddItemButtons,
+  assertMultipleAddItemButtonsText,
 } from '../../support/collection-list-assertions'
 import { companies } from '../../../../../src/lib/urls'
 import {
@@ -42,8 +43,12 @@ describe('Generic Documents / Files Collections for company', () => {
     assertListLength(genericDocumentsList)
   })
 
-  it('should display multiple buttons', () => {
+  it('should render the correct amount of buttons', () => {
     assertMultipleAddItemButtons(1)
+  })
+
+  it('should render buttons with the correct text', () => {
+    assertMultipleAddItemButtonsText(0, 'Add SharePoint link')
   })
 
   context('SharePoint type documents / files', () => {

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -18,9 +18,6 @@ import { companyFaker } from '../../fakers/companies'
 import { genericDocumentsListFaker } from '../../fakers/generic-documents'
 
 describe('Generic Documents / Files Collections for company', () => {
-  const genericDocumentsList = [...genericDocumentsListFaker(3)]
-  const apiUrl = `/api-proxy/v4/document/?related_object_id=${company.id}&limit=10&offset=0&sortby=-created_on`
-
   const company = companyFaker({
     id: '4cd4128b-1bad-4f1e-9146-5d4678c6a018',
     archived: true,
@@ -28,6 +25,8 @@ describe('Generic Documents / Files Collections for company', () => {
     archived_by: 'Sam Smith',
     archived_reason: 'Left job',
   })
+  const genericDocumentsList = [...genericDocumentsListFaker(3)]
+  const apiUrl = `/api-proxy/v4/document/?related_object_id=${company.id}&limit=10&offset=0&sortby=-created_on`
 
   // Helper function to intercept the API request
   const interceptApiRequest = () => {

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -42,11 +42,10 @@ const assertAddItemButtonNotPresent = () => {
   cy.get('[data-test="add-collection-item-button"]').should('not.exist')
 }
 
-const assertMultipleAddItemButtons = (buttonText) => {
+const assertMultipleAddItemButtons = (buttonLength) => {
   cy.get('[data-test="add-collection-item-button"]')
-    .should('have.length.greaterThan', 0)
     .should('exist')
-    .should('contain', buttonText)
+    .should('have.length', buttonLength)
 }
 
 const assertBadge = (item, badgeText) => {

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -42,6 +42,13 @@ const assertAddItemButtonNotPresent = () => {
   cy.get('[data-test="add-collection-item-button"]').should('not.exist')
 }
 
+const assertMultipleAddItemButtons = (buttonText) => {
+  cy.get('[data-test="add-collection-item-button"]')
+    .should('have.length.greaterThan', 0)
+    .should('exist')
+    .should('contain', buttonText)
+}
+
 const assertBadge = (item, badgeText) => {
   cy.get(item).find('[data-test="badge"]').should('contain', badgeText)
 }
@@ -220,4 +227,5 @@ module.exports = {
   assertSummaryCardTitle,
   assertSummaryCardLinks,
   assertSummaryCardList,
+  assertMultipleAddItemButtons,
 }

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -48,6 +48,12 @@ const assertMultipleAddItemButtons = (buttonLength) => {
     .should('have.length', buttonLength)
 }
 
+const assertMultipleAddItemButtonsText = (index, buttonText) => {
+  cy.get('[data-test="add-collection-item-button"]')
+    .eq(index)
+    .should('contain.text', buttonText)
+}
+
 const assertBadge = (item, badgeText) => {
   cy.get(item).find('[data-test="badge"]').should('contain', badgeText)
 }
@@ -227,4 +233,5 @@ module.exports = {
   assertSummaryCardLinks,
   assertSummaryCardList,
   assertMultipleAddItemButtons,
+  assertMultipleAddItemButtonsText,
 }


### PR DESCRIPTION
## Description of change

An 'Upload file' button has been added to the header in the 'Files' tab within a company. This change also extends the current collection header component to support multiple buttons. The button will be hidden until an upload link screen has been implemented. 

## Test instructions

_What should I see?_

## Screenshots

### Before
<img width="1040" alt="Screenshot 2025-03-25 at 14 25 15" src="https://github.com/user-attachments/assets/38b19eae-c946-4a1f-ba88-b798b6282559" />


### After
<img width="1014" alt="Screenshot 2025-03-25 at 14 25 32" src="https://github.com/user-attachments/assets/5e650c17-b2ed-46f8-b09e-b3b53167772b" />


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
