### PR TITLE
New EW questionnaire approved review - thank you layout

### DIFF
--- a/src/client/modules/ExportWins/Review/Layout.jsx
+++ b/src/client/modules/ExportWins/Review/Layout.jsx
@@ -149,13 +149,13 @@ const Layout = ({ children, title, supertitle, headingContent }) => {
       <MainBar>Department for Business and Trade</MainBar>
       <HeaderBackground />
       <Header>
+        {headingContent}
         <p>{supertitle}</p>
         <Title>{title}</Title>
         <CookieConsentConfirmation
           dismiss={dismiss}
           onDismiss={() => setDismiss(true)}
         />
-        {headingContent}
       </Header>
       <Main>{children}</Main>
       <GridCellFooter

--- a/src/client/modules/ExportWins/Review/ThankYou.jsx
+++ b/src/client/modules/ExportWins/Review/ThankYou.jsx
@@ -2,13 +2,17 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import styled from 'styled-components'
 
-import { GREEN, WHITE } from '../../../utils/colours'
+import { BLACK, GREEN, WHITE } from '../../../utils/colours'
 import { StatusMessage } from '../../../components'
 
 import Layout from './Layout'
 
 export const StyledStatusMessage = styled(StatusMessage)({
+  color: BLACK,
   background: WHITE,
+  fontWeight: 'normal',
+  padding: '5px 10px',
+
   '& > *:first-child': {
     marginTop: 0,
   },


### PR DESCRIPTION
## Description of change

A revised customer questionnaire journey recently iterates and reviewed. The thank you screen after approving the Wins was modified.

## Test instructions

- From company overview profile, `Add export win` and fill-in the necessary information(Note: make it sure has an access the company contact being selected).
- Upon receiving a wins email confirmation, click `Review wins` link from email content.
- From `Review export win` summary page, select one of the radio button `I confirm this information is correct`.

   Scenarios:
     - `I confirm...` then continue button, it takes you into series of steps questionnaires to fill-in.
     - At the final question, click `Submit and continue` button 
     - Export win reviewed - Thank you screen message will appear.
     

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/26f45485-35f9-4152-95a9-194b89dc6f32)

### After

![image](https://github.com/user-attachments/assets/ca10e57d-0fa7-494a-8355-b1ed82932e13)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
