### PR TITLE
Change h3 header to be h2 for accessibility order but still styled like h3

### DIFF
--- a/src/client/components/DataHubFeed/index.jsx
+++ b/src/client/components/DataHubFeed/index.jsx
@@ -23,7 +23,7 @@ const Date = styled('div')({
 
 const DataHubFeed = ({ items, feedLimit = 5 }) => (
   <FeedContainer>
-    <H3>What's new?</H3>
+    <H3 as="h2">What's new?</H3>
     {!!items.length && (
       <>
         <UnorderedList listStyleType="none">

--- a/test/functional/cypress/specs/dashboard/dashboard-spec.js
+++ b/test/functional/cypress/specs/dashboard/dashboard-spec.js
@@ -26,7 +26,7 @@ describe('Dashboard', () => {
     })
 
     it('should display the correct heading', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
+      cy.get('@dataHubFeed').find('h2').should('have.text', "What's new?")
     })
 
     it('should display the info feed list', () => {

--- a/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
+++ b/test/functional/cypress/specs/dashboard/data-hub-feed-spec.js
@@ -14,7 +14,7 @@ describe('Dashboard - Data Hub feed', () => {
     })
 
     it('Should contain a header and no updates available text', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
+      cy.get('@dataHubFeed').find('h2').should('have.text', "What's new?")
 
       cy.get('@dataHubFeed')
         .find('p')
@@ -45,7 +45,7 @@ describe('Dashboard - Data Hub feed', () => {
     })
 
     it('should display only one feed item', () => {
-      cy.get('@dataHubFeed').find('h3').should('have.text', "What's new?")
+      cy.get('@dataHubFeed').find('h2').should('have.text', "What's new?")
 
       cy.get('@dataHubFeed')
         .find('[data-test="data-hub-feed-link-0"]')


### PR DESCRIPTION
## Description of change

Small change for accessibility to change a h3 header (no parent h2) to be a h2 header.
To keep it visually the same on the page, the h2 header is styled as a h3 but will be a h2.

## Test instructions

Page working as before.

## Screenshots

### Before

<img width="1860" alt="Screenshot 2025-04-17 at 16 19 34" src="https://github.com/user-attachments/assets/1d5d46ba-0eae-4f08-a905-f8cc50fb9950" />

### After

<img width="1860" alt="Screenshot 2025-04-17 at 16 19 38" src="https://github.com/user-attachments/assets/94d9908a-96cb-4923-901f-db81ad02c366" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
