### PR TITLE
EGTB-1738: update visible label to secondary service dropdown for accessibility

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -221,7 +221,7 @@ const StepInteractionDetails = ({
         emptyOption="-- Select service --"
         options={secondTierServices}
         validate={validateSecondTierServices}
-        aria-label="service second level"
+        aria-label="Select service category"
       />
 
       {selectedService?.interaction_questions?.map((question) => (

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -205,6 +205,11 @@ function fillCommonFields({
 }) {
   fillSelect('[data-test=field-service]', service)
   if (subservice) {
+    cy.get('[data-test=field-service_2nd_level] select')
+      .should('exist')
+      .should('be.visible')
+      .should('have.attr', 'aria-label', 'Select service category')
+
     fillSelect('[data-test=field-service_2nd_level]', subservice)
   }
 


### PR DESCRIPTION
## Description of change

This is changing the naming of the label, so that it gives clarity to screen reader user when it tab into the secondary dropdown component in interaction form (Add and Edit)

## Test instructions

Updated component test

## Screenshots

### Before
![Screenshot 2025-05-08 at 22 01 26](https://github.com/user-attachments/assets/c23e8cea-e14a-4629-bf9f-0a921cfaf3ad)
![Screenshot 2025-05-08 at 22 02 11](https://github.com/user-attachments/assets/1ce54862-bc6a-4deb-bebe-34fcd365df10)


### After

![After1](https://github.com/user-attachments/assets/7c99e714-e88e-431b-9c6c-c8b081ddfc46)
![After2](https://github.com/user-attachments/assets/a08929c1-0e9f-4fcf-90ed-501ec117a053)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
