### PR TITLE
Fix job field rules and validation

### DIFF
--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -67,11 +67,6 @@ const isJobFieldRequired = (project, fieldName) => {
     return false
   }
 
-  // If it's a non-FDI or a commitment to invest project, it's not required
-  if (project.investmentType.name !== 'FDI') {
-    return false
-  }
-
   // If it's an expansion FDI project, it's required
   if (
     project.fdiType?.name === FDI_TYPES.expansionOfExistingSiteOrActivity.label

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -92,7 +92,7 @@ const isNumberSafeguardedJobsRequired = (project) => {
 
 const validateNumberNewJobs = (project, value) => {
   if (!isNumberNewJobsRequired(project)) {
-    return null
+    return
   }
   if (!value) {
     return NUMBER_NEW_JOBS_REQUIRED_MESSAGE
@@ -107,27 +107,7 @@ const validateNumberNewJobs = (project, value) => {
     return 'Number of new jobs must be greater than 0'
   }
 
-  return null
-}
-
-const validateAverageSalary = (project, value) => {
-  if (!isAverageSalaryRequired(project)) {
-    return null
-  }
-  if (!value) {
-    return AVERAGE_SALARY_REQUIRED_MESSAGE
-  }
-  return null
-}
-
-const validateNumberSafeguardedJobs = (project, value) => {
-  if (!isNumberSafeguardedJobsRequired(project)) {
-    return null
-  }
-  if (!value) {
-    return NUMBER_SAFEGUARDED_JOBS_REQUIRED_MESSAGE
-  }
-  return null
+  return
 }
 
 const EditProjectValue = () => {
@@ -310,7 +290,7 @@ const EditProjectValue = () => {
                         validateNumberNewJobs(project, value)
                       }
                       initialValue={project.numberNewJobs}
-                    ></FieldInput>
+                    />
                     {project.investmentType.name === 'FDI' &&
                       project.gvaMultiplier
                         ?.sectorClassificationGvaMultiplier === 'labour' && (
@@ -349,8 +329,9 @@ const EditProjectValue = () => {
                           )
                         )
                       }
-                      validate={(value) =>
-                        validateAverageSalary(project, value)
+                      required={
+                        isAverageSalaryRequired(project) &&
+                        AVERAGE_SALARY_REQUIRED_MESSAGE
                       }
                     />
                     <FieldInput
@@ -366,8 +347,9 @@ const EditProjectValue = () => {
                       }
                       type="number"
                       initialValue={project.numberSafeguardedJobs?.toString()}
-                      validate={(value) =>
-                        validateNumberSafeguardedJobs(project, value)
+                      required={
+                        isNumberSafeguardedJobsRequired(project) &&
+                        NUMBER_SAFEGUARDED_JOBS_REQUIRED_MESSAGE
                       }
                     />
                   </>

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -305,7 +305,6 @@ const EditProjectValue = () => {
                       name="number_new_jobs"
                       type="number"
                       {...(isNumberNewJobsRequired(project) && {
-                        required: NUMBER_NEW_JOBS_REQUIRED_MESSAGE,
                         hint:
                           project.fdiType?.name ===
                           FDI_TYPES.expansionOfExistingSiteOrActivity.label

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -40,12 +40,6 @@ const testNumberOfNewJobs = ({ required, value }) =>
       'have.text',
       required ? 'Number of new jobs (required)' : 'Number of new jobs'
     )
-
-    required
-      ? cy.contains('An expansion project must always have at least 1 new job')
-      : cy
-          .contains('An expansion project must always have at least 1 new job')
-          .should('not.exist')
   })
 
 const assertJobFieldLabel = (fieldSelector, label, required) => {

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -1473,48 +1473,6 @@ describe('Edit the value details of a project', () => {
       }
     )
 
-    context('Non-FDI project', () => {
-      const nonFDIProject = setupProjectFaker({
-        investment_type: {
-          name: 'Non-FDI',
-          id: 'foo',
-        },
-        fdi_type: null,
-      })
-
-      beforeEach(() => {
-        setup(nonFDIProject)
-      })
-
-      it('should mark all job fields as optional', () => {
-        assertJobFieldLabel(
-          '[data-test="field-number_new_jobs"]',
-          'Number of new jobs',
-          false
-        )
-        assertJobFieldLabel(
-          '[data-test="field-average_salary"]',
-          'Average salary of new jobs',
-          false
-        )
-        assertJobFieldLabel(
-          '[data-test="field-number_safeguarded_jobs"]',
-          'Number of safeguarded jobs',
-          false
-        )
-      })
-
-      it('should not show errors for empty job fields', () => {
-        fillNonJobFields()
-
-        cy.get('[data-test="submit-button"]').click()
-
-        assertNotExists('[data-test="error-number_new_jobs"]')
-        assertNotExists('[data-test="error-average_salary"]')
-        assertNotExists('[data-test="error-number_safeguarded_jobs"]')
-      })
-    })
-
     context('FDI Expansion project', () => {
       const expansionFDIProject = setupProjectFaker({
         investment_type: {

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -1,3 +1,4 @@
+import { FDI_TYPES } from '../../../../../src/client/modules/Investments/Projects/constants'
 import { INVESTMENT_PROJECT_STAGES } from '../../fakers/constants'
 import { clickButton } from '../../support/actions'
 
@@ -46,6 +47,13 @@ const testNumberOfNewJobs = ({ required, value }) =>
           .contains('An expansion project must always have at least 1 new job')
           .should('not.exist')
   })
+
+const assertJobFieldLabel = (fieldSelector, label, required) => {
+  cy.get(fieldSelector).should(
+    'have.text',
+    required ? `${label} (required)` : `${label} (optional)`
+  )
+}
 
 const setupProjectFaker = (overrides) =>
   investmentProjectFaker({
@@ -1407,112 +1415,271 @@ describe('Edit the value details of a project', () => {
     }
   )
 
-  context('Number of jobs error handling', () => {
-    context('When editing an FDI project', () => {
-      context('With involvement', () => {
-        const expansionProject = setupProjectFaker({
-          stage: INVESTMENT_PROJECT_STAGES.active,
+  context('Requirement and validation of job-related fields', () => {
+    const fillNonJobFields = () => {
+      cy.get('[data-test="client-cannot-provide-total-investment-yes"]').click()
+      cy.get('[data-test="total-investment-input"]').type(20000000)
+      cy.get(
+        '[data-test="client-cannot-provide-foreign-investment-yes"]'
+      ).click()
+      cy.get('[data-test="foreign-equity-investment-input"]').type(15000000)
+      cy.get('[data-test="foreign-equity-investment-input"]').click()
+      cy.get('[data-test="government-assistance-yes"]').click()
+      cy.get('[data-test="r-and-d-budget-yes"]').click()
+      cy.get('[data-test="non-fdi-r-and-d-budget-yes"]').click()
+      cy.get('[data-test="new-tech-to-uk-yes"]').click()
+      cy.get('[data-test="export-revenue-yes"]').click()
+    }
+
+    context(
+      'when editing the value of an FDI project with no involvement (at any stage)',
+      () => {
+        const fdiNoInvolvementProject = setupProjectFaker({
           investment_type: {
             name: 'FDI',
             id: 'foo',
           },
           level_of_involvement: {
-            name: 'Foo',
+            name: 'No Involvement',
             id: 'bar',
           },
         })
+
         beforeEach(() => {
-          setup(expansionProject)
+          setup(fdiNoInvolvementProject)
         })
-        testNumberOfNewJobs({
-          required: true,
+
+        it('should mark all job fields as optional', () => {
+          assertJobFieldLabel(
+            '[data-test="field-number_new_jobs"]',
+            'Number of new jobs',
+            false
+          )
+          assertJobFieldLabel(
+            '[data-test="field-average_salary"]',
+            'Average salary of new jobs',
+            false
+          )
+          assertJobFieldLabel(
+            '[data-test="field-number_safeguarded_jobs"]',
+            'Number of safeguarded jobs',
+            false
+          )
         })
-        it('should show an error if the number of new jobs is empty', () => {
+
+        it('should not show errors for empty job fields', () => {
+          fillNonJobFields()
+
           cy.get('[data-test="submit-button"]').click()
-          assertErrorSummary(['Value for number of new jobs is required'])
+
+          assertNotExists('[data-test="error-number_new_jobs"]')
+          assertNotExists('[data-test="error-average_salary"]')
+          assertNotExists('[data-test="error-number_safeguarded_jobs"]')
         })
-        it('should show an error if the number of new jobs is 0', () => {
-          cy.get('[data-test="number-new-jobs-input"]').type(0)
-          cy.get('[data-test="submit-button"]').click()
-          assertErrorSummary(['Number of new jobs must be greater than 0'])
-        })
-        it('should not show an error if the number of new jobs is 1', () => {
-          cy.get('[data-test="number-new-jobs-input"]').type(1)
-          cy.get('[data-test="submit-button"]').click()
-          assertNotExists('[data-test="summary-form-errors"]')
-        })
+      }
+    )
+
+    context('Non-FDI project', () => {
+      const nonFDIProject = setupProjectFaker({
+        investment_type: {
+          name: 'Non-FDI',
+          id: 'foo',
+        },
+        fdi_type: null,
       })
 
-      context('With no involvement', () => {
-        const expansionProject = setupProjectFaker({
-          stage: INVESTMENT_PROJECT_STAGES.active,
-          investment_type: {
-            name: 'FDI',
-            id: 'foo',
-          },
-          level_of_involvement: null,
-        })
-        beforeEach(() => {
-          setup(expansionProject)
-        })
+      beforeEach(() => {
+        setup(nonFDIProject)
+      })
 
-        testNumberOfNewJobs({
-          required: false,
-        })
+      it('should mark all job fields as optional', () => {
+        assertJobFieldLabel(
+          '[data-test="field-number_new_jobs"]',
+          'Number of new jobs',
+          false
+        )
+        assertJobFieldLabel(
+          '[data-test="field-average_salary"]',
+          'Average salary of new jobs',
+          false
+        )
+        assertJobFieldLabel(
+          '[data-test="field-number_safeguarded_jobs"]',
+          'Number of safeguarded jobs',
+          false
+        )
+      })
 
-        it('should show an error if the number of new jobs is empty', () => {
-          cy.get('[data-test="submit-button"]').click()
-          cy.contains('Value for number of new jobs is required').should(
-            'not.exist'
-          )
-        })
+      it('should not show errors for empty job fields', () => {
+        fillNonJobFields()
 
-        it('should not show an error if the number of new jobs is 0', () => {
-          cy.get('[data-test="number-new-jobs-input"]').type(0)
-          cy.get('[data-test="submit-button"]').click()
-          cy.contains('Number of new jobs must be greater than 0').should(
-            'not.exist'
-          )
-        })
+        cy.get('[data-test="submit-button"]').click()
 
-        it('should not show an error if the number of new jobs is 1', () => {
-          cy.get('[data-test="number-new-jobs-input"]').type(1)
-          cy.get('[data-test="submit-button"]').click()
-          assertNotExists('[data-test="summary-form-errors"]')
-        })
+        assertNotExists('[data-test="error-number_new_jobs"]')
+        assertNotExists('[data-test="error-average_salary"]')
+        assertNotExists('[data-test="error-number_safeguarded_jobs"]')
       })
     })
 
-    context('When editing an non expansion project', () => {
-      it('should show an error or hint text if number of new jobs is empty and it is a non FDI project', () => {
-        const nonFdiProject = setupProjectFaker({
-          stage: INVESTMENT_PROJECT_STAGES.active,
-          investment_type: {
-            name: 'non-FDI',
-            id: '3d2c94e4-7871-465c-a7f7-45651eeffc64',
-          },
-          fdi_type: null,
-          gva_multiplier: null,
-        })
-        setup(nonFdiProject)
+    context('FDI Expansion project', () => {
+      const expansionFDIProject = setupProjectFaker({
+        investment_type: {
+          name: 'FDI',
+          id: 'foo',
+        },
+        fdi_type: {
+          name: FDI_TYPES.expansionOfExistingSiteOrActivity.label,
+          id: FDI_TYPES.expansionOfExistingSiteOrActivity.value,
+        },
+      })
+
+      beforeEach(() => {
+        setup(expansionFDIProject)
+      })
+
+      it('should mark all job fields as required', () => {
         cy.get('[data-test="field-number_new_jobs"]').should(
-          'not.contain',
-          '[data-test="hint-text"]'
+          'contain.text',
+          'Number of new jobs (required)'
         )
+        assertJobFieldLabel(
+          '[data-test="field-average_salary"]',
+          'Average salary of new jobs',
+          true
+        )
+        assertJobFieldLabel(
+          '[data-test="field-number_safeguarded_jobs"]',
+          'Number of safeguarded jobs',
+          true
+        )
+      })
+
+      it('should show the hint text about requiring at least 1 new job', () => {
+        cy.get('[data-test="field-number_new_jobs"]').contains(
+          'An expansion project must always have at least 1 new job'
+        )
+      })
+
+      it('should show error if number of new jobs is 0', () => {
+        cy.get('[data-test="number-new-jobs-input"]').type(0)
+
+        // Fill in other job fields to satisfy requirements
+        cy.get('[data-test="average-salary-below-25-000"]').click()
+        cy.get('[data-test="number-safeguarded-jobs-input"]').type(0)
+
         cy.get('[data-test="submit-button"]').click()
+
+        assertErrorSummary(['Number of new jobs must be greater than 0'])
+      })
+
+      it('should not show error if number of new jobs is >= 1', () => {
+        fillNonJobFields()
+
+        // Fill in job related fields
+        cy.get('[data-test="number-new-jobs-input"]').type(1)
+        cy.get('[data-test="average-salary-below-25-000"]').click()
+        cy.get('[data-test="number-safeguarded-jobs-input"]').type(0)
+
+        cy.get('[data-test="submit-button"]').click()
+
+        assertNotExists('[data-test="error-number_new_jobs"]')
+      })
+    })
+
+    context('FDI Capital Only project', () => {
+      const capitalOnlyFDIProject = setupProjectFaker({
+        investment_type: {
+          name: 'FDI',
+          id: 'foo',
+        },
+        fdi_type: {
+          name: FDI_TYPES.capitalOnly.label,
+          id: FDI_TYPES.capitalOnly.value,
+        },
+      })
+
+      beforeEach(() => {
+        setup(capitalOnlyFDIProject)
+      })
+
+      it('should not display the job fields', () => {
+        cy.get('[data-test="field-number_new_jobs"]').should('not.exist')
+        cy.get('[data-test="field-average_salary"]').should('not.exist')
+        cy.get('[data-test="field-number_safeguarded_jobs"]').should(
+          'not.exist'
+        )
+      })
+
+      it('should submit the form with job fields set to fixed values', () => {
+        fillNonJobFields()
+
+        cy.get('[data-test="submit-button"]').click()
+
+        assertNotExists('[data-test="error-number_new_jobs"]')
+        assertNotExists('[data-test="error-average_salary"]')
+        assertNotExists('[data-test="error-number_safeguarded_jobs"]')
+
+        cy.wait('@editValueSubmissionRequest')
+          .its('request.body')
+          .should('include', {
+            number_new_jobs: 0,
+            average_salary: null,
+            number_safeguarded_jobs: 0,
+          })
+      })
+    })
+
+    context('Other FDI project at prospect stage', () => {
+      const otherFDIProspectProject = setupProjectFaker({
+        stage: INVESTMENT_PROJECT_STAGES.prospect,
+        investment_type: {
+          name: 'FDI',
+          id: 'foo',
+        },
+        fdi_type: {
+          name: ' Other',
+          id: 'bar',
+        },
+      })
+
+      beforeEach(() => {
+        setup(otherFDIProspectProject)
+      })
+
+      it('should mark the fields as required based on stage validation', () => {
+        assertJobFieldLabel(
+          '[data-test="field-number_new_jobs"]',
+          'Number of new jobs',
+          true
+        )
+        assertJobFieldLabel(
+          '[data-test="field-average_salary"]',
+          'Average salary of new jobs',
+          false
+        )
+        assertJobFieldLabel(
+          '[data-test="field-number_safeguarded_jobs"]',
+          'Number of safeguarded jobs',
+          false
+        )
+      })
+
+      it('should show errors for only new jobs', () => {
+        fillNonJobFields()
+
+        cy.get('[data-test="submit-button"]').click()
+
         assertErrorSummary(['Value for number of new jobs is required'])
       })
-      it('should show an error or hint text if number of new jobs is empty and it is not an expansion FDI project', () => {
-        const nonExpansionFdiProject = setupProjectFaker({
-          stage: INVESTMENT_PROJECT_STAGES.active,
-        })
-        setup(nonExpansionFdiProject)
-        cy.get('[data-test="field-number_new_jobs"]').should(
-          'not.contain',
-          '[data-test="hint-text"]'
-        )
+
+      it('should allow 0 new jobs', () => {
+        fillNonJobFields()
+
+        cy.get('[data-test="number-new-jobs-input"]').type(0)
+
         cy.get('[data-test="submit-button"]').click()
-        assertErrorSummary(['Value for number of new jobs is required'])
+
+        assertNotExists('[data-test="error-number_new_jobs"]')
       })
     })
   })

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -1586,49 +1586,6 @@ describe('Edit the value details of a project', () => {
       })
     })
 
-    context('FDI Capital Only project', () => {
-      const capitalOnlyFDIProject = setupProjectFaker({
-        investment_type: {
-          name: 'FDI',
-          id: 'foo',
-        },
-        fdi_type: {
-          name: FDI_TYPES.capitalOnly.label,
-          id: FDI_TYPES.capitalOnly.value,
-        },
-      })
-
-      beforeEach(() => {
-        setup(capitalOnlyFDIProject)
-      })
-
-      it('should not display the job fields', () => {
-        cy.get('[data-test="field-number_new_jobs"]').should('not.exist')
-        cy.get('[data-test="field-average_salary"]').should('not.exist')
-        cy.get('[data-test="field-number_safeguarded_jobs"]').should(
-          'not.exist'
-        )
-      })
-
-      it('should submit the form with job fields set to fixed values', () => {
-        fillNonJobFields()
-
-        cy.get('[data-test="submit-button"]').click()
-
-        assertNotExists('[data-test="error-number_new_jobs"]')
-        assertNotExists('[data-test="error-average_salary"]')
-        assertNotExists('[data-test="error-number_safeguarded_jobs"]')
-
-        cy.wait('@editValueSubmissionRequest')
-          .its('request.body')
-          .should('include', {
-            number_new_jobs: 0,
-            average_salary: null,
-            number_safeguarded_jobs: 0,
-          })
-      })
-    })
-
     context('Other FDI project at prospect stage', () => {
       const otherFDIProspectProject = setupProjectFaker({
         stage: INVESTMENT_PROJECT_STAGES.prospect,


### PR DESCRIPTION
## Description of change

This PR tidies up the ruleset and validation for the job-related fields (number of new jobs, average salary, number of safeguarded jobs) in the investment project edit value form. It also fixes a bug where number of new jobs was required with a value of >1 for non-FDI projects.

## Test instructions

The rules for the job fields are as follows:
- Number of new jobs field is required at the Prospect stage. Average salary and number of safeguarded jobs are only required at the Assign PM stage.
- Capital only (FDI) projects will always have 0 new jobs (so we don't show the questions and fix the values in the payload).
- Expansion (FDI) projects must have at least 1 new job.
- Any FDI projects with no involvement should not require a value for number of new jobs at any stage.
- Non FDI and commitment to invest projects will only require the job fields at their default stages (there's no other rules applied).

## Screenshots

### Before

<img width="997" alt="image" src="https://github.com/user-attachments/assets/9d108f37-2cf4-44c1-ba5b-430bb3e0725b" />

### After

<img width="985" alt="image" src="https://github.com/user-attachments/assets/bb610849-3f40-4c19-a7a7-7d8819c4e4fd" />

<img width="985" alt="image" src="https://github.com/user-attachments/assets/977bba58-eaf5-4cab-8c8b-d1f90f1aa40d" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
