### PR TITLE
Accessibility changes in create events journey

### DIFF
--- a/src/client/modules/Events/EventDetails/index.jsx
+++ b/src/client/modules/Events/EventDetails/index.jsx
@@ -171,7 +171,7 @@ const EventDetails = ({ name, ...props }) => {
       {({ flashMessages }) => (
         <DefaultLayout
           heading={name}
-          pageTitle="Events"
+          pageTitle={`Details - ${name} - Events`}
           flashMessages={{
             ...flashMessages,
             info: [

--- a/src/client/modules/Events/EventForm/EventFormFields.jsx
+++ b/src/client/modules/Events/EventForm/EventFormFields.jsx
@@ -28,13 +28,11 @@ export const EventFormFields = ({ values }) => (
         <Link
           href={urls.external.helpCentre.tradeAgreementGuidance}
           target="_blank"
-          aria-label="This will open in a new window"
+          aria-label="more information (opens in a new tab)"
         >
-          more information
+          more information (opens in a new tab)
         </Link>{' '}
         about selecting trade agreements.
-        <br />
-        This will open in a new window.
       </p>
     </article>
     <FieldRadios

--- a/src/client/modules/Events/EventForm/index.jsx
+++ b/src/client/modules/Events/EventForm/index.jsx
@@ -43,7 +43,7 @@ const EventForm = () => {
   return (
     <DefaultLayout
       heading={id ? DISPLAY_EDIT_EVENT : DISPLAY_ADD_EVENT}
-      pageTitle={id ? DISPLAY_EDIT_EVENT : DISPLAY_ADD_EVENT}
+      pageTitle={`${id ? DISPLAY_EDIT_EVENT : DISPLAY_ADD_EVENT} - Events`}
       breadcrumbs={breadcrumbs}
       useReactRouter={true}
     >

--- a/test/functional/cypress/specs/events/create-spec.js
+++ b/test/functional/cypress/specs/events/create-spec.js
@@ -42,6 +42,10 @@ describe('Event create', () => {
     assertLocalHeader('Add event')
   })
 
+  it('should render a meta title', () => {
+    cy.title().should('eq', 'Add event - Events - DBT Data Hub')
+  })
+
   it('should render add event breadcrumb', () => {
     assertBreadcrumbs({
       Home: '/',

--- a/test/functional/cypress/specs/events/details-spec.js
+++ b/test/functional/cypress/specs/events/details-spec.js
@@ -43,6 +43,11 @@ describe('Event Details', () => {
       'href',
       urls.events.edit(fixtures.event.oneDayExhibition.id)
     )
+
+    cy.title().should(
+      'eq',
+      'Details - One-day exhibition - Events - DBT Data Hub'
+    )
   })
 
   it('should display one day event details with no teams', () => {

--- a/test/functional/cypress/specs/events/edit-spec.js
+++ b/test/functional/cypress/specs/events/edit-spec.js
@@ -33,6 +33,10 @@ describe('Event edit', () => {
     })
   })
 
+  it('should render a meta title', () => {
+    cy.title().should('eq', 'Edit event - Events - DBT Data Hub')
+  })
+
   context('when loading in a valid event form', () => {
     it('should render expected form fields with original values ', () => {
       cy.wait('@getEventHttpRequest')

--- a/test/functional/cypress/support/event-assertions.js
+++ b/test/functional/cypress/support/event-assertions.js
@@ -16,7 +16,7 @@ const assertTradeAgreementArticle = (articleElement) => {
     .parent()
     .contains('Select a trade agreement and then a related event.')
   assertTextVisible(
-    'Find more information about selecting trade agreements.This will open in a new window'
+    'Find more information (opens in a new tab) about selecting trade agreements.'
   )
   cy.contains('more information')
     .should('have.attr', 'href')
@@ -27,7 +27,7 @@ const assertTradeAgreementArticle = (articleElement) => {
   cy.contains('more information').should(
     'have.attr',
     'aria-label',
-    'This will open in a new window'
+    'more information (opens in a new tab)'
   )
 }
 


### PR DESCRIPTION
## Description of change

Some small changes to the create events journey following the accessibility audit:
* More information link text and aria-label updated to be more accessible for those using screen readers
* Titles have been updated according to recommendations - "Every page title must be its breadcrumbs in reverse order with DBT Data Hub replacing Home" (changes applied to "Add event", "Update event" and "Event Details" pages)

## Test instructions
1. On the Events page, click "Add event"
2. You will see that the title reflects the breadcrumb structure in reverse order
3. You will also see new wording for the 'more information' link
4. Create an event in the form and click through to see event details
5. You will see this title also reflects the breadcrumb structure in reverse order

_What should I see?_

## Screenshots

### Before
![Screenshot 2025-04-03 at 14 32 26](https://github.com/user-attachments/assets/a596f587-cc10-464d-aa0d-658d023972d9)


<img width="312" alt="Screenshot 2025-04-03 at 14 29 34" src="https://github.com/user-attachments/assets/f147a8a0-0bec-4b1f-a1cb-c3f98aa34354" />

### After
![Screenshot 2025-04-03 at 14 32 41](https://github.com/user-attachments/assets/e45c894d-139f-4ea5-94df-6e1d81aad68c)

<img width="277" alt="Screenshot 2025-04-03 at 14 25 09" src="https://github.com/user-attachments/assets/c947fb6e-7069-4299-a205-545214b3d5f6" />


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
