### PR TITLE
Feature CLS2 1211 enable account managers to assign account managers

### DIFF
--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -8,7 +8,6 @@ import { LEVEL_SIZE } from '@govuk-react/constants'
 import { FormActions } from '../../../components'
 import { TEXT_COLOUR, GREY_3 } from '../../../utils/colours'
 import urls from '../../../../lib/urls'
-import { current } from '@reduxjs/toolkit'
 import { isOneListAccountOwner } from '../CompanyBusinessDetails/utils'
 
 const ButtonSecondary = (props) => (

--- a/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
+++ b/src/client/modules/Companies/AccountManagement/LeadAdvisers.jsx
@@ -8,19 +8,23 @@ import { LEVEL_SIZE } from '@govuk-react/constants'
 import { FormActions } from '../../../components'
 import { TEXT_COLOUR, GREY_3 } from '../../../utils/colours'
 import urls from '../../../../lib/urls'
+import { current } from '@reduxjs/toolkit'
+import { isOneListAccountOwner } from '../CompanyBusinessDetails/utils'
 
 const ButtonSecondary = (props) => (
   <Button buttonColour={GREY_3} buttonTextColour={TEXT_COLOUR} {...props} />
 )
 
-const hasPermissionToAddIta = (permissions) =>
+const hasPermissionToAddIta = (permissions, company, currentAdviserId) =>
+  isOneListAccountOwner(company, currentAdviserId) ||
   permissions.includes('company.change_regional_account_manager')
 
 const RenderHasAccountManager = ({
   leadITA,
   addUrl,
-  companyId,
+  company,
   permissions,
+  currentAdviserId,
 }) => (
   <div>
     <Table data-test="lead-adviser-table">
@@ -45,18 +49,18 @@ const RenderHasAccountManager = ({
     </Table>
     <p>
       You can{' '}
-      <a href={urls.companies.editHistory.index(companyId)}>
+      <a href={urls.companies.editHistory.index(company.id)}>
         see changes in the Edit history
       </a>
     </p>
-    {hasPermissionToAddIta(permissions) && (
+    {hasPermissionToAddIta(permissions, company, currentAdviserId) && (
       <FormActions>
         <ButtonSecondary as={'a'} href={addUrl} data-test="replace-ita-button">
           Replace Lead ITA
         </ButtonSecondary>
         <ButtonSecondary
           as={'a'}
-          href={urls.companies.accountManagement.advisers.remove(companyId)}
+          href={urls.companies.accountManagement.advisers.remove(company.id)}
           data-test="remove-ita-button"
         >
           Remove Lead ITA
@@ -66,7 +70,7 @@ const RenderHasAccountManager = ({
   </div>
 )
 
-export const LeadITA = ({ company, permissions }) => (
+export const LeadITA = ({ company, permissions, currentAdviserId }) => (
   <>
     <H2 size={LEVEL_SIZE[3]} data-test="lead-ita-heading">
       {company.oneListGroupTier?.id == '1929c808-99b4-4abf-a891-45f2e187b410'
@@ -76,16 +80,17 @@ export const LeadITA = ({ company, permissions }) => (
     {!!company.oneListGroupGlobalAccountManager ? (
       <RenderHasAccountManager
         leadITA={company.oneListGroupGlobalAccountManager}
-        companyId={company.id}
+        company={company}
         permissions={permissions}
         addUrl={urls.companies.accountManagement.advisers.assign(company.id)}
+        currentAdviserId={currentAdviserId}
       />
     ) : (
       <>
         <p>
           This company record has no Lead International Trade Adviser (ITA).
         </p>
-        {hasPermissionToAddIta(permissions) && (
+        {hasPermissionToAddIta(permissions, company, currentAdviserId) && (
           <>
             <p>
               You can add a Lead ITA. This will be visible to all Data Hub

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -6,7 +6,6 @@ import Details from '@govuk-react/details'
 import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
-import PropTypes from 'prop-types'
 import { typography } from '@govuk-react/lib'
 
 import { Metadata, NewWindowLink } from '../../../components'

--- a/src/client/modules/Companies/AccountManagement/index.jsx
+++ b/src/client/modules/Companies/AccountManagement/index.jsx
@@ -6,6 +6,7 @@ import Details from '@govuk-react/details'
 import styled from 'styled-components'
 import { useParams } from 'react-router-dom'
 import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
 import { typography } from '@govuk-react/lib'
 
 import { Metadata, NewWindowLink } from '../../../components'
@@ -27,7 +28,10 @@ import { isItaTierDAccount } from '../utils'
 import { ONE_LIST_EMAIL } from './constants'
 import DefaultLayoutBase from '../../../components/Layout/DefaultLayoutBase'
 import { state2propsMainTab } from './state'
-import { canEditOneList } from '../CompanyBusinessDetails/utils'
+import {
+  canEditOneList,
+  isOneListAccountOwner,
+} from '../CompanyBusinessDetails/utils'
 import AccessibleLink from '../../../components/Link'
 
 const LastUpdatedHeading = styled.div`
@@ -259,7 +263,7 @@ const objectiveMetadata = (objective) => {
   return rows
 }
 
-const AccountManagement = ({ permissions }) => {
+const AccountManagement = ({ permissions, currentAdviserId }) => {
   const { companyId } = useParams()
 
   return (
@@ -276,14 +280,19 @@ const AccountManagement = ({ permissions }) => {
             <Objectives company={company} />
             {!company.oneListGroupTier ||
             isItaTierDAccount(company.oneListGroupTier) ? (
-              <LeadITA company={company} permissions={permissions} />
+              <LeadITA
+                company={company}
+                permissions={permissions}
+                currentAdviserId={currentAdviserId}
+              />
             ) : (
               <div>
                 <CoreTeamAdvisers
                   company={company}
                   oneListEmail={ONE_LIST_EMAIL}
                 />
-                {canEditOneList(permissions) && (
+                {(isOneListAccountOwner(company, currentAdviserId) ||
+                  canEditOneList(permissions)) && (
                   <div>
                     <Button
                       data-test="edit-core-team-button"

--- a/src/client/modules/Companies/AccountManagement/state.js
+++ b/src/client/modules/Companies/AccountManagement/state.js
@@ -15,6 +15,10 @@ export const state2props = (state) => {
   return { objectiveItem }
 }
 
-export const state2propsMainTab = (state) => ({
-  permissions: state.userPermissions,
-})
+export const state2propsMainTab = (state) => {
+  const { currentAdviserId } = state
+  return {
+    permissions: state.userPermissions,
+    currentAdviserId: currentAdviserId,
+  }
+}

--- a/src/client/modules/Companies/CompanyBusinessDetails/utils.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/utils.js
@@ -1,5 +1,6 @@
 export const isOneListAccountOwner = (company, currentAdviserId) =>
-  company?.one_list_group_global_account_manager?.id == currentAdviserId
+  company?.one_list_group_global_account_manager?.id == currentAdviserId ||
+  company?.oneListGroupGlobalAccountManager?.id == currentAdviserId
 
 export const canEditOneList = (permissions) =>
   permissions &&

--- a/src/client/modules/Companies/CompanyBusinessDetails/utils.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/utils.js
@@ -1,6 +1,6 @@
-export const isOneListAccountOwner = (company, currentAdviserId) =>
-  company?.one_list_group_global_account_manager?.id == currentAdviserId ||
-  company?.oneListGroupGlobalAccountManager?.id == currentAdviserId
+export const isOneListAccountOwner = (company, currentAdviserId) => {
+  return company?.oneListGroupGlobalAccountManager?.id == currentAdviserId
+}
 
 export const canEditOneList = (permissions) =>
   permissions &&

--- a/src/client/modules/Companies/CompanyBusinessDetails/utils.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/utils.js
@@ -1,5 +1,8 @@
 export const isOneListAccountOwner = (company, currentAdviserId) => {
-  return company?.oneListGroupGlobalAccountManager?.id == currentAdviserId
+  return (
+    company?.oneListGroupGlobalAccountManager?.id == currentAdviserId ||
+    company?.one_list_group_global_account_manager?.id == currentAdviserId
+  )
 }
 
 export const canEditOneList = (permissions) =>

--- a/src/client/modules/Companies/CompanyBusinessDetails/utils.js
+++ b/src/client/modules/Companies/CompanyBusinessDetails/utils.js
@@ -1,5 +1,5 @@
 export const isOneListAccountOwner = (company, currentAdviserId) =>
-  company?.oneListGroupGlobalAccountManager?.id == currentAdviserId
+  company?.one_list_group_global_account_manager?.id == currentAdviserId
 
 export const canEditOneList = (permissions) =>
   permissions &&

--- a/src/client/modules/Companies/CoreTeam/EditOneList.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneList.jsx
@@ -27,6 +27,7 @@ const EditOneList = ({
   oneListTiers,
   globalAccountManager,
   userPermissions,
+  currentAdviserId,
 }) => {
   const { companyId } = useParams()
   const query = useQuery()
@@ -77,6 +78,7 @@ const EditOneList = ({
                 [ACCOUNT_MANAGER_FIELD_NAME]: globalAccountManager,
                 [ONE_LIST_TEAM_FIELD_NAME]: oneListTeam,
               }}
+              currentAdviserId={currentAdviserId}
             />
           )
         }

--- a/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
@@ -16,6 +16,7 @@ import {
 } from '../../../components'
 import urls from '../../../../lib/urls'
 import { FORM_LAYOUT } from '../../../../common/constants'
+import { isOneListAccountOwner } from '../CompanyBusinessDetails/utils'
 
 const EditOneListForm = ({
   company,
@@ -23,6 +24,7 @@ const EditOneListForm = ({
   formInitialValues,
   returnUrl,
   userPermissions,
+  currentAdviserId,
 }) => (
   <Form
     id="edit-one-list"
@@ -58,17 +60,18 @@ const EditOneListForm = ({
         {values.one_list_tier !== NONE && (
           <FormLayout setWidth={FORM_LAYOUT.THREE_QUARTERS}>
             <Step name="oneListAdvisers">
-              {userPermissions &&
-                userPermissions.includes('company.change_company') &&
-                userPermissions.includes(
-                  'company.change_one_list_tier_and_global_account_manager'
-                ) && (
-                  <FieldAdvisersTypeahead
-                    name={ACCOUNT_MANAGER_FIELD_NAME}
-                    label="Global Account Manager"
-                    required="Select at least one adviser"
-                  />
-                )}
+              {(isOneListAccountOwner(company, currentAdviserId) ||
+                (userPermissions &&
+                  userPermissions.includes('company.change_company') &&
+                  userPermissions.includes(
+                    'company.change_one_list_tier_and_global_account_manager'
+                  ))) && (
+                <FieldAdvisersTypeahead
+                  name={ACCOUNT_MANAGER_FIELD_NAME}
+                  label="Global Account Manager"
+                  required="Select at least one adviser"
+                />
+              )}
               <FieldAdvisersTypeahead
                 name={ONE_LIST_TEAM_FIELD_NAME}
                 label="Advisers on the core team (optional)"

--- a/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
+++ b/src/client/modules/Companies/CoreTeam/EditOneListForm.jsx
@@ -34,8 +34,9 @@ const EditOneListForm = ({
     analyticsFormName="editOneList"
     transformPayload={(values) => ({
       values,
-      companyId: company.id,
+      company: company,
       userPermissions,
+      currentAdviserId,
     })}
     redirectTo={() =>
       returnUrl ? returnUrl : urls.companies.businessDetails(company.id)

--- a/src/client/modules/Companies/CoreTeam/state.js
+++ b/src/client/modules/Companies/CoreTeam/state.js
@@ -10,6 +10,7 @@ export const TASK_SAVE_ONE_LIST_DETAILS = 'TASK_SAVE_ONE_LIST_DETAILS'
 export const TASK_GET_ONE_LIST_DETAILS = 'TASK_GET_ONE_LIST_DETAILS'
 
 export const state2props = (state) => {
+  const { currentAdviserId } = state
   return {
     ...state[ID],
     globalAccountManager: transformAdviserData(
@@ -18,5 +19,6 @@ export const state2props = (state) => {
     oneListTiers: transformOneListTiers(state[ID].oneListTiers),
     oneListTeam: transformTeamMembers(state[ID].oneListTeam),
     userPermissions: state.userPermissions,
+    currentAdviserId: currentAdviserId,
   }
 }

--- a/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
+++ b/src/client/modules/Files/CollectionList/CompanyFilesCollection.jsx
@@ -75,7 +75,7 @@ const CompanyFilesCollection = ({
               }
               addItemButtons={[
                 // Un-comment when upload file screen has been implemented
-                /* eslint-disable */
+                // Also enable * eslint-disable */
                 // {
                 //   text: 'Upload file',
                 //   url: company.archived

--- a/test/functional/cypress/fakers/companies.js
+++ b/test/functional/cypress/fakers/companies.js
@@ -317,9 +317,9 @@ export const companyNoGlobalUltimateAllDetails = companyFaker({
   ukRegion: {
     name: 'South East',
   },
-  oneListGroupGlobalAccountManager: {
+  oneListGroupGlobalAccountManager: adviserFaker({
     name: 'Billy Bob',
-  },
+  }),
   oneListGroupTier: {
     name: 'Tier D - International Trade Adviser Accounts',
     id: '1929c808-99b4-4abf-a891-45f2e187b410',

--- a/test/functional/cypress/fakers/export.js
+++ b/test/functional/cypress/fakers/export.js
@@ -18,7 +18,9 @@ const exportFaker = (overrides = {}) => ({
   contacts: [contactFaker()],
   destination_country: countryFaker(),
   sector: sectorFaker(),
-  exporter_experience: faker.helpers.arrayElement(EXPORTER_EXPERIENCE),
+  exporter_experience: faker.helpers.arrayElement(
+    EXPORTER_EXPERIENCE.filter((element) => !element.disabled_on)
+  ),
   estimated_export_value_years: faker.helpers.arrayElement(
     ESTIMATED_EXPORT_VALUE_YEARS
   ),

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -444,33 +444,6 @@ describe('One List core Tier D team', () => {
       cy.get('[data-test="edit-core-team-button"]').should('not.exist')
     })
   })
-  // context.only('when viewing a One List Tier D company', () => {
-  //   context('when viewing business details', () => {
-  //     beforeEach(() => {
-  //       cy.setModulePermissions(['company.view_company'])
-  //     })
-  //     after(() => {
-  //       cy.resetUser()
-  //     })
-  //     it('the adviser assigned as account manager should see the Add a Lead ITA button', () => {
-  //       const company = companyTierD
-  //       // company.one_list_group_tier = company.oneListGroupTier
-  //       // company.one_list_group_global_account_manager =
-  //       //   company.oneListGroupGlobalAccountManager
-  //       console.log(company)
-  //       cy.setAdviserId(company.one_list_group_global_account_manager.id)
-
-  //       cy.intercept('GET', `/api-proxy/v4/company/${company.id}`, company).as(
-  //         'businessDetails'
-  //       )
-  //       cy.visit(urls.companies.businessDetails(company.id))
-  //       cy.wait('@businessDetails')
-  //       cy.get('[data-test="edit-one-list-information"]')
-  //         .should('be.visible')
-  //         .should('have.text', 'Add Lead ITA')
-  //     })
-  //   })
-  // })
 
   context(
     'when viewing a One List Tier D company without DIT team name for account manager',

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -1,5 +1,8 @@
 import { faker } from '../../../../sandbox/utils/random'
-import { companyFaker } from '../../fakers/companies'
+import {
+  companyFaker,
+  companyNoGlobalUltimateAllDetails,
+} from '../../fakers/companies'
 import { userFaker } from '../../fakers/users'
 import objectiveListFaker, { objectiveFaker } from '../../fakers/objective'
 import { adviserFaker } from '../../fakers/advisers'
@@ -444,6 +447,33 @@ describe('One List core Tier D team', () => {
       cy.get('[data-test="edit-core-team-button"]').should('not.exist')
     })
   })
+  // context.only('when viewing a One List Tier D company', () => {
+  //   context('when viewing business details', () => {
+  //     beforeEach(() => {
+  //       cy.setModulePermissions(['company.view_company'])
+  //     })
+  //     after(() => {
+  //       cy.resetUser()
+  //     })
+  //     it('the adviser assigned as account manager should see the Add a Lead ITA button', () => {
+  //       const company = companyTierD
+  //       // company.one_list_group_tier = company.oneListGroupTier
+  //       // company.one_list_group_global_account_manager =
+  //       //   company.oneListGroupGlobalAccountManager
+  //       console.log(company)
+  //       cy.setAdviserId(company.one_list_group_global_account_manager.id)
+
+  //       cy.intercept('GET', `/api-proxy/v4/company/${company.id}`, company).as(
+  //         'businessDetails'
+  //       )
+  //       cy.visit(urls.companies.businessDetails(company.id))
+  //       cy.wait('@businessDetails')
+  //       cy.get('[data-test="edit-one-list-information"]')
+  //         .should('be.visible')
+  //         .should('have.text', 'Add Lead ITA')
+  //     })
+  //   })
+  // })
 
   context(
     'when viewing a One List Tier D company without DIT team name for account manager',

--- a/test/functional/cypress/specs/companies/account-management-spec.js
+++ b/test/functional/cypress/specs/companies/account-management-spec.js
@@ -1,8 +1,5 @@
 import { faker } from '../../../../sandbox/utils/random'
-import {
-  companyFaker,
-  companyNoGlobalUltimateAllDetails,
-} from '../../fakers/companies'
+import { companyFaker } from '../../fakers/companies'
 import { userFaker } from '../../fakers/users'
 import objectiveListFaker, { objectiveFaker } from '../../fakers/objective'
 import { adviserFaker } from '../../fakers/advisers'

--- a/test/functional/cypress/specs/companies/edit-one-list-spec.js
+++ b/test/functional/cypress/specs/companies/edit-one-list-spec.js
@@ -260,7 +260,50 @@ describe('Edit One List', () => {
     })
   })
 
-  context('non Account managers when editing One list', () => {
+  context(
+    'basic users assigned as account manager when editing One list',
+    () => {
+      const testCompany = fixtures.company.oneListCorp
+
+      beforeEach(() => {
+        cy.setModulePermissions([
+          'company.view_company',
+          'company.change_company',
+        ])
+        cy.setAdviserId(testCompany.one_list_group_global_account_manager.id)
+
+        visitWithWait(
+          testCompany.id,
+          urls.companies.editOneList(testCompany.id)
+        )
+      })
+      after(() => {
+        cy.resetUser()
+      })
+
+      it('should have account manager field', () => {
+        cy.contains('Continue').click()
+        cy.get('#global_account_manager').should('exist')
+      })
+
+      it('should submit updated data', () => {
+        cy.contains('Continue').click()
+
+        cy.get(
+          selectors.companyEditOneList.coreTeamField
+        ).selectTypeaheadOptionInFieldset('leroy')
+
+        cy.contains('Submit').click()
+
+        cy.location('pathname').should(
+          'eq',
+          urls.companies.businessDetails(testCompany.id)
+        )
+      })
+    }
+  )
+
+  context('not assigned as account managers when editing One list', () => {
     const testCompany = fixtures.company.oneListCorp
 
     beforeEach(() => {


### PR DESCRIPTION
## Description of change

A non-super user who is a companies' account manager should be able to re-assign a different user as the account manager for that company.

## Test instructions

Tip: before making permission changes in your local API; I've setup an additional user using the "Add adviser +" button to create test2@gov.uk with staff and super user status. This allows resetting the companies account manager from the API easily.

In your local API remove staff status and superuser status for the account you login with in the front end:

<img width="416" alt="image" src="https://github.com/user-attachments/assets/79bc658a-833a-42b2-b7c5-5d73d9c7911b" />

With the non-super user Companies where you are an Account manager should display the Edit core team button and allow you to edit both the Global Account Manager and Advisers on the core team (optional) fields.


## Screenshots

### Before

#### User not assigned as Account manager:
Advisers on the core team section in Company > Account Management page:
<img width="954" alt="image" src="https://github.com/user-attachments/assets/72ca3d1f-c879-4fd2-ad77-5614ae27f4d6" />

#### User is assigned as Account manager:
<img width="947" alt="image" src="https://github.com/user-attachments/assets/1381cb4b-9f98-47f8-88c4-d804359d5f12" />

### After

#### Edit core team form

<img width="984" alt="image" src="https://github.com/user-attachments/assets/bbe042a0-d154-49b9-80df-c830699ad7c9" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
