### PR TITLE
Remove the @nivo dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,12 +52,6 @@ updates:
       - dependency-name: '@sentry/tracing'
         versions:
           - '>= 0'
-      - dependency-name: '@nivo/pie'
-        versions:
-          - '>= 0'
-      - dependency-name: '@nivo/tooltip'
-        versions:
-          - '>= 0'
       - dependency-name: 'cypress-image-diff-js'
         versions:
           - '>= 2.2.1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "license": "MIT",
       "dependencies": {
         "@govuk-react/constants": "^0.10.7",
-        "@nivo/core": "^0.88.0",
-        "@nivo/pie": "^0.88.0",
-        "@nivo/tooltip": "^0.88.0",
         "@redux-devtools/extension": "^3.3.0",
         "@reduxjs/toolkit": "^2.6.1",
         "@sentry/browser": "^9.10.1",
@@ -5329,116 +5326,6 @@
         "eslint-scope": "5.1.1"
       }
     },
-    "node_modules/@nivo/arcs": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/arcs/-/arcs-0.88.0.tgz",
-      "integrity": "sha512-q7MHxT71s/KKlDDtSJS4L9+/JIa5HPZZrDr3ZFECLnvp0TC1qzyFMtVevN2CsXopSTj8poN4uFXPWxYVXOq8vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-shape": "^3.2.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/colors": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/colors/-/colors-0.88.0.tgz",
-      "integrity": "sha512-IZ+leYIqAlo7dyLHmsQwujanfRgXyoQ5H7PU3RWLEn1PP0zxDKLgEjFEDADpDauuslh2Tx0L81GNkWR6QSP0Mw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.88.0",
-        "@types/d3-color": "^3.0.0",
-        "@types/d3-scale": "^4.0.8",
-        "@types/d3-scale-chromatic": "^3.0.0",
-        "@types/prop-types": "^15.7.2",
-        "d3-color": "^3.1.0",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/core": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/core/-/core-0.88.0.tgz",
-      "integrity": "sha512-XjUkA5MmwjLP38bdrJwn36Gj7T5SYMKD55LYQp/1nIJPdxqJ38dUfE4XyBDfIEgfP6yrHOihw3C63cUdnUBoiw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/tooltip": "0.88.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2",
-        "@types/d3-shape": "^3.1.6",
-        "d3-color": "^3.1.0",
-        "d3-format": "^1.4.4",
-        "d3-interpolate": "^3.0.1",
-        "d3-scale": "^4.0.2",
-        "d3-scale-chromatic": "^3.0.0",
-        "d3-shape": "^3.2.0",
-        "d3-time-format": "^3.0.0",
-        "lodash": "^4.17.21",
-        "prop-types": "^15.7.2"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nivo/donate"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/legends": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/legends/-/legends-0.88.0.tgz",
-      "integrity": "sha512-d4DF9pHbD8LmGJlp/Gp1cF4e8y2wfQTcw3jVhbZj9zkb7ZWB7JfeF60VHRfbXNux9bjQ9U78/SssQqueVDPEmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
-        "@types/d3-scale": "^4.0.8",
-        "d3-scale": "^4.0.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/pie": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/pie/-/pie-0.88.0.tgz",
-      "integrity": "sha512-BE6dFWlGne1SnaEkFHNbg0sZBiwtcIqBFwmMRJ0F11SiKOzVeJyq3KiyY1I2ySSCx5VR1V8/MNBXzXFu3vJMAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/arcs": "0.88.0",
-        "@nivo/colors": "0.88.0",
-        "@nivo/core": "0.88.0",
-        "@nivo/legends": "0.88.0",
-        "@nivo/tooltip": "0.88.0",
-        "@types/d3-shape": "^3.1.6",
-        "d3-shape": "^3.2.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
-    "node_modules/@nivo/tooltip": {
-      "version": "0.88.0",
-      "resolved": "https://registry.npmjs.org/@nivo/tooltip/-/tooltip-0.88.0.tgz",
-      "integrity": "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw==",
-      "license": "MIT",
-      "dependencies": {
-        "@nivo/core": "0.88.0",
-        "@react-spring/web": "9.4.5 || ^9.7.2"
-      },
-      "peerDependencies": {
-        "react": ">= 16.14.0 < 19.0.0"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -6455,78 +6342,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.8"
-      }
-    },
-    "node_modules/@react-spring/animated": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/animated/-/animated-9.7.5.tgz",
-      "integrity": "sha512-Tqrwz7pIlsSDITzxoLS3n/v/YCUHQdOIKtOJf4yL6kYVSDTSmVK1LI1Q3M/uu2Sx4X3pIWF3xLUhlsA6SPNTNg==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/core": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/core/-/core-9.7.5.tgz",
-      "integrity": "sha512-rmEqcxRcu7dWh7MnCcMXLvrf6/SDlSokLaLTxiPlAYi11nN3B5oiCUAblO72o+9z/87j2uzxa2Inm8UbLjXA+w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/react-spring/donate"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/rafz": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/rafz/-/rafz-9.7.5.tgz",
-      "integrity": "sha512-5ZenDQMC48wjUzPAm1EtwQ5Ot3bLIAwwqP2w2owG5KoNdNHpEJV263nGhCeKKmuA3vG2zLLOdu3or6kuDjA6Aw==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/shared": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/shared/-/shared-9.7.5.tgz",
-      "integrity": "sha512-wdtoJrhUeeyD/PP/zo+np2s1Z820Ohr/BbuVYv+3dVLW7WctoiN7std8rISoYoHpUXtbkpesSKuPIw/6U1w1Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/rafz": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-spring/types": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.7.5.tgz",
-      "integrity": "sha512-HVj7LrZ4ReHWBimBvu2SKND3cDVUPWKLqRTmWe/fNY6o1owGOX0cAHbdPDTMelgBlVbrTKrre6lFkhqGZErK/g==",
-      "license": "MIT"
-    },
-    "node_modules/@react-spring/web": {
-      "version": "9.7.5",
-      "resolved": "https://registry.npmjs.org/@react-spring/web/-/web-9.7.5.tgz",
-      "integrity": "sha512-lmvqGwpe+CSttsWNZVr+Dg62adtKhauGwLyGE/RRyZ8AAMLgb9x3NDMA5RMElXo+IMyTkPp7nxTB8ZQlmhb6JQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-spring/animated": "~9.7.5",
-        "@react-spring/core": "~9.7.5",
-        "@react-spring/shared": "~9.7.5",
-        "@react-spring/types": "~9.7.5"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@redis/bloom": {
@@ -8054,48 +7869,6 @@
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
     },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
-      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -8338,12 +8111,6 @@
       "dependencies": {
         "@types/pg": "*"
       }
-    },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.14",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
-      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "license": "MIT"
     },
     "node_modules/@types/qs": {
       "version": "6.9.18",
@@ -11601,140 +11368,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
-      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-time": "1 - 2"
-      }
-    },
-    "node_modules/d3-time-format/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-time-format/node_modules/d3-time": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
-      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "2"
-      }
-    },
-    "node_modules/d3-time-format/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -16180,15 +15813,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/interpret": {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "adr-graph": "adr generate graph",
     "adr-toc": "adr generate toc",
     "dependabot:update-storybook": "npm install --save-dev @storybook/addon-a11y@latest @storybook/addon-essentials@latest @storybook/addon-webpack5-compiler-babel@latest @storybook/manager-api@latest @storybook/react@latest @storybook/react-webpack5@latest @storybook/test@latest storybook@latest",
-    "dependabot:update-sentry": "npm install @sentry/browser@latest @sentry/node@latest @sentry/react@latest",
-    "dependabot:update-nivo": "npm install @nivo/core@latest @nivo/pie@latest @nivo/tooltip@latest"
+    "dependabot:update-sentry": "npm install @sentry/browser@latest @sentry/node@latest @sentry/react@latest"
   },
   "nyc": {
     "report-dir": "cypress-coverage",
@@ -63,9 +62,6 @@
   },
   "dependencies": {
     "@govuk-react/constants": "^0.10.7",
-    "@nivo/core": "^0.88.0",
-    "@nivo/pie": "^0.88.0",
-    "@nivo/tooltip": "^0.88.0",
     "@redux-devtools/extension": "^3.3.0",
     "@reduxjs/toolkit": "^2.6.1",
     "@sentry/browser": "^9.10.1",

--- a/src/client/components/PieChart/index.jsx
+++ b/src/client/components/PieChart/index.jsx
@@ -57,12 +57,13 @@ const Filling = styled.div({
 
 const PieChart = ({ data, unit = '' }) => {
   const total = data.reduce((a, { value }) => a + value, 0)
+  const pluralizedProject = pluralize(unit, total)
   return (
-    <Root>
+    <Root data-test="pie-chart" aria-label={`${total} ${pluralizedProject}`}>
       <Pie data={data} total={total}>
         <Filling>
           <div style={{ fontSize: '3em' }}>{total}</div>
-          <div>{pluralize(unit, total)}</div>
+          <div>{pluralizedProject}</div>
         </Filling>
       </Pie>
       <Legend data={data} total={total} />

--- a/src/client/components/PieChart/index.jsx
+++ b/src/client/components/PieChart/index.jsx
@@ -1,108 +1,73 @@
-import React, { useEffect, useRef } from 'react'
-import PropTypes from 'prop-types'
-import { FONT_WEIGHTS, SPACING } from '@govuk-react/constants'
-import { ResponsivePie } from '@nivo/pie'
+import React from 'react'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 
 import Legend from './Legend'
 import { MID_GREY } from '../../utils/colours'
 
-const StyledFigure = styled('figure')({
+const dataToGradient = ({ data, total }) => {
+  const stops = data.reduce((a, { colour, value }, i) => {
+    const percentage = value / total
+    const from = a[i - 1]?.to ?? 0
+    const to = from + percentage
+
+    return [
+      ...a,
+      {
+        to,
+        stop: `${colour} ${from}turn ${to}turn`,
+      },
+    ]
+  }, [])
+
+  return `conic-gradient(from -90deg, ${stops.map((x) => x.stop).join(',')}) border-box`
+}
+
+const Root = styled.figure({
   border: `1px solid ${MID_GREY}`,
 })
 
-const StyledPieContainer = styled('div')(({ height }) => ({
-  paddingTop: SPACING.SCALE_3,
-  height: `${height}px`,
-}))
+const Pie = styled.div({
+  position: 'relative',
+  // This must be a string because of a styled-components bug:
+  // https://github.com/styled-components/styled-components/issues/3254#issuecomment-1265113393
+  aspectRatio: '1',
+  borderRadius: '50%',
+  maskComposite: 'exclude',
+  background: dataToGradient,
+  maxWidth: 250,
+  margin: '30px auto',
+})
 
-const centredText = (text, fontSize, x, y) => (
-  <text
-    x={x}
-    y={y}
-    textAnchor="middle"
-    dominantBaseline="central"
-    style={{
-      fontSize: `${fontSize}px`,
-      fontWeight: FONT_WEIGHTS.bold,
-    }}
-  >
-    {text}
-  </text>
-)
+const Filling = styled.div({
+  background: 'white',
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  borderRadius: '50%',
+  aspectRatio: '1 / 1',
+  width: '75%',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  fontWeight: 'bold',
+})
 
-const PieChart = ({ data, unit = '', height }) => {
-  const pieWrapperRef = useRef(null)
-
-  // Nivo currently doesn't support aria labels as props
-  // https://github.com/plouc/nivo/issues/126
-  // This is our workaround until/if nivo updates its accessibility
-  useEffect(() => {
-    const pieWrapper = pieWrapperRef.current
-    const svgWrapper = pieWrapper.children[0].children[0]
-    const total = data.reduce(
-      (accumulator, datum) => accumulator + datum.value,
-      0
-    )
-    if (svgWrapper) {
-      svgWrapper.children[0].setAttribute(
-        'aria-label',
-        `${total} ${pluralize(unit, total)}`
-      )
-    }
-  })
-  const CentredProjectTotal = ({ dataWithArc, centerX, centerY }) => {
-    const projectTotal = dataWithArc.reduce(
-      (accumulator, datum) => accumulator + datum.value,
-      0
-    )
-
-    return (
-      <>
-        {centredText(projectTotal, 60, centerX, centerY - 20)}
-        {centredText(pluralize(unit, projectTotal), 20, centerX, centerY + 30)}
-      </>
-    )
-  }
+const PieChart = ({ data, unit = '' }) => {
+  const total = data.reduce((a, { value }) => a + value, 0)
   return (
-    <StyledFigure>
-      <StyledPieContainer
-        ref={pieWrapperRef}
-        height={height}
-        data-test="pie-chart"
-      >
-        <ResponsivePie
-          theme={{
-            fontSize: '16px',
-          }}
-          data={data}
-          colors={(item) => item.data.colour}
-          margin={{ top: 20, bottom: 20 }}
-          startAngle={-90}
-          innerRadius={0.75}
-          padAngle={0}
-          enableArcLabels={false}
-          isInteractive={false}
-          layers={['arcs', CentredProjectTotal]}
-        />
-      </StyledPieContainer>
-      <Legend data={data} />
-    </StyledFigure>
+    <Root>
+      <Pie data={data} total={total}>
+        <Filling>
+          <div style={{ fontSize: '3em' }}>{total}</div>
+          <div>{pluralize(unit, total)}</div>
+        </Filling>
+      </Pie>
+      <Legend data={data} total={total} />
+    </Root>
   )
-}
-
-PieChart.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      name: PropTypes.string.isRequired,
-      value: PropTypes.number.isRequired,
-      link: PropTypes.string,
-    })
-  ).isRequired,
-  height: PropTypes.number,
-  unit: PropTypes.string,
 }
 
 export default PieChart

--- a/test/functional/cypress/specs/dashboard/investment-project-summary-spec.js
+++ b/test/functional/cypress/specs/dashboard/investment-project-summary-spec.js
@@ -32,9 +32,8 @@ describe('Investment projects summary', () => {
   })
 
   context('after initial load', () => {
-    it('should display an SVG representing a chart', () => {
+    it('should display a chart', () => {
       cy.get('[data-test="pie-chart"]')
-        .find('svg')
         .should('exist')
         .should('have.attr', 'aria-label', `${projectCount} Projects`)
     })


### PR DESCRIPTION
## Description of change

The [@nivo] dependency was preventing us from upgrading to React 19. It turned out that it was only ever used in the [PieChart] component.

In this PR, I re-implemented the [PieChart] component with CSS only and removed the [@nivo] dependency.
The new implementation looks almost exactly as the old one, except tiny difference in sizing of the large number and its label in the middle of the circle. This is because in the original implementation the text was an SVG `<text>` with fixed `font-size: 60px` and scaled with the whole SVG, whereas now it's a div with `font-size: 3em` which looks almost the same, but it's just a tiny little bit smaller. 

## Test instructions

1. Navigate to `/investment-projects`
2. You should see a breakdown of projects by type in a pie-chart
3. The pie chart should look (almost) exactly as before.

## Screenshots

### Before

<img width="380" alt="Screenshot 2025-04-16 at 12 20 06" src="https://github.com/user-attachments/assets/ccf1305d-9404-4590-aaa0-ae5521081487" />

### After

<img width="380" alt="Screenshot 2025-04-16 at 12 20 30" src="https://github.com/user-attachments/assets/ff2a090a-5487-488f-9111-8eb67d6ca511" />
