### PR TITLE
Remove alt tag for decorative image

### DIFF
--- a/src/client/components/MyInvestmentProjects/NoInvestmentProjects.jsx
+++ b/src/client/components/MyInvestmentProjects/NoInvestmentProjects.jsx
@@ -64,10 +64,7 @@ const NoInvestmentProjects = () => (
     <StyledParagraph>
       View and track investment projects from your dashboard
     </StyledParagraph>
-    <StyledImage
-      src={TimelineImage}
-      alt="An image of the stage timeline and estimated land date"
-    />
+    <StyledImage src={TimelineImage} alt="" />
     <div>
       <StyledParagraph>Once added, you'll be able to:</StyledParagraph>
       <StyledUnorderedList listStyleType="bullet">

--- a/test/functional/cypress/specs/dashboard/no-investment-projects-spec.js
+++ b/test/functional/cypress/specs/dashboard/no-investment-projects-spec.js
@@ -32,13 +32,7 @@ describe('Dashboard - no investment projects', () => {
     })
 
     it('should have an image of the stage timeline and estimated land date', () => {
-      cy.get('@tabPanel')
-        .find('img')
-        .should(
-          'have.attr',
-          'alt',
-          'An image of the stage timeline and estimated land date'
-        )
+      cy.get('@tabPanel').find('img').should('have.attr', 'alt', '')
     })
 
     it('should have a body paragraph', () => {


### PR DESCRIPTION
## Description of change

Use empty alt tag for decorative image on Homepage > Investment projects tab:

![image](https://github.com/user-attachments/assets/548b1e3a-c50d-44e0-b95e-2fd6c6532374)

## Test instructions

No visible changes

## Screenshots

<img width="1207" alt="image" src="https://github.com/user-attachments/assets/f1d011ea-47bf-45e5-bd0e-c1e0297977ed" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
