### PR TITLE
Add service interaction hint.

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepCompanyExportInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepCompanyExportInteractionType.jsx
@@ -1,10 +1,12 @@
 import React, { useEffect } from 'react'
 import { useLocation } from 'react-router-dom'
+import InsetText from '@govuk-react/inset-text'
 import { omitBy, isUndefined } from 'lodash'
 
 import { useFormContext } from '../../../../../client/components/Form/hooks'
-import { FieldRadios } from '../../../../../client/components'
-import { KINDS } from '../../../constants'
+import { FieldRadios, NewWindowLink } from '../../../../../client/components'
+import { THEMES, KINDS } from '../../../constants'
+import urls from '../../../../../lib/urls'
 
 const StepCompanyExportInteractionType = () => {
   const { resetFields, getFieldState } = useFormContext()
@@ -31,21 +33,48 @@ const StepCompanyExportInteractionType = () => {
 
   return (
     <>
+      <InsetText data-test="trade-agreement-guide">
+        Select 'trade agreement' if your interaction deals with a named trade
+        agreement.
+        <br />
+        <br />
+        For more information see{' '}
+        <NewWindowLink href={urls.external.helpCentre.tradeAgreementGuidance}>
+          recording trade agreement activity
+        </NewWindowLink>
+        .{' '}
+      </InsetText>
+
       <FieldRadios
-        label="What would you like to record?"
-        name="kind"
-        dataTestPrefix="export"
+        name="theme"
+        label="What is this regarding?"
         required="Select interaction type"
+        initialValue={THEMES.EXPORT}
+        data-test="field-theme"
         options={[
           {
-            label: 'A standard interaction',
-            hint: 'For example, an email, phone call or meeting',
-            value: KINDS.INTERACTION,
-          },
-          {
-            label: 'A service you have provided',
-            hint: 'For example, a significant assist or event',
-            value: KINDS.SERVICE_DELIVERY,
+            label: 'Export',
+            value: THEMES.EXPORT,
+            children: (
+              <FieldRadios
+                label="What would you like to record?"
+                name="kind"
+                dataTestPrefix="export"
+                required="Select interaction type"
+                options={[
+                  {
+                    label: 'A standard interaction',
+                    hint: 'For example, an email, phone call or meeting',
+                    value: KINDS.INTERACTION,
+                  },
+                  {
+                    label: 'A service you have provided',
+                    hint: 'For example, a significant assist or event',
+                    value: KINDS.SERVICE_DELIVERY,
+                  },
+                ]}
+              />
+            ),
           },
         ]}
       />

--- a/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/export-project-interaction-spec.js
@@ -147,9 +147,14 @@ describe('Create Export project interaction', () => {
     })
 
     it('should offer selection of interaction or service delivery only', () => {
-      cy.get('[data-test="field-kind"]')
-        .should('contain', 'What would you like to record?')
-        .should('not.contain', 'What is this regarding?')
+      cy.get('[data-test="field-theme"]')
+        .should('contain', 'What is this regarding?')
+        .should('contain', 'Export')
+        .should('not.contain', 'Investment')
+      cy.get('[data-test="field-kind"]').should(
+        'contain',
+        'What would you like to record?'
+      )
     })
 
     it('should continue to second page and add interaction', () => {


### PR DESCRIPTION
## Description of change

This adds service interaction hint text to add company export interaction's form first step.

## Test instructions

Go to company export's interactions section and click "Add interaction".

## Screenshots

### Before

<img width="904" alt="Screenshot 2025-03-26 at 09 25 16" src="https://github.com/user-attachments/assets/10f91fde-2379-42b5-9785-3e74bab1f0da" />

### After

<img width="867" alt="Screenshot 2025-03-26 at 09 25 42" src="https://github.com/user-attachments/assets/469021e6-d40a-4eeb-ac5c-6192acf7b843" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
