### PR TITLE
Bug/EGTB-1646 : fix export win breadcrumb typo

### DIFF
--- a/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
+++ b/src/client/modules/ExportWins/Status/ExportWinsTabNav.jsx
@@ -24,7 +24,7 @@ const ExportWinsTabNav = () => {
         { link: urls.dashboard.index(), text: 'Home' },
         {
           link: urls.companies.exportWins.index(),
-          text: 'Export Wins',
+          text: 'Export wins',
         },
         { text: capitalize(title) },
       ]}

--- a/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/TabNav.cy.jsx
@@ -13,7 +13,7 @@ describe('Export wins tab navigation', () => {
       })
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
-        'Export Wins': urls.companies.exportWins.index(),
+        'Export wins': urls.companies.exportWins.index(),
         Rejected: null,
       })
     })
@@ -24,7 +24,7 @@ describe('Export wins tab navigation', () => {
 
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
-        'Export Wins': urls.companies.exportWins.index(),
+        'Export wins': urls.companies.exportWins.index(),
         Pending: null,
       })
     })
@@ -34,7 +34,7 @@ describe('Export wins tab navigation', () => {
       })
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
-        'Export Wins': urls.companies.exportWins.index(),
+        'Export wins': urls.companies.exportWins.index(),
         Confirmed: null,
       })
     })

--- a/test/functional/cypress/specs/export-win/tabbed-navigation-breadcrumbs.js
+++ b/test/functional/cypress/specs/export-win/tabbed-navigation-breadcrumbs.js
@@ -23,7 +23,7 @@ describe('Tabbed navigation breadcrumbs', () => {
       cy.visit(url)
       assertBreadcrumbs({
         Home: urls.dashboard.index(),
-        'Export Wins': urls.companies.exportWins.index(),
+        'Export wins': urls.companies.exportWins.index(),
         [name]: null,
       })
     })


### PR DESCRIPTION
## Description of change

This is to change the word 'win' in the breadcrumb from upper to lower case

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/cf04cdb0-eb9c-4b04-a01a-ab283008f349)

### After

![image](https://github.com/user-attachments/assets/eb5d8983-c670-4543-b510-fc26b689525d)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
