### PR TITLE
Fix/EGTB-1737: Add the missing 'remove' on the aria label

### DIFF
--- a/src/client/components/Typeahead/SelectedChips.jsx
+++ b/src/client/components/Typeahead/SelectedChips.jsx
@@ -56,7 +56,7 @@ const SelectedChips = ({ name, label, selectedOptions, onOptionRemove }) => (
       <Chip key={option.value} data-test="typeahead-chip">
         <ChipButton
           type="button"
-          aria-label={`${option.chipLabel || option.label} from ${label}`}
+          aria-label={`Remove ${option.chipLabel || option.label} from ${label}`}
           onClick={() => {
             onOptionRemove(option)
           }}

--- a/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
+++ b/test/a11y/cypress/specs/component/Shared/selected-chips-accessibility.js
@@ -22,23 +22,21 @@ describe('SelectedChips – Accessibility', () => {
   testCases.forEach(({ name, label, displayLabel }) => {
     it(`adds accessible aria-labels to remove buttons for field labeled "${label}"`, () => {
       const selectedOptions = [{ value: '1', label: displayLabel }]
+      const expectedLabel = `Remove ${displayLabel} from ${label}`
 
       mount(
         <SelectedChips
           name={name}
-          label={label} // pass the label into SelectedChips
+          label={label}
           selectedOptions={selectedOptions}
           onOptionRemove={() => {}}
         />
       )
 
-      const expectedLabel = `Remove ${displayLabel} from ${label}`
-
-      cy.contains('button', displayLabel).should(
-        'have.attr',
-        'aria-label',
-        expectedLabel
-      )
+      cy.contains('button', displayLabel)
+        .should('exist')
+        .invoke('attr', 'aria-label')
+        .should('eq', expectedLabel)
     })
   })
 
@@ -51,6 +49,7 @@ describe('SelectedChips – Accessibility', () => {
       const chipLabelOptions = [
         { value: '2', label: 'John Smith', chipLabel: chipDisplayLabel },
       ]
+      const expectedLabel = `Remove ${chipDisplayLabel} from ${label}`
 
       mount(
         <SelectedChips
@@ -61,13 +60,10 @@ describe('SelectedChips – Accessibility', () => {
         />
       )
 
-      const expectedLabel = `Remove ${chipDisplayLabel} from ${label}`
-
-      cy.contains('button', chipDisplayLabel).should(
-        'have.attr',
-        'aria-label',
-        expectedLabel
-      )
+      cy.contains('button', chipDisplayLabel)
+        .should('exist')
+        .invoke('attr', 'aria-label')
+        .should('eq', expectedLabel)
     })
   })
 


### PR DESCRIPTION
## Description of change

There is a missing word of 'Remove' in the aria-label for selectedChip. This PR is to fix it.

## Screenshots
There is no changes on the front-end UI perspective but you could see the changes if you inspect the elements. Fields below can be found in edit or add interaction page which are using this component:

    Contact
    Adviser(s)
    Countries currently exporting to
    Future countries of interest
    Countries not interested in

### Before
Please follow this path:
Select Companies (in menu bar) --> Add interaction --> Select standard interaction
Select Interaction (in menu bar) --> Select one of the interaction --> Edit interaction
![image](https://github.com/user-attachments/assets/30e26d31-eded-4d73-907b-43f64bfeb5b4)
![image](https://github.com/user-attachments/assets/4c291090-eb81-4d0f-81e5-376b38f5fada)


### After
Select Companies (in menu bar) --> Add interaction --> Select standard interaction
Select Interaction (in menu bar) --> Select one of the interaction --> Edit interaction
![image](https://github.com/user-attachments/assets/11c55def-d670-4286-90eb-7c30ac3e290b)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
