### PR TITLE
Update contact message on view rejected win page

### DIFF
--- a/src/client/modules/ExportWins/Form/ExportWinForm.jsx
+++ b/src/client/modules/ExportWins/Form/ExportWinForm.jsx
@@ -42,14 +42,20 @@ const StyledParagraph = styled('p')({
   fontWeight: 'bold',
 })
 
-export const ContactLink = ({ sections = [], shouldPluralize = true }) => {
+export const ContactLink = ({
+  sections = [],
+  shouldPluralize = true,
+  hideSectionNames = false,
+}) => {
   const section = shouldPluralize
     ? `${pluralize('section', sections.length)}:`
     : 'section.'
+
   return (
     <>
       Contact <AccessibleLink href={`mailto:${EMAIL}`}>{EMAIL}</AccessibleLink>{' '}
-      if you need to update the {section} {sections.join(', ')}
+      if you need to update the {section}
+      {!hideSectionNames && ` ${sections.join(', ')}`}
     </>
   )
 }

--- a/src/client/modules/ExportWins/Form/SummaryStep.jsx
+++ b/src/client/modules/ExportWins/Form/SummaryStep.jsx
@@ -318,34 +318,45 @@ const WinDetailsTable = ({ values, goToStep, isEditing }) => {
   )
 }
 
-const SupportGivenTable = ({ values, goToStep }) => (
-  <SummaryTable
-    caption="Support given"
-    data-test="support-given"
-    actions={
-      <StyledButtonLink
-        onClick={() => {
-          goToStep(steps.SUPPORT_PROVIDED)
-        }}
-      >
-        Edit
-      </StyledButtonLink>
-    }
-  >
-    <SummaryTable.Row heading="High Value Campaign (HVC) code">
-      {values?.hvc?.label}
-    </SummaryTable.Row>
-    <SummaryTable.ListRow
-      heading="What type of support was given?"
-      value={values.type_of_support}
-      emptyValue="Not set"
-    />
-    <SummaryTable.ListRow
-      heading="Was there a DBT campaign or event that contributed to this win?"
-      value={values.associated_programme}
-      emptyValue="Not set"
-    />
-  </SummaryTable>
+const SupportGivenTable = ({ values, goToStep, isEditing }) => (
+  <>
+    <SummaryTable
+      caption="Support given"
+      data-test="support-given"
+      actions={
+        <StyledButtonLink
+          onClick={() => {
+            goToStep(steps.SUPPORT_PROVIDED)
+          }}
+        >
+          Edit
+        </StyledButtonLink>
+      }
+    >
+      <SummaryTable.Row heading="High Value Campaign (HVC) code">
+        {values?.hvc?.label}
+      </SummaryTable.Row>
+      <SummaryTable.ListRow
+        heading="What type of support was given?"
+        value={values.type_of_support}
+        emptyValue="Not set"
+      />
+      <SummaryTable.ListRow
+        heading="Was there a DBT campaign or event that contributed to this win?"
+        value={values.associated_programme}
+        emptyValue="Not set"
+      />
+    </SummaryTable>
+    {isEditing && (
+      <StyledInsetText data-test="support-given-contact">
+        <ContactLink
+          sections={['Support given']}
+          shouldPluralize={false}
+          hideSectionNames={true}
+        />
+      </StyledInsetText>
+    )}
+  </>
 )
 
 const AdditionalInformation = ({ values, isEditing }) => {
@@ -394,6 +405,15 @@ const AdditionalInformation = ({ values, isEditing }) => {
           </>
         )}
       </StyledSummaryTable>
+      {isEditing && (
+        <StyledInsetText data-test="additional-info-contact">
+          <ContactLink
+            sections={['Additional information']}
+            shouldPluralize={false}
+            hideSectionNames={true}
+          />
+        </StyledInsetText>
+      )}
     </>
   )
 }

--- a/test/functional/cypress/specs/export-win/edit-export-win-rejected-spec.js
+++ b/test/functional/cypress/specs/export-win/edit-export-win-rejected-spec.js
@@ -1,7 +1,6 @@
 import { exportWinsFaker } from '../../fakers/export-wins'
 import urls from '../../../../../src/lib/urls'
-
-import { company } from './constants'
+import { company, formFields } from './constants'
 
 const exportWin = {
   ...exportWinsFaker(),
@@ -14,12 +13,122 @@ const exportWin = {
 }
 
 describe('Editing a rejected export win', () => {
-  it('should not render a customer feedback link when the win is rejected', () => {
+  beforeEach(() => {
     cy.intercept('GET', '/api-proxy/v4/export-win/*', exportWin).as(
       'apiGetExportWin'
     )
+
+    cy.intercept('GET', '/api-proxy/v4/metadata/team-type*', [
+      { id: '1', name: 'Trade (TD or ST)' },
+    ]).as('apiTeamType')
+
+    cy.intercept('GET', '/api-proxy/v4/metadata/hq-team-region-or-post?*', [
+      {
+        id: '1',
+        name: 'TD - Events - Financial & Professional Business Services',
+        team_type: { name: 'Trade (TD or ST)', id: '1' },
+      },
+      {
+        id: '2',
+        name: 'TD - Events - Education',
+        team_type: { name: 'Trade (TD or ST)', id: '1' },
+      },
+    ]).as('apiHqTeam')
+  })
+
+  it('should not render a customer feedback link when the win is rejected', () => {
     cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
     cy.wait(['@apiGetExportWin'])
     cy.get('[data-test="customer-feedback"]').should('not.exist')
+  })
+
+  context('Officer details', () => {
+    it('should render an edit status message', () => {
+      cy.visit(
+        urls.companies.exportWins.editOfficerDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+      cy.get('[data-test="status-message"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section: lead officer name'
+      )
+    })
+  })
+
+  context('Credit for this win', () => {
+    it('should not render an edit status message', () => {
+      cy.visit(
+        urls.companies.exportWins.editCreditForThisWin(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+      cy.get('[data-test="status-message"]').should('not.exist')
+    })
+  })
+
+  context('Customer details', () => {
+    beforeEach(() => {
+      cy.visit(
+        urls.companies.exportWins.editCustomerDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+    })
+
+    it('should render an edit status message', () => {
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the section: export experience'
+        )
+    })
+
+    it('should not render Export experience', () => {
+      cy.get(formFields.customerDetails.experience).should('not.exist')
+    })
+  })
+
+  context('Win details', () => {
+    beforeEach(() => {
+      cy.visit(
+        urls.companies.exportWins.editWinDetails(company.id, exportWin.id)
+      )
+      cy.wait(['@apiGetExportWin', '@apiTeamType', '@apiHqTeam'])
+    })
+
+    it('should render an edit status message', () => {
+      cy.get('[data-test="status-message"]')
+        .should('exist')
+        .should(
+          'have.text',
+          'Contact exportwins@businessandtrade.gov.uk if you need to update the sections: summary of the support given, destination country, date won, type of win and value.'
+        )
+    })
+  })
+
+  context('Summary', () => {
+    beforeEach(() => {
+      cy.visit(urls.companies.exportWins.editSummary(company.id, exportWin.id))
+      cy.wait(['@apiGetExportWin'])
+    })
+
+    it('should render support given contact link', () => {
+      cy.get('[data-test="support-given-contact"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section.'
+      )
+    })
+
+    it('should render additional information contact link', () => {
+      cy.get('[data-test="additional-info-contact"]').should(
+        'have.text',
+        'Contact exportwins@businessandtrade.gov.uk if you need to update the section.'
+      )
+    })
+
+    it('should display What type of support was given when clicking Edit on Support given', () => {
+      cy.get('[data-test="support-given"]').contains('Edit').click()
+
+      cy.get('label').should('contain.text', 'What type of support was given?')
+    })
   })
 })


### PR DESCRIPTION
## Description of change

This is to reinstate the rejected page AS-IS

## Test instructions

Please go to /exportwins/rejected and select one of the rejected win in the list. You should see UI changes as per below

## Screenshots

### Before

![1](https://github.com/user-attachments/assets/cdda0619-d1e2-40f6-a896-178ef224e9ca)

### After

![2](https://github.com/user-attachments/assets/7cf696c4-e095-4589-a5cc-e3f14e739698)


## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
