### PR TITLE
feat: accessible collection items

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -90,82 +90,103 @@ const CollectionItem = ({
   footerRenderer,
   footerdata,
   showTagsInMetadata = false,
-}) => (
-  <ItemWrapper data-test="collection-item">
-    {/* tags take precidence over badges as they are the newer style, however not all components
-     have been updated so the component needs to handle rendering both props */}
-    {tags && tags.length > 0 && !showTagsInMetadata && (
-      <StyledBadgesWrapper data-test="collection-item-tags">
-        {renderTags(tags)}
-      </StyledBadgesWrapper>
-    )}
+  getLinkText,
+  getAriaLabel,
+  ...itemProps
+}) => {
+  const itemDataForCustomFunctions = { headingText, metadata, ...itemProps }
 
-    {!tags && badges && (
-      <StyledBadgesWrapper data-test="collection-item-badges">
-        {badges.map((badge) => (
-          <Badge key={badge.text} borderColour={badge.borderColour}>
-            {badge.text}
-          </Badge>
-        ))}
-      </StyledBadgesWrapper>
-    )}
+  const linkTextToDisplay = getLinkText
+    ? getLinkText(itemDataForCustomFunctions)
+    : headingText
 
-    {titleRenderer ? (
-      titleRenderer(headingText, headingUrl)
-    ) : headingUrl ? (
-      <StyledHeader>
-        {useReactRouter ? (
-          <AccessibleLink
-            showUnderline={false}
-            as={RouterLink}
-            to={headingUrl}
-            onClick={onClick}
-          >
-            {headingText}
-          </AccessibleLink>
-        ) : (
-          <AccessibleLink
-            showUnderline={false}
-            href={headingUrl}
-            onClick={onClick}
-          >
-            {headingText}
-          </AccessibleLink>
-        )}
-      </StyledHeader>
-    ) : (
-      <StyledHeader>{headingText}</StyledHeader>
-    )}
-    {subheading ? (
-      subheadingUrl ? (
-        <StyledSubheading data-test="collection-item-subheading" fontSize={19}>
-          <AccessibleLink href={subheadingUrl}>{subheading}</AccessibleLink>
-        </StyledSubheading>
+  const ariaLabelToUse = getAriaLabel
+    ? getAriaLabel(itemDataForCustomFunctions)
+    : undefined
+
+  return (
+    <ItemWrapper data-test="collection-item">
+      {/* tags take precidence over badges as they are the newer style, however
+      not all components have been updated so the component needs to handle
+      rendering both props */}
+      {tags && tags.length > 0 && !showTagsInMetadata && (
+        <StyledBadgesWrapper data-test="collection-item-tags">
+          {renderTags(tags)}
+        </StyledBadgesWrapper>
+      )}
+
+      {!tags && badges && (
+        <StyledBadgesWrapper data-test="collection-item-badges">
+          {badges.map((badge) => (
+            <Badge key={badge.text} borderColour={badge.borderColour}>
+              {badge.text}
+            </Badge>
+          ))}
+        </StyledBadgesWrapper>
+      )}
+
+      {titleRenderer ? (
+        titleRenderer(linkTextToDisplay, headingUrl)
+      ) : headingUrl ? (
+        <StyledHeader>
+          {useReactRouter ? (
+            <AccessibleLink
+              showUnderline={false}
+              as={RouterLink}
+              to={headingUrl}
+              onClick={onClick}
+              aria-label={ariaLabelToUse}
+            >
+              {linkTextToDisplay}
+            </AccessibleLink>
+          ) : (
+            <AccessibleLink
+              showUnderline={false}
+              href={headingUrl}
+              onClick={onClick}
+              aria-label={ariaLabelToUse}
+            >
+              {linkTextToDisplay}
+            </AccessibleLink>
+          )}
+        </StyledHeader>
       ) : (
-        <StyledSubheading data-test="collection-item-subheading">
-          {subheading}
-        </StyledSubheading>
-      )
-    ) : null}
+        <StyledHeader>{linkTextToDisplay}</StyledHeader>
+      )}
+      {subheading ? (
+        subheadingUrl ? (
+          <StyledSubheading
+            data-test="collection-item-subheading"
+            fontSize={19}
+          >
+            <AccessibleLink href={subheadingUrl}>{subheading}</AccessibleLink>
+          </StyledSubheading>
+        ) : (
+          <StyledSubheading data-test="collection-item-subheading">
+            {subheading}
+          </StyledSubheading>
+        )
+      ) : null}
 
-    {showTagsInMetadata && (
-      <StyledInlineTagWrapper>{renderTags(tags)}</StyledInlineTagWrapper>
-    )}
-    {metadataRenderer ? (
-      metadataRenderer(metadata)
-    ) : (
-      <Metadata rows={metadata} />
-    )}
-    {buttons && <StyledButtonWrapper>{buttons}</StyledButtonWrapper>}
-    {footerRenderer && (
-      <StyledFooterWrapper>{footerRenderer(footerdata)} </StyledFooterWrapper>
-    )}
-  </ItemWrapper>
-)
+      {showTagsInMetadata && (
+        <StyledInlineTagWrapper>{renderTags(tags)}</StyledInlineTagWrapper>
+      )}
+      {metadataRenderer ? (
+        metadataRenderer(metadata)
+      ) : (
+        <Metadata rows={metadata} />
+      )}
+      {buttons && <StyledButtonWrapper>{buttons}</StyledButtonWrapper>}
+      {footerRenderer && (
+        <StyledFooterWrapper>{footerRenderer(footerdata)} </StyledFooterWrapper>
+      )}
+    </ItemWrapper>
+  )
+}
 
 CollectionItem.propTypes = {
   headingUrl: PropTypes.string,
-  headingText: PropTypes.string.isRequired,
+  headingText: PropTypes.string,
   subheading: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
   subheadingUrl: PropTypes.string,
   badges: PropTypes.arrayOf(
@@ -184,7 +205,7 @@ CollectionItem.propTypes = {
     PropTypes.shape({
       label: PropTypes.string,
       key: PropTypes.string,
-      value: PropTypes.node.isRequired,
+      value: PropTypes.node,
     })
   ),
   type: PropTypes.string,
@@ -192,6 +213,8 @@ CollectionItem.propTypes = {
   titleRenderer: PropTypes.func,
   buttonRenderer: PropTypes.func,
   footerRenderer: PropTypes.func,
+  getLinkText: PropTypes.func,
+  getAriaLabel: PropTypes.func,
 }
 
 export default CollectionItem

--- a/src/client/components/FilteredCollectionList/index.jsx
+++ b/src/client/components/FilteredCollectionList/index.jsx
@@ -46,7 +46,9 @@ const collectionItemTemplateDefault = (
   useReactRouter,
   pushAnalytics,
   selectedFilters,
-  sanitizeFiltersForAnalytics
+  sanitizeFiltersForAnalytics,
+  getLinkText,
+  getAriaLabel
 ) => {
   return (
     <CollectionItem
@@ -64,6 +66,8 @@ const collectionItemTemplateDefault = (
           },
         })
       }}
+      getLinkText={getLinkText}
+      getAriaLabel={getAriaLabel}
     />
   )
 }
@@ -91,6 +95,8 @@ const FilteredCollectionList = ({
   sanitizeFiltersForAnalytics = null,
   useReactRouter = false,
   collectionItemTemplate = collectionItemTemplateDefault,
+  getLinkTextForItem,
+  getAriaLabelForItem,
 }) => {
   const navigate = useNavigate()
   const location = useLocation()
@@ -154,7 +160,9 @@ const FilteredCollectionList = ({
                           useReactRouter,
                           pushAnalytics,
                           selectedFilters,
-                          sanitizeFiltersForAnalytics
+                          sanitizeFiltersForAnalytics,
+                          getLinkTextForItem,
+                          getAriaLabelForItem
                         )
                       }
                     </Analytics>
@@ -217,6 +225,8 @@ FilteredCollectionList.propTypes = {
   titleRenderer: PropTypes.func,
   sanitizeFiltersForAnalytics: PropTypes.func,
   width: PropTypes.string,
+  getLinkTextForItem: PropTypes.func,
+  getAriaLabelForItem: PropTypes.func,
 }
 
 export default FilteredCollectionList

--- a/src/client/modules/Companies/CollectionList/index.jsx
+++ b/src/client/modules/Companies/CollectionList/index.jsx
@@ -15,6 +15,7 @@ import {
 } from '../../../components'
 
 import { LABELS } from './constants'
+import labels from './labels'
 
 import {
   ID,
@@ -33,6 +34,32 @@ import {
   companyCollectionListTask,
   companyCollectionListMetadataTask,
 } from '../utils'
+
+const getCompanyLinkText = (item) =>
+  item.headingText || 'DBT doesn’t know the company name yet'
+
+const getCompanyAriaLabel = (item) => {
+  const companyName = item.headingText || 'unknown'
+  let sector = 'unknown'
+  let addressValue = 'unknown'
+
+  if (item.metadata) {
+    const sectorItem = item.metadata.find(
+      (meta) => meta.label === labels.companyDetailsLabels.sector
+    )
+    if (sectorItem && sectorItem.value != null) {
+      sector = sectorItem.value || 'unknown'
+    }
+
+    const addressItem = item.metadata.find(
+      (meta) => meta.label === labels.address.companyAddress
+    )
+    if (addressItem && addressItem.value != null) {
+      addressValue = addressItem.value || 'unknown'
+    }
+  }
+  return `Company ${companyName}. Sector ${sector}. Address ${addressValue}.`
+}
 
 const CompaniesCollection = ({
   payload,
@@ -74,6 +101,8 @@ const CompaniesCollection = ({
         entityName="company"
         entityNamePlural="companies"
         addItemUrl="/companies/create"
+        getLinkTextForItem={getCompanyLinkText}
+        getAriaLabelForItem={getCompanyAriaLabel}
         sanitizeFiltersForAnalytics={({
           name,
           ukPostcode,

--- a/src/client/modules/Contacts/CollectionList/CompanyContactsCollection.jsx
+++ b/src/client/modules/Contacts/CollectionList/CompanyContactsCollection.jsx
@@ -17,6 +17,29 @@ import {
 } from './state'
 import AccessibleLink from '../../../components/Link'
 
+const getContactLinkText = (item) =>
+  item.headingText || 'Contact name not available'
+
+const getContactAriaLabel = (item) => {
+  const contactName = item.headingText || 'unknown'
+  let companyName = 'unknown'
+  let jobTitle = 'unknown'
+
+  if (item.metadata) {
+    const companyItem = item.metadata.find((meta) => meta.label === 'Company')
+    if (companyItem && companyItem.value != null) {
+      companyName = companyItem.value
+    }
+    const jobTitleItem = item.metadata.find(
+      (meta) => meta.label === 'Job title'
+    )
+    if (jobTitleItem && jobTitleItem.value != null) {
+      jobTitle = jobTitleItem.value
+    }
+  }
+  return `Contact ${contactName}. Company ${companyName}. Job title ${jobTitle}.`
+}
+
 const CompanyContactsCollection = ({
   payload,
   optionMetadata,
@@ -76,6 +99,8 @@ const CompanyContactsCollection = ({
                 sortby: 'modified_on:desc',
                 page: 1,
               }}
+              getLinkTextForItem={getContactLinkText}
+              getAriaLabelForItem={getContactAriaLabel}
             />
           </CompanyLayout>
         )}

--- a/src/client/modules/Contacts/CollectionList/index.jsx
+++ b/src/client/modules/Contacts/CollectionList/index.jsx
@@ -29,6 +29,29 @@ import {
 
 import { sanitizeFilter } from '../../../../client/filters'
 
+const getContactLinkText = (item) =>
+  item.headingText || 'Contact name not available'
+
+const getContactAriaLabel = (item) => {
+  const contactName = item.headingText || 'unknown'
+  let companyName = 'unknown'
+  let jobTitle = 'unknown'
+
+  if (item.metadata) {
+    const companyItem = item.metadata.find((meta) => meta.label === 'Company')
+    if (companyItem && companyItem.value != null) {
+      companyName = companyItem.value
+    }
+    const jobTitleItem = item.metadata.find(
+      (meta) => meta.label === 'Job title'
+    )
+    if (jobTitleItem && jobTitleItem.value != null) {
+      jobTitle = jobTitleItem.value
+    }
+  }
+  return `Contact ${contactName}. Company ${companyName}. Job title ${jobTitle}.`
+}
+
 const ContactsCollection = ({
   payload,
   optionMetadata,
@@ -77,6 +100,8 @@ const ContactsCollection = ({
           ...sanitizeFilter(name),
           ...sanitizeFilter(companyName),
         })}
+        getLinkTextForItem={getContactLinkText}
+        getAriaLabelForItem={getContactAriaLabel}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           <FilterToggleSection

--- a/src/client/modules/Interactions/CollectionList/index.jsx
+++ b/src/client/modules/Interactions/CollectionList/index.jsx
@@ -46,6 +46,28 @@ const StyledCheckboxGroup = styled(Filters.CheckboxGroup)`
   margin-bottom: ${SPACING.SCALE_2};
 `
 
+const getInteractionLinkText = (item) =>
+  item.headingText || 'Interaction subject not available'
+
+const getInteractionAriaLabel = (item) => {
+  const subject = item.headingText || 'unknown'
+  let companyName = 'unknown'
+  let date = 'unknown'
+
+  if (item.metadata) {
+    const companyItem = item.metadata.find((meta) => meta.label === 'Company')
+    if (companyItem && companyItem.value != null) {
+      companyName = companyItem.value
+    }
+
+    const dateItem = item.metadata.find((meta) => meta.label === 'Date')
+    if (dateItem && dateItem.value != null) {
+      date = dateItem.value
+    }
+  }
+  return `Interaction ${subject}. Company ${companyName}. Date ${date}.`
+}
+
 const InteractionCollection = ({
   payload,
   optionMetadata,
@@ -132,6 +154,8 @@ const InteractionCollection = ({
           ...sanitizeFilter(advisers),
           ...sanitizeFilter(teams),
         })}
+        getLinkTextForItem={getInteractionLinkText}
+        getAriaLabelForItem={getInteractionAriaLabel}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           <Filters.CheckboxGroup

--- a/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
+++ b/src/client/modules/Investments/EYBLeads/EYBLeadsCollection.jsx
@@ -25,6 +25,38 @@ import {
   InputPlaceholder,
 } from '../../../components/SkeletonPlaceholder'
 
+const getEybLeadLinkText = (item) =>
+  item.headingText || 'EYB Lead company name not available'
+
+const getEybLeadAriaLabel = (item) => {
+  const companyName = item.headingText || 'unknown'
+  let valueLabel = 'unknown'
+  let sector = 'unknown'
+  let landDate = 'unknown'
+
+  if (item.tags) {
+    const valueTag = item.tags.find((tag) => tag.dataTest === 'value-label')
+    if (valueTag && valueTag.text) {
+      valueLabel = valueTag.text
+    }
+  }
+
+  if (item.metadata) {
+    const sectorItem = item.metadata.find((meta) => meta.label === 'Sector')
+    if (sectorItem && sectorItem.value) {
+      sector = sectorItem.value
+    }
+    const landDateItem = item.metadata.find(
+      (meta) => meta.label === 'Estimated land date'
+    )
+    if (landDateItem && landDateItem.value) {
+      landDate = landDateItem.value
+    }
+  }
+
+  return `EYB Lead for ${companyName}. Value ${valueLabel}. Sector ${sector}. Estimated land date ${landDate}.`
+}
+
 const EYBLeadCollection = ({
   filterOptions,
   payload,
@@ -120,6 +152,8 @@ const EYBLeadCollection = ({
           sortby: '-triage_created',
         }}
         selectedFilters={selectedFilters}
+        getLinkTextForItem={getEybLeadLinkText}
+        getAriaLabelForItem={getEybLeadAriaLabel}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           &nbsp;

--- a/src/client/modules/Investments/Projects/ProjectsCollection.jsx
+++ b/src/client/modules/Investments/Projects/ProjectsCollection.jsx
@@ -38,6 +38,35 @@ import AccessibleLink from '../../../components/Link'
 const StyledParagraph = styled(Paragraph)`
   font-size: ${FONT_SIZE.SIZE_16};
 `
+
+const getProjectLinkText = (item) =>
+  item.headingText || 'Project name not available'
+
+const getProjectAriaLabel = (item) => {
+  const projectName = item.headingText || 'unknown'
+  let investor = 'unknown'
+  let sector = 'unknown'
+  let landDate = 'unknown'
+
+  if (item.metadata) {
+    const investorItem = item.metadata.find((meta) => meta.label === 'Investor')
+    if (investorItem && investorItem.value) {
+      investor = investorItem.value
+    }
+    const sectorItem = item.metadata.find((meta) => meta.label === 'Sector')
+    if (sectorItem && sectorItem.value) {
+      sector = sectorItem.value
+    }
+    const landDateItem = item.metadata.find(
+      (meta) => meta.label === 'Estimated land date'
+    )
+    if (landDateItem && landDateItem.value) {
+      landDate = landDateItem.value
+    }
+  }
+  return `Project ${projectName}. Investor ${investor}. Sector ${sector}. Estimated land date ${landDate}.`
+}
+
 const StyledDetails = styled(Details)`
   margin-bottom: 0;
   span {
@@ -139,6 +168,8 @@ const ProjectsCollection = ({
           page: 1,
           sortby: 'created_on:desc',
         }}
+        getLinkTextForItem={getProjectLinkText}
+        getAriaLabelForItem={getProjectAriaLabel}
       >
         <CollectionFilters taskProps={collectionListMetadataTask}>
           {company && (


### PR DESCRIPTION
## Description of change

#### tet-1006 (accessibility audit)
* collection items to handle missing heading text
* always add aria-label for header/link level accessibility
* removing the .isRequired on headingText and metadata>value props to match expected data

## Test instructions

* make a company with no name and see companies collection list
* similarly for company contacts, contacts, interactions, investment projects, investment eyb leads
* (skipped events, company activities, contact activities, and omis/orders for larger future rework)

## Screenshots

### Before

<img width="1912" alt="image" src="https://github.com/user-attachments/assets/84765c8c-6607-4f53-87a7-6a309e88f191" />

### After

![image](https://github.com/user-attachments/assets/74e11571-2e66-4f76-850e-9b4a2b3dd52a)

## Checklist

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
