### PR TITLE
Update tab content to contain h2 element instead of h1 as there is already a h1

### DIFF
--- a/src/client/components/Dashboard/my-tasks/NoTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/NoTasks.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { H1, H3 } from '@govuk-react/heading'
+import { H2, H3 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import Button from '@govuk-react/button'
 
@@ -44,7 +44,7 @@ const StyledImage = styled('img')`
 
 const NoTasks = () => (
   <StyledContainer>
-    <H3 as={H1}>You don't currently have any tasks</H3>
+    <H3 as={H2}>You don't currently have any tasks</H3>
     <StyledParagraph>
       You can create your own tasks or collaborate with colleagues and assign
       tasks to other users.

--- a/test/functional/cypress/specs/dashboard/no-tasks-spec.js
+++ b/test/functional/cypress/specs/dashboard/no-tasks-spec.js
@@ -17,7 +17,7 @@ describe('Dashboard - no taskss', () => {
   context('Tabbed navigation', () => {
     it("should have a heading of `You don't currently have any tasks`", () => {
       cy.get('@tabPanel')
-        .find('h1')
+        .find('h2')
         .should('have.text', "You don't currently have any tasks")
     })
 


### PR DESCRIPTION
## Description of change

There is already a h1 tag on the page, this updates the second h1 to be a h2 instead of h1.

## Test instructions

No visual changes but a h2 tag instead of a h1 tag.

## Screenshots

### Before

<img width="1461" alt="Screenshot 2025-04-22 at 13 59 35" src="https://github.com/user-attachments/assets/f4cd8808-fd8f-42e5-b389-3ac08838e292" />

### After

<img width="1856" alt="Screenshot 2025-04-22 at 14 00 17" src="https://github.com/user-attachments/assets/f490eac8-c20e-45a4-8c9c-f02295b83ab1" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
