### PR TITLE
Make the Number of new jobs field optional for Expansion projects with no involvement

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -59,362 +59,371 @@ const EditProjectValue = () => {
       pageTitle="Edit value"
     >
       <InvestmentResource id={projectId}>
-        {(project) => (
-          <>
-            <H2 size={LEVEL_SIZE[3]}>Edit value</H2>
-            <Form
-              id="edit-project-value"
-              analyticsFormName="editInvestmentProjectValue"
-              cancelButtonLabel="Back"
-              cancelRedirectTo={() =>
-                urls.investments.projects.details(project.id)
-              }
-              flashMessage={() => 'Investment value updated'}
-              submitButtonlabel="Save"
-              redirectTo={() => urls.investments.projects.details(project.id)}
-              submissionTaskName={TASK_EDIT_INVESTMENT_PROJECT_VALUE}
-              transformPayload={(values) =>
-                transformProjectValueForApi({
-                  projectId,
-                  values,
-                  fdiTypeId: project.fdiType?.id,
-                })
-              }
-            >
-              <FieldRadios
-                name="client_cannot_provide_total_investment"
-                label={
-                  'Can client provide total investment value?' +
-                  isFieldOptionalForStageLabel(
-                    'client_cannot_provide_total_investment',
-                    project
-                  )
+        {(project) => {
+          const isExpansion =
+            project.fdiType?.name === 'Expansion of existing site or activity'
+
+          const isNumberNewJobsRequired =
+            isExpansion && project.levelOfInvolvement
+
+          return (
+            <>
+              <H2 size={LEVEL_SIZE[3]}>Edit value</H2>
+              <Form
+                id="edit-project-value"
+                analyticsFormName="editInvestmentProjectValue"
+                cancelButtonLabel="Back"
+                cancelRedirectTo={() =>
+                  urls.investments.projects.details(project.id)
                 }
-                hint="Includes capital, operational and R&D expenditure"
-                initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
-                  project.clientCannotProvideTotalInvestment
-                )}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether client can provide total investment value'
-                  )
-                }}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                  ...(option.value === OPTION_YES && {
-                    children: (
-                      <FieldCurrency
-                        name="total_investment"
-                        label={
-                          'Total investment' +
-                          isFieldOptionalForStageLabel(
-                            'total_investment',
-                            project
-                          )
-                        }
-                        hint="Enter the total number of GB pounds"
-                        initialValue={project.totalInvestment}
-                        type="text"
-                        required="Enter the total investment"
-                        validate={(value, field, formFields) => {
-                          const result = validateFieldForStage(
-                            field,
-                            formFields,
-                            project,
-                            'Value for number of new jobs is required'
-                          )
-                          return result
-                            ? result
-                            : totalInvestmentValidator(
-                                value,
-                                formFields.values.foreign_equity_investment
-                              )
-                        }}
-                      />
-                    ),
-                  }),
-                }))}
-              />
-              <FieldRadios
-                name="client_cannot_provide_foreign_investment"
-                label={
-                  'Can client provide capital expenditure value?' +
-                  isFieldOptionalForStageLabel(
-                    'client_cannot_provide_foreign_investment',
-                    project
-                  )
+                flashMessage={() => 'Investment value updated'}
+                submitButtonlabel="Save"
+                redirectTo={() => urls.investments.projects.details(project.id)}
+                submissionTaskName={TASK_EDIT_INVESTMENT_PROJECT_VALUE}
+                transformPayload={(values) =>
+                  transformProjectValueForApi({
+                    projectId,
+                    values,
+                    fdiTypeId: project.fdiType?.id,
+                  })
                 }
-                hint="Foreign equity only, excluding operational and R&D expenditure"
-                initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
-                  project.clientCannotProvideForeignInvestment
-                )}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether client can provide capital expenditure value'
-                  )
-                }}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                  ...(option.value === OPTION_YES && {
-                    children: (
-                      <>
+              >
+                <FieldRadios
+                  name="client_cannot_provide_total_investment"
+                  label={
+                    'Can client provide total investment value?' +
+                    isFieldOptionalForStageLabel(
+                      'client_cannot_provide_total_investment',
+                      project
+                    )
+                  }
+                  hint="Includes capital, operational and R&D expenditure"
+                  initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
+                    project.clientCannotProvideTotalInvestment
+                  )}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether client can provide total investment value'
+                    )
+                  }}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                    ...(option.value === OPTION_YES && {
+                      children: (
                         <FieldCurrency
-                          name="foreign_equity_investment"
-                          label="Capital expenditure value"
+                          name="total_investment"
+                          label={
+                            'Total investment' +
+                            isFieldOptionalForStageLabel(
+                              'total_investment',
+                              project
+                            )
+                          }
                           hint="Enter the total number of GB pounds"
-                          initialValue={project.foreignEquityInvestment}
+                          initialValue={project.totalInvestment}
                           type="text"
-                          required="Enter the capital expenditure"
-                          validate={(value) => {
-                            return project.fdiType?.name === 'Capital only'
-                              ? capitalExpenditureValidator(value)
-                              : null
+                          required="Enter the total investment"
+                          validate={(value, field, formFields) => {
+                            const result = validateFieldForStage(
+                              field,
+                              formFields,
+                              project,
+                              'Value for number of new jobs is required'
+                            )
+                            return result
+                              ? result
+                              : totalInvestmentValidator(
+                                  value,
+                                  formFields.values.foreign_equity_investment
+                                )
                           }}
                         />
-                        {project.investmentType.name === 'FDI' &&
-                          project.gvaMultiplier
-                            ?.sectorClassificationGvaMultiplier ===
-                            'capital' && (
-                            <FieldUneditable
-                              label="Gross value added (GVA)"
-                              name="gross_value_added_capital"
-                            >
-                              <>
-                                {project.grossValueAdded
-                                  ? currencyGBP(project.grossValueAdded)
-                                  : setGVAMessage(project)}
-                              </>
-                            </FieldUneditable>
-                          )}
-                      </>
-                    ),
-                  }),
-                }))}
-              />
-              {project.fdiType?.name === 'Capital only' ? null : (
-                <>
-                  <FieldInput
-                    label={
-                      'Number of new jobs' +
-                      isFieldOptionalForStageLabel('number_new_jobs', project)
-                    }
-                    name="number_new_jobs"
-                    type="number"
-                    required={
-                      project.fdiType?.name ===
-                        'Expansion of existing site or activity' &&
-                      'Value for number of new jobs is required'
-                    }
-                    hint={
-                      project.fdiType?.name ===
-                        'Expansion of existing site or activity' &&
-                      'An expansion project must always have at least 1 new job'
-                    }
-                    validate={(value, field, formFields) => {
-                      let result = validateFieldForStage(
-                        field,
-                        formFields,
-                        project,
-                        'Value for number of new jobs is required'
-                      )
-                      return project.fdiType?.name ===
-                        'Expansion of existing site or activity' && value < 1
-                        ? 'Number of new jobs must be greater than 0'
-                        : result
-                    }}
-                    initialValue={project.numberNewJobs?.toString()}
-                  />
-                  {project.investmentType.name === 'FDI' &&
-                    project.gvaMultiplier?.sectorClassificationGvaMultiplier ===
-                      'labour' && (
-                      <FieldUneditable
-                        label="Gross value added (GVA)"
-                        name="gross_value_added_labour"
-                      >
+                      ),
+                    }),
+                  }))}
+                />
+                <FieldRadios
+                  name="client_cannot_provide_foreign_investment"
+                  label={
+                    'Can client provide capital expenditure value?' +
+                    isFieldOptionalForStageLabel(
+                      'client_cannot_provide_foreign_investment',
+                      project
+                    )
+                  }
+                  hint="Foreign equity only, excluding operational and R&D expenditure"
+                  initialValue={transformBoolToInvertedRadioOptionWithNullCheck(
+                    project.clientCannotProvideForeignInvestment
+                  )}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether client can provide capital expenditure value'
+                    )
+                  }}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                    ...(option.value === OPTION_YES && {
+                      children: (
                         <>
-                          {project.grossValueAdded
-                            ? currencyGBP(project.grossValueAdded)
-                            : setGVAMessage(project)}
+                          <FieldCurrency
+                            name="foreign_equity_investment"
+                            label="Capital expenditure value"
+                            hint="Enter the total number of GB pounds"
+                            initialValue={project.foreignEquityInvestment}
+                            type="text"
+                            required="Enter the capital expenditure"
+                            validate={(value) => {
+                              return project.fdiType?.name === 'Capital only'
+                                ? capitalExpenditureValidator(value)
+                                : null
+                            }}
+                          />
+                          {project.investmentType.name === 'FDI' &&
+                            project.gvaMultiplier
+                              ?.sectorClassificationGvaMultiplier ===
+                              'capital' && (
+                              <FieldUneditable
+                                label="Gross value added (GVA)"
+                                name="gross_value_added_capital"
+                              >
+                                <>
+                                  {project.grossValueAdded
+                                    ? currencyGBP(project.grossValueAdded)
+                                    : setGVAMessage(project)}
+                                </>
+                              </FieldUneditable>
+                            )}
                         </>
-                      </FieldUneditable>
-                    )}
-                  <ResourceOptionsField
-                    name="average_salary"
-                    label={
-                      'Average salary of new jobs' +
-                      isFieldOptionalForStageLabel('average_salary', project)
-                    }
-                    resource={SalaryRangeResource}
-                    field={FieldRadios}
-                    initialValue={project.averageSalary?.id}
-                    resultToOptions={(result) =>
-                      idNamesToValueLabels(
-                        result.filter((option) =>
-                          option.disabledOn
-                            ? new Date(option.disabledOn) >
-                              new Date(project.createdOn)
-                            : true
+                      ),
+                    }),
+                  }))}
+                />
+                {project.fdiType?.name === 'Capital only' ? null : (
+                  <>
+                    <FieldInput
+                      label={
+                        'Number of new jobs' +
+                        (project.levelOfInvolvement === null && isExpansion
+                          ? ' (optional)'
+                          : isFieldOptionalForStageLabel(
+                              'number_new_jobs',
+                              project
+                            ))
+                      }
+                      name="number_new_jobs"
+                      type="number"
+                      {...(isNumberNewJobsRequired && {
+                        required: 'Value for number of new jobs is required',
+                        hint: 'An expansion project must always have at least 1 new job',
+                      })}
+                      validate={(value, field, formFields) => {
+                        let result = validateFieldForStage(
+                          field,
+                          formFields,
+                          project,
+                          'Value for number of new jobs is required'
                         )
-                      )
-                    }
-                    validate={(values, field, formFields) => {
-                      return validateFieldForStage(
-                        field,
-                        formFields,
-                        project,
-                        'Value for average salary of new jobs is required'
-                      )
-                    }}
-                  />
-                  <FieldInput
-                    name="number_safeguarded_jobs"
-                    label={
-                      'Number of safeguarded jobs' +
-                      isFieldOptionalForStageLabel(
-                        'number_safeguarded_jobs',
-                        project
-                      )
-                    }
-                    type="number"
-                    initialValue={project.numberSafeguardedJobs?.toString()}
-                    validate={(values, field, formFields) => {
-                      return validateFieldForStage(
-                        field,
-                        formFields,
-                        project,
-                        'Value for number of safeguarded jobs is required'
-                      )
-                    }}
-                  />
-                </>
-              )}
-              {showFDIValueField(project) &&
-                project.investmentType.name === 'FDI' && (
-                  <ResourceOptionsField
-                    name="fdi_value"
-                    label="Project value"
-                    resource={FDIValuesResource}
-                    field={FieldRadios}
-                    initialValue={project.fdiValue?.id}
-                  />
+                        return isNumberNewJobsRequired && value < 1
+                          ? 'Number of new jobs must be greater than 0'
+                          : result
+                      }}
+                      initialValue={project.numberNewJobs}
+                    />
+                    {project.investmentType.name === 'FDI' &&
+                      project.gvaMultiplier
+                        ?.sectorClassificationGvaMultiplier === 'labour' && (
+                        <FieldUneditable
+                          label="Gross value added (GVA)"
+                          name="gross_value_added_labour"
+                        >
+                          <>
+                            {project.grossValueAdded
+                              ? currencyGBP(project.grossValueAdded)
+                              : setGVAMessage(project)}
+                          </>
+                        </FieldUneditable>
+                      )}
+                    <ResourceOptionsField
+                      name="average_salary"
+                      label={
+                        'Average salary of new jobs' +
+                        isFieldOptionalForStageLabel('average_salary', project)
+                      }
+                      resource={SalaryRangeResource}
+                      field={FieldRadios}
+                      initialValue={project.averageSalary?.id}
+                      resultToOptions={(result) =>
+                        idNamesToValueLabels(
+                          result.filter((option) =>
+                            option.disabledOn
+                              ? new Date(option.disabledOn) >
+                                new Date(project.createdOn)
+                              : true
+                          )
+                        )
+                      }
+                      validate={(values, field, formFields) => {
+                        return validateFieldForStage(
+                          field,
+                          formFields,
+                          project,
+                          'Value for average salary of new jobs is required'
+                        )
+                      }}
+                    />
+                    <FieldInput
+                      name="number_safeguarded_jobs"
+                      label={
+                        'Number of safeguarded jobs' +
+                        isFieldOptionalForStageLabel(
+                          'number_safeguarded_jobs',
+                          project
+                        )
+                      }
+                      type="number"
+                      initialValue={project.numberSafeguardedJobs?.toString()}
+                      validate={(values, field, formFields) => {
+                        return validateFieldForStage(
+                          field,
+                          formFields,
+                          project,
+                          'Value for number of safeguarded jobs is required'
+                        )
+                      }}
+                    />
+                  </>
                 )}
-              <FieldRadios
-                name="government_assistance"
-                label={
-                  'Is this project receiving government financial assistance?' +
-                  isFieldOptionalForStageLabel('government_assistance', project)
-                }
-                initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.governmentAssistance
-                )}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                }))}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether project receives government financial assitance'
-                  )
-                }}
-              />
-              <FieldRadios
-                name="r_and_d_budget"
-                label={
-                  'Does this project have budget for research and development?' +
-                  isFieldOptionalForStageLabel('r_and_d_budget', project)
-                }
-                initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.rAndDBudget
-                )}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                }))}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether project has budget for research and development'
-                  )
-                }}
-              />
-              <FieldRadios
-                name="non_fdi_r_and_d_budget"
-                label={
-                  'Is this project associated with a non-FDI R&D project?' +
-                  isFieldOptionalForStageLabel(
-                    'non_fdi_r_and_d_budget',
-                    project
-                  )
-                }
-                initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.nonFdiRAndDBudget
-                )}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                }))}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether the project is associated with a non-FDI R&D project'
-                  )
-                }}
-              />
-              <FieldRadios
-                name="new_tech_to_uk"
-                label={
-                  'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?' +
-                  isFieldOptionalForStageLabel('new_tech_to_uk', project)
-                }
-                initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.newTechToUk
-                )}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                }))}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select whether project brings new technology to the UK'
-                  )
-                }}
-              />
-              <FieldRadios
-                name="export_revenue"
-                label={
-                  'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?' +
-                  isFieldOptionalForStageLabel('export_revenue', project)
-                }
-                initialValue={transformBoolToRadioOptionWithNullCheck(
-                  project.exportRevenue
-                )}
-                options={OPTIONS_YES_NO.map((option) => ({
-                  ...option,
-                }))}
-                validate={(values, field, formFields) => {
-                  return validateFieldForStage(
-                    field,
-                    formFields,
-                    project,
-                    'Select export revenue as a result of the FDI project'
-                  )
-                }}
-              />
-            </Form>
-          </>
-        )}
+                {showFDIValueField(project) &&
+                  project.investmentType.name === 'FDI' && (
+                    <ResourceOptionsField
+                      name="fdi_value"
+                      label="Project value"
+                      resource={FDIValuesResource}
+                      field={FieldRadios}
+                      initialValue={project.fdiValue?.id}
+                    />
+                  )}
+                <FieldRadios
+                  name="government_assistance"
+                  label={
+                    'Is this project receiving government financial assistance?' +
+                    isFieldOptionalForStageLabel(
+                      'government_assistance',
+                      project
+                    )
+                  }
+                  initialValue={transformBoolToRadioOptionWithNullCheck(
+                    project.governmentAssistance
+                  )}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                  }))}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether project receives government financial assitance'
+                    )
+                  }}
+                />
+                <FieldRadios
+                  name="r_and_d_budget"
+                  label={
+                    'Does this project have budget for research and development?' +
+                    isFieldOptionalForStageLabel('r_and_d_budget', project)
+                  }
+                  initialValue={transformBoolToRadioOptionWithNullCheck(
+                    project.rAndDBudget
+                  )}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                  }))}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether project has budget for research and development'
+                    )
+                  }}
+                />
+                <FieldRadios
+                  name="non_fdi_r_and_d_budget"
+                  label={
+                    'Is this project associated with a non-FDI R&D project?' +
+                    isFieldOptionalForStageLabel(
+                      'non_fdi_r_and_d_budget',
+                      project
+                    )
+                  }
+                  initialValue={transformBoolToRadioOptionWithNullCheck(
+                    project.nonFdiRAndDBudget
+                  )}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                  }))}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether the project is associated with a non-FDI R&D project'
+                    )
+                  }}
+                />
+                <FieldRadios
+                  name="new_tech_to_uk"
+                  label={
+                    'Does the project bring ‘New To World’ Technology, IP or Business Model to the UK site?' +
+                    isFieldOptionalForStageLabel('new_tech_to_uk', project)
+                  }
+                  initialValue={transformBoolToRadioOptionWithNullCheck(
+                    project.newTechToUk
+                  )}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                  }))}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select whether project brings new technology to the UK'
+                    )
+                  }}
+                />
+                <FieldRadios
+                  name="export_revenue"
+                  label={
+                    'Will the UK company export a significant proportion of their products and services produced in the UK as a result of the FDI project?' +
+                    isFieldOptionalForStageLabel('export_revenue', project)
+                  }
+                  initialValue={transformBoolToRadioOptionWithNullCheck(
+                    project.exportRevenue
+                  )}
+                  options={OPTIONS_YES_NO.map((option) => ({
+                    ...option,
+                  }))}
+                  validate={(values, field, formFields) => {
+                    return validateFieldForStage(
+                      field,
+                      formFields,
+                      project,
+                      'Select export revenue as a result of the FDI project'
+                    )
+                  }}
+                />
+              </Form>
+            </>
+          )
+        }}
       </InvestmentResource>
     </ProjectLayoutNew>
   )


### PR DESCRIPTION
## Description of change

Make the Number of new jobs field optional for Expansion projects with no involvement.

## Test instructions

1. Create a new _investment project_ with
    * _Investment type_ = _FDI -> Expansion of existing site or activity_ and
    * _Level of investor involvement_ = _No Involvement_
    Or find an existing project with the above properties and grab its ID
2. Navigate to `/investments/projects/{project-id}/edit-value`
4. There should be a _Number of new jobs (optional)_ field
5. You should be able to leave the field empty or put `0` into it as a value
6. Upon submitting the form, there should be no form error related to that field
7. Change the _Level of investor involvement_ of the project to any value other than _No Involvement_
8. Now the field should be required and have a label _Number of new jobs (required)_
9. If you leave the field empty or put `0` into it as a value and submit the form
10. You should see a form error related to the field saying that the field is required or that the value must not be `0`

