### PR TITLE
Improve and unify focus state style of tabs in tab navs

### DIFF
--- a/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
+++ b/src/client/components/CompanyTabbedLocalNavigation/CompanyLocalTab.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 
 import { BLACK, GREY_2, GREY_4, WHITE } from '../../../client/utils/colours'
+import { FOCUS_MIXIN } from '../../utils/styles'
 
 export const StyledListItem = styled.li`
   *,
@@ -64,6 +65,8 @@ export const StyledAnchorTag = styled.a`
         background-color: ${WHITE};
         height: auto;
       `}
+
+    ${FOCUS_MIXIN}
   }
 `
 const CompanyLocalTab = (props) => {

--- a/src/client/components/LocalNav/index.jsx
+++ b/src/client/components/LocalNav/index.jsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import { FONT_SIZE } from '@govuk-react/constants'
 
 import deprecated from '../../utils/deprecated'
+import { FOCUS_MIXIN } from '../../utils/styles'
 
 import {
   DARK_BLUE_LEGACY,
@@ -24,6 +25,7 @@ const StyledActiveLink = styled('a')({
     textDecoration: 'none',
     fontWeight: 600,
   },
+  ...FOCUS_MIXIN,
 })
 
 const StyledInactiveLink = styled('a')({
@@ -38,6 +40,7 @@ const StyledInactiveLink = styled('a')({
     color: BLACK,
     backgroundColor: GREY_4,
   },
+  ...FOCUS_MIXIN,
 })
 
 const _LocalNav = ({ children, dataTest = 'local-nav' }) => {

--- a/src/client/components/TabNav/index.jsx
+++ b/src/client/components/TabNav/index.jsx
@@ -12,8 +12,8 @@ import {
   DARK_BLUE_LEGACY,
   TEXT_COLOUR,
   BORDER_COLOUR,
-  FOCUS_COLOUR,
 } from '../../../client/utils/colours'
+import { FOCUS_MIXIN } from '../../utils/styles'
 
 import multiInstance from '../../utils/multiinstance'
 import { TAB_NAV__SELECT, TAB_NAV__FOCUS } from '../../actions'
@@ -23,19 +23,6 @@ const LEFT_ARROW_KEY = 37
 const RIGHT_ARROW_KEY = 39
 
 const BORDER = `1px solid ${BORDER_COLOUR}`
-
-const focusStyle = {
-  '&:focus': {
-    outline: `3px solid transparent`,
-    background: FOCUS_COLOUR,
-    color: 'BLACK',
-    boxShadow: `0 -2px ${FOCUS_COLOUR}, 0 4px ${BLACK}`,
-    textDecoration: 'none',
-    [MEDIA_QUERIES.TABLET]: {
-      background: WHITE,
-    },
-  },
-}
 
 const createId = (id, key, routed) =>
   routed ? `${id}.tab.${key.replace('/', '_')}` : `tab.${key}`
@@ -196,8 +183,8 @@ export const HeadlessTabNav = multiInstance({
 const SmallScreenTabNav = styled(HeadlessTabNav)({
   // We must use direct child combinators everywhere, otherwise the styles
   // would leak to nested tab navs
+  '& > [role="tab"': FOCUS_MIXIN,
   '& > [role="tablist"] > [role="tab"]': {
-    ...focusStyle,
     padding: '0px',
     margin: '0px 0px 10px',
     color: BLUE,
@@ -230,6 +217,7 @@ export const HorizontalTabNav = styled(SmallScreenTabNav)({
       borderBottom: BORDER,
     },
     '& > [role="tab"]': {
+      ...FOCUS_MIXIN,
       [MEDIA_QUERIES.TABLET]: {
         '&::before': {
           display: 'none',
@@ -252,6 +240,7 @@ export const HorizontalTabNav = styled(SmallScreenTabNav)({
           background: WHITE,
           marginBottom: '-1px',
           padding: '14px 19px 16px',
+          ...FOCUS_MIXIN,
         },
       },
     },
@@ -274,6 +263,7 @@ export const VerticalTabNav = styled(SmallScreenTabNav)({
       display: 'flex',
       flexDirection: 'column',
       '& > [role="tab"]': {
+        ...FOCUS_MIXIN,
         [MEDIA_QUERIES.TABLET]: {
           '&::before': {
             display: 'none',
@@ -292,6 +282,7 @@ export const VerticalTabNav = styled(SmallScreenTabNav)({
             color: WHITE,
             background: DARK_BLUE_LEGACY,
             fontWeight: '600',
+            ...FOCUS_MIXIN,
           },
         },
       },

--- a/src/client/utils/styles.js
+++ b/src/client/utils/styles.js
@@ -1,0 +1,10 @@
+import { FOCUS_COLOUR, BLACK } from './colours'
+
+export const FOCUS_MIXIN = {
+  '&:focus': {
+    outline: `3px solid transparent`,
+    background: FOCUS_COLOUR,
+    color: BLACK,
+    boxShadow: `0 2px 0 ${BLACK}`,
+  },
+}


### PR DESCRIPTION
## Description of change

Improve accessibility of focus state of the various tab navs that we have. I took the liberty to style the focus state roughly according to how it's done in the [GDS Tabs](https://design-system.service.gov.uk/components/tabs/). 

## Test instructions

1. Find all the places where a tab nav appears
2. Get the tabs into focused state
3. A focused tab should have a black text on a yellow background with black border on bottom

## Screenshots

### Before
<img width="477" alt="Screenshot 2025-05-02 at 11 43 25" src="https://github.com/user-attachments/assets/a028b8bd-a1cf-4ae0-b7d0-ec6ec50dc6ae" />

### After
<img width="477" alt="Screenshot 2025-05-02 at 11 43 03" src="https://github.com/user-attachments/assets/15676dde-4aa6-4434-82ea-983bc37ea8e2" />

### Before
<img width="467" alt="Screenshot 2025-05-02 at 11 44 06" src="https://github.com/user-attachments/assets/f0190b01-943c-46ac-ab9c-035f6f84f556" />

### After
<img width="467" alt="Screenshot 2025-05-02 at 11 44 36" src="https://github.com/user-attachments/assets/dbab4073-8806-4187-a364-98e08b25741d" />

### Before
<img width="650" alt="Screenshot 2025-05-02 at 11 45 29" src="https://github.com/user-attachments/assets/c401764f-fc1b-4527-aa4b-b24a11e01d85" />

### After
<img width="650" alt="Screenshot 2025-05-02 at 11 45 12" src="https://github.com/user-attachments/assets/6d0e8fd3-0a49-4799-b6e2-01d9a7de064f" />

### Before
<img width="828" alt="Screenshot 2025-05-02 at 11 46 07" src="https://github.com/user-attachments/assets/2caa740c-8548-414f-834e-1c1c89ad565c" />

### After
<img width="828" alt="Screenshot 2025-05-02 at 11 46 25" src="https://github.com/user-attachments/assets/2458a07b-20fa-4380-807d-2d0601e8c94a" />
