### PR TITLE
Update collection lists to use unordered list instead of ordered list

### DIFF
--- a/src/client/components/CollectionList/index.jsx
+++ b/src/client/components/CollectionList/index.jsx
@@ -63,7 +63,7 @@ const CollectionList = ({
               entityNamePlural={entityNamePlural}
             />
           )}
-          <ol aria-live="polite">
+          <ul aria-live="polite">
             {items.map((item, index) =>
               collectionItemTemplate ? (
                 collectionItemTemplate(item)
@@ -82,19 +82,19 @@ const CollectionList = ({
                 />
               )
             )}
-          </ol>
+          </ul>
           {taskProps && (
             <Task.Status {...taskProps}>
               {() =>
                 isComplete && (
                   <>
-                    <ol>
+                    <ul>
                       <li>
                         {results.map((item, i) => (
                           <CollectionItem {...item} key={i} />
                         ))}
                       </li>
-                    </ol>
+                    </ul>
                   </>
                 )
               }

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -144,7 +144,7 @@ const FilteredCollectionList = ({
           <Task.Status {...taskProps}>
             {() =>
               isComplete && (
-                <ol aria-live="polite">
+                <ul aria-live="polite">
                   {results.map((item, index) => (
                     <Analytics key={`${item.id}-${index}`}>
                       {(pushAnalytics) =>
@@ -159,7 +159,7 @@ const FilteredCollectionList = ({
                       }
                     </Analytics>
                   ))}
-                </ol>
+                </ul>
               )
             }
           </Task.Status>

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -271,7 +271,7 @@ describe('Company overview page', () => {
     })
     it('the card should contain three activities', () => {
       cy.get('[data-test="recent-activity-card-container"]')
-        .find('ol')
+        .find('ul')
         .children()
         .should('have.length', 3)
     })
@@ -305,7 +305,7 @@ describe('Company overview page', () => {
     })
     it('the card should contain two activities', () => {
       cy.get('[data-test="upcoming-activity-card-container"]')
-        .find('ol')
+        .find('ul')
         .children()
         .should('have.length', 2)
     })


### PR DESCRIPTION
## Description of change

Changes ordered lists to unordered lists as instructed for accessibility audit.

This ticket was specifically for the company list page but this uses a reused component so will fix the events, interactions and so on lists.

## Test instructions

No visual changes, just different html markup.

## Screenshots

### Before
<img width="985" alt="Screenshot 2025-05-07 at 17 15 17" src="https://github.com/user-attachments/assets/b9e7a2e3-d4ed-4201-b51e-3e97ba858f5c" />

### After
<img width="985" alt="Screenshot 2025-05-07 at 17 15 30" src="https://github.com/user-attachments/assets/7965dd5d-9570-4c2f-a098-e31a799b4de2" />


## Checklist

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
