### PR TITLE
Hide customer feedback link from rejected Wins summary details

### DIFF
--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -164,7 +164,7 @@ const ExportWinForm = ({
                 </Form>
                 {currentStepName === steps.SUMMARY && (
                   <VerticalSpacerWithMarginBottom>
-                    {winStatus !== WIN_STATUS.PENDING && (
+                    {winStatus === WIN_STATUS.CONFIRMED && (
                       <AccessibleLink
                         as={ReactRouterLink}
                         data-test="customer-feedback"

--- a/test/functional/cypress/specs/export-win/edit-export-win-rejected-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-rejected-spec.js
@@ -14,19 +14,12 @@ const exportWin = {
 }
 
 describe('Editing a rejected export win', () => {
-  it('should render a customer feedback link when the win is rejected', () => {
+  it('should not render a customer feedback link when the win is rejected', () => {
     cy.intercept('GET', '/api-proxy/v4/export-win/*', exportWin).as(
       'apiGetExportWin'
     )
     cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
-    cy.wait('@apiGetExportWin')
-    cy.get('[data-test="customer-feedback"]')
-      .should('exist')
-      .should('have.text', 'Customer feedback')
-      .should(
-        'have.attr',
-        'href',
-        urls.companies.exportWins.customerFeedback(company.id, exportWin.id)
-      )
+    cy.wait(['@apiGetExportWin'])
+    cy.get('[data-test="customer-feedback"]').should('not.exist')
   })
 })


### PR DESCRIPTION
## Description of change

Hide customer feedback link from rejected Wins summary details page. Since the customer comments only requires when Win being rejected, therefore customer feedback summary details no longer necessary.

## Test instructions

- Create export win and send to customer email

- Customer review then rejected the win, it asking to fill-in a comment form then submitted.

- ITA would like to see rejected win summary only without Customer feedback link. Since additional information being provided when wins being rejected.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/680363ea-ccc3-47f7-b1aa-e90c642210d9)

### After

<img width="895" alt="image" src="https://github.com/user-attachments/assets/82921386-adbf-4ed5-aab9-34679fe087ce" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [X] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
