### PR TITLE
Make mobile tab navs accessible with black color instead of blue and match design system

### DIFF
--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -26,8 +26,11 @@ const BORDER = `1px solid ${BORDER_COLOUR}`
 
 const focusStyle = {
   '&:focus': {
-    outline: `3px solid ${FOCUS_COLOUR}`,
+    outline: `3px solid transparent`,
     background: FOCUS_COLOUR,
+    color: 'BLACK',
+    boxShadow: `0 -2px ${FOCUS_COLOUR}, 0 4px ${BLACK}`,
+    textDecoration: 'none',
     [MEDIA_QUERIES.TABLET]: {
       background: WHITE,
     },


### PR DESCRIPTION
## Description of change

Previously when focusing on tabs on small screens, the background would change to yellow but the text would remain blue causing a contrast accessibility fail.

See design system below and compare with before and after screenshots. See also the new colours contrast now passing.

Gov.uk Design System: https://design-system.service.gov.uk/components/tabs/ 
<img width="698" alt="Screenshot 2025-04-17 at 17 29 56" src="https://github.com/user-attachments/assets/076b54f7-1165-4775-b3bd-ddf3d825b53c" />

Passing contrast ratio now:
<img width="730" alt="Screenshot 2025-04-17 at 17 30 51" src="https://github.com/user-attachments/assets/28d125d0-bfdf-4141-a305-0c6b627a8baa" />

## Test instructions

Styling changes to tab navs on small devices (see my tasks page and any page with tab navs)

## Screenshots

### Before

<img width="574" alt="Screenshot 2025-04-17 at 17 33 27" src="https://github.com/user-attachments/assets/7f84aa8d-00e3-4887-9b5c-f090f10de770" />

### After

<img width="574" alt="Screenshot 2025-04-17 at 17 33 08" src="https://github.com/user-attachments/assets/ded0e1dd-22c2-40b4-ad80-06739d8f9feb" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)

Tabbing does not seem to work on Safari?
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
