### PR TITLE
Remove alt text for decorative image in tasks tab

### DIFF
--- a/src/client/components/Dashboard/my-tasks/NoTasks.jsx
+++ b/src/client/components/Dashboard/my-tasks/NoTasks.jsx
@@ -52,7 +52,7 @@ const NoTasks = () => (
     <Button as={'a'} href={tasks.create()}>
       Add a task
     </Button>
-    <StyledImage src={NoTaskImage} alt="An image of a list of tasks" />
+    <StyledImage src={NoTaskImage} alt="" />
   </StyledContainer>
 )
 

--- a/test/functional/cypress/specs/dashboard/no-tasks-spec.js
+++ b/test/functional/cypress/specs/dashboard/no-tasks-spec.js
@@ -32,9 +32,7 @@ describe('Dashboard - no taskss', () => {
     })
 
     it('should have an image of a list of tasks', () => {
-      cy.get('@tabPanel')
-        .find('img')
-        .should('have.attr', 'alt', 'An image of a list of tasks')
+      cy.get('@tabPanel').find('img').should('have.attr', 'alt', '')
     })
 
     it('should have a button to add a task', () => {


### PR DESCRIPTION
## Description of change

This PR changes the 'alt' text for the decorative image in the 'Tasks' tab to a null value. 

## Test instructions

_What should I see?_

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
