### PR TITLE
devops: hot reload with docker

### DIFF
--- a/docker-compose.frontend.dev.yml
+++ b/docker-compose.frontend.dev.yml
@@ -3,8 +3,8 @@ services:
   frontend:
     depends_on:
       - mock-sso
-    entrypoint: dockerize -wait tcp://api:8000 -timeout 5m -wait-retry-interval 5s
     env_file: .env
+    command: bash -c 'dockerize -wait tcp://api:8000 -timeout 5m -wait-retry-interval 5s && npm run develop'
 
   mock-sso:
     image: gcr.io/sre-docker-registry/github.com/uktrade/mock-sso:latest
@@ -20,4 +20,3 @@ networks:
   default:
     external:
       name: data-infrastructure-shared-network
-


### PR DESCRIPTION
## Description of change

* `docker-compose.base.yml` defines a default command for the frontend service: `bash -c 'npm run build:for-test-coverage && npm run start:coverage'`, which overrides the original `npm run develop` in `Dockerfile` which would have started the development server needed for hot reloading

* `docker-compose.frontend.dev.yml` was overriding the entrypoint inherited from `docker-compose.base.yml`. docker compose merging rules mean the command from `docker-compose.base.yml` is still active

* this pr restores the `npm run develop` command

## Test instructions

* `make start-dev` and any frontend changes should trigger webpack recompile

## Checklist

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
