### PR TITLE
Show customer comments questionnaire only when Wins being rejected by the customer

### DIFF
--- a/src/client/modules/ExportWins/Review/index.jsx
+++ b/src/client/modules/ExportWins/Review/index.jsx
@@ -32,6 +32,7 @@ import { formatDate, DATE_FORMAT_MEDIUM } from '../../../utils/date-utils'
 
 import AccesibilityStatement from './AccesibilityStatement'
 import PrivacyNotice from './PrivacyNotice'
+import { OPTION_NO, OPTION_YES } from '../../../../common/constants'
 
 const FORM_ID = 'export-wins-customer-feedback'
 
@@ -195,22 +196,29 @@ const Step1 = ({ win, name }) => {
 }
 
 const Step2 = ({ agree }) => (
-  <Step name="2">
-    <H2>The extent our support helped</H2>
-    <WithoutOurSupport.FieldRadios
-      name="expected_portion_without_help"
-      legend="What value do you estimate you would have achieved without our support?"
-      required="Select the estimated support value"
-    />
+  <Step name="2" submitButtonLabel={agree === OPTION_NO && 'Confirm and send'}>
+    {agree === OPTION_YES && (
+      <>
+        <H2>The extent our support helped</H2>
+        <WithoutOurSupport.FieldRadios
+          name="expected_portion_without_help"
+          legend="What value do you estimate you would have achieved without our support?"
+          required="Select the estimated support value"
+        />
+      </>
+    )}
     <FieldTextarea
       name="comments"
-      label={`Comments${agree ? ' (optional)' : ''}`}
+      label={`Comments${agree === OPTION_YES ? ' (optional)' : ''}`}
       hint={
         agree
           ? 'Please provide feedback on the help we have provided. If any of the information is incorrect please provide details.'
           : 'Please let us know what information was incorrect'
       }
-      required={!agree && 'Please let us know what information was incorrect'}
+      required={
+        agree === OPTION_NO &&
+        'Please let us know what information was incorrect'
+      }
     />
   </Step>
 )
@@ -385,11 +393,17 @@ const ReviewForm = () => {
             {(formData) => (
               <>
                 <Step1 win={review.win} name={review?.companyContact?.name} />
-                <Step2 agree={formData.values.agree_with_win === 'yes'} />
-                <Step3 />
-                <Step4 />
-                <Step5 />
-                <Step6 />
+                {formData.values.agree_with_win === OPTION_YES ? (
+                  <>
+                    <Step2 agree={OPTION_YES} />
+                    <Step3 />
+                    <Step4 />
+                    <Step5 />
+                    <Step6 />
+                  </>
+                ) : (
+                  <Step2 agree={OPTION_NO} />
+                )}
               </>
             )}
           </Form>

--- a/test/component/cypress/specs/ExportWins/Review.cy.jsx
+++ b/test/component/cypress/specs/ExportWins/Review.cy.jsx
@@ -124,8 +124,6 @@ const assertReviewForm = ({ agree }) => {
     .should('match', 'h2')
     .should('have.text', 'Details of your recent success')
 
-  cy.contains(DBT_HEADING + 'Step 1 of 6' + HEADING)
-
   assertSummaryTableStrict({
     rows: [
       ['Destination country', EXPORT_WIN.country.name],
@@ -149,20 +147,23 @@ const assertReviewForm = ({ agree }) => {
     selectIndex: agree ? 0 : 1,
   })
 
-  cy.contains('button', 'Continue').as('continue').click()
-
-  // Assert that the step info is between the headings
-  cy.contains(DBT_HEADING + 'Step 2 of 6' + HEADING)
-
-  assertFieldRadiosStrict({
-    inputName: 'expected_portion_without_help',
-    legend:
-      'What value do you estimate you would have achieved without our support?',
-    options: WITHOUT_OUR_SUPPORT.map((x) => x.name),
-    selectIndex: 1,
-  })
-
   if (agree) {
+    cy.contains(DBT_HEADING + 'Step 1 of 6' + HEADING)
+
+    // Continue next step
+    cy.contains('button', 'Continue').as('continue').click()
+
+    cy.contains(DBT_HEADING + 'Step 2 of 6' + HEADING)
+    cy.contains('h1', 'Tell us what made a difference')
+
+    assertFieldRadiosStrict({
+      inputName: 'expected_portion_without_help',
+      legend:
+        'What value do you estimate you would have achieved without our support?',
+      options: WITHOUT_OUR_SUPPORT.map((x) => x.name),
+      selectIndex: 1,
+    })
+
     cy.get('#field-comments').then((element) => {
       assertFieldTextarea({
         element,
@@ -170,157 +171,162 @@ const assertReviewForm = ({ agree }) => {
         hint: 'Please provide feedback on the help we have provided. If any of the information is incorrect please provide details.',
       })
     })
-  } else {
-    cy.get('#field-comments').then((el) =>
-      assertFieldTextarea({
-        element: el,
-        label: 'Comments',
-        hint: 'Please let us know what information was incorrect',
-      })
-    )
 
+    // Continue next step
     cy.get('@continue').click()
 
+    cy.contains(DBT_HEADING + 'Step 3 of 6' + HEADING)
+    cy.contains('h2', 'The extent our support helped')
+    ;[
+      { inputName: 'our_support', legend: 'Securing the win overall?' },
+      {
+        inputName: 'access_to_contacts',
+        legend: 'Gaining access to contacts?',
+      },
+      {
+        inputName: 'access_to_information',
+        legend: 'Getting information or improved understanding of the country?',
+      },
+      {
+        inputName: 'improved_profile',
+        legend: 'Improving your profile or credibility in the country?',
+      },
+      {
+        inputName: 'gained_confidence',
+        legend: 'Having confidence to explore or expand in the country?',
+      },
+      {
+        inputName: 'developed_relationships',
+        legend: 'Developing or nurturing critical relationships?',
+      },
+      {
+        inputName: 'overcame_problem',
+        legend:
+          'Overcoming a problem in the country (for example legal, regulatory, commercial)',
+      },
+    ].forEach(({ inputName, legend }) => {
+      assertFieldRadiosStrict({
+        inputName,
+        legend,
+        options: RATING.map((x) => x.name),
+        selectIndex: 1,
+      })
+    })
+
+    // Continue next step
+    cy.get('@continue').click()
+
+    cy.contains(DBT_HEADING + 'Step 4 of 6' + HEADING)
+    cy.contains('h2', 'About this win')
+
+    assertFieldCheckboxes({
+      element: '#field-checkboxes1',
+      legend: 'Please tick all that apply to this win:',
+      options: [
+        {
+          label:
+            'The win involved a foreign government or state-owned enterprise (for example as an intermediary or facilitator)',
+        },
+        { label: 'Our support was a prerequisite to generate this value' },
+        { label: 'Our support helped you achieve this win more quickly' },
+      ],
+    })
+
+    assertFieldCheckboxes({
+      element: '#field-checkboxes2',
+      legend: 'Tick any that apply to this win:',
+      options: [
+        { label: 'It enabled you to expand into a new market' },
+        {
+          label: 'It enabled you to maintain or expand in an existing market',
+        },
+        {
+          label:
+            'It enabled you to increase exports as a proportion of your turnover',
+        },
+        {
+          label:
+            "If you hadn't achieved this win, your company might have stopped exporting",
+        },
+        {
+          label:
+            'Apart from this win, you already have plans to export in the next 12 months',
+        },
+      ],
+    })
+
+    // Continue next step
+    cy.get('@continue').click()
+
+    cy.contains(DBT_HEADING + 'Step 5 of 6' + HEADING)
+    cy.contains('h2', 'Your export experience')
+
+    assertFieldRadiosStrict({
+      inputName: 'last_export',
+      legend:
+        'Apart from this win, when did your company last export goods or services?',
+      options: EXPERIENCE.map((x) => x.name),
+      selectIndex: 1,
+    })
+
+    // Continue next step
+    cy.get('@continue').click()
+
+    cy.contains(DBT_HEADING + 'Step 6 of 6' + HEADING)
+    cy.contains('h2', 'Marketing')
+
+    assertFieldRadiosStrict({
+      inputName: 'case_study_willing',
+      legend:
+        'Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?',
+      options: ['Yes', 'No'],
+      selectIndex: 1,
+    })
+
+    assertFieldRadiosStrict({
+      inputName: 'marketing_source',
+      legend: 'How did you first hear about DBT (or it predecessor, DIT)?',
+      options: MARKETING_SOURCE.map((x) => x.name),
+      selectIndex: 1,
+    })
+
+    // There should appear an input field
+    cy.get('input#other_marketing_source')
+    cy.get('label[for="other_marketing_source"]').should(
+      'have.text',
+      'Other way you heard about DBT'
+    )
+
+    // The field should be required
+    cy.contains('button', 'Confirm and send').click()
+    assertErrorSummary([
+      'Enter a description of the other way you heard about DBT',
+    ])
+
+    // Fill out the field
+    cy.get('input#other_marketing_source').type('Blah blah blah')
+  } else {
+    cy.contains(DBT_HEADING + 'Step 1 of 2' + HEADING)
+
+    // Continue next step
+    cy.contains('button', 'Continue').as('continue').click()
+
+    cy.contains(DBT_HEADING + 'Step 2 of 2' + HEADING)
+    cy.contains('h1', 'Tell us what made a difference')
+
+    cy.contains('button', 'Confirm and send').click()
+
+    // Show error message when submitted without comments into rejected response
     cy.get('[data-test="textarea-error"]').should(
       'have.text',
       'Please let us know what information was incorrect'
     )
 
+    // Set comments into rejected response
     cy.get('#comments').type('Lorem ipsum dolor sit amet')
   }
 
-  cy.contains('button', 'Back')
-
-  cy.get('@continue').click()
-
-  cy.contains(DBT_HEADING + 'Step 3 of 6' + HEADING)
-  cy.contains('h2', 'The extent our support helped')
-  ;[
-    { inputName: 'our_support', legend: 'Securing the win overall?' },
-    {
-      inputName: 'access_to_contacts',
-      legend: 'Gaining access to contacts?',
-    },
-    {
-      inputName: 'access_to_information',
-      legend: 'Getting information or improved understanding of the country?',
-    },
-    {
-      inputName: 'improved_profile',
-      legend: 'Improving your profile or credibility in the country?',
-    },
-    {
-      inputName: 'gained_confidence',
-      legend: 'Having confidence to explore or expand in the country?',
-    },
-    {
-      inputName: 'developed_relationships',
-      legend: 'Developing or nurturing critical relationships?',
-    },
-    {
-      inputName: 'overcame_problem',
-      legend:
-        'Overcoming a problem in the country (for example legal, regulatory, commercial)',
-    },
-  ].forEach(({ inputName, legend }) => {
-    assertFieldRadiosStrict({
-      inputName,
-      legend,
-      options: RATING.map((x) => x.name),
-      selectIndex: 1,
-    })
-  })
-
-  cy.get('@continue').click()
-
-  cy.contains(DBT_HEADING + 'Step 4 of 6' + HEADING)
-  cy.contains('h2', 'About this win')
-
-  assertFieldCheckboxes({
-    element: '#field-checkboxes1',
-    legend: 'Please tick all that apply to this win:',
-    options: [
-      {
-        label:
-          'The win involved a foreign government or state-owned enterprise (for example as an intermediary or facilitator)',
-      },
-      { label: 'Our support was a prerequisite to generate this value' },
-      { label: 'Our support helped you achieve this win more quickly' },
-    ],
-  })
-
-  assertFieldCheckboxes({
-    element: '#field-checkboxes2',
-    legend: 'Tick any that apply to this win:',
-    options: [
-      { label: 'It enabled you to expand into a new market' },
-      {
-        label: 'It enabled you to maintain or expand in an existing market',
-      },
-      {
-        label:
-          'It enabled you to increase exports as a proportion of your turnover',
-      },
-      {
-        label:
-          "If you hadn't achieved this win, your company might have stopped exporting",
-      },
-      {
-        label:
-          'Apart from this win, you already have plans to export in the next 12 months',
-      },
-    ],
-  })
-
-  cy.get('@continue').click()
-
-  cy.contains(DBT_HEADING + 'Step 5 of 6' + HEADING)
-  cy.contains('h2', 'Your export experience')
-
-  assertFieldRadiosStrict({
-    inputName: 'last_export',
-    legend:
-      'Apart from this win, when did your company last export goods or services?',
-    options: EXPERIENCE.map((x) => x.name),
-    selectIndex: 1,
-  })
-
-  cy.get('@continue').click()
-
-  cy.contains(DBT_HEADING + 'Step 6 of 6' + HEADING)
-  cy.contains('h2', 'Marketing')
-
-  assertFieldRadiosStrict({
-    inputName: 'case_study_willing',
-    legend:
-      'Would you be willing for DBT/Exporting is GREAT to feature your success in marketing materials?',
-    options: ['Yes', 'No'],
-    selectIndex: 1,
-  })
-
-  assertFieldRadiosStrict({
-    inputName: 'marketing_source',
-    legend: 'How did you first hear about DBT (or it predecessor, DIT)?',
-    options: MARKETING_SOURCE.map((x) => x.name),
-    selectIndex: 1,
-  })
-
-  // There should appear an input field
-  cy.get('input#other_marketing_source')
-  cy.get('label[for="other_marketing_source"]').should(
-    'have.text',
-    'Other way you heard about DBT'
-  )
-
-  // The field should be required
-  cy.contains('button', 'Confirm and send').click()
-  assertErrorSummary([
-    'Enter a description of the other way you heard about DBT',
-  ])
-
-  // Fill out the field
-  cy.get('input#other_marketing_source').type('Blah blah blah')
-
+  // Confirm and send customer response
   cy.contains('button', 'Confirm and send').click()
 }
 


### PR DESCRIPTION
## Description of change

This task covers to show customer comments questionnaire when Wins being rejected by the Customer. Also, it won't allow at the FE for questionnaire comments being empty.

Jira reference: https://uktrade.atlassian.net/browse/CPS-711

## Test instructions

- From company overview profile, `Add export win` and fill-in the necessary information(Note: make it sure has an access the company contact being selected).
- Upon receiving a wins email confirmation, click `Review wins` link from email content.
- From `Review export win` summary page, select one of the radio button either `I confirm this information is correct` or `Some of this information needs revising`.

   Scenarios:
     - `I confirm...` then continue button, it takes you into series of steps questionnaires to fill-in.
     - `needs revising...` then continue button,  it takes you into required customer comments questionnaire with `Confirm and send` button.



## Screenshots

### Before

[ReviewWins.webm](https://github.com/user-attachments/assets/a823a958-6b0c-4577-8a22-b2a45822ab8b)


### After

[ReviewWins-Rejected.webm](https://github.com/user-attachments/assets/2074c860-12e7-4c23-a0e2-89773c94df8a)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
