### PR TITLE
Restore focus for select component after selection.

### DIFF
--- a/src/client/components/Form/elements/FieldSelect/index.jsx
+++ b/src/client/components/Form/elements/FieldSelect/index.jsx
@@ -126,6 +126,15 @@ const FieldSelect = ({
     required,
     initialValue,
   })
+
+  const handleChange = (e) => {
+    onChange(e)
+    requestAnimationFrame(() => {
+      const el = document.getElementById(name)
+      el?.focus()
+    })
+  }
+
   return (
     <FieldWrapper
       {...{ name, label, legend, hint, error, boldLabel, className, style }}
@@ -133,7 +142,7 @@ const FieldSelect = ({
       <StyledSelect
         fullWidth={fullWidth}
         name={name}
-        onChange={onChange}
+        onChange={handleChange}
         onBlur={onBlur}
         meta={{ error, touched }}
         key={Array.isArray(options) && options.length > 0 ? value : undefined}

--- a/test/a11y/cypress/specs/component/Shared/field-select-accessibility.js
+++ b/test/a11y/cypress/specs/component/Shared/field-select-accessibility.js
@@ -1,0 +1,31 @@
+import 'cypress-axe'
+import React from 'react'
+import { mount } from 'cypress/react'
+
+import { FieldSelect } from '../../../../../../src/client/components'
+import Form from '../../../../../../src/client/components/Form'
+import { createTestProvider } from '../../../../../component/cypress/specs/provider'
+
+describe('FieldSelect – Accessibility', () => {
+  it('Check select stays focused after selecting an option', () => {
+    const Provider = createTestProvider({})
+
+    mount(
+      <Provider>
+        <Form id="test-form" store="test">
+          <FieldSelect
+            name="select-test"
+            options={[
+              { value: 'a', label: 'label 1' },
+              { value: 'b', label: 'label 2' },
+            ]}
+          />
+        </Form>
+      </Provider>
+    )
+
+    cy.get('#select-test').focus().should('have.focus')
+    cy.get('#select-test').select('label 2')
+    cy.get('#select-test').should('have.focus')
+  })
+})


### PR DESCRIPTION
## Description of change

Currently when something is selected from the drop down, the focus is lost after selection.
This ensures the focus is restored.

## Test instructions

Try to select something from the drop down menu. The field should keep being focused after the selection.

## Screenshots

### Before

_Add a screenshot_

### After

_Add a screenshot_

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [ ] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [ ] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
