### PR TITLE
CPS-704-Update service link to interaction

### DIFF
--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -46,7 +46,13 @@ const Attendees = ({ eventId, isDisabled }) => (
       {(page) => (
         <ul>
           {page.map(
-            ({ contacts: [contact], companies: [company], date, service }) => (
+            ({
+              id,
+              contacts: [contact],
+              companies: [company],
+              date,
+              service,
+            }) => (
               <CollectionItem
                 headingText={contact?.name || 'Not available'}
                 headingUrl={contact && `/contacts/${contact?.id}`}
@@ -70,9 +76,7 @@ const Attendees = ({ eventId, isDisabled }) => (
                   {
                     label: 'Service delivery',
                     value: (
-                      <Link href={`/companies/${service.id}`}>
-                        {service.name}
-                      </Link>
+                      <Link href={`/interactions/${id}`}>{service.name}</Link>
                     ),
                   },
                 ]}


### PR DESCRIPTION
## Description of change

This is to fix the link that is not working in the event attendee list page.
see story for more details [CPS-704](https://uktrade.atlassian.net/browse/CPS-704)

## Test instructions

_What should I see?_

## Screenshots

### Before
Currently when you click on the link (as highlighted in the image below)
![image](https://github.com/user-attachments/assets/1359cdfc-4aa5-4dc7-8a5e-2619c9dc6c5e)

You will be redirected to incorrect company page
![image](https://github.com/user-attachments/assets/0dcb4703-31f7-4a8a-9a82-e9f639db65eb)

### After
When you click the link, it should bring you to the relevant in interaction page

https://github.com/user-attachments/assets/e4d8ba98-f20a-4d25-8311-5d82056bed1b

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)


[CPS-704]: https://uktrade.atlassian.net/browse/CPS-704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ