### PR TITLE
CPS-808: Fix checkbox value transformation for is_personally_confirmed and is_line_manager_confirmed

### DIFF
--- a/src/client/modules/ExportWins/Form/transformers.js
+++ b/src/client/modules/ExportWins/Form/transformers.js
@@ -166,11 +166,11 @@ export const transformExportWinForForm = (exportWin) => ({
   type_of_support: exportWin.type_of_support.map(idNameToValueLabel),
   associated_programme: exportWin.associated_programme.map(idNameToValueLabel),
   is_personally_confirmed: exportWin.is_personally_confirmed
-    ? OPTION_YES
-    : OPTION_NO,
+    ? [OPTION_YES]
+    : [OPTION_NO],
   is_line_manager_confirmed: exportWin.is_line_manager_confirmed
-    ? OPTION_YES
-    : OPTION_NO,
+    ? [OPTION_YES]
+    : [OPTION_NO],
   // Summary page
   company: exportWin.company,
   customer_response: exportWin.customer_response,

--- a/test/functional/cypress/support/actions.js
+++ b/test/functional/cypress/support/actions.js
@@ -166,6 +166,13 @@ export const clickSubmitButton = () => {
 }
 
 /**
+ * Click on a Save button
+ */
+export const clickSaveButton = () => {
+  cy.get('[data-test="save"]').click()
+}
+
+/**
  * Generic search request for a CollectionList
  * @param {*} endpoint The search endpoint
  * @param {*} fakeList The fake list of items to display


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/CPS-808

## Description of change

Currently when you update an ExportWin the data confimation fields (`is_personally_confirmed` and `is_line_manager_confirmed`) are not transformed correctly so when save is clicked `false` is incorrectly sent to the api even if they were ticked.

## Test instructions

_What should I see?_

To reproduce the original issue, on main branch:

- Navigate to Companies tab and select a company
- Click "Add export win"
- Fill out the form and save
- Check that the `is_personally_confirmed` and `is_line_manager_confirmed` fields are set as True for the backend record
- Navigate to "Pending Export Wins"
- Select the just created Export Win
- Click "Save"
- Observe that the `is_personally_confirmed` and `is_line_manager_confirmed` fields are set as False for the backend record

To test repeat the above with this branch and check that the confirmed fields are *not* changed on the final step.

## Screenshots

Using this branch: https://github.com/uktrade/data-hub-api/pull/6096 which adds backend validation for these fields.

### Before

![image](https://github.com/user-attachments/assets/c5d73d2f-889f-4562-a76e-2cf66b7a5213)

### After

![image](https://github.com/user-attachments/assets/e073a547-f7f8-4c63-b41f-a4cacf31b4b3)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
