### PR TITLE
Swap the header for a paragraph as it doesn't introduce new content

### DIFF
--- a/src/client/components/CollectionList/CollectionItem.jsx
+++ b/src/client/components/CollectionList/CollectionItem.jsx
@@ -42,7 +42,7 @@ const StyledHeader = styled(H3)`
   font-size: ${HEADING_SIZES.SMALL}px;
 `
 
-const StyledSubheading = styled('h4')`
+const StyledSubheading = styled('p')`
   font-size: ${({ fontSize }) => (fontSize ? `${fontSize}px` : '14px')};
   line-height: 20px;
   color: ${DARK_GREY};
@@ -138,11 +138,13 @@ const CollectionItem = ({
     )}
     {subheading ? (
       subheadingUrl ? (
-        <StyledSubheading fontSize={19}>
+        <StyledSubheading data-test="collection-item-subheading" fontSize={19}>
           <AccessibleLink href={subheadingUrl}>{subheading}</AccessibleLink>
         </StyledSubheading>
       ) : (
-        <StyledSubheading>{subheading}</StyledSubheading>
+        <StyledSubheading data-test="collection-item-subheading">
+          {subheading}
+        </StyledSubheading>
       )
     ) : null}
 

--- a/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsConfirmedList.cy.jsx
@@ -47,7 +47,7 @@ describe('WinsConfirmedList', () => {
           )
         )
 
-      cy.get('h4 a')
+      cy.get('[data-test="collection-item-subheading"] a')
         .should('have.text', exportWin.company.name)
         .and(
           'have.attr',
@@ -152,8 +152,11 @@ describe('WinsConfirmedList', () => {
       )
       cy.get('h3 a').should('not.exist')
 
-      cy.get('h4').should('have.text', exportWin.company_name)
-      cy.get('h4 a').should('not.exist')
+      cy.get('[data-test="collection-item-subheading"]').should(
+        'have.text',
+        exportWin.company_name
+      )
+      cy.get('[data-test="collection-item-subheading"] a').should('not.exist')
     })
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsPendingList.cy.jsx
@@ -51,7 +51,7 @@ describe('WinsPendingList', () => {
           )
         )
 
-      cy.get('h4 a')
+      cy.get('[data-test="collection-item-subheading"] a')
         .should('have.text', exportWin.company.name)
         .and(
           'have.attr',
@@ -180,8 +180,11 @@ describe('WinsPendingList', () => {
       )
       cy.get('h3 a').should('not.exist')
 
-      cy.get('h4').should('have.text', exportWin.company_name)
-      cy.get('h4 a').should('not.exist')
+      cy.get('[data-test="collection-item-subheading"]').should(
+        'have.text',
+        exportWin.company_name
+      )
+      cy.get('[data-test="collection-item-subheading"] a').should('not.exist')
     })
   })
 })

--- a/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/WinsRejectedList.cy.jsx
@@ -49,7 +49,7 @@ describe('WinsRejectedList', () => {
           )
         )
 
-      cy.get('h4 a')
+      cy.get('[data-test="collection-item-subheading"] a')
         .should('have.text', exportWin.company.name)
         .and(
           'have.attr',
@@ -161,8 +161,11 @@ describe('WinsRejectedList', () => {
       )
       cy.get('h3 a').should('not.exist')
 
-      cy.get('h4').should('have.text', exportWin.company_name)
-      cy.get('h4 a').should('not.exist')
+      cy.get('[data-test="collection-item-subheading"]').should(
+        'have.text',
+        exportWin.company_name
+      )
+      cy.get('[data-test="collection-item-subheading"] a').should('not.exist')
     })
   })
 })

--- a/test/functional/cypress/specs/companies/export/history-spec.js
+++ b/test/functional/cypress/specs/companies/export/history-spec.js
@@ -426,7 +426,7 @@ describe('Company Export tab - Export countries history', () => {
           cy.contains(item.subject)
             .as(link)
             .parent()
-            .siblings('h4')
+            .siblings('[data-test="collection-item-subheading"]')
             .as(subHeading)
             .parent()
             .as(interaction)

--- a/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
+++ b/test/functional/cypress/specs/companies/investments/investment-project-collection-spec.js
@@ -55,7 +55,9 @@ function assertListItem({
   })
 
   it('should render the project code', () => {
-    cy.get(alias).find('h4').should('have.text', `Project code ${project_code}`)
+    cy.get(alias)
+      .find('[data-test="collection-item-subheading"]')
+      .should('have.text', `Project code ${project_code}`)
   })
 
   it('should render the investor name', () => {

--- a/test/functional/cypress/specs/investments/project-edit-associated-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-associated-spec.js
@@ -34,7 +34,10 @@ describe('Edit the associated FDI R&D project', () => {
           'href',
           investments.projects.editAssociatedProject(fixture.id, project.id)
         )
-      cy.get('h4').should('contain', `Project code ${project.project_code}`)
+      cy.get('[data-test="collection-item-subheading"]').should(
+        'contain',
+        `Project code ${project.project_code}`
+      )
       cy.get('@metadataLabels').eq(0).should('contain', 'Investor')
       cy.get('@metadataValues')
         .eq(0)

--- a/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-recipient-spec.js
@@ -36,7 +36,7 @@ describe('Edit the recipient company', () => {
           'href',
           investments.projects.editRecipientCompany(fixture.id, company.id)
         )
-      cy.get('h4').should(
+      cy.get('[data-test="collection-item-subheading"]').should(
         'contain',
         `Updated on ${formatDate(company.modified_on, DATE_FORMAT_MEDIUM_WITH_TIME)}`
       )

--- a/test/functional/cypress/support/collection-list-assertions.js
+++ b/test/functional/cypress/support/collection-list-assertions.js
@@ -137,7 +137,9 @@ const assertUnarchiveLink = (url) => {
 }
 
 const assertUpdatedOn = (item, text) => {
-  cy.get(item).find('h4').should('have.text', text)
+  cy.get(item)
+    .find('[data-test="collection-item-subheading"]')
+    .should('have.text', text)
 }
 
 const assertRole = (roleType) => {


### PR DESCRIPTION
## Description of change

As part of the accessibility audit, this element was flagged as it is a header however it doesn't introduce new content and is often times used to display a timestamp which doesn't warrant the use a header.

## Test instructions

No visual changes but the subheadings are now a paragraph instead of a h4.
## Screenshots

### Before

H4 tag
<img width="1238" alt="Screenshot 2025-05-08 at 16 15 34" src="https://github.com/user-attachments/assets/34e64ebb-6bd8-4303-91da-a821f120a1bb" />

### After

p tag
<img width="1238" alt="Screenshot 2025-05-08 at 16 17 10" src="https://github.com/user-attachments/assets/f4f3a8dd-fba1-4076-b972-910ed6f9c66a" />

## Checklist
- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)

