### PR TITLE
Make number of new jobs optional for FDI projects with no involvement

### DIFF
--- a/src/client/components/Layout/EYBLeadLayout.jsx
+++ b/src/client/components/Layout/EYBLeadLayout.jsx
@@ -31,8 +31,6 @@ const GlobalStyles = createGlobalStyle`
 
 const LocalHeader = styled('div')`
   background-color: ${GREY_4};
-  paddingTop: SPACING.SCALE_5,
-  textAlign: 'center',
 `
 
 const StyledHeader = styled(InnerContainer)`

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -60,11 +60,8 @@ const EditProjectValue = () => {
     >
       <InvestmentResource id={projectId}>
         {(project) => {
-          const isExpansion =
-            project.fdiType?.name === 'Expansion of existing site or activity'
-
-          const isNumberNewJobsRequired =
-            isExpansion && project.levelOfInvolvement
+          const isNumberNewJobsOptional =
+            project.investmentType.name === 'FDI' && !project.levelOfInvolvement
 
           return (
             <>
@@ -209,30 +206,19 @@ const EditProjectValue = () => {
                     <FieldInput
                       label={
                         'Number of new jobs' +
-                        (project.levelOfInvolvement === null && isExpansion
-                          ? ' (optional)'
-                          : isFieldOptionalForStageLabel(
-                              'number_new_jobs',
-                              project
-                            ))
+                        (isNumberNewJobsOptional ? '' : ' (required)')
                       }
                       name="number_new_jobs"
                       type="number"
-                      {...(isNumberNewJobsRequired && {
+                      {...(!isNumberNewJobsOptional && {
                         required: 'Value for number of new jobs is required',
                         hint: 'An expansion project must always have at least 1 new job',
                       })}
-                      validate={(value, field, formFields) => {
-                        let result = validateFieldForStage(
-                          field,
-                          formFields,
-                          project,
-                          'Value for number of new jobs is required'
-                        )
-                        return isNumberNewJobsRequired && value < 1
-                          ? 'Number of new jobs must be greater than 0'
-                          : result
-                      }}
+                      validate={(value) =>
+                        !isNumberNewJobsOptional &&
+                        value < 1 &&
+                        'Number of new jobs must be greater than 0'
+                      }
                       initialValue={project.numberNewJobs}
                     />
                     {project.investmentType.name === 'FDI' &&

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -373,27 +373,6 @@ describe('Edit the value details of a project', () => {
         value: capitalIntensiveProjectWithValue.number_new_jobs,
       })
 
-      // it.only('should display the number of new jobs field', () => {
-      //   // cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-      //   //   assertFieldInput({
-      //   //     element,
-      //   //     label: 'Number of new jobs (required)',
-      //   //     value: capitalIntensiveProjectWithValue.number_new_jobs,
-      //   //   })
-      //   // })
-      //   cy.get('#number_new_jobs').should(
-      //     'have.value',
-      //     capitalIntensiveProjectWithValue.number_new_jobs
-      //   )
-
-      //   cy.get('label[for="number_new_jobs"]').should(
-      //     'have.text',
-      //     'Number of new jobs (required)'
-      //   )
-
-      //   cy.contains('An expansion project must always have at least 1 new job')
-      // })
-
       it('should not display the GVA calculation for number of new jobs', () => {
         cy.get('[data-test="field-gross_value_added_labour"]').should(
           'not.exist'
@@ -837,14 +816,6 @@ describe('Edit the value details of a project', () => {
       testNumberOfNewJobs({
         required: true,
       })
-      // it('should display the number of new jobs field', () => {
-      //   cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-      //     assertFieldInput({
-      //       element,
-      //       label: 'Number of new jobs (required)',
-      //     })
-      //   })
-      // })
 
       it('should display message to add number of new jobs to calculate GVA', () => {
         cy.get('[data-test="field-gross_value_added_labour"]').then(
@@ -1044,15 +1015,6 @@ describe('Edit the value details of a project', () => {
       required: true,
       value: labourIntensiveProjectWithValue.number_new_jobs,
     })
-    // it('should display the number of new jobs field', () => {
-    //   cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-    //     assertFieldInput({
-    //       element,
-    //       label: 'Number of new jobs (required)',
-    //       value: labourIntensiveProjectWithValue.number_new_jobs,
-    //     })
-    //   })
-    // })
 
     it('should display the GVA calculation for number of new jobs', () => {
       cy.get('[data-test="field-gross_value_added_labour"]').then((element) => {

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -27,8 +27,25 @@ const setup = (project) => {
     'editValueSubmissionRequest'
   )
   cy.visit(investments.projects.editValue(project.id))
-  // cy.wait('@getProjectDetails')
 }
+
+const testNumberOfNewJobs = ({ required, value }) =>
+  it('should display the number of new jobs field', () => {
+    if (value !== null && value !== undefined) {
+      cy.get('#number_new_jobs').should('have.value', value)
+    }
+
+    cy.get('label[for="number_new_jobs"]').should(
+      'have.text',
+      required ? 'Number of new jobs (required)' : 'Number of new jobs'
+    )
+
+    required
+      ? cy.contains('An expansion project must always have at least 1 new job')
+      : cy
+          .contains('An expansion project must always have at least 1 new job')
+          .should('not.exist')
+  })
 
 const setupProjectFaker = (overrides) =>
   investmentProjectFaker({
@@ -157,13 +174,8 @@ describe('Edit the value details of a project', () => {
         )
       })
 
-      it('should display the number of new jobs field', () => {
-        cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Number of new jobs (required)',
-          })
-        })
+      testNumberOfNewJobs({
+        required: true,
       })
 
       it('should not display the GVA calculation for number of new jobs', () => {
@@ -356,15 +368,31 @@ describe('Edit the value details of a project', () => {
         )
       })
 
-      it('should display the number of new jobs field', () => {
-        cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Number of new jobs (required)',
-            value: capitalIntensiveProjectWithValue.number_new_jobs,
-          })
-        })
+      testNumberOfNewJobs({
+        required: true,
+        value: capitalIntensiveProjectWithValue.number_new_jobs,
       })
+
+      // it.only('should display the number of new jobs field', () => {
+      //   // cy.get('[data-test="field-number_new_jobs"]').then((element) => {
+      //   //   assertFieldInput({
+      //   //     element,
+      //   //     label: 'Number of new jobs (required)',
+      //   //     value: capitalIntensiveProjectWithValue.number_new_jobs,
+      //   //   })
+      //   // })
+      //   cy.get('#number_new_jobs').should(
+      //     'have.value',
+      //     capitalIntensiveProjectWithValue.number_new_jobs
+      //   )
+
+      //   cy.get('label[for="number_new_jobs"]').should(
+      //     'have.text',
+      //     'Number of new jobs (required)'
+      //   )
+
+      //   cy.contains('An expansion project must always have at least 1 new job')
+      // })
 
       it('should not display the GVA calculation for number of new jobs', () => {
         cy.get('[data-test="field-gross_value_added_labour"]').should(
@@ -806,14 +834,17 @@ describe('Edit the value details of a project', () => {
         )
       })
 
-      it('should display the number of new jobs field', () => {
-        cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-          assertFieldInput({
-            element,
-            label: 'Number of new jobs (required)',
-          })
-        })
+      testNumberOfNewJobs({
+        required: true,
       })
+      // it('should display the number of new jobs field', () => {
+      //   cy.get('[data-test="field-number_new_jobs"]').then((element) => {
+      //     assertFieldInput({
+      //       element,
+      //       label: 'Number of new jobs (required)',
+      //     })
+      //   })
+      // })
 
       it('should display message to add number of new jobs to calculate GVA', () => {
         cy.get('[data-test="field-gross_value_added_labour"]').then(
@@ -1009,15 +1040,19 @@ describe('Edit the value details of a project', () => {
       )
     })
 
-    it('should display the number of new jobs field', () => {
-      cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-        assertFieldInput({
-          element,
-          label: 'Number of new jobs (required)',
-          value: labourIntensiveProjectWithValue.number_new_jobs,
-        })
-      })
+    testNumberOfNewJobs({
+      required: true,
+      value: labourIntensiveProjectWithValue.number_new_jobs,
     })
+    // it('should display the number of new jobs field', () => {
+    //   cy.get('[data-test="field-number_new_jobs"]').then((element) => {
+    //     assertFieldInput({
+    //       element,
+    //       label: 'Number of new jobs (required)',
+    //       value: labourIntensiveProjectWithValue.number_new_jobs,
+    //     })
+    //   })
+    // })
 
     it('should display the GVA calculation for number of new jobs', () => {
       cy.get('[data-test="field-gross_value_added_labour"]').then((element) => {
@@ -1411,13 +1446,13 @@ describe('Edit the value details of a project', () => {
   )
 
   context('Number of jobs error handling', () => {
-    context('When editing an expansion project', () => {
+    context('When editing an FDI project', () => {
       context('With involvement', () => {
         const expansionProject = setupProjectFaker({
           stage: INVESTMENT_PROJECT_STAGES.active,
-          fdi_type: {
-            name: 'Expansion of existing site or activity',
-            id: '8dc41652-12bc-4ecf-8e60-bdb6dfd5eab1',
+          investment_type: {
+            name: 'FDI',
+            id: 'foo',
           },
           level_of_involvement: {
             name: 'Foo',
@@ -1427,15 +1462,8 @@ describe('Edit the value details of a project', () => {
         beforeEach(() => {
           setup(expansionProject)
         })
-
-        it('should show the hint text for the number of new jobs input', () => {
-          cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-            assertFieldInput({
-              element,
-              label: 'Number of new jobs (required)',
-              hint: 'An expansion project must always have at least 1 new job',
-            })
-          })
+        testNumberOfNewJobs({
+          required: true,
         })
         it('should show an error if the number of new jobs is empty', () => {
           cy.get('[data-test="submit-button"]').click()
@@ -1456,9 +1484,9 @@ describe('Edit the value details of a project', () => {
       context('With no involvement', () => {
         const expansionProject = setupProjectFaker({
           stage: INVESTMENT_PROJECT_STAGES.active,
-          fdi_type: {
-            name: 'Expansion of existing site or activity',
-            id: '8dc41652-12bc-4ecf-8e60-bdb6dfd5eab1',
+          investment_type: {
+            name: 'FDI',
+            id: 'foo',
           },
           level_of_involvement: null,
         })
@@ -1466,18 +1494,17 @@ describe('Edit the value details of a project', () => {
           setup(expansionProject)
         })
 
-        it('should not show the hint text for the number of new jobs input', () => {
-          cy.get('[data-test="field-number_new_jobs"]').then((element) => {
-            assertFieldInput({
-              element,
-              label: 'Number of new jobs (optional)',
-            })
-          })
+        testNumberOfNewJobs({
+          required: false,
         })
+
         it('should show an error if the number of new jobs is empty', () => {
           cy.get('[data-test="submit-button"]').click()
-          assertErrorSummary(['Value for number of new jobs is required'])
+          cy.contains('Value for number of new jobs is required').should(
+            'not.exist'
+          )
         })
+
         it('should not show an error if the number of new jobs is 0', () => {
           cy.get('[data-test="number-new-jobs-input"]').type(0)
           cy.get('[data-test="submit-button"]').click()
@@ -1485,6 +1512,7 @@ describe('Edit the value details of a project', () => {
             'not.exist'
           )
         })
+
         it('should not show an error if the number of new jobs is 1', () => {
           cy.get('[data-test="number-new-jobs-input"]').type(1)
           cy.get('[data-test="submit-button"]').click()

--- a/test/selectors/investment/value.js
+++ b/test/selectors/investment/value.js
@@ -9,7 +9,7 @@ module.exports = {
   foreignEquityInvestmentRadioNo:
     '[data-test="client-cannot-provide-foreign-investment-no"]',
   foreignEquityInvestment: '[data-test="foreign-equity-investment-input"]',
-  newJobs: '[data-test="field-number_new_jobs"]',
+  newJobs: '[data-test="number-new-jobs-input"]',
   safeguardedJobs: '[data-test="field-number_safeguarded_jobs"]',
   governmentAssistanceRadioYes: '[data-test="government-assistance-yes"]',
   governmentAssistanceRadioNo: '[data-test="government-assistance-no"]',


### PR DESCRIPTION
## Description of change

This PR makes the _number of new jobs_ field in the _edit project values_ form optional for all _FDI_ projects with no _level of involvement_.

## Test instructions

1. Create a new _investment project_ with
    * _Investment type_ = _FDI -> [whatever]_ and
    * _Level of investor involvement_ = _No Involvement_
    Or find an existing project with the above properties and grab its ID
2. Navigate to `/investments/projects/{project-id}/edit-value`
4. There should be a _Number of new jobs (optional)_ field
5. You should be able to leave the field empty or put `0` into it as a value
6. Upon submitting the form, there should be no form error related to that field
7. Change the _Level of investor involvement_ of the project to any value other than _No Involvement_
8. Now the field should be required and have a label _Number of new jobs (required)_
9. If you leave the field empty or put `0` into it as a value and submit the form
10. You should see a form error related to the field saying that the field is required or that the value must not be `0`
