### PR TITLE
Fix delete URL in file list item

### DIFF
--- a/src/client/components/CompanyTabbedLocalNavigation/constants.js
+++ b/src/client/components/CompanyTabbedLocalNavigation/constants.js
@@ -30,7 +30,7 @@ export const localNavItems = (companyId) => {
     },
     {
       path: 'files',
-      url: urls.companies.files(companyId),
+      url: urls.companies.files.index(companyId),
       label: 'Files',
       ariaDescription: 'Files',
     },

--- a/src/client/modules/Files/CollectionList/transformers.js
+++ b/src/client/modules/Files/CollectionList/transformers.js
@@ -29,7 +29,7 @@ export const transformFileToListItem = () => (file) => {
         },
         {
           text: 'Delete',
-          url: `files/${file.id}/delete?related_object_id=${file.related_object_id}&related_object_type=${file.related_object_type}&document_type=${file.document_type}`,
+          url: `/files/${file.id}/delete?related_object_id=${file.related_object_id}&related_object_type=${file.related_object_type}&document_type=${file.document_type}`,
         }
       )
 

--- a/src/client/modules/Files/CollectionList/transformers.js
+++ b/src/client/modules/Files/CollectionList/transformers.js
@@ -3,6 +3,7 @@ import {
   DATE_FORMAT_MEDIUM_WITH_TIME,
 } from '../../../utils/date-utils'
 import { DOCUMENT_TYPES } from './constants'
+import urls from '../../../../lib/urls'
 
 export const transformFileToListItem = () => (file) => {
   let title = ''
@@ -29,7 +30,7 @@ export const transformFileToListItem = () => (file) => {
         },
         {
           text: 'Delete',
-          url: `/files/${file.id}/delete?related_object_id=${file.related_object_id}&related_object_type=${file.related_object_type}&document_type=${file.document_type}`,
+          url: `${urls.companies.files.delete(file.id)}?related_object_id=${file.related_object_id}&related_object_type=${file.related_object_type}&document_type=${file.document_type}`,
         }
       )
 

--- a/src/client/modules/Files/CreateFile/CreateFile.jsx
+++ b/src/client/modules/Files/CreateFile/CreateFile.jsx
@@ -41,11 +41,11 @@ const SharePointForm = ({ relatedObjectId }) => {
       id="add-sharepoint-link-form"
       submissionTaskName={TASK_CREATE_FILE}
       analyticsFormName="addSharePointLink"
-      redirectTo={() => urls.companies.files(relatedObjectId)}
+      redirectTo={() => urls.companies.files.index(relatedObjectId)}
       flashMessage={() => 'SharePoint link added successfully'}
       submitButtonLabel="Add SharePoint link"
       cancelButtonLabel="Cancel"
-      cancelRedirectTo={() => urls.companies.files(relatedObjectId)}
+      cancelRedirectTo={() => urls.companies.files.index(relatedObjectId)}
       transformPayload={(values) =>
         transformFileForApi({
           relatedObjectId,
@@ -103,7 +103,7 @@ const CreateFile = () => {
         text: <CompanyName id={relatedObjectId} />,
       },
       {
-        link: urls.companies.files(relatedObjectId),
+        link: urls.companies.files.index(relatedObjectId),
         text: 'Files',
       },
       {

--- a/src/client/modules/Files/DeleteFile/DeleteFile.jsx
+++ b/src/client/modules/Files/DeleteFile/DeleteFile.jsx
@@ -26,12 +26,12 @@ const SharePointForm = ({ file }) => {
       id="delete-sharepoint-link-form"
       submissionTaskName={TASK_DELETE_FILE}
       analyticsFormName="deleteSharePointLink"
-      redirectTo={() => urls.companies.files(file?.relatedObjectId)}
+      redirectTo={() => urls.companies.files.index(file?.relatedObjectId)}
       flashMessage={() => 'SharePoint link successfully deleted'}
       submitButtonLabel={`Delete ${DOCUMENT_TYPES.SHAREPOINT.label}`}
       cancelButtonLabel="Cancel"
       submitButtonColour={RED}
-      cancelRedirectTo={() => urls.companies.files(file?.relatedObjectId)}
+      cancelRedirectTo={() => urls.companies.files.index(file?.relatedObjectId)}
       transformPayload={() => file?.id}
     >
       <H2>
@@ -73,7 +73,7 @@ const DeleteFile = () => {
         text: <CompanyName id={relatedObjectId} />,
       },
       {
-        link: urls.companies.files(relatedObjectId),
+        link: urls.companies.files.index(relatedObjectId),
         text: 'Files',
       },
       {

--- a/src/lib/urls.js
+++ b/src/lib/urls.js
@@ -174,7 +174,10 @@ module.exports = {
     details: url('/companies', '/:companyId/details'),
     archive: url('/companies', '/:companyId/archive'),
     contacts: url('/companies', '/:companyId/contacts'),
-    files: url('/companies', '/:companyId/files'),
+    files: {
+      index: url('/companies', '/:companyId/files'),
+      delete: url('/files', '/:fileId/delete'),
+    },
     unarchive: url('/companies', '/:companyId/unarchive'),
     businessDetails: url('/companies', '/:companyId/business-details'),
     editOneList: url('/companies', '/:companyId/edit-one-list'),

--- a/test/a11y/cypress/config/urlTestExclusions.js
+++ b/test/a11y/cypress/config/urlTestExclusions.js
@@ -14,6 +14,7 @@ export const urlTestExclusions = [
   { url: '/search/:searchPath?' },
   { url: '/tasks/:taskId/edit' },
   { url: '/companies/:companyId/overview' },
+  { url: '/files/:fileId/delete' },
   // 404 errors and or no sandbox data available
   { url: '/companies/:companyId/audit' },
   { url: '/companies/:companyId/archive' },

--- a/test/functional/cypress/specs/files/collection-spec.js
+++ b/test/functional/cypress/specs/files/collection-spec.js
@@ -8,6 +8,7 @@ import {
   assertMultipleAddItemButtonsText,
   assertAddItemButton,
 } from '../../support/collection-list-assertions'
+import { assertUrl } from '../../support/assertions'
 import { companies } from '../../../../../src/lib/urls'
 import {
   formatDate,
@@ -42,7 +43,7 @@ describe('Generic Documents / Files Collections for company', () => {
     const linkUrl = `/api-proxy/v4/company/${company.id}`
     interceptApiRequest()
     cy.intercept('GET', linkUrl, company).as('companyRequest')
-    cy.visit(companies.files(company.id), {
+    cy.visit(companies.files.index(company.id), {
       qs: { sortby: '-created_on' },
     })
     cy.wait(['@companyRequest', '@apiRequest'])
@@ -56,7 +57,10 @@ describe('Generic Documents / Files Collections for company', () => {
   context('SharePoint header buttons', () => {
     it('if url not set, return page url', () => {
       // Should button not be shown if no url is set?
-      assertAddItemButton('Add SharePoint link', companies.files(company.id))
+      assertAddItemButton(
+        'Add SharePoint link',
+        companies.files.index(company.id)
+      )
     })
 
     it('should render the correct amount of buttons', () => {
@@ -87,6 +91,13 @@ describe('Generic Documents / Files Collections for company', () => {
         ['Added by', genericDocumentsList[0].created_by.name],
         ['SharePoint url', genericDocumentsList[0].document.url],
       ])
+    })
+
+    it('should link to the delete confirmation page url', () => {
+      cy.get('@firstListItem').within(() => {
+        cy.get('span').eq(1).should('contain', 'Delete').click()
+      })
+      assertUrl(companies.files.delete(genericDocumentsList[0].id))
     })
   })
 

--- a/test/functional/cypress/specs/files/create-spec.js
+++ b/test/functional/cypress/specs/files/create-spec.js
@@ -74,7 +74,7 @@ describe('SharePoint link file create for company', () => {
 
       cy.wait('@fileHttpRequest').then((xhr) => {
         expect(xhr.request.body).to.deep.equal(expectedBody)
-        assertUrl(urls.companies.files(company.id))
+        assertUrl(urls.companies.files.index(company.id))
         assertTextVisible(`SharePoint link added successfully`)
       })
     })
@@ -83,7 +83,7 @@ describe('SharePoint link file create for company', () => {
   context('when a user cancels', () => {
     it('should return without saving and return to the correct endpoint', () => {
       cy.contains('Cancel').click()
-      assertUrl(urls.companies.files(company.id))
+      assertUrl(urls.companies.files.index(company.id))
     })
   })
 })

--- a/test/functional/cypress/specs/files/delete-spec.js
+++ b/test/functional/cypress/specs/files/delete-spec.js
@@ -60,7 +60,7 @@ describe('Delete SharePoint link from company', () => {
       cy.contains('button', 'Delete SharePoint link').click()
 
       cy.wait('@fileHttpRequest').then(() => {
-        assertUrl(urls.companies.files(company.id))
+        assertUrl(urls.companies.files.index(company.id))
         assertTextVisible(`SharePoint link successfully deleted`)
       })
     })
@@ -69,7 +69,7 @@ describe('Delete SharePoint link from company', () => {
   context('when a user cancels', () => {
     it('should return without saving and return to the correct endpoint', () => {
       cy.contains('Cancel').click()
-      assertUrl(urls.companies.files(company.id))
+      assertUrl(urls.companies.files.index(company.id))
     })
   })
 })

--- a/test/functional/cypress/specs/files/sort-spec.js
+++ b/test/functional/cypress/specs/files/sort-spec.js
@@ -16,7 +16,7 @@ describe('Files Collections Sort', () => {
           results: genericDocumentsList,
         },
       }).as('apiRequest')
-      cy.visit(companies.files(company.id), {
+      cy.visit(companies.files.index(company.id), {
         qs: { sortby: '-created_on' },
       })
     })
@@ -36,7 +36,7 @@ describe('Files Collections Sort', () => {
           results: genericDocumentsList,
         },
       }).as('apiRequest')
-      cy.visit(companies.files(company.id), {
+      cy.visit(companies.files.index(company.id), {
         qs: { sortby: 'created_on' },
       })
     })


### PR DESCRIPTION
## Description of change

This PR fixes a bug (a missing leading slash) where the delete file link (on the company files collection tab) would take you to a page that did not exist. 

![image](https://github.com/user-attachments/assets/c923cc77-98b1-4dfc-9e6d-638c16c89b90)

## Test instructions

The link should now take you to the confirmation page.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/84aee8c3-c2a4-4662-bd20-d86d8ecaf016)

### After

<img width="991" alt="image" src="https://github.com/user-attachments/assets/17644456-3b4d-4290-897b-efd6916c0c77" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
