### PR TITLE
Use descriptive lists to improve screen reader experience

### DIFF
--- a/src/client/components/AuditHistory/transformers.js
+++ b/src/client/components/AuditHistory/transformers.js
@@ -61,7 +61,7 @@ const transformAuditLogItem = (
         (change, index) =>
           metadata.push({
             key: `${logItem.id}-${index}-field-name`,
-            value: <strong>{change.fieldName}</strong>,
+            label: <strong>{change.fieldName}</strong>,
           }) &&
           metadata.push({
             key: `${logItem.id}-${index}-old-value`,
@@ -75,7 +75,7 @@ const transformAuditLogItem = (
           })
       )
     : metadata.push({
-        value: `No changes were made to ${auditType} in this update`,
+        label: `No changes were made to ${auditType} in this update`,
       })
 
   const badges = [

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -14,6 +14,8 @@ import Tag from '../Tag'
 const ItemWrapper = styled('li')`
   border-bottom: 1px solid ${GREY_2};
   padding: ${SPACING.SCALE_3} 0;
+  clear: left;
+  display: inline-block;
 `
 
 export const StyledBadgesWrapper = styled('div')`

--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -14,8 +14,6 @@ import Tag from '../Tag'
 const ItemWrapper = styled('li')`
   border-bottom: 1px solid ${GREY_2};
   padding: ${SPACING.SCALE_3} 0;
-  clear: left;
-  display: inline-block;
 `
 
 export const StyledBadgesWrapper = styled('div')`

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -4,26 +4,25 @@ import PropTypes from 'prop-types'
 
 import { BLACK, DARK_GREY } from '../../utils/colours'
 
-const StyledMetaWrapper = styled('div')`
-  color: ${BLACK};
+const StyledItemLabel = styled('dt')`
+  color: ${DARK_GREY};
+  display: inline;
+  clear: left;
+  float: left;
+  margin-right: 0.5em;
 `
 
 const StyledItemValues = styled('dd')`
   color: ${BLACK};
-  display: inline;
-`
-
-const StyledItemLabel = styled('dt')`
-  color: ${DARK_GREY};
-  display: inline;
+  float: left;
 `
 
 function MetadataItem({ label, children }) {
   return (
-    <StyledMetaWrapper data-test="metadata-item" role="presentation">
+    <>
       {label && <StyledItemLabel>{label}</StyledItemLabel>}{' '}
       {<StyledItemValues>{children}</StyledItemValues>}
-    </StyledMetaWrapper>
+    </>
   )
 }
 

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -8,14 +8,21 @@ const StyledMetaWrapper = styled('div')`
   color: ${BLACK};
 `
 
-const StyledItemLabel = styled('span')`
+const StyledItemValues = styled('dd')`
+  color: ${BLACK};
+  display: inline;
+`
+
+const StyledItemLabel = styled('dt')`
   color: ${DARK_GREY};
+  display: inline;
 `
 
 function MetadataItem({ label, children }) {
   return (
-    <StyledMetaWrapper data-test="metadata-item">
-      {label && <StyledItemLabel>{label}</StyledItemLabel>} {children}
+    <StyledMetaWrapper data-test="metadata-item" role="presentation">
+      {label && <StyledItemLabel>{label}</StyledItemLabel>}{' '}
+      {<StyledItemValues>{children}</StyledItemValues>}
     </StyledMetaWrapper>
   )
 }

--- a/src/client/components/Metadata/MetadataItem.jsx
+++ b/src/client/components/Metadata/MetadataItem.jsx
@@ -20,8 +20,14 @@ const StyledItemValues = styled('dd')`
 function MetadataItem({ label, children }) {
   return (
     <>
-      {label && <StyledItemLabel>{label}</StyledItemLabel>}{' '}
-      {<StyledItemValues>{children}</StyledItemValues>}
+      {label && (
+        <StyledItemLabel data-test="metadata-label">{label}</StyledItemLabel>
+      )}
+      {
+        <StyledItemValues data-test="metadata-value">
+          {children}
+        </StyledItemValues>
+      }
     </>
   )
 }

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -5,7 +5,7 @@ import { FONT_SIZE } from '@govuk-react/constants'
 
 import MetadataItem from './MetadataItem'
 
-const StyledMetadataWrapper = styled('div')`
+const StyledMetadataWrapper = styled('dl')`
   font-size: ${FONT_SIZE.SIZE_16};
   line-height: ${FONT_SIZE.SIZE_27};
   display: grid;

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -9,6 +9,7 @@ const StyledMetadataWrapper = styled('dl')`
   font-size: ${FONT_SIZE.SIZE_16};
   line-height: ${FONT_SIZE.SIZE_27};
   display: block;
+  overflow: hidden;
 
   & > * {
     margin-bottom: 0px;

--- a/src/client/components/Metadata/index.jsx
+++ b/src/client/components/Metadata/index.jsx
@@ -8,7 +8,7 @@ import MetadataItem from './MetadataItem'
 const StyledMetadataWrapper = styled('dl')`
   font-size: ${FONT_SIZE.SIZE_16};
   line-height: ${FONT_SIZE.SIZE_27};
-  display: grid;
+  display: block;
 
   & > * {
     margin-bottom: 0px;

--- a/test/component/cypress/specs/Companies/CompanyActivity/EYBActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/EYBActivity.cy.jsx
@@ -53,8 +53,8 @@ describe('EYB lead activity card', () => {
         assertInvestmentThemeLabel()
         assertActivitySubject(LINKED_COMPANY_NAME, PROJECT_URL)
         assertMetadataItems([
-          `Submitted to EYB date 01 Dec 2024`,
-          'Value Unknown',
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'Unknown' },
         ])
       })
     }
@@ -72,7 +72,10 @@ describe('EYB lead activity card', () => {
         assertEYBLabel()
         assertInvestmentThemeLabel()
         assertActivitySubject(LINKED_COMPANY_NAME, PROJECT_URL)
-        assertMetadataItems([`Submitted to EYB date 01 Dec 2024`, 'Value High'])
+        assertMetadataItems([
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'High' },
+        ])
       })
     }
   )
@@ -89,7 +92,10 @@ describe('EYB lead activity card', () => {
         assertEYBLabel()
         assertInvestmentThemeLabel()
         assertActivitySubject(LINKED_COMPANY_NAME, PROJECT_URL)
-        assertMetadataItems([`Submitted to EYB date 01 Dec 2024`, 'Value Low'])
+        assertMetadataItems([
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'Low' },
+        ])
       })
     }
   )
@@ -107,8 +113,8 @@ describe('EYB lead activity card', () => {
         assertInvestmentThemeLabel()
         assertActivitySubject(EYB_COMPANY_NAME, PROJECT_URL)
         assertMetadataItems([
-          `Submitted to EYB date 01 Dec 2024`,
-          'Value Unknown',
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'Unknown' },
         ])
       })
     }
@@ -126,7 +132,10 @@ describe('EYB lead activity card', () => {
         assertEYBLabel()
         assertInvestmentThemeLabel()
         assertActivitySubject(EYB_COMPANY_NAME, PROJECT_URL)
-        assertMetadataItems([`Submitted to EYB date 01 Dec 2024`, 'Value High'])
+        assertMetadataItems([
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'High' },
+        ])
       })
     }
   )
@@ -143,7 +152,10 @@ describe('EYB lead activity card', () => {
         assertEYBLabel()
         assertInvestmentThemeLabel()
         assertActivitySubject(EYB_COMPANY_NAME, PROJECT_URL)
-        assertMetadataItems([`Submitted to EYB date 01 Dec 2024`, 'Value Low'])
+        assertMetadataItems([
+          { label: 'Submitted to EYB date', value: '01 Dec 2024' },
+          { label: 'Value', value: 'Low' },
+        ])
       })
     }
   )

--- a/test/component/cypress/specs/Companies/CompanyActivity/GreatExportActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/GreatExportActivity.cy.jsx
@@ -60,13 +60,23 @@ describe('Great Export Enquiry activity card', () => {
         .should('exist')
         .should('have.text', `Enquiry ${SUBJECT}`)
         .should('not.have.attr', 'href')
-      assertMetadataItems([
-        ` ${NOTES}`,
-        'Date 25 Nov 2058',
-        'Contact Alexander Hamilton',
-        'Job title Test Job',
-        'Email bernardharrispatel@test.com',
-      ])
+
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 4)
+      cy.get(itemLabels).eq(0).should('have.text', 'Date')
+      cy.get(itemLabels).eq(1).should('have.text', 'Contact')
+      cy.get(itemLabels).eq(2).should('have.text', 'Job title')
+      cy.get(itemLabels).eq(3).should('have.text', 'Email')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 5)
+      cy.get(itemValues).eq(0).should('have.text', `${NOTES}`)
+      cy.get(itemValues).eq(1).should('have.text', '25 Nov 2058')
+      cy.get(itemValues).eq(2).should('have.text', 'Alexander Hamilton')
+      cy.get(itemValues).eq(3).should('have.text', 'Test Job')
+      cy.get(itemValues)
+        .eq(4)
+        .should('have.text', 'bernardharrispatel@test.com')
     })
   })
 
@@ -78,7 +88,7 @@ describe('Great Export Enquiry activity card', () => {
 
     it('should render the date and the labels', () => {
       assertGreatLabels()
-      assertMetadataItems(['Date 25 Nov 2058'])
+      assertMetadataItems([{ label: 'Date', value: '25 Nov 2058' }])
     })
   })
 
@@ -96,13 +106,28 @@ describe('Great Export Enquiry activity card', () => {
         .should('exist')
         .should('have.text', 'Enquiry Lorem ipsum dolor sit amet, ...')
         .should('not.have.attr', 'href')
-      assertMetadataItems([
-        ' Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ...',
-        'Date 25 Nov 2058',
-        'Contact Alexander Hamilton',
-        'Job title Test Job',
-        'Email bernardharrispatel@test.com',
-      ])
+
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 4)
+      cy.get(itemLabels).eq(0).should('have.text', 'Date')
+      cy.get(itemLabels).eq(1).should('have.text', 'Contact')
+      cy.get(itemLabels).eq(2).should('have.text', 'Job title')
+      cy.get(itemLabels).eq(3).should('have.text', 'Email')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 5)
+      cy.get(itemValues)
+        .eq(0)
+        .should(
+          'have.text',
+          'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec ...'
+        )
+      cy.get(itemValues).eq(1).should('have.text', '25 Nov 2058')
+      cy.get(itemValues).eq(2).should('have.text', 'Alexander Hamilton')
+      cy.get(itemValues).eq(3).should('have.text', 'Test Job')
+      cy.get(itemValues)
+        .eq(4)
+        .should('have.text', 'bernardharrispatel@test.com')
     })
   })
 })

--- a/test/component/cypress/specs/Companies/CompanyActivity/InteractionActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/InteractionActivity.cy.jsx
@@ -26,11 +26,11 @@ const TYPE = 'interaction'
 const SERVICE_DELIVERY = 'service_delivery'
 const INTERACTION_URL = urls.companies.interactions.detail('1', '2')
 const ONE_ADVISER_TEXT =
-  'Adviser Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  '
+  'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  '
 const TWO_ADVISERS_TEXT =
-  'Advisers Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  Puck Head  puckhead@test.com, Test Team 2  '
-const ONE_CONTACT_TEXT = 'Contact Alexander Hamilton'
-const TWO_CONTACTS_TEXT = 'Contacts Alexander Hamilton, Oliver Twist'
+  'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  Puck Head  puckhead@test.com, Test Team 2  '
+const ONE_CONTACT_TEXT = 'Alexander Hamilton'
+const TWO_CONTACTS_TEXT = 'Alexander Hamilton, Oliver Twist'
 
 const INTERACTION_SERVICES = {
   specificDITService:
@@ -59,10 +59,6 @@ const INTERACTION_SERVICES = {
 }
 
 const DIT_SERVICE = INTERACTION_SERVICES.specificDITService
-
-const buildServiceLabel = (service) => {
-  return 'Service ' + service
-}
 
 const buildAndMountActivity = (
   serviceName,
@@ -112,11 +108,11 @@ describe('Interaction activity card', () => {
       assertKindLabel()
       assertActivitySubject(SUBJECT, INTERACTION_URL)
       assertMetadataItems([
-        'Date 25 Nov 2058',
-        ONE_CONTACT_TEXT,
-        'Communication channel Email/Fax',
-        ONE_ADVISER_TEXT,
-        buildServiceLabel(DIT_SERVICE),
+        { label: 'Date', value: '25 Nov 2058' },
+        { label: 'Contact', value: ONE_CONTACT_TEXT },
+        { label: 'Communication channel', value: 'Email/Fax' },
+        { label: 'Adviser', value: ONE_ADVISER_TEXT },
+        { label: 'Service', value: DIT_SERVICE },
       ])
 
       cy.get('[data-test=contact-link-0]').should(
@@ -140,11 +136,11 @@ describe('Interaction activity card', () => {
 
       it('should render multiple contacts and advisers', () => {
         assertMetadataItems([
-          'Date 25 Nov 2058',
-          TWO_CONTACTS_TEXT,
-          'Communication channel Email/Fax',
-          TWO_ADVISERS_TEXT,
-          buildServiceLabel(DIT_SERVICE),
+          { label: 'Date', value: '25 Nov 2058' },
+          { label: 'Contacts', value: TWO_CONTACTS_TEXT },
+          { label: 'Communication channel', value: 'Email/Fax' },
+          { label: 'Advisers', value: TWO_ADVISERS_TEXT },
+          { label: 'Service', value: DIT_SERVICE },
         ])
       })
     })
@@ -181,10 +177,10 @@ describe('Interaction activity card', () => {
 
       it('should not render the date label', () => {
         assertMetadataItems([
-          ONE_CONTACT_TEXT,
-          'Communication channel Email/Fax',
-          ONE_ADVISER_TEXT,
-          buildServiceLabel(DIT_SERVICE),
+          { label: 'Contact', value: ONE_CONTACT_TEXT },
+          { label: 'Communication channel', value: 'Email/Fax' },
+          { label: 'Adviser', value: ONE_ADVISER_TEXT },
+          { label: 'Service', value: DIT_SERVICE },
         ])
       })
     })
@@ -197,10 +193,10 @@ describe('Interaction activity card', () => {
 
       it('should not render the advisers label', () => {
         assertMetadataItems([
-          'Date 25 Nov 2058',
-          ONE_CONTACT_TEXT,
-          'Communication channel Email/Fax',
-          buildServiceLabel(DIT_SERVICE),
+          { label: 'Date', value: '25 Nov 2058' },
+          { label: 'Contact', value: ONE_CONTACT_TEXT },
+          { label: 'Communication channel', value: 'Email/Fax' },
+          { label: 'Service', value: DIT_SERVICE },
         ])
       })
     })
@@ -213,10 +209,10 @@ describe('Interaction activity card', () => {
 
       it('should not render the communication channel label', () => {
         assertMetadataItems([
-          'Date 25 Nov 2058',
-          ONE_CONTACT_TEXT,
-          ONE_ADVISER_TEXT,
-          buildServiceLabel(DIT_SERVICE),
+          { label: 'Date', value: '25 Nov 2058' },
+          { label: 'Contact', value: ONE_CONTACT_TEXT },
+          { label: 'Adviser', value: ONE_ADVISER_TEXT },
+          { label: 'Service', value: DIT_SERVICE },
         ])
       })
     })
@@ -312,16 +308,19 @@ function assertService(service = DIT_SERVICE, index = 4) {
   beforeEach(() => {
     buildAndMountWithCustomService(service)
     cy.get('[data-test="collection-item"]').should('exist')
-    cy.get('[data-test="metadata-item"]').as('metadataItems')
+    cy.get('[data-test="metadata-label"]').as('metadataLabels')
+    cy.get('[data-test="metadata-value"]').as('metadataValues')
   })
 
   it('should display the correct service', () => {
     assertServiceLabel(service)
   })
 
-  it('should render the full service label', () => {
-    cy.get('@metadataItems')
-      .eq(index)
-      .should('have.text', buildServiceLabel(service))
+  it('should render the Service label', () => {
+    cy.get('@metadataLabels').eq(index).should('have.text', 'Service')
+  })
+
+  it('should render the service value', () => {
+    cy.get('@metadataValues').eq(index).should('have.text', service)
   })
 }

--- a/test/component/cypress/specs/Companies/CompanyActivity/InvestmentActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/InvestmentActivity.cy.jsx
@@ -76,15 +76,19 @@ describe('Investment project activity card', () => {
         assertNotEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contact Alexander Hamilton',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          { label: 'Company contact', value: 'Alexander Hamilton' },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -108,15 +112,19 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contact Alexander Hamilton',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          { label: 'Company contact', value: 'Alexander Hamilton' },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -140,15 +148,19 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contact Alexander Hamilton',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          { label: 'Company contact', value: 'Alexander Hamilton' },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -167,15 +179,22 @@ describe('Investment project activity card', () => {
         assertNotEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contacts Alexander Hamilton, Oliver Twist',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          {
+            label: 'Company contacts',
+            value: 'Alexander Hamilton, Oliver Twist',
+          },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -199,15 +218,22 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contacts Alexander Hamilton, Oliver Twist',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          {
+            label: 'Company contacts',
+            value: 'Alexander Hamilton, Oliver Twist',
+          },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -231,15 +257,22 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
-          'Company contacts Alexander Hamilton, Oliver Twist',
-          'Total investment £1,234,567,890',
-          'Capital expenditure value £123,456,789',
-          'Gross value added (GVA) £12,345',
-          'Number of jobs 1',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
+          {
+            label: 'Company contacts',
+            value: 'Alexander Hamilton, Oliver Twist',
+          },
+          { label: 'Total investment', value: '£1,234,567,890' },
+          { label: 'Capital expenditure value', value: '£123,456,789' },
+          { label: 'Gross value added (GVA)', value: '£12,345' },
+          { label: 'Number of jobs', value: '1' },
         ])
       })
     }
@@ -258,10 +291,14 @@ describe('Investment project activity card', () => {
         assertNotEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -285,10 +322,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -312,10 +353,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -334,10 +379,14 @@ describe('Investment project activity card', () => {
         assertNotEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Non-FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Non-FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -361,10 +410,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Non-FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Non-FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -388,10 +441,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Non-FDI',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Non-FDI' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -414,10 +471,14 @@ describe('Investment project activity card', () => {
         assertNotEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Commitment to invest',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Commitment to invest' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -441,10 +502,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Commitment to invest',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Commitment to invest' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }
@@ -468,10 +533,14 @@ describe('Investment project activity card', () => {
         assertEYBLabel()
         assertActivitySubject(NAME, PROJECT_URL)
         assertMetadataItems([
-          'Created on 25 Nov 2058',
-          'Investment type Commitment to invest',
-          'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-          'Estimated land date 1 Dec 2023',
+          { label: 'Created on', value: '25 Nov 2058' },
+          { label: 'Investment type', value: 'Commitment to invest' },
+          {
+            label: 'Added by',
+            value:
+              'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+          },
+          { label: 'Estimated land date', value: '1 Dec 2023' },
         ])
       })
     }

--- a/test/component/cypress/specs/Companies/CompanyActivity/OrderActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/OrderActivity.cy.jsx
@@ -59,11 +59,15 @@ describe('Order activity card', () => {
       assertOrderLabels()
       assertActivitySubject(REFERENCE, ORDER_URL)
       assertMetadataItems([
-        'Date 25 Nov 2058',
-        'Country Test Country',
-        'UK region Test UK Region',
-        'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-        'Company contact Alexander Hamilton, Test Job',
+        { label: 'Date', value: '25 Nov 2058' },
+        { label: 'Country', value: 'Test Country' },
+        { label: 'UK region', value: 'Test UK Region' },
+        {
+          label: 'Added by',
+          value:
+            'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+        },
+        { label: 'Company contact', value: 'Alexander Hamilton, Test Job' },
       ])
     })
   })
@@ -78,10 +82,14 @@ describe('Order activity card', () => {
       assertOrderLabels()
       assertActivitySubject(REFERENCE, ORDER_URL)
       assertMetadataItems([
-        'Date 25 Nov 2058',
-        'Country Test Country',
-        'Added by Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-        'Company contact Oliver Twist',
+        { label: 'Date', value: '25 Nov 2058' },
+        { label: 'Country', value: 'Test Country' },
+        {
+          label: 'Added by',
+          value:
+            'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+        },
+        { label: 'Company contact', value: 'Oliver Twist' },
       ])
     })
   })

--- a/test/component/cypress/specs/Companies/CompanyActivity/ReferralActivity.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyActivity/ReferralActivity.cy.jsx
@@ -55,10 +55,17 @@ describe('Referral activity card', () => {
       assertReferralLabel()
       assertActivitySubject(SUBJECT, REFERRAL_URL)
       assertMetadataItems([
-        'Created on 25 Nov 2058',
-        'Completed on 25 Dec 2058',
-        'Sending adviser Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-        'Receiving adviser Puck Head  puckhead@test.com, Test Team 2  ',
+        { label: 'Created on', value: '25 Nov 2058' },
+        { label: 'Completed on', value: '25 Dec 2058' },
+        {
+          label: 'Sending adviser',
+          value:
+            'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+        },
+        {
+          label: 'Receiving adviser',
+          value: 'Puck Head  puckhead@test.com, Test Team 2  ',
+        },
       ])
     })
   })
@@ -73,9 +80,16 @@ describe('Referral activity card', () => {
       assertReferralLabel('Outstanding referral')
       assertActivitySubject(SUBJECT, REFERRAL_URL)
       assertMetadataItems([
-        'Created on 25 Nov 2058',
-        'Sending adviser Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
-        'Receiving adviser Puck Head  puckhead@test.com, Test Team 2  ',
+        { label: 'Created on', value: '25 Nov 2058' },
+        {
+          label: 'Sending adviser',
+          value:
+            'Bernard Harris-Patel  bernardharrispatel@test.com, Test Team 1  ',
+        },
+        {
+          label: 'Receiving adviser',
+          value: 'Puck Head  puckhead@test.com, Test Team 2  ',
+        },
       ])
     })
   })

--- a/test/component/cypress/specs/Event/StovaEventDetails/Attendees.cy.jsx
+++ b/test/component/cypress/specs/Event/StovaEventDetails/Attendees.cy.jsx
@@ -29,10 +29,7 @@ describe('AttendeeList', () => {
       cy.mountWithProvider(<AttendeeList interactions={interactions} />)
 
       assertTitle('Not Available')
-      assertMetadataItem(
-        '[data-test=collection-item]',
-        'Job title Not available'
-      )
+      assertMetadataItem('[data-test=collection-item]', 'Not available')
     })
 
     it('should render values from interaction', () => {
@@ -42,10 +39,16 @@ describe('AttendeeList', () => {
 
       assertTitle('Ima Contact')
       assertMetadataItems([
-        `Company ${interactions[0].companies[0].name}`,
-        `Job title ${interactions[0].contacts[0].job_title}`,
-        `Date attended ${formatDate(interactions[0].date, DATE_FORMAT_FULL)}`,
-        `Service delivery ${interactions[0].service.name}`,
+        { label: 'Company', value: `${interactions[0].companies[0].name}` },
+        {
+          label: 'Job title',
+          value: `${interactions[0].contacts[0].job_title}`,
+        },
+        {
+          label: 'Date attended',
+          value: `${formatDate(interactions[0].date, DATE_FORMAT_FULL)}`,
+        },
+        { label: 'Service delivery', value: `${interactions[0].service.name}` },
       ])
     })
   })

--- a/test/component/cypress/specs/ExportPipeline/ExportInteractionsList.cy.jsx
+++ b/test/component/cypress/specs/ExportPipeline/ExportInteractionsList.cy.jsx
@@ -62,19 +62,23 @@ describe('ExportInteractionsList', () => {
         .should('have.text', 'Video call meeting to Baileys')
         .and('have.attr', 'href', '/export/987/interactions/123/details')
 
-      const items = '[data-test="metadata-item"]'
-      cy.get(items).should('have.length', 4)
-      cy.get(items).eq(0).should('have.text', 'Date: 23 December 2024')
-      cy.get(items).eq(1).should('have.text', 'Contact(s): James Brown')
-      cy.get(items)
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 4)
+      cy.get(itemLabels).eq(0).should('have.text', 'Date:')
+      cy.get(itemLabels).eq(1).should('have.text', 'Contact(s):')
+      cy.get(itemLabels).eq(2).should('have.text', 'Adviser(s):')
+      cy.get(itemLabels).eq(3).should('have.text', 'Service:')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 4)
+      cy.get(itemValues).eq(0).should('have.text', '23 December 2024')
+      cy.get(itemValues).eq(1).should('have.text', 'James Brown')
+      cy.get(itemValues)
         .eq(2)
-        .should(
-          'have.text',
-          'Adviser(s): David Buffer - Digital Data Hub - Live Service'
-        )
-      cy.get(items)
+        .should('have.text', 'David Buffer - Digital Data Hub - Live Service')
+      cy.get(itemValues)
         .eq(3)
-        .should('have.text', 'Service: Account management : General')
+        .should('have.text', 'Account management : General')
     })
   })
 
@@ -106,9 +110,12 @@ describe('ExportInteractionsList', () => {
       },
     })
 
-    cy.get('[data-test="metadata-item"]')
+    cy.get('[data-test="metadata-label"]')
       .eq(1)
-      .should('have.text', 'Contact(s): James Brown, Jim Brown, Jude Brown')
+      .should('have.text', 'Contact(s):')
+    cy.get('[data-test="metadata-value"]')
+      .eq(1)
+      .should('have.text', 'James Brown, Jim Brown, Jude Brown')
   })
 
   it('should render a list of multiple advisers', () => {
@@ -153,11 +160,14 @@ describe('ExportInteractionsList', () => {
       },
     })
 
-    cy.get('[data-test="metadata-item"]')
+    cy.get('[data-test="metadata-label"]')
+      .eq(2)
+      .should('have.text', 'Adviser(s):')
+    cy.get('[data-test="metadata-value"]')
       .eq(2)
       .should(
         'have.text',
-        'Adviser(s): James Brown - British Water, Jim Brown - Cumbria LEP, Jude Brown - Doncaster Council'
+        'James Brown - British Water, Jim Brown - Cumbria LEP, Jude Brown - Doncaster Council'
       )
   })
 

--- a/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
@@ -55,19 +55,23 @@ describe('WinsConfirmedList', () => {
           urls.companies.overview.index(exportWinsList[0].company.id)
         )
 
-      const items = '[data-test="metadata-item"]'
-      cy.get(items).should('have.length', 4)
-      cy.get(items)
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 4)
+      cy.get(itemLabels).eq(0).should('have.text', `Contact name:`)
+      cy.get(itemLabels).eq(1).should('have.text', `Total value:`)
+      cy.get(itemLabels).eq(2).should('have.text', 'Date won:')
+      cy.get(itemLabels).eq(3).should('have.text', `Date responded:`)
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 4)
+      cy.get(itemValues)
         .eq(0)
-        .should(
-          'have.text',
-          `Contact name: ${exportWin.company_contacts[0].name}`
-        )
-      cy.get(items)
+        .should('have.text', `${exportWin.company_contacts[0].name}`)
+      cy.get(itemValues)
         .eq(1)
         .should(
           'have.text',
-          `Total value: ${currencyGBP(
+          `${currencyGBP(
             sumExportValues(
               pick(exportWin, [
                 'total_expected_export_value',
@@ -77,12 +81,12 @@ describe('WinsConfirmedList', () => {
             )
           )}`
         )
-      cy.get(items).eq(2).should('have.text', 'Date won: May 2023')
-      cy.get(items)
+      cy.get(itemValues).eq(2).should('have.text', 'May 2023')
+      cy.get(itemValues)
         .eq(3)
         .should(
           'have.text',
-          `Date responded: ${formatDate(exportWin.customer_response.responded_on)}`
+          `${formatDate(exportWin.customer_response.responded_on)}`
         )
     })
   })

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -59,21 +59,32 @@ describe('WinsPendingList', () => {
           urls.companies.overview.index(exportWinsList[0].company.id)
         )
 
-      const items = '[data-test="metadata-item"]'
-      cy.get(items).should('have.length', 6)
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 6)
 
-      cy.get(items)
+      cy.get(itemLabels).eq(0).should('have.text', `Contact name:`)
+
+      cy.get(itemLabels).eq(1).should('have.text', `Total value:`)
+
+      cy.get(itemLabels).eq(2).should('have.text', 'Date won:')
+
+      cy.get(itemLabels).eq(3).should('have.text', `Date modified:`)
+      cy.get(itemLabels).eq(4).should('have.text', `First sent:`)
+
+      cy.get(itemLabels).eq(5).should('have.text', `Last sent:`)
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 6)
+
+      cy.get(itemValues)
         .eq(0)
-        .should(
-          'have.text',
-          `Contact name: ${exportWin.company_contacts[0].name}`
-        )
+        .should('have.text', `${exportWin.company_contacts[0].name}`)
 
-      cy.get(items)
+      cy.get(itemValues)
         .eq(1)
         .should(
           'have.text',
-          `Total value: ${currencyGBP(
+          `${currencyGBP(
             sumExportValues(
               pick(exportWin, [
                 'total_expected_export_value',
@@ -84,26 +95,26 @@ describe('WinsPendingList', () => {
           )}`
         )
 
-      cy.get(items).eq(2).should('have.text', 'Date won: May 2023')
+      cy.get(itemValues).eq(2).should('have.text', 'May 2023')
 
-      cy.get(items)
+      cy.get(itemValues)
         .eq(3)
         .should(
           'have.text',
-          `Date modified: ${formatDate(exportWin.modified_on, DATE_FORMAT_MEDIUM)}`
+          `${formatDate(exportWin.modified_on, DATE_FORMAT_MEDIUM)}`
         )
-      cy.get(items)
+      cy.get(itemValues)
         .eq(4)
         .should(
           'have.text',
-          `First sent: ${formatDate(exportWin.first_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
+          `${formatDate(exportWin.first_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
         )
 
-      cy.get(items)
+      cy.get(itemValues)
         .eq(5)
         .should(
           'have.text',
-          `Last sent: ${formatDate(exportWin.last_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
+          `${formatDate(exportWin.last_sent, DATE_FORMAT_MEDIUM_WITH_TIME)}`
         )
     })
   })

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -57,21 +57,29 @@ describe('WinsRejectedList', () => {
           urls.companies.overview.index(exportWinsList[0].company.id)
         )
 
-      const items = '[data-test="metadata-item"]'
-      cy.get(items).should('have.length', 4)
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).should('have.length', 4)
 
-      cy.get(items)
+      cy.get(itemLabels).eq(0).should('have.text', `Contact name:`)
+
+      cy.get(itemLabels).eq(1).should('have.text', `Total value:`)
+
+      cy.get(itemLabels).eq(2).should('have.text', 'Date won:')
+
+      cy.get(itemLabels).eq(3).should('have.text', `Date modified:`)
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues).should('have.length', 4)
+
+      cy.get(itemValues)
         .eq(0)
-        .should(
-          'have.text',
-          `Contact name: ${exportWin.company_contacts[0].name}`
-        )
+        .should('have.text', `${exportWin.company_contacts[0].name}`)
 
-      cy.get(items)
+      cy.get(itemValues)
         .eq(1)
         .should(
           'have.text',
-          `Total value: ${currencyGBP(
+          `${currencyGBP(
             sumExportValues(
               pick(exportWin, [
                 'total_expected_export_value',
@@ -82,13 +90,13 @@ describe('WinsRejectedList', () => {
           )}`
         )
 
-      cy.get(items).eq(2).should('have.text', 'Date won: May 2023')
+      cy.get(itemValues).eq(2).should('have.text', 'May 2023')
 
-      cy.get(items)
+      cy.get(itemValues)
         .eq(3)
         .should(
           'have.text',
-          `Date modified: ${formatDate(exportWin.modified_on, DATE_FORMAT_MEDIUM)}`
+          `${formatDate(exportWin.modified_on, DATE_FORMAT_MEDIUM)}`
         )
     })
   })

--- a/test/component/cypress/support/activity-assertions.js
+++ b/test/component/cypress/support/activity-assertions.js
@@ -24,11 +24,21 @@ export const assertActivitySubject = (
  * Asserts that a given metadata element in an activity item is correct
  */
 export const assertMetadataItems = (expectedMetadata) => {
-  cy.get('[data-test="metadata-item"]').as('metadataItems')
-  cy.get('@metadataItems')
+  cy.get('[data-test="metadata-label"]').as('metadataLabels')
+  cy.get('@metadataLabels')
     .should('have.length', expectedMetadata.length)
     .each((x, i) => {
-      cy.get('@metadataItems').eq(i).should('have.text', expectedMetadata[i])
+      cy.get('@metadataLabels')
+        .eq(i)
+        .should('have.text', expectedMetadata[i].label)
+    })
+  cy.get('[data-test="metadata-value"]').as('metadataValues')
+  cy.get('@metadataValues')
+    .should('have.length', expectedMetadata.length)
+    .each((x, i) => {
+      cy.get('@metadataValues')
+        .eq(i)
+        .should('have.text', expectedMetadata[i].value)
     })
 }
 

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -181,13 +181,14 @@ describe('Company account management', () => {
     it('should display the blocker text when an objective has a blocker', () => {
       cy.get('[data-test="objective has-blocker"]')
         .eq(0)
-        .find('[data-test="metadata-item"]')
-        .should('contain', objectives[0].blocker_description)
+        .find('[data-test="metadata-value"]')
+        .eq(1)
+        .should('have.text', objectives[0].blocker_description)
     })
 
     it('should not display the blocker text when an objective has no blocker', () => {
       cy.get('[data-test="objective no-blocker"]')
-        .find('[data-test="metadata-item"]')
+        .find('[data-test="metadata-value"]')
         .should('not.contain', noBlockersObjective.blocker_description)
     })
   })

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -100,12 +100,12 @@ describe('Company activity feed', () => {
       )
     })
     it('displays the Great export enquiry contact', () => {
-      cy.get('[data-test="metadata-item"]').contains(
+      cy.get('[data-test="metadata-value"]').contains(
         activity.great_export_enquiry.contact.name
       )
     })
     it('displays the Great export enquiry comment', () => {
-      cy.get('[data-test="metadata-item"]').contains(great_comment)
+      cy.get('[data-test="metadata-value"]').contains(great_comment)
     })
   })
 
@@ -297,7 +297,8 @@ describe('Company activity feed', () => {
         EYBListHighValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value High')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('High')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')
@@ -316,7 +317,8 @@ describe('Company activity feed', () => {
         EYBListLowValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value Low')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('Low')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')
@@ -335,7 +337,8 @@ describe('Company activity feed', () => {
         EYBListUnknownValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value Unknown')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('Unknown')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')
@@ -383,7 +386,8 @@ describe('Company activity feed', () => {
         EYBListHighValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value High')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('High')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')
@@ -402,7 +406,8 @@ describe('Company activity feed', () => {
         EYBListLowValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value Low')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('Low')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')
@@ -421,7 +426,8 @@ describe('Company activity feed', () => {
         EYBListUnknownValue,
         urls.companies.activity.index(fixtures.company.venusLtd.id)
       )
-      cy.get('[data-test="metadata-item"]').contains('Value Unknown')
+      cy.get('[data-test="metadata-label"]').contains('Value')
+      cy.get('[data-test="metadata-value"]').contains('Unknown')
       cy.get('[data-test="collection-item"]').each(() =>
         cy
           .get('a')

--- a/test/functional/cypress/specs/companies/activity-feed-spec.js
+++ b/test/functional/cypress/specs/companies/activity-feed-spec.js
@@ -150,7 +150,7 @@ describe('Company activity feed', () => {
     })
     it('displays the order with a uk region', () => {
       cy.get('[data-test="collection-item"]').each(() =>
-        cy.get('span').contains('UK region')
+        cy.get('dt').contains('UK region')
       )
     })
 

--- a/test/functional/cypress/specs/companies/add-company-spec.js
+++ b/test/functional/cypress/specs/companies/add-company-spec.js
@@ -101,7 +101,7 @@ describe('Add company form', () => {
           .next()
           .should(
             'have.text',
-            'Trading name(s) Some matched company trading nameLocation at 123 Fake Street, Brighton, BN1 4SE'
+            'Trading name(s)Some matched company trading nameLocation at123 Fake Street, Brighton, BN1 4SE'
           )
           .next()
           .should(

--- a/test/functional/cypress/specs/companies/contact-collection-spec.js
+++ b/test/functional/cypress/specs/companies/contact-collection-spec.js
@@ -184,30 +184,36 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should render the job title', () => {
+      assertMetadataItem('@firstListItem', 'Job title')
       assertMetadataItem(
         '@firstListItem',
-        'Job title Dynamic Accountability Administrator'
+        'Dynamic Accountability Administrator'
       )
     })
 
     it('should render the sector', () => {
-      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector')
+      assertMetadataItem('@firstListItem', 'Advanced Engineering')
     })
 
     it('should render the country', () => {
-      assertMetadataItem('@firstListItem', 'Country United Kingdom')
+      assertMetadataItem('@firstListItem', 'Country')
+      assertMetadataItem('@firstListItem', 'United Kingdom')
     })
 
     it('should render the UK region', () => {
-      assertMetadataItem('@firstListItem', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region')
+      assertMetadataItem('@firstListItem', 'London')
     })
 
     it('should render the UK telephone number', () => {
-      assertMetadataItem('@firstListItem', 'Phone number +44 02071234567')
+      assertMetadataItem('@firstListItem', 'Phone number')
+      assertMetadataItem('@firstListItem', '+44 02071234567')
     })
 
     it('should render the email', () => {
-      assertMetadataItem('@firstListItem', 'Email gloria33@gmail.com')
+      assertMetadataItem('@firstListItem', 'Email')
+      assertMetadataItem('@firstListItem', 'gloria33@gmail.com')
     })
   })
 
@@ -241,15 +247,18 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should render the job title', () => {
-      assertMetadataItem('@secondListItem', 'Job title Legacy Branding Agent')
+      assertMetadataItem('@secondListItem', 'Job title')
+      assertMetadataItem('@secondListItem', 'Legacy Branding Agent')
     })
 
     it('should render the sector', () => {
-      assertMetadataItem('@secondListItem', 'Sector Creative and Media')
+      assertMetadataItem('@secondListItem', 'Sector')
+      assertMetadataItem('@secondListItem', 'Creative and Media')
     })
 
     it('should render the foreign country', () => {
-      assertMetadataItem('@secondListItem', 'Country United States')
+      assertMetadataItem('@secondListItem', 'Country')
+      assertMetadataItem('@secondListItem', 'United States')
     })
 
     it('should not render the UK region', () => {
@@ -257,7 +266,8 @@ describe('Company Contacts Collections', () => {
     })
 
     it('should render the telephone number', () => {
-      assertMetadataItem('@secondListItem', 'Phone number (0045) 48770000')
+      assertMetadataItem('@secondListItem', 'Phone number')
+      assertMetadataItem('@secondListItem', '(0045) 48770000')
     })
   })
 

--- a/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
+++ b/test/functional/cypress/specs/companies/export/company-export-wins-spec.js
@@ -16,7 +16,6 @@ const exportWinList = [exportWin1, exportWin2, exportWin3]
 
 const getExpectedMetadata = (win) => ({
   'Lead officer name': win.lead_officer.name,
-  'Company name': 'Not set',
   'Contact name': `${win.contact.name} (${win.contact.job_title} - ${win.contact.email})`,
   Destination: win.country,
   'Date won': formatDate(win.date, DATE_FORMAT_MONTH_YEAR),
@@ -72,17 +71,22 @@ describe('Company export wins', () => {
           })
 
         // Loop through each metadata item and assert label and value
-        cy.get('[data-test="metadata-item"]').each((metaItem) => {
-          cy.wrap(metaItem).within(() => {
-            cy.get('span')
-              .first()
-              .invoke('text')
-              .then((label) => {
-                const expectedValue = expectedMetadata[index][label.trim()]
-                cy.get('span').last().should('have.text', expectedValue)
-              })
-          })
-        })
+        cy.get('[data-test="metadata-label"]').each(
+          (metadataLabel, metadataIndex) => {
+            const expectedLabel = Object.keys(expectedMetadata[index])[
+              metadataIndex
+            ]
+            expect(metadataLabel).to.have.text(expectedLabel)
+          }
+        )
+        cy.get('[data-test="metadata-value"]').each(
+          (metadataValue, metadataIndex) => {
+            const expectedValue = Object.values(expectedMetadata[index])[
+              metadataIndex
+            ]
+            expect(metadataValue).to.have.text(expectedValue)
+          }
+        )
       })
     })
   })

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -72,53 +72,73 @@ describe('Company Export tab - Export countries history', () => {
         checkListItems([
           [
             'Belarus added to countries of no interest',
-            'By DBT Staff',
-            'Date 11 Feb 2020, 10:47am',
+            'By',
+            'DBT Staff',
+            'Date',
+            '11 Feb 2020, 10:47am',
           ],
           [
             'Botswana added to future countries of interest',
-            'By DBT Staff',
-            'Date 11 Feb 2020, 10:47am',
+            'By',
+            'DBT Staff',
+            'Date',
+            '11 Feb 2020, 10:47am',
           ],
           [
             'Georgia added to currently exporting',
-            'By DBT Staff',
-            'Date 11 Feb 2020, 10:48am',
+            'By',
+            'DBT Staff',
+            'Date',
+            '11 Feb 2020, 10:48am',
           ],
           [
             'France added to currently exporting',
-            'By DBT Staff',
-            'Date 11 Feb 2020, 10:47am',
+            'By',
+            'DBT Staff',
+            'Date',
+            '11 Feb 2020, 10:47am',
           ],
           [
             'Fiji added to currently exporting',
-            'By DBT Staff',
-            'Date 11 Feb 2020, 10:46am',
+            'By',
+            'DBT Staff',
+            'Date',
+            '11 Feb 2020, 10:46am',
           ],
           [
             'Argentina added to currently exporting',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 4:06pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 4:06pm',
           ],
           [
             'Andorra added to currently exporting',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 4:05pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 4:05pm',
           ],
           [
             'Afghanistan added to future countries of interest',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 3:42pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 3:42pm',
           ],
           [
             'Andorra removed from future countries of interest',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 3:41pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 3:41pm',
           ],
           [
             'Angola added to countries of no interest',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 3:41pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 3:41pm',
           ],
         ])
       })
@@ -140,13 +160,17 @@ describe('Company Export tab - Export countries history', () => {
         checkListItems([
           [
             'Andorra removed from future countries of interest',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 3:41pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 3:41pm',
           ],
           [
             'Angola added to countries of no interest',
-            'By DBT Staff',
-            'Date 6 Feb 2020, 3:41pm',
+            'By',
+            'DBT Staff',
+            'Date',
+            '6 Feb 2020, 3:41pm',
           ],
         ])
       })
@@ -185,53 +209,73 @@ describe('Company Export tab - Export countries history', () => {
         checkListItems([
           [
             'Afghanistan, Bahrain, Bangladesh, Barbados added to countries of no interest',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 4:33pm',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 4:33pm',
           ],
           [
             'France removed from future countries of interest',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 4:33pm',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 4:33pm',
           ],
           [
             'Spain added to currently exporting',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 4:33pm',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 4:33pm',
           ],
           [
             'Albania, Brazil, Gibraltar removed from currently exporting',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:55am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:55am',
           ],
           [
             'France added to future countries of interest',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:55am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:55am',
           ],
           [
             'Albania, Brazil, Gibraltar added to currently exporting',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:55am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:55am',
           ],
           [
             'Germany, Spain removed from future countries of interest',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:54am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:54am',
           ],
           [
             'France removed from currently exporting',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:54am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:54am',
           ],
           [
             'Germany, Spain added to future countries of interest',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:54am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:54am',
           ],
           [
             'France added to currently exporting',
-            'By Stephan Padberg',
-            'Date 4 Mar 2020, 8:53am',
+            'By',
+            'Stephan Padberg',
+            'Date',
+            '4 Mar 2020, 8:53am',
           ],
         ])
       })
@@ -265,8 +309,10 @@ describe('Company Export tab - Export countries history', () => {
           checkListItems([
             [
               'Andorra removed from future countries of interest',
-              'By unknown',
-              'Date 6 Feb 2020, 3:41pm',
+              'By',
+              'unknown',
+              'Date',
+              '6 Feb 2020, 3:41pm',
             ],
           ])
         })
@@ -295,23 +341,31 @@ describe('Company Export tab - Export countries history', () => {
           checkListItems([
             [
               'Gibraltar, Maldives added to currently exporting',
-              'By unknown',
-              'Date 6 Feb 2020, 5:07pm',
+              'By',
+              'unknown',
+              'Date',
+              '6 Feb 2020, 5:07pm',
             ],
             [
               'Angola moved to currently exporting',
-              'By unknown',
-              'Date 6 Feb 2020, 5:07pm',
+              'By',
+              'unknown',
+              'Date',
+              '6 Feb 2020, 5:07pm',
             ],
             [
               'Andorra added to currently exporting',
-              'By unknown',
-              'Date 6 Feb 2020, 5:07pm',
+              'By',
+              'unknown',
+              'Date',
+              '6 Feb 2020, 5:07pm',
             ],
             [
               'Angola, Czechia, Hong Kong, Kiribati added to future countries of interest',
-              'By unknown',
-              'Date 6 Feb 2020, 5:06pm',
+              'By',
+              'unknown',
+              'Date',
+              '6 Feb 2020, 5:06pm',
             ],
           ])
         })
@@ -329,8 +383,10 @@ describe('Company Export tab - Export countries history', () => {
         checkListItems([
           [
             'Andorra moved to future countries of interest',
-            'By unknown',
-            'Date 6 Feb 2020, 3:41pm',
+            'By',
+            'unknown',
+            'Date',
+            '6 Feb 2020, 3:41pm',
           ],
         ])
       })
@@ -402,11 +458,16 @@ describe('Company Export tab - Export countries history', () => {
             [
               'contain',
               [
-                'Company contacts Stephan Padberg, Stephanie Stokes',
-                'Advisers Mr. Genesis Kub (et nihil repudiandae), Solon Lynch (ea est totam), Dr. Meda Mraz (fuga corporis architecto)',
-                'Service Deserunt magni sapiente soluta praesentium sapiente.',
-                'Countries currently exporting to Benin',
-                'Future countries of interest Brunei Darussalam, French Polynesia',
+                'Company contacts',
+                'Stephan Padberg, Stephanie Stokes',
+                'Advisers',
+                'Mr. Genesis Kub (et nihil repudiandae), Solon Lynch (ea est totam), Dr. Meda Mraz (fuga corporis architecto)',
+                'Service',
+                'Deserunt magni sapiente soluta praesentium sapiente.',
+                'Countries currently exporting to',
+                'Benin',
+                'Future countries of interest',
+                'Brunei Darussalam, French Polynesia',
               ],
             ],
             ['not.contain', ['Countries not interested in']],
@@ -415,11 +476,16 @@ describe('Company Export tab - Export countries history', () => {
             [
               'contain',
               [
-                'Company contact Justus Simonis',
-                'Adviser Carolanne Langworth (sit delectus recusandae)',
-                'Service Ipsa dicta omnis pariatur.',
-                'Countries currently exporting to Christmas Island, Indonesia, Martinique',
-                'Countries not interested in Serbia',
+                'Company contact',
+                'Justus Simonis',
+                'Adviser',
+                'Carolanne Langworth (sit delectus recusandae)',
+                'Service',
+                'Ipsa dicta omnis pariatur.',
+                'Countries currently exporting to',
+                'Christmas Island, Indonesia, Martinique',
+                'Countries not interested in',
+                'Serbia',
               ],
             ],
             ['not.contain', ['Future countries of interest']],
@@ -428,11 +494,16 @@ describe('Company Export tab - Export countries history', () => {
             [
               'contain',
               [
-                'Company contacts Karen Mayer Jr., Ari Von',
-                'Adviser Horace Orn (nisi ipsa quisquam)',
-                'Service Architecto suscipit et aliquam architecto.',
-                'Countries currently exporting to Burkina Faso',
-                'Future countries of interest Kyrgyz Republic, Trinidad and Tobago',
+                'Company contacts',
+                'Karen Mayer Jr., Ari Von',
+                'Adviser',
+                'Horace Orn (nisi ipsa quisquam)',
+                'Service',
+                'Architecto suscipit et aliquam architecto.',
+                'Countries currently exporting to',
+                'Burkina Faso',
+                'Future countries of interest',
+                'Kyrgyz Republic, Trinidad and Tobago',
               ],
             ],
             ['not.contain', ['Countries not interested in']],
@@ -441,12 +512,18 @@ describe('Company Export tab - Export countries history', () => {
             [
               'contain',
               [
-                'Company contact Leonie Deckow',
-                'Advisers Napoleon Powlowski (veritatis temporibus unde), Giovanna Anderson (delectus repellendus ducimus), Tessie Hane (perferendis nihil nam)',
-                'Service Repellat quia fugiat velit delectus expedita omnis doloribus.',
-                'Countries currently exporting to Bolivia, Cameroon',
-                'Future countries of interest Bolivia, Qatar',
-                'Countries not interested in Australia, Greenland',
+                'Company contact',
+                'Leonie Deckow',
+                'Advisers',
+                'Napoleon Powlowski (veritatis temporibus unde), Giovanna Anderson (delectus repellendus ducimus), Tessie Hane (perferendis nihil nam)',
+                'Service',
+                'Repellat quia fugiat velit delectus expedita omnis doloribus.',
+                'Countries currently exporting to',
+                'Bolivia, Cameroon',
+                'Future countries of interest',
+                'Bolivia, Qatar',
+                'Countries not interested in',
+                'Australia, Greenland',
               ],
             ],
           ],
@@ -473,8 +550,10 @@ describe('Company Export tab - Export countries history', () => {
 
         cy.contains('Belarus added to countries of no interest')
           .siblings()
-          .should('contain', 'By DBT Staff')
-          .should('contain', 'Date 11 Feb 2020, 10:47am')
+          .should('contain', 'By')
+          .should('contain', 'DBT Staff')
+          .should('contain', 'Date')
+          .should('contain', '11 Feb 2020, 10:47am')
       })
     })
   })
@@ -525,13 +604,17 @@ describe('Company Export tab - Export countries history', () => {
       checkListItems([
         [
           'Andorra added to currently exporting',
-          'By DBT Staff',
-          'Date 6 Feb 2020, 4:06pm',
+          'By',
+          'DBT Staff',
+          'Date',
+          '6 Feb 2020, 4:06pm',
         ],
         [
           'Andorra removed from future countries of interest',
-          'By DBT Staff',
-          'Date 6 Feb 2020, 3:41pm',
+          'By',
+          'DBT Staff',
+          'Date',
+          '6 Feb 2020, 3:41pm',
         ],
       ])
     })

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -63,14 +63,13 @@ function assertListItem({
   })
 
   it('should render the sector', () => {
-    assertMetadataItem(alias, `Sector ${sector.name}`)
+    assertMetadataItem(alias, 'Sector')
+    assertMetadataItem(alias, `${sector.name}`)
   })
 
   it('should render the estimated land date', () => {
-    assertMetadataItem(
-      alias,
-      `Estimated land date ${formattedEstimatedLandDate}`
-    )
+    assertMetadataItem(alias, 'Estimated land date')
+    assertMetadataItem(alias, `${formattedEstimatedLandDate}`)
   })
 
   it('should render the subsidiary companies enabled', () => {

--- a/test/functional/cypress/specs/companies/omis-collection-spec.js
+++ b/test/functional/cypress/specs/companies/omis-collection-spec.js
@@ -162,27 +162,33 @@ describe('Company Orders (OMIS) Collection Page', () => {
     })
 
     it('should render the company name', () => {
-      assertMetadataItem('@firstListItem', 'Company Williams-Rose')
+      assertMetadataItem('@firstListItem', 'Company')
+      assertMetadataItem('@firstListItem', 'Williams-Rose')
     })
 
     it('should render the created date (created_on)', () => {
-      assertMetadataItem('@firstListItem', 'Created 30 Nov 2020, 1:28am')
+      assertMetadataItem('@firstListItem', 'Created')
+      assertMetadataItem('@firstListItem', '30 Nov 2020, 1:28am')
     })
 
     it('should render the contact name', () => {
-      assertMetadataItem('@firstListItem', 'Contact Melissa Compton')
+      assertMetadataItem('@firstListItem', 'Contact')
+      assertMetadataItem('@firstListItem', 'Melissa Compton')
     })
 
     it('should render the UK region', () => {
-      assertMetadataItem('@firstListItem', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region')
+      assertMetadataItem('@firstListItem', 'London')
     })
 
     it('should render the sector', () => {
-      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector')
+      assertMetadataItem('@firstListItem', 'Advanced Engineering')
     })
 
     it('should render the delivery date (delivery_date)', () => {
-      assertMetadataItem('@firstListItem', 'Delivery date 11 Dec 2022')
+      assertMetadataItem('@firstListItem', 'Delivery date')
+      assertMetadataItem('@firstListItem', '11 Dec 2022')
     })
   })
 

--- a/test/functional/cypress/specs/contacts/activity-spec.js
+++ b/test/functional/cypress/specs/contacts/activity-spec.js
@@ -112,23 +112,27 @@ describe('Contact activity', () => {
       })
 
       it('should display the date', () => {
-        cy.get('@firstListItem').contains('Date 10 Jun 2019')
+        cy.get('@firstListItem').contains('Date')
+        cy.get('@firstListItem').contains('10 Jun 2019')
       })
 
       it('should display the advisers with email', () => {
+        cy.get('@firstListItem').contains('Adviser')
         cy.get('@firstListItem').contains(
-          'Adviser Puck Head Puck.Head@example.com, Digital Data Hub - Live Service'
+          'Puck Head Puck.Head@example.com, Digital Data Hub - Live Service'
         )
       })
 
       it('should display the service', () => {
+        cy.get('@firstListItem').contains('Service')
         cy.get('@firstListItem').contains(
-          'Service Export introductions : Someone else in DBT'
+          'Export introductions : Someone else in DBT'
         )
       })
 
       it('should display the communication channel', () => {
-        cy.get('@firstListItem').contains('Communication channel Email/Website')
+        cy.get('@firstListItem').contains('Communication channel')
+        cy.get('@firstListItem').contains('Email/Website')
       })
 
       context('when optional data is missing', () => {

--- a/test/functional/cypress/specs/contacts/audit-spec.js
+++ b/test/functional/cypress/specs/contacts/audit-spec.js
@@ -65,9 +65,10 @@ describe('Contact audit history', () => {
       it('should only render the updated on and no changes text', () => {
         cy.get('@listItem1')
           .should('exist')
-          .should('contain', 'Updated on 19 May 2022, 1:56pm by Joseph Woof')
+          .should('contain', 'Updated on')
+          .should('contain', '19 May 2022, 1:56pm by Joseph Woof')
           .find('[data-test="metadata"]')
-          .find('[data-test="metadata-item"]')
+          .find('[data-test="metadata-label"]')
           .should(
             'contain',
             'No changes were made to the contact in this update'

--- a/test/functional/cypress/specs/contacts/collection-spec.js
+++ b/test/functional/cypress/specs/contacts/collection-spec.js
@@ -101,19 +101,23 @@ describe('Contacts Collections', () => {
       assertTagNotPresent('@firstListItem', 'Archived')
       assertTagNotPresent('@firstListItem', 'UNKNOWN EMAIL')
       assertUpdatedOn('@firstListItem', 'Updated on 10 Aug 2020, 8:09pm')
+      assertMetadataItem('@firstListItem', 'Company')
+      assertMetadataItem('@firstListItem', 'Murray, Price and Hodkiewicz')
+      assertMetadataItem('@firstListItem', 'Job title')
       assertMetadataItem(
         '@firstListItem',
-        'Company Murray, Price and Hodkiewicz'
+        'Dynamic Accountability Administrator'
       )
-      assertMetadataItem(
-        '@firstListItem',
-        'Job title Dynamic Accountability Administrator'
-      )
-      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
-      assertMetadataItem('@firstListItem', 'Country United Kingdom')
-      assertMetadataItem('@firstListItem', 'UK region London')
-      assertMetadataItem('@firstListItem', 'Phone number +44 02071234567')
-      assertMetadataItem('@firstListItem', 'Email gloria33@gmail.com')
+      assertMetadataItem('@firstListItem', 'Sector')
+      assertMetadataItem('@firstListItem', 'Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Country')
+      assertMetadataItem('@firstListItem', 'United Kingdom')
+      assertMetadataItem('@firstListItem', 'UK region')
+      assertMetadataItem('@firstListItem', 'London')
+      assertMetadataItem('@firstListItem', 'Phone number')
+      assertMetadataItem('@firstListItem', '+44 02071234567')
+      assertMetadataItem('@firstListItem', 'Email')
+      assertMetadataItem('@firstListItem', 'gloria33@gmail.com')
     })
   })
 
@@ -121,9 +125,11 @@ describe('Contacts Collections', () => {
     it('should render the correct elements', () => {
       assertItemLink('@secondListItem', 'Ted Woods', '/contacts/2/details')
       assertTagShouldNotExist('@secondListItem')
-      assertMetadataItem('@secondListItem', 'Country United States')
+      assertMetadataItem('@secondListItem', 'Country')
+      assertMetadataItem('@secondListItem', 'United States')
       assertMetadataItemNotPresent('@secondListItem', 'UK region')
-      assertMetadataItem('@secondListItem', 'Phone number 0045 48770000')
+      assertMetadataItem('@secondListItem', 'Phone number')
+      assertMetadataItem('@secondListItem', '0045 48770000')
     })
   })
 

--- a/test/functional/cypress/specs/events/attendees-search-spec.js
+++ b/test/functional/cypress/specs/events/attendees-search-spec.js
@@ -111,37 +111,41 @@ describe('Event attendee search', () => {
       })
 
       it('should render the company name', () => {
-        assertMetadataItem(
-          '@firstListItem',
-          'Company Murray, Price and Hodkiewicz'
-        )
+        assertMetadataItem('@firstListItem', 'Company')
+        assertMetadataItem('@firstListItem', 'Murray, Price and Hodkiewicz')
       })
 
       it('should render the job title', () => {
+        assertMetadataItem('@firstListItem', 'Job title')
         assertMetadataItem(
           '@firstListItem',
-          'Job title Dynamic Accountability Administrator'
+          'Dynamic Accountability Administrator'
         )
       })
 
       it('should render the sector', () => {
-        assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
+        assertMetadataItem('@firstListItem', 'Sector')
+        assertMetadataItem('@firstListItem', 'Advanced Engineering')
       })
 
       it('should render the country', () => {
-        assertMetadataItem('@firstListItem', 'Country United Kingdom')
+        assertMetadataItem('@firstListItem', 'Country')
+        assertMetadataItem('@firstListItem', 'United Kingdom')
       })
 
       it('should render the UK region', () => {
-        assertMetadataItem('@firstListItem', 'UK region London')
+        assertMetadataItem('@firstListItem', 'UK region')
+        assertMetadataItem('@firstListItem', 'London')
       })
 
       it('should render the UK telephone number', () => {
-        assertMetadataItem('@firstListItem', 'Phone number +44 02071234567')
+        assertMetadataItem('@firstListItem', 'Phone number')
+        assertMetadataItem('@firstListItem', '+44 02071234567')
       })
 
       it('should render the email', () => {
-        assertMetadataItem('@firstListItem', 'Email gloria33@gmail.com')
+        assertMetadataItem('@firstListItem', 'Email')
+        assertMetadataItem('@firstListItem', 'gloria33@gmail.com')
       })
     })
 
@@ -159,13 +163,15 @@ describe('Event attendee search', () => {
       })
 
       it('should render the foreign country', () => {
-        assertMetadataItem('@secondListItem', 'Country United States')
+        assertMetadataItem('@secondListItem', 'Country')
+        assertMetadataItem('@secondListItem', 'United States')
       })
       it('should not render the UK region', () => {
         assertMetadataItemNotPresent('@secondListItem', 'UK region')
       })
       it('should render the telephone number', () => {
-        assertMetadataItem('@secondListItem', 'Phone number 0045 48770000')
+        assertMetadataItem('@secondListItem', 'Phone number')
+        assertMetadataItem('@secondListItem', '0045 48770000')
       })
     })
   })

--- a/test/functional/cypress/specs/events/collection-spec.js
+++ b/test/functional/cypress/specs/events/collection-spec.js
@@ -100,22 +100,23 @@ describe('Event Collection List Page', () => {
     })
 
     it('should display a data hub event date', () => {
-      assertMetadataItem('@firstListItem', 'Event date 24 Sep to 01 Oct 2017')
+      assertMetadataItem('@firstListItem', 'Event date')
+      assertMetadataItem('@firstListItem', '24 Sep to 01 Oct 2017')
     })
 
     it('should display the event organiser', () => {
-      assertMetadataItem('@firstListItem', `Organiser ${event1.organiser.name}`)
+      assertMetadataItem('@firstListItem', 'Organiser')
+      assertMetadataItem('@firstListItem', `${event1.organiser.name}`)
     })
 
     it('should display the service type', () => {
-      assertMetadataItem(
-        '@firstListItem',
-        `Service type ${event1.service.name}`
-      )
+      assertMetadataItem('@firstListItem', 'Service type')
+      assertMetadataItem('@firstListItem', `${event1.service.name}`)
     })
 
     it('should display the lead team', () => {
-      assertMetadataItem('@firstListItem', `Lead team ${event1.lead_team.name}`)
+      assertMetadataItem('@firstListItem', 'Lead team')
+      assertMetadataItem('@firstListItem', `${event1.lead_team.name}`)
     })
 
     it('should not display missing metadata items', () => {

--- a/test/functional/cypress/specs/interaction/collection-spec.js
+++ b/test/functional/cypress/specs/interaction/collection-spec.js
@@ -104,18 +104,28 @@ const assertInteractionDetails = ({
   it('should display an interaction date', () => {
     cy.get('@collectionItems')
       .eq(listItemNumber)
-      .find('[data-test="metadata-item"]')
+      .find('[data-test="metadata-label"]')
       .eq(0)
-      .should('have.text', 'Date 05 June 2019')
+      .should('have.text', 'Date')
+    cy.get('@collectionItems')
+      .eq(listItemNumber)
+      .find('[data-test="metadata-value"]')
+      .eq(0)
+      .should('have.text', '05 June 2019')
   })
   it('should display contact details', () => {
     cy.get('@collectionItems')
       .eq(listItemNumber)
-      .find('[data-test="metadata-item"]')
+      .find('[data-test="metadata-label"]')
+      .eq(1)
+      .should('have.text', 'Contact(s)')
+    cy.get('@collectionItems')
+      .eq(listItemNumber)
+      .find('[data-test="metadata-value"]')
       .eq(1)
       .should(
         'have.text',
-        `Contact(s) ${
+        `${
           hasMultipleContacts
             ? 'Multiple contacts'
             : `${listType.contacts[0].name}`
@@ -125,18 +135,28 @@ const assertInteractionDetails = ({
   it('should display company details', () => {
     cy.get('@collectionItems')
       .eq(listItemNumber)
-      .find('[data-test="metadata-item"]')
+      .find('[data-test="metadata-label"]')
       .eq(2)
-      .should('have.text', `Company ${listType.companies[0].name}`)
+      .should('have.text', 'Company')
+    cy.get('@collectionItems')
+      .eq(listItemNumber)
+      .find('[data-test="metadata-value"]')
+      .eq(2)
+      .should('have.text', `${listType.companies[0].name}`)
   })
   it('should display adviser details', () => {
     cy.get('@collectionItems')
       .eq(listItemNumber)
-      .find('[data-test="metadata-item"]')
+      .find('[data-test="metadata-label"]')
+      .eq(3)
+      .should('have.text', 'Adviser(s)')
+    cy.get('@collectionItems')
+      .eq(listItemNumber)
+      .find('[data-test="metadata-value"]')
       .eq(3)
       .should(
         'have.text',
-        `Adviser(s) ${
+        `${
           hasMultipleAdvisers
             ? 'Multiple advisers'
             : `${listType.dit_participants[0].adviser.name}, ${listType.dit_participants[0].team.name}`
@@ -148,14 +168,24 @@ const assertInteractionDetails = ({
     ? it('should display service details', () => {
         cy.get('@collectionItems')
           .eq(listItemNumber)
-          .find('[data-test="metadata-item"]')
+          .find('[data-test="metadata-label"]')
           .eq(4)
-          .should('have.text', `Service ${listType.service.name}`)
+          .should('have.text', 'Service')
+        cy.get('@collectionItems')
+          .eq(listItemNumber)
+          .find('[data-test="metadata-value"]')
+          .eq(4)
+          .should('have.text', `${listType.service.name}`)
       })
     : it('should not display service details', () => {
         cy.get('@collectionItems')
           .eq(listItemNumber)
-          .find('[data-test="metadata-item"]')
+          .find('[data-test="metadata-label"]')
+          .eq(5)
+          .should('not.exist')
+        cy.get('@collectionItems')
+          .eq(listItemNumber)
+          .find('[data-test="metadata-value"]')
           .eq(5)
           .should('not.exist')
       })

--- a/test/functional/cypress/specs/investments/eyb-leads-spec.js
+++ b/test/functional/cypress/specs/investments/eyb-leads-spec.js
@@ -264,26 +264,41 @@ describe('EYB leads collection page', () => {
         .should('contain', eybLead.company.name)
         .should(
           'contain',
-          `Submitted to EYB ${formatDate(eybLead.triage_created, DATE_FORMAT_COMPACT)}`
-        )
-        .should('contain', `Estimated spend ${eybLead.spend}`)
-        .should(
-          'contain',
-          `Location of company headquarters ${eybLead.address.country.name}`
-        )
-        .should('contain', `Sector ${eybLead.sector.name}`)
-        .should(
-          'contain',
-          `Estimated land date ${convertEYBChoicesToLabels(eybLead.landing_timeframe)}`
-        )
-        .should(
-          'contain',
-          `Location ${eybLead.proposed_investment_region.name}`
-        )
-        .should(
-          'contain',
           VALUES_VALUE_TO_LABEL_MAP[eybLead.is_high_value].toUpperCase()
         )
+      cy.get('[data-test="metadata-label"]').as('metadataLabels')
+      cy.get('[data-test="metadata-value"]').as('metadataValues')
+
+      cy.get('@metadataLabels').eq(0).should('have.text', 'Submitted to EYB')
+      cy.get('@metadataLabels').eq(1).should('have.text', 'Estimated spend')
+      cy.get('@metadataLabels')
+        .eq(2)
+        .should('have.text', 'Location of company headquarters')
+      cy.get('@metadataLabels').eq(3).should('have.text', 'Sector')
+      cy.get('@metadataLabels').eq(4).should('have.text', 'Estimated land date')
+      cy.get('@metadataLabels').eq(5).should('have.text', 'Location')
+      cy.get('@metadataValues')
+        .eq(0)
+        .should(
+          'have.text',
+          `${formatDate(eybLead.triage_created, DATE_FORMAT_COMPACT)}`
+        )
+      cy.get('@metadataValues').eq(1).should('have.text', `${eybLead.spend}`)
+      cy.get('@metadataValues')
+        .eq(2)
+        .should('have.text', `${eybLead.address.country.name}`)
+      cy.get('@metadataValues')
+        .eq(3)
+        .should('have.text', `${eybLead.sector.name}`)
+      cy.get('@metadataValues')
+        .eq(4)
+        .should(
+          'have.text',
+          `${convertEYBChoicesToLabels(eybLead.landing_timeframe)}`
+        )
+      cy.get('@metadataValues')
+        .eq(5)
+        .should('have.text', `${eybLead.proposed_investment_region.name}`)
     })
     it('should display the other name when company is null for a collection item', () => {
       cy.get('[data-test="collection-item"]')
@@ -293,24 +308,48 @@ describe('EYB leads collection page', () => {
     it('should display the audit log metadata for each collection item correctly', () => {
       cy.get('[data-test="collection-item"]')
         .eq(3)
-        .should(
-          'contain',
-          `Value modified on ${formatDate(eybLeadWithAuditDataHighToLowValue.audit_log[1].timestamp, DATE_FORMAT_COMPACT)}`
-        )
-        .should('contain', `Value change High to Low`)
+        .find('[data-test="metadata-label"]')
+        .then((items) => {
+          expect(items[1]).to.have.text('Value modified on')
+          expect(items[2]).to.have.text('Value change')
+        })
+
+      cy.get('[data-test="collection-item"]')
+        .eq(3)
+        .find('[data-test="metadata-value"]')
+        .then((items) => {
+          expect(items[1]).to.have.text(
+            `${formatDate(eybLeadWithAuditDataHighToLowValue.audit_log[1].timestamp, DATE_FORMAT_COMPACT)}`
+          )
+          expect(items[2]).to.have.text('High to Low')
+        })
 
       cy.get('[data-test="collection-item"]')
         .eq(1)
-        .should('not.contain', 'Value modified on')
-        .should('not.contain', `Value change`)
+        .find('[data-test="metadata-label"]')
+        .invoke('text')
+        .then((text) => {
+          expect(text).to.not.contain('Value modified on') //If you don't know the position
+          expect(text).to.not.contain('Value change')
+        })
 
       cy.get('[data-test="collection-item"]')
         .eq(4)
-        .should(
-          'contain',
-          `Value modified on ${formatDate(eybLeadWithAuditDataLowToHighValue.audit_log[0].timestamp, DATE_FORMAT_COMPACT)}`
-        )
-        .should('contain', `Value change Low to High`)
+        .find('[data-test="metadata-label"]')
+        .then((items) => {
+          expect(items[1]).to.have.text('Value modified on')
+          expect(items[2]).to.have.text('Value change')
+        })
+
+      cy.get('[data-test="collection-item"]')
+        .eq(4)
+        .find('[data-test="metadata-value"]')
+        .then((items) => {
+          expect(items[1]).to.have.text(
+            `${formatDate(eybLeadWithAuditDataLowToHighValue.audit_log[0].timestamp, DATE_FORMAT_COMPACT)}`
+          )
+          expect(items[2]).to.have.text('Low to High')
+        })
     })
   })
 

--- a/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
+++ b/test/functional/cypress/specs/investments/opportunity-interactions-spec.js
@@ -66,19 +66,35 @@ describe('The interactions tab on an opportunity page', () => {
         .should('have.text', `${interaction.subject}`)
         .and('have.attr', 'href', urls.interactions.detail(interaction.id))
 
-      cy.get('[data-test="collection-item"]')
-        .find('[data-test="metadata"]')
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).eq(0).should('have.text', 'Date')
+      cy.get(itemLabels).eq(1).should('have.text', 'Contact(s)')
+      cy.get(itemLabels).eq(2).should('have.text', 'Company')
+      cy.get(itemLabels).eq(3).should('have.text', 'Adviser(s)')
+      cy.get(itemLabels).eq(4).should('have.text', 'Service')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues)
+        .eq(0)
         .should(
-          'contain',
-          `Date ${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
+          'have.text',
+          `${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
         )
-        .and('contain', `Contact(s) ${interaction.contacts[0].name}`)
-        .and('contain', `Company ${interaction.companies[0].name}`)
-        .and(
-          'contain',
-          `Adviser(s) ${interaction.dit_participants[0].adviser.name}, ${interaction.dit_participants[0].team.name}`
+      cy.get(itemValues)
+        .eq(1)
+        .should('have.text', `${interaction.contacts[0].name}`)
+      cy.get(itemValues)
+        .eq(2)
+        .should('have.text', `${interaction.companies[0].name}`)
+      cy.get(itemValues)
+        .eq(3)
+        .should(
+          'have.text',
+          `${interaction.dit_participants[0].adviser.name}, ${interaction.dit_participants[0].team.name}`
         )
-        .and('contain', `Service ${interaction.service.name}`)
+      cy.get(itemValues)
+        .eq(4)
+        .should('have.text', `${interaction.service.name}`)
     })
 
     it('should not show pagination', () => {

--- a/test/functional/cypress/specs/investments/project-edit-associated-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-associated-spec.js
@@ -21,7 +21,8 @@ describe('Edit the associated FDI R&D project', () => {
         investments.projects.findAssociatedProject(fixture.id)
       )
       getCollectionList()
-      cy.get('[data-test="metadata-item"]').as('metadataItems')
+      cy.get('[data-test="metadata-label"]').as('metadataLabels')
+      cy.get('[data-test="metadata-value"]').as('metadataValues')
     })
 
     it('should render the potential associated project information correctly', () => {
@@ -34,20 +35,20 @@ describe('Edit the associated FDI R&D project', () => {
           investments.projects.editAssociatedProject(fixture.id, project.id)
         )
       cy.get('h4').should('contain', `Project code ${project.project_code}`)
-      cy.get('@metadataItems')
+      cy.get('@metadataLabels').eq(0).should('contain', 'Investor')
+      cy.get('@metadataValues')
         .eq(0)
-        .should('contain', `Investor ${project.investor_company.name}`)
-      cy.get('@metadataItems')
+        .should('contain', `${project.investor_company.name}`)
+      cy.get('@metadataLabels').eq(1).should('contain', 'Sector')
+      cy.get('@metadataValues')
         .eq(1)
-        .should('contain', `Sector ${project.sector.name}`)
-      cy.get('@metadataItems')
+        .should('contain', `${project.sector.name}`)
+      cy.get('@metadataLabels').eq(2).should('contain', 'Estimated land date')
+      cy.get('@metadataValues')
         .eq(2)
         .should(
           'contain',
-          `Estimated land date ${formatDate(
-            project.estimated_land_date,
-            DATE_FORMAT_MONTH_YEAR
-          )}`
+          `${formatDate(project.estimated_land_date, DATE_FORMAT_MONTH_YEAR)}`
         )
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
@@ -23,7 +23,8 @@ describe('Edit the recipient company', () => {
         investments.projects.recipientCompany(fixture.id)
       )
       getCollectionList()
-      cy.get('[data-test="metadata-item"]').as('metadataItems')
+      cy.get('[data-test="metadata-label"]').as('metadataLabels')
+      cy.get('[data-test="metadata-value"]').as('metadataValues')
     })
 
     it('should render the potential recipient company information correctly', () => {
@@ -39,14 +40,16 @@ describe('Edit the recipient company', () => {
         'contain',
         `Updated on ${formatDate(company.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       )
-      cy.get('@metadataItems')
+      cy.get('@metadataLabels').eq(0).should('have.text', 'Sector')
+      cy.get('@metadataLabels').eq(1).should('contain', 'Address')
+      cy.get('@metadataValues')
         .eq(0)
-        .should('contain', `Sector ${company.sector.name}`)
-      cy.get('@metadataItems')
+        .should('have.text', `${company.sector.name}`)
+      cy.get('@metadataValues')
         .eq(1)
         .should(
           'contain',
-          `Address ${company.address.line_1}, ${company.address.line_2}, ${company.address.town}, ${company.address.county}, ${company.address.postcode}`
+          `${company.address.line_1}, ${company.address.line_2}, ${company.address.town}, ${company.address.county}, ${company.address.postcode}`
         )
     })
     it('should link the recipient company and redirect back to the details page', () => {

--- a/test/functional/cypress/specs/investments/project-interactions-spec.js
+++ b/test/functional/cypress/specs/investments/project-interactions-spec.js
@@ -52,19 +52,35 @@ describe('Investment project interactions', () => {
         .should('have.text', `${interaction.subject}`)
         .and('have.attr', 'href', urls.interactions.detail(interaction.id))
 
-      cy.get('[data-test="collection-item"]')
-        .find('[data-test="metadata"]')
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).eq(0).should('have.text', 'Date')
+      cy.get(itemLabels).eq(1).should('have.text', 'Contact(s)')
+      cy.get(itemLabels).eq(2).should('have.text', 'Company')
+      cy.get(itemLabels).eq(3).should('have.text', 'Adviser(s)')
+      cy.get(itemLabels).eq(4).should('have.text', 'Service')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues)
+        .eq(0)
         .should(
-          'contain',
-          `Date ${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
+          'have.text',
+          `${formatDate(interaction.date, DATE_FORMAT_DAY_MONTH_YEAR)}`
         )
-        .and('contain', `Contact(s) ${interaction.contacts[0].name}`)
-        .and('contain', `Company ${interaction.companies[0].name}`)
-        .and(
-          'contain',
-          `Adviser(s) ${interaction.dit_participants[0].adviser.name}, ${interaction.dit_participants[0].team.name}`
+      cy.get(itemValues)
+        .eq(1)
+        .should('have.text', `${interaction.contacts[0].name}`)
+      cy.get(itemValues)
+        .eq(2)
+        .should('have.text', `${interaction.companies[0].name}`)
+      cy.get(itemValues)
+        .eq(3)
+        .should(
+          'have.text',
+          `${interaction.dit_participants[0].adviser.name}, ${interaction.dit_participants[0].team.name}`
         )
-        .and('contain', `Service ${interaction.service.name}`)
+      cy.get(itemValues)
+        .eq(4)
+        .should('have.text', `${interaction.service.name}`)
     })
 
     it('should not show pagination', () => {

--- a/test/functional/cypress/specs/investments/project-propositions-spec.js
+++ b/test/functional/cypress/specs/investments/project-propositions-spec.js
@@ -43,14 +43,21 @@ describe('Investment project propositions', () => {
           )
         )
 
-      cy.get('[data-test="collection-item"]')
-        .find('[data-test="metadata"]')
+      const itemLabels = '[data-test="metadata-label"]'
+      cy.get(itemLabels).eq(0).should('have.text', 'Deadline')
+      cy.get(itemLabels).eq(1).should('have.text', 'Created on')
+      cy.get(itemLabels).eq(2).should('have.text', 'Adviser')
+
+      const itemValues = '[data-test="metadata-value"]'
+      cy.get(itemValues)
+        .eq(0)
         .should(
-          'contain',
-          'Deadline ' + formatDate(new Date(), DATE_FORMAT_DAY_MONTH_YEAR)
+          'have.text',
+          `${formatDate(new Date(), DATE_FORMAT_DAY_MONTH_YEAR)}`
         )
-        .and('contain', 'Created on 15 June 2017')
-        .and('contain', 'Adviser Paula Churing')
+      cy.get(itemValues).eq(1).should('have.text', '15 June 2017')
+      cy.get(itemValues).eq(2).should('have.text', 'Paula Churing')
+
       cy.get('[data-test="badge"]').should('exist').should('contain', 'Ongoing')
       cy.get('[data-test="abandon-button"]')
         .should('exist')

--- a/test/functional/cypress/specs/investments/project-tasks-spec.js
+++ b/test/functional/cypress/specs/investments/project-tasks-spec.js
@@ -49,23 +49,31 @@ const assertTaskItem = (index, investmentTask) => {
 
   cy.get('[data-test="collection-item"]')
     .eq(index)
-    .find('[data-test="metadata"]')
-    .should(
-      'contain',
-      `Date created ${formatDate(investmentTask.createdOn, DATE_FORMAT_DAY_MONTH_YEAR)}`
-    )
-    .and(
-      'contain',
-      `Due date ${
-        investmentTask.dueDate
-          ? formatDate(investmentTask.dueDate, DATE_FORMAT_DAY_MONTH_YEAR)
-          : NOT_SET_TEXT
-      }`
-    )
-    .and(
-      'contain',
-      `Assigned to ${investmentTask.advisers.map((a) => a.name).join(', ')}`
-    )
+    .find('[data-test="metadata-label"]')
+    .then((items) => {
+      expect(items[0]).to.have.text('Date created')
+      expect(items[1]).to.have.text('Due date')
+      expect(items[2]).to.have.text('Assigned to')
+    })
+
+  cy.get('[data-test="collection-item"]')
+    .eq(index)
+    .find('[data-test="metadata-value"]')
+    .then((items) => {
+      expect(items[0]).to.have.text(
+        `${formatDate(investmentTask.createdOn, DATE_FORMAT_DAY_MONTH_YEAR)}`
+      )
+      expect(items[1]).to.have.text(
+        `${
+          investmentTask.dueDate
+            ? formatDate(investmentTask.dueDate, DATE_FORMAT_DAY_MONTH_YEAR)
+            : NOT_SET_TEXT
+        }`
+      )
+      expect(items[2]).to.have.text(
+        `${investmentTask.advisers.map((a) => a.name).join(', ')}`
+      )
+    })
 }
 
 describe('Investment project tasks', () => {

--- a/test/functional/cypress/specs/omis/collection-spec.js
+++ b/test/functional/cypress/specs/omis/collection-spec.js
@@ -94,27 +94,33 @@ describe('Orders (OMIS) Collection List Page', () => {
     })
 
     it('should render the company name', () => {
-      assertMetadataItem('@firstListItem', 'Company Williams-Rose')
+      assertMetadataItem('@firstListItem', 'Company')
+      assertMetadataItem('@firstListItem', 'Williams-Rose')
     })
 
     it('should render the created date (created_on)', () => {
-      assertMetadataItem('@firstListItem', 'Created 30 Nov 2020, 1:28am')
+      assertMetadataItem('@firstListItem', 'Created')
+      assertMetadataItem('@firstListItem', '30 Nov 2020, 1:28am')
     })
 
     it('should render the contact name', () => {
-      assertMetadataItem('@firstListItem', 'Contact Melissa Compton')
+      assertMetadataItem('@firstListItem', 'Contact')
+      assertMetadataItem('@firstListItem', 'Melissa Compton')
     })
 
     it('should render the UK region', () => {
-      assertMetadataItem('@firstListItem', 'UK region London')
+      assertMetadataItem('@firstListItem', 'UK region')
+      assertMetadataItem('@firstListItem', 'London')
     })
 
     it('should render the sector', () => {
-      assertMetadataItem('@firstListItem', 'Sector Advanced Engineering')
+      assertMetadataItem('@firstListItem', 'Sector')
+      assertMetadataItem('@firstListItem', 'Advanced Engineering')
     })
 
     it('should render the delivery date (delivery_date)', () => {
-      assertMetadataItem('@firstListItem', 'Delivery date 11 Dec 2022')
+      assertMetadataItem('@firstListItem', 'Delivery date')
+      assertMetadataItem('@firstListItem', '11 Dec 2022')
     })
   })
 


### PR DESCRIPTION
## Description of change
Fix accessibility issue flagged in DAC report:

Within each list item on the company’s page, users are presented with content structured as a list with introductory text such as ‘sector’, ‘Address’, ‘Trading Names’, etc. However, the same information and relationships in content is not conveyed to users of screen reading assistive technologies, as the content is only marked up as \<div> and \<span> elements. Use a descriptive list <dl> using terms \<dt> and data \<dd> for the associate content.

Change: \<div> and \<span> elements have been changed to [descriptive list](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dl), [description term](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dt) and [description details](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/dd) elements in the metadata/metadataItem components. Since these components are widely used, this change affected a large number of tests, which have been updated to reflect the new format.  

## Screenshots:

**Companies List** 
Before:
![image](https://github.com/user-attachments/assets/0f12195a-5d4d-4906-befb-42fee30bca61)

After:
![image](https://github.com/user-attachments/assets/5ddeab03-b7c6-4daf-a2c1-6a477752e597)

Export Country History
Before:
![image](https://github.com/user-attachments/assets/a9a73ba6-0fc8-4ff6-ace1-e6af8a1998a1)

After:
![image](https://github.com/user-attachments/assets/567546df-914e-4096-8ac6-04e584b0932d)

**Interactions List**
Before:
![image](https://github.com/user-attachments/assets/5e1fedf7-53a0-411e-99c0-0acfa2d33c6c)

After:
![image](https://github.com/user-attachments/assets/a1f6c54c-f350-49d9-a755-7757b8c4b138)


## Test instructions
Frontend looks the same - this change should only affect users of screen readers. 

