### PR TITLE
Form error summary focus fix.

### DIFF
--- a/src/client/components/ErrorSummary/index.jsx
+++ b/src/client/components/ErrorSummary/index.jsx
@@ -89,7 +89,15 @@ const ErrorSummary = React.forwardRef(
         <UnorderedList mb={0} listStyleType="none">
           {errors.map(({ targetName, text }) => (
             <ListItem key={targetName}>
-              <StyledErrorText href={`#field-${targetName}`}>
+              <StyledErrorText
+                href={`#field-${targetName}`}
+                onClick={(e) => {
+                  e.preventDefault()
+                  const wrapper = document.getElementById(`field-${targetName}`)
+                  const input = wrapper?.querySelector('input,textarea,select')
+                  input?.focus()
+                }}
+              >
                 {text}
               </StyledErrorText>
             </ListItem>

--- a/src/client/components/Form/elements/FieldInput/index.jsx
+++ b/src/client/components/Form/elements/FieldInput/index.jsx
@@ -59,10 +59,11 @@ const FieldInput = ({
     required,
     initialValue,
   })
+  const errorId = `${name}-error`
   return (
     <FieldWrapper {...{ name, label, legend, hint, error, reduced }}>
       <StyledInputWrapper error={error}>
-        {touched && error && <ErrorText>{error}</ErrorText>}
+        {touched && error && <ErrorText id={errorId}>{error}</ErrorText>}
         <Input
           key={name}
           error={touched && Boolean(error)}
@@ -70,6 +71,8 @@ const FieldInput = ({
           type={type}
           name={name}
           value={value}
+          aria-invalid={!!error}
+          aria-describedby={error ? errorId : undefined}
           onChange={onChange}
           onBlur={onBlur}
           onWheel={(event) => {

--- a/test/a11y/cypress/specs/component/Shared/error-summary-accessibility.js
+++ b/test/a11y/cypress/specs/component/Shared/error-summary-accessibility.js
@@ -1,0 +1,45 @@
+import 'cypress-axe'
+import React from 'react'
+import { mount } from 'cypress/react'
+
+import { FieldInput } from '../../../../../../src/client/components'
+import Form from '../../../../../../src/client/components/Form'
+import { createTestProvider } from '../../../../../component/cypress/specs/provider'
+
+describe('ErrorSummary – Accessibility', () => {
+  it('Check input is focused when clicking on error message', () => {
+    const Provider = createTestProvider({})
+
+    mount(
+      <Provider>
+        <Form id="test-form" store="test">
+          <FieldInput
+            label="Text"
+            hint="Some hint"
+            required="Enter text"
+            type="text"
+            name="test"
+            data-test="test-field"
+          />
+        </Form>
+      </Provider>
+    )
+
+    cy.get('[data-test="submit-button"]').click()
+
+    const input = cy.get('[data-test="test-field"]')
+
+    input.should('have.attr', 'aria-invalid', 'true')
+
+    input.invoke('attr', 'aria-describedBy').then((describedById) => {
+      expect(describedById).to.exist
+      cy.get(`#${describedById}`).should('have.text', 'Enter text')
+    })
+
+    cy.get('[data-test="summary-form-errors"]').within(() => {
+      cy.get('ul > li').should('have.length', 1)
+      cy.get('li a').click()
+      cy.focused().should('have.attr', 'data-test', 'test-field')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

When there was error in the form, the input fields were not annotated with appropriate aria attributes.
Error summary component also was not focusing the field with an error when clicked on corresponding error in the summary list.

## Test instructions

Have screen reader turned on. Got to any form and try to submit it without filling in required fields.
Click on the error message in the summary list.

## Screenshots

### Before

<img width="393" alt="Screenshot 2025-05-06 at 09 02 30" src="https://github.com/user-attachments/assets/878f54db-fbd5-49d8-946c-dc5945fb0c77" />

### After

<img width="596" alt="Screenshot 2025-05-06 at 08 55 18" src="https://github.com/user-attachments/assets/cab728b9-266c-4c06-84e5-71a3b8a67b3a" />

<img width="489" alt="Screenshot 2025-05-06 at 08 56 14" src="https://github.com/user-attachments/assets/9c57b10a-29ea-45b9-97ec-08c1ba7eea7c" />

Going to error summary:

<img width="641" alt="Screenshot 2025-05-06 at 08 56 38" src="https://github.com/user-attachments/assets/936a34a7-ca7e-48e0-a020-264d39d2bc5a" />

Clicking on the relevant error message, the input field corresponding to the error is now focused:

<img width="515" alt="Screenshot 2025-05-06 at 08 56 28" src="https://github.com/user-attachments/assets/f1d8d59b-d917-48a1-94a1-0070f77cd256" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
