### PR TITLE
Update error summary heading to be h2 instead of h1 as h1 already on page

### DIFF
--- a/src/templates/_macros/form/error-summary.njk
+++ b/src/templates/_macros/form/error-summary.njk
@@ -8,9 +8,9 @@
 {% macro ErrorSummary(errors) %}
   {% if errors.messages | length or errors.summary or errors.nonField %}
     <div class="c-error-summary js-ErrorSummary" role="alert" data-test="form-alert">
-      <h1 class="c-error-summary__heading heading-medium" data-test="form-alert-heading">
+      <h2 class="c-error-summary__heading heading-medium" data-test="form-alert-heading">
         There was a problem submitting this form
-      </h1>
+      </h2>
       {% if errors.nonField %}
         <ul class="c-error-summary__non-field" data-test="form-alert-non-field-errors">
           {% for str in errors.nonField %}


### PR DESCRIPTION
## Description of change

Change h1 header for error summary to be h2. No visual differences as styled by the same class.

## Test instructions

Same as before.

## Screenshots

### Before

<img width="1860" alt="Screenshot 2025-04-17 at 16 31 30" src="https://github.com/user-attachments/assets/0896899b-8d61-4b0d-8aa1-ff0e4ead9780" />

### After

<img width="1860" alt="Screenshot 2025-04-17 at 16 31 40" src="https://github.com/user-attachments/assets/5b0be2f1-8cbc-40d4-8f3e-272a44519662" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
