### PR TITLE
Revert "Implement EW migration alert banner messages (#7278)"

### DIFF
--- a/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
+++ b/src/client/modules/Companies/CompanyExports/ExportsIndex.jsx
@@ -21,7 +21,6 @@ import {
   transformExportCountries,
 } from './transformers'
 import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
-import { HistoricWinsAlertBanner } from '../../ExportWins/Status/ExportWinsTabNav'
 
 const StyledSummaryTable = styled(SummaryTable)`
   margin-top: 0;
@@ -42,7 +41,6 @@ const ExportsIndex = () => {
             company={company}
             breadcrumbs={[{ text: 'Exports' }]}
             pageTitle="Export"
-            flashMessages={[[HistoricWinsAlertBanner]]}
           >
             <SummaryTable
               caption="Exports"

--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -4,6 +4,7 @@ import { Link } from 'govuk-react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
+import { FONT_SIZE } from '@govuk-react/constants'
 
 import FlashMessages from '../../../components/LocalHeader/FlashMessages'
 import { steps, EMAIL, STEP_TO_EXCLUDED_FIELDS_MAP } from './constants'
@@ -21,10 +22,21 @@ import { ExportWinSuccess } from './Success'
 import State from '../../../components/State'
 import urls from '../../../../lib/urls'
 import SummaryStep from './SummaryStep'
-import { Form, FormLayout, DefaultLayout } from '../../../components'
-import { HistoricWinsAlertBanner } from '../Status/ExportWinsTabNav'
+import {
+  Form,
+  FormLayout,
+  DefaultLayout,
+  StatusMessage,
+} from '../../../components'
 
 const FORM_ID = 'export-win-form'
+
+const StyledStatusMessage = styled(StatusMessage)({
+  fontSize: FONT_SIZE.SIZE_20,
+  fontWeight: 700,
+  marginTop: 25,
+  marginBottom: 5,
+})
 
 const StyledParagraph = styled('p')({
   fontWeight: 'bold',
@@ -81,28 +93,6 @@ const ExportWinForm = ({
               heading={heading}
               subheading={subheading}
               breadcrumbs={breadcrumbs}
-              flashMessages={[
-                [
-                  isEditing ? (
-                    <>
-                      <StyledParagraph>
-                        {HistoricWinsAlertBanner}
-                      </StyledParagraph>
-                      {currentStepName === steps.SUMMARY ? (
-                        <>
-                          <StyledParagraph>
-                            To edit an export win: edit each section that needs
-                            changing then return to the summary page. When you
-                            are happy with all the changes save the page.
-                          </StyledParagraph>
-                        </>
-                      ) : excludedStepFields ? (
-                        <ContactLink sections={excludedStepFields} />
-                      ) : null}
-                    </>
-                  ) : null,
-                ],
-              ]}
               localHeaderChildren={
                 isEditing ? (
                   currentStepName === steps.SUMMARY ? (
@@ -114,12 +104,24 @@ const ExportWinForm = ({
                           }}
                         />
                       )}
+                      <StyledStatusMessage>
+                        <StyledParagraph>To edit an export win</StyledParagraph>
+                        <StyledParagraph>
+                          Edit each section that needs changing then return to
+                          the summary page. When you are happy with all the
+                          changes save the page.
+                        </StyledParagraph>
+                      </StyledStatusMessage>
                       {winStatus === WIN_STATUS.PENDING && (
                         <ResentExportWinContainer>
                           <ResendExportWin id={exportWinId} />
                         </ResentExportWinContainer>
                       )}
                     </>
+                  ) : excludedStepFields ? (
+                    <StyledStatusMessage>
+                      <ContactLink sections={excludedStepFields} />
+                    </StyledStatusMessage>
                   ) : null
                 ) : null
               }

--- a/src/client/modules/ExportWins/Form/constants.js
+++ b/src/client/modules/ExportWins/Form/constants.js
@@ -53,8 +53,8 @@ export const bothGoodsAndServices = {
 }
 
 export const STEP_TO_EXCLUDED_FIELDS_MAP = {
-  [steps.OFFICER_DETAILS]: ['lead officer name.'],
-  [steps.CUSTOMER_DETAILS]: ['export experience.'],
+  [steps.OFFICER_DETAILS]: ['lead officer name'],
+  [steps.CUSTOMER_DETAILS]: ['export experience'],
   [steps.WIN_DETAILS]: [
     'summary of the support given',
     'destination country',

--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { capitalize } from 'lodash'
-import { Link } from 'govuk-react'
 
 import { DefaultLayout } from '../../../components'
 import TabNav from '../../../components/TabNav'
@@ -9,25 +8,8 @@ import WinsRejectedList from './WinsRejectedList'
 import WinsPendingList from './WinsPendingList'
 import WinsConfirmedList from './WinsConfirmedList'
 import urls from '../../../../lib/urls'
-import { HISTORIC_WINS_ALERT_MESSAGE } from './constants'
 
 const LAST_WORD = /([^\/]+)$/
-
-export const HistoricWinsAlertBanner = (
-  <>
-    {[HISTORIC_WINS_ALERT_MESSAGE.ELEMENT].concat(' ')}
-    {[
-      <Link
-        href={HISTORIC_WINS_ALERT_MESSAGE.URI_LINK}
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Find out more about historic wins moved to Data Hub"
-      >
-        {HISTORIC_WINS_ALERT_MESSAGE.URI_ELEMENT}
-      </Link>,
-    ].concat('.')}
-  </>
-)
 
 const ExportWinsTabNav = () => {
   const location = useLocation()
@@ -46,7 +28,6 @@ const ExportWinsTabNav = () => {
         },
         { text: capitalize(title) },
       ]}
-      flashMessages={[[HistoricWinsAlertBanner]]}
     >
       <TabNav
         id="exportwins-tab-nav"

--- a/src/client/modules/ExportWins/Status/constants.js
+++ b/src/client/modules/ExportWins/Status/constants.js
@@ -22,10 +22,3 @@ export const ADVISER_ROLES = {
   TEAM_MEMBER: 'team member',
   CONTRIBUTING_OFFICER: 'contributing officer',
 }
-
-export const HISTORIC_WINS_ALERT_MESSAGE = {
-  ELEMENT: 'Historic export wins have now moved to Data Hub,',
-  URI_ELEMENT: 'see the export wins announcement',
-  URI_LINK:
-    'https://data-services-help.trade.gov.uk/data-hub/updates/announcements/historic-export-wins-are-now-on-data-hub/',
-}

--- a/test/functional/cypress/specs/companies/export/index-spec.js
+++ b/test/functional/cypress/specs/companies/export/index-spec.js
@@ -1,9 +1,6 @@
 const { company } = require('../../../fixtures')
 const { assertBreadcrumbs } = require('../../../support/assertions')
 const urls = require('../../../../../../src/lib/urls')
-const {
-  assertHistoricExportWinsMessage,
-} = require('../../export-win/edit-export-win-pending-spec.js')
 
 describe('Company Export tab', () => {
   function assertTable({ rows, caption, action }) {
@@ -68,10 +65,6 @@ describe('Company Export tab', () => {
           [company.dnbCorp.name]: urls.companies.detail(company.dnbCorp.id),
           Exports: null,
         })
-      })
-
-      it('should render historic export win banner message', () => {
-        assertHistoricExportWinsMessage()
       })
 
       it('should render the "Exports" table', () => {

--- a/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-pending-spec.js.js
@@ -1,47 +1,8 @@
 import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
 import { company, formFields } from './constants'
-import { HISTORIC_WINS_ALERT_MESSAGE } from '../../../../../src/client/modules/ExportWins/Status/constants'
 
 const exportWin = exportWinsFaker()
-
-export const assertHistoricExportWinsMessage = () => {
-  cy.get('[data-test="status-message"]')
-    .should('contain', HISTORIC_WINS_ALERT_MESSAGE.ELEMENT)
-    .should('contain.text', HISTORIC_WINS_ALERT_MESSAGE.URI_ELEMENT)
-    .find('a')
-    .should('have.attr', 'href', HISTORIC_WINS_ALERT_MESSAGE.URI_LINK)
-}
-
-const assertCustomerDetailsMessage = () => {
-  cy.get('[data-test="status-message"]').should(
-    'contain.text',
-    'Contact exportwins@businessandtrade.gov.uk if you need to update the section: export experience.'
-  )
-}
-
-const assertLeadOfficerDetailsMessage = () => {
-  cy.get('[data-test="status-message"]').should(
-    'contain.text',
-    'Contact exportwins@businessandtrade.gov.uk if you need to update the section: lead officer name.'
-  )
-}
-
-const assertWinDetailsMessage = () => {
-  cy.get('[data-test="status-message"]').should(
-    'contain.text',
-    'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
-      'summary of the support given, destination country, date won, type of win and value.'
-  )
-}
-
-const assertSummaryMessage = () => {
-  cy.get('[data-test="status-message"]').should(
-    'contain.text',
-    'To edit an export win: edit each section that needs changing then return to the summary page. ' +
-      'When you are happy with all the changes save the page.'
-  )
-}
 
 describe('Editing a pending export win', () => {
   beforeEach(() => {
@@ -80,8 +41,10 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editOfficerDetails(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
-      assertHistoricExportWinsMessage()
-      assertLeadOfficerDetailsMessage()
+      cy.get('[data-test="status-message"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: lead officer name'
+      )
     })
   })
 
@@ -91,7 +54,7 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editCreditForThisWin(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
-      assertHistoricExportWinsMessage()
+      cy.get('[data-test="status-message"]').should('not.exist')
     })
   })
 
@@ -104,8 +67,12 @@ describe('Editing a pending export win', () => {
     })
 
     it('should render an edit status message', () => {
-      assertHistoricExportWinsMessage()
-      assertCustomerDetailsMessage()
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the section: export experience'
+        )
     })
 
     it('should not render Export experience', () => {
@@ -124,8 +91,13 @@ describe('Editing a pending export win', () => {
     })
 
     it('should render an edit status message', () => {
-      assertHistoricExportWinsMessage()
-      assertWinDetailsMessage()
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: ' +
+            'summary of the support given, destination country, date won, type of win and value.'
+        )
     })
 
     it('should not render a hint', () => {
@@ -165,8 +137,7 @@ describe('Editing a pending export win', () => {
         urls.companies.exportWins.editSupportProvided(company.id, exportWin.id)
       )
       cy.wait(['@apiGetExportWin'])
-      cy.get('[data-test="status-message"]')
-      assertHistoricExportWinsMessage()
+      cy.get('[data-test="status-message"]').should('not.exist')
     })
   })
 
@@ -174,8 +145,12 @@ describe('Editing a pending export win', () => {
     it('should render an edit status message', () => {
       cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
       cy.wait(['@apiGetExportWin'])
-      assertHistoricExportWinsMessage()
-      assertSummaryMessage()
+      cy.get('[data-test="status-message"]').should(
+        'contain',
+        'To edit an export win' +
+          'Edit each section that needs changing then return to the summary page. ' +
+          'When you are happy with all the changes save the page.'
+      )
     })
 
     it('should render a lead officer name contact link', () => {
@@ -274,7 +249,7 @@ describe('Editing a pending export win', () => {
       cy.get('[data-test="resend-export-win"]').click()
       cy.wait('@apiResendExportWin')
       cy.get('[data-test="flash"]').should(
-        'contain.text',
+        'have.text',
         `The export win ${exportWin.name_of_export} to ${exportWin.country.name} has been sent to ${exportWin.company_contacts[0].email} for review and confirmation.`
       )
     })


### PR DESCRIPTION
This reverts commit 1989bcf0fdb7cfe8b4cf0aede754c96f86a50b7c.

## Description of change

This ticket is reverting a banner message `Historic export wins have now move to Datahub` being implemented from this PR https://github.com/uktrade/data-hub-frontend/pull/7278. 
Now more than 5-months, PM created a ticket to revert/removed these banner.

Jira ticket: https://uktrade.atlassian.net/browse/EGTB-1750 


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
