### PR TITLE
Add the aria-current attribute to LocalNavLink

### DIFF
--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -72,13 +72,11 @@ const _LocalNavLink = ({
 }) => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const location = useLocation()
-
-  const NavLink = href?.includes(location.pathname)
-    ? StyledActiveLink
-    : StyledInactiveLink
+  const active = href?.includes(location.pathname)
+  const NavLink = active ? StyledActiveLink : StyledInactiveLink
 
   return (
-    <NavLink href={href} data-test={dataTest} {...rest}>
+    <NavLink href={href} data-test={dataTest} aria-current={active} {...rest}>
       {children}
     </NavLink>
   )


### PR DESCRIPTION
## Description of change

Adds the `aria-current="true"` attribute to active `LocalNavLink` for better accessibility.

## Test instructions

1. Navigate to `/investments/projects/{id}/details`
2. Inspect the active link of the left panel navigation in dev tools
3. It should have the `aria-current="true"` attribute
4. The inactive items should have `aria-current="true"`
5. This should apply everywherethe `LocalNavLink` is used (the only other place seems to be `/contacts/{id}/details`)

## Screenshots

There should be no visible change.
