### PR TITLE
Fix/EGTB-1736 EGTB-1737: Clarity button purpose for screen reader user 

### DIFF
--- a/src/client/components/Typeahead/SelectedChips.jsx
+++ b/src/client/components/Typeahead/SelectedChips.jsx
@@ -56,7 +56,7 @@ const SelectedChips = ({ name, selectedOptions, onOptionRemove }) => (
       <Chip key={option.value} data-test="typeahead-chip">
         <ChipButton
           type="button"
-          aria-describedby={`${name}-remove`}
+          aria-label={`Remove ${option.chipLabel || option.label} as a contact`}
           onClick={() => {
             onOptionRemove(option)
           }}

--- a/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
+++ b/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
@@ -1,0 +1,38 @@
+import 'cypress-axe'
+import React from 'react'
+import { mount } from 'cypress/react'
+
+import SelectedChips from '../../../../../../src/client/components/Typeahead/SelectedChips'
+
+describe('SelectedChips – Accessibility', () => {
+  const selectedOptions = [
+    { value: '1', label: 'Jake Roberts' },
+    { value: '2', label: 'Sarah Connor' },
+  ]
+
+  it('adds accessible aria-labels to remove buttons', () => {
+    mount(
+      <SelectedChips
+        name="contacts"
+        selectedOptions={selectedOptions}
+        onOptionRemove={() => {}}
+      />
+    )
+
+    selectedOptions.forEach((option) => {
+      const expectedLabel = `Remove ${option.label} as a contact`
+      cy.contains('button', option.label).should(
+        'have.attr',
+        'aria-label',
+        expectedLabel
+      )
+    })
+  })
+
+  it('has no critical accessibility violations (axe)', () => {
+    cy.injectAxe()
+    cy.checkA11y(null, {
+      includedImpacts: ['critical'],
+    })
+  })
+})

--- a/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
+++ b/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
@@ -29,6 +29,29 @@ describe('SelectedChips – Accessibility', () => {
     })
   })
 
+  // scenario where chipLabel is populated
+  it('uses chipLabel when present and applies correct aria-label', () => {
+    const chipLabelOptions = [
+      { value: '3', label: 'John Smith', chipLabel: 'Johnny S' },
+    ]
+
+    mount(
+      <SelectedChips
+        name="contacts"
+        selectedOptions={chipLabelOptions}
+        onOptionRemove={() => {}}
+      />
+    )
+
+    const expectedLabel = 'Remove Johnny S as a contact'
+
+    cy.contains('button', 'Johnny S').should(
+      'have.attr',
+      'aria-label',
+      expectedLabel
+    )
+  })
+
   it('has no critical accessibility violations (axe)', () => {
     cy.injectAxe()
     cy.checkA11y(null, {


### PR DESCRIPTION
## Description of change

This PR updates the SelectedChips component to include a descriptive aria-label for each remove button, ensuring screen reader users understand its purpose. It replaces aria-describedby with dynamic labels like “Remove Jake Roberts as a contact” to meet accessibility acceptance criteria and improve out-of-context navigation support.

## Screenshots

### Before
Select Companies (in menu bar) --> Add project
Select Existing project under any company --> Edit
Select Interaction (in menu bar) --> Select one of the interaction --> Edit interaction
![Before](https://github.com/user-attachments/assets/5232dadb-3f09-4b5b-8ea3-8288888408ed)


### After
Select Companies (in menu bar) --> Add project
Select Existing project under any company --> Edit
Select Interaction (in menu bar) --> Select one of the interaction --> Edit interaction
![After](https://github.com/user-attachments/assets/026d577e-d7b9-4126-a9b6-7de639c010fb)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
