### PR TITLE
Add focus colours to match GOV.UK design system for contrast accessibility requirements

### DIFF
--- a/src/client/components/ErrorSummary/index.jsx
+++ b/src/client/components/ErrorSummary/index.jsx
@@ -18,7 +18,12 @@ import {
 } from '@govuk-react/constants'
 import { spacing } from '@govuk-react/lib'
 
-import { TEXT_COLOUR, ERROR_COLOUR } from '../../../client/utils/colours'
+import {
+  BLACK,
+  ERROR_COLOUR,
+  FOCUS_COLOUR,
+  TEXT_COLOUR,
+} from '../../../client/utils/colours'
 import { focusMixin } from '../../styles'
 
 const StyledErrorText = styled(Link)({
@@ -38,6 +43,12 @@ const StyledErrorText = styled(Link)({
   },
   ':visited': {
     color: `${ERROR_COLOUR}`,
+  },
+  ':focus': {
+    outline: '3px solid transparent',
+    color: BLACK,
+    boxShadow: `0 -2px ${FOCUS_COLOUR}, 0 4px ${BLACK}`,
+    textDecoration: 'none',
   },
   [MEDIA_QUERIES.LARGESCREEN]: {
     fontSize: FONT_SIZE.SIZE_19,


### PR DESCRIPTION
## Description of change

The current error summary focus state puts a yellow background but the text colour remains red causing a contrast accessibility issue.

Gov.UK Design System: https://design-system.service.gov.uk/components/error-summary/

## Test instructions

On pages (except support page) with an error summary to have their focus state updated to be black text with a black underline.

## Screenshots

### Design System

<img width="543" alt="Screenshot 2025-04-22 at 12 03 51" src="https://github.com/user-attachments/assets/70225dc2-1b89-4d83-a2f3-89210ed8a9f5" />

### Before

<img width="558" alt="Screenshot 2025-04-22 at 12 04 51" src="https://github.com/user-attachments/assets/93e47965-f02a-4612-9f88-da26aaf2e747" />

### After

<img width="558" alt="Screenshot 2025-04-22 at 12 04 57" src="https://github.com/user-attachments/assets/27fc8023-7441-4592-a5a0-ea6ecc1542a1" />

## Checklist

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
-- **Safari doesn't allow you to tab by default but is an enabled option in the settings and works after enabling.**