### PR TITLE
Reduced metadata line spacing bottom margin

### DIFF
--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+import { FONT_SIZE } from '@govuk-react/constants'
 
 import MetadataItem from './MetadataItem'
 
@@ -11,7 +11,7 @@ const StyledMetadataWrapper = styled('div')`
   display: grid;
 
   & > * {
-    margin-bottom: ${SPACING.SCALE_1};
+    margin-bottom: 0px;
   }
 `
 


### PR DESCRIPTION
## Description of change

Reduced metadata line spacing at Export Project Interaction list, as requested by designer.

Reference jira ticket: https://uktrade.atlassian.net/browse/EGTB-1741

## Test instructions

Navigate into Export Project Interaction list, it will shown the list of related interactions for the project. From the list of interactions, it show the summary details.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/5df665a6-47a5-4e09-8298-5f9e361fd0f0)

### After

![image](https://github.com/user-attachments/assets/f38dfb82-e534-4346-b1d2-209fad631062)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
