### PR TITLE
The Typeahead now doesn't react on blur

### DIFF
--- a/src/client/components/RoutedInput/index.jsx
+++ b/src/client/components/RoutedInput/index.jsx
@@ -56,9 +56,6 @@ const RoutedInput = ({
           writeQs(e.target.value)
         }
       }}
-      onBlur={(e) => {
-        writeQs(e.target.value)
-      }}
     />
   )
 }

--- a/test/functional/cypress/specs/investments/profiles-filtered-spec.js
+++ b/test/functional/cypress/specs/investments/profiles-filtered-spec.js
@@ -49,7 +49,7 @@ const testInputFilter = ({ selector, text, expectedNumberOfResults }) => {
     beforeEach(() => {
       cy.visit(urls.investments.profiles.index())
       expandToggleSections()
-      cy.get(selector).within((e) => cy.wrap(e).type(text).blur())
+      cy.get(selector).within((e) => cy.wrap(e).type(`${text}{enter}`))
     })
 
     it(`There should be ${expectedNumberOfResults} items found`, () => {


### PR DESCRIPTION
## Description of change

Fixes a bug when the _company name_ filter on the `/companies` page could be selected by clicking out of the input field which action creates a _filter tag_. Removing the _filter tag_ didn't reset the input field as expected.

The fix is in removing the `onBlur` event from the `Typeahead` component.

## Test instructions

1. Navigate to `/companies`
2. Type something into the _Company name_ field on top of the left hand panel
3. Click outside of the input or hit the TAB key to _blur_ the field
4. Nothing should happen
    - No filter tag should be created
    - The input field value should not be reset 
