### PR TITLE
Replace average_salary radio group with actual_average_salary number input

### DIFF
--- a/src/client/components/Form/hooks/useField.js
+++ b/src/client/components/Form/hooks/useField.js
@@ -21,7 +21,13 @@ function useField({
     const validators = castArray(validate).filter((v) => v)
 
     if (required) {
-      validators.unshift((value) => (isEmpty(value) ? required : null))
+      validators.unshift((value) => {
+        if (typeof value === 'number') {
+          return
+        }
+
+        return isEmpty(value) ? required : null
+      })
     }
 
     return validators

--- a/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
+++ b/src/client/modules/Investments/Projects/Details/EditProjectValue.jsx
@@ -14,7 +14,6 @@ import ResourceOptionsField from '../../../../components/Form/elements/ResourceO
 import {
   FDIValuesResource,
   InvestmentResource,
-  SalaryRangeResource,
 } from '../../../../components/Resource'
 import urls from '../../../../../lib/urls'
 import { TASK_EDIT_INVESTMENT_PROJECT_VALUE } from './state'
@@ -26,7 +25,6 @@ import {
 } from './transformers'
 import { OPTIONS_YES_NO, OPTION_YES } from '../../../../../common/constants'
 import { currencyGBP } from '../../../../utils/number-utils'
-import { idNamesToValueLabels } from '../../../../utils'
 import ProjectLayoutNew from '../../../../components/Layout/ProjectLayoutNew'
 import InvestmentName from '../InvestmentName'
 import {
@@ -305,8 +303,8 @@ const EditProjectValue = () => {
                           </>
                         </FieldUneditable>
                       )}
-                    <ResourceOptionsField
-                      name="average_salary"
+                    <FieldCurrency
+                      name="actual_average_salary"
                       label={
                         'Average salary of new jobs' +
                         (isAverageSalaryRequired(project)
@@ -316,19 +314,12 @@ const EditProjectValue = () => {
                             )
                           : ' (optional)')
                       }
-                      resource={SalaryRangeResource}
-                      field={FieldRadios}
-                      initialValue={project.averageSalary?.id}
-                      resultToOptions={(result) =>
-                        idNamesToValueLabels(
-                          result.filter((option) =>
-                            option.disabledOn
-                              ? new Date(option.disabledOn) >
-                                new Date(project.createdOn)
-                              : true
-                          )
-                        )
+                      hint={
+                        project.actualAverageSalary === null &&
+                        project.averageSalary &&
+                        `The current value is "${project.averageSalary?.name}"`
                       }
+                      initialValue={project.actualAverageSalary}
                       required={
                         isAverageSalaryRequired(project) &&
                         AVERAGE_SALARY_REQUIRED_MESSAGE

--- a/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
+++ b/src/client/modules/Investments/Projects/Details/ProjectDetails.jsx
@@ -388,11 +388,18 @@ const ProjectDetails = ({ currentAdviserId }) => {
                   value={project.numberNewJobs + ' new jobs'}
                 />
               )}
-              {project.averageSalary && (
-                <SummaryTable.TextRow
+              {typeof project.actualAverageSalary === 'number' ? (
+                <SummaryTable.CurrencyRow
                   heading="Average salary of new jobs"
-                  value={project.averageSalary?.name}
+                  value={project.actualAverageSalary}
                 />
+              ) : (
+                project.averageSalary && (
+                  <SummaryTable.TextRow
+                    heading="Average salary of new jobs"
+                    value={project.averageSalary?.name}
+                  />
+                )
               )}
               {(project.numberSafeguardedJobs ||
                 project.numberSafeguardedJobs === 0) && (

--- a/src/client/modules/Investments/Projects/Details/transformers.js
+++ b/src/client/modules/Investments/Projects/Details/transformers.js
@@ -246,6 +246,7 @@ export const transformProjectValueForApi = ({
 }) => {
   const {
     average_salary,
+    actual_average_salary,
     client_cannot_provide_foreign_investment,
     client_cannot_provide_total_investment,
     export_revenue,
@@ -264,6 +265,7 @@ export const transformProjectValueForApi = ({
   const valuePayload = {
     id: projectId,
     average_salary: checkIfItemHasValue(average_salary),
+    actual_average_salary,
     client_cannot_provide_foreign_investment:
       transformRadioOptionToInvertedBool(
         client_cannot_provide_foreign_investment

--- a/test/component/cypress/specs/Companies/AccountManagement/Objective/ObjectiveForm.cy.jsx
+++ b/test/component/cypress/specs/Companies/AccountManagement/Objective/ObjectiveForm.cy.jsx
@@ -134,7 +134,6 @@ describe('Objective form', () => {
         assertFieldInput({
           element,
           label: 'Objective subject',
-          ignoreHint: true,
           value: objective.subject,
         })
       })
@@ -143,7 +142,6 @@ describe('Objective form', () => {
         assertFieldTextarea({
           element,
           label: 'Objective detail (optional)',
-          ignoreHint: true,
           value: objective.detail,
         })
       })
@@ -152,7 +150,6 @@ describe('Objective form', () => {
         assertFieldDate({
           element,
           label: 'Target date',
-          ignoreHint: true,
           value: objective.target_date,
         })
       })
@@ -170,7 +167,6 @@ describe('Objective form', () => {
         assertFieldTextarea({
           element,
           label: 'Blocker description',
-          ignoreHint: true,
           value: objective.blocker_description,
         })
       })

--- a/test/functional/cypress/fixtures/investment/capital-investment-has-existing-value.json
+++ b/test/functional/cypress/fixtures/investment/capital-investment-has-existing-value.json
@@ -108,6 +108,7 @@
   "some_new_jobs": null,
   "number_new_jobs": 0,
   "will_new_jobs_last_two_years": null,
+  "actual_average_salary": 54321,
   "average_salary": {
     "name": "Below £25,000",
     "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"

--- a/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
+++ b/test/functional/cypress/specs/export-pipeline/edit-export-spec.js
@@ -127,7 +127,6 @@ describe('Export pipeline edit', () => {
           assertFieldInput({
             element,
             label: 'Export title',
-            ignoreHint: true,
             value: exportItem.title,
           })
         })

--- a/test/functional/cypress/specs/investments/constants.js
+++ b/test/functional/cypress/specs/investments/constants.js
@@ -133,7 +133,7 @@ export const FIELDS = {
     message: 'Value for number of new jobs is required',
   },
   AVERAGE_SALARY: {
-    name: 'average_salary',
+    name: 'actual_average_salary',
     message: 'Value for average salary of new jobs is required',
   },
   NUMBER_SAFEGUARDED_JOBS: {

--- a/test/functional/cypress/specs/investments/project-details-spec.js
+++ b/test/functional/cypress/specs/investments/project-details-spec.js
@@ -174,7 +174,7 @@ describe('Investment project details', () => {
           'Gross Value Added (GVA)': '£34,568',
           'Government assistance': 'Has government assistance',
           'New jobs': '0 new jobs',
-          'Average salary of new jobs': 'Below £25,000',
+          'Average salary of new jobs': '£54,321',
           'Safeguarded jobs': '11234 safeguarded jobs',
           'R&D budget': R_AND_D_FALSE,
           'Non-FDI R&D project': 'Find project',
@@ -212,6 +212,35 @@ describe('Investment project details', () => {
         )
       cy.get('[data-test="value-inset"]').should('not.exist')
       cy.get('[data-test="add-value-button"]').should('not.exist')
+    })
+  })
+
+  it('When actual_average_salary is empty and average_salary is not empty', () => {
+    const AVERAGE_SALARY = 'Average salary band'
+    cy.intercept('GET', '/api-proxy/v3/investment/*', {
+      body: {
+        ...fixtures.investment.investmentWithValue,
+        actual_average_salary: null,
+        average_salary: { name: AVERAGE_SALARY },
+      },
+    })
+    cy.visit('/investments/projects/foo/details')
+    assertSummaryTable({
+      dataTest: 'project-value-table',
+      showEditLink: false,
+      content: {
+        'Total investment': '£1,000,000',
+        'Capital expenditure value': '£200,000',
+        'Gross Value Added (GVA)': '£34,568',
+        'Government assistance': 'Has government assistance',
+        'New jobs': '0 new jobs',
+        'Average salary of new jobs': AVERAGE_SALARY,
+        'Safeguarded jobs': '11234 safeguarded jobs',
+        'R&D budget': R_AND_D_FALSE,
+        'Non-FDI R&D project': 'Find project',
+        'New-to-world tech': NEW_TECH_FALSE,
+        'Export revenue': EXPORT_REVENUE_TRUE,
+      },
     })
   })
 

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -72,6 +72,7 @@ const setupProjectFaker = (overrides) =>
     number_new_jobs: null,
     number_safeguarded_jobs: null,
     gross_value_added: null,
+    actual_average_salary: null,
     average_salary: null,
     foreign_equity_investment: null,
     ...overrides,
@@ -187,11 +188,11 @@ describe('Edit the value details of a project', () => {
       })
 
       it('should display the average salary field', () => {
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
+        cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+          assertFieldInput({
             element,
             label: 'Average salary of new jobs (required)',
-            optionsCount: 3,
+            value: '',
           })
         })
       })
@@ -296,6 +297,7 @@ describe('Edit the value details of a project', () => {
         gross_value_added: 34568,
         total_investment: 1000000,
         foreign_equity_investment: 200000,
+        actual_average_salary: 54321,
         average_salary: {
           name: 'Below £25,000',
           id: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
@@ -382,12 +384,11 @@ describe('Edit the value details of a project', () => {
       })
 
       it('should display the average salary field', () => {
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
+        cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+          assertFieldInput({
             element,
             label: 'Average salary of new jobs (required)',
-            optionsCount: 3,
-            value: capitalIntensiveProjectWithValue.average_salary.name,
+            value: '54,321',
           })
         })
       })
@@ -547,7 +548,7 @@ describe('Edit the value details of a project', () => {
 
     it('should not display the jobs fields', () => {
       cy.get('[data-test="field-number_new_jobs"]').should('not.exist')
-      cy.get('[data-test="field-average_salary"]').should('not.exist')
+      cy.get('[data-test="field-actual_average_salary"]').should('not.exist')
       cy.get('[data-test="field-number_safeguarded_jobs"]').should('not.exist')
     })
 
@@ -570,6 +571,7 @@ describe('Edit the value details of a project', () => {
       total_investment: 20000000,
       foreign_equity_investment: 15000000,
       number_new_jobs: 120,
+      actual_average_salary: 54321,
       average_salary: {
         name: 'Below £25,000',
         id: '2943bf3d-32dd-43be-8ad4-969b006dee7b',
@@ -624,7 +626,7 @@ describe('Edit the value details of a project', () => {
 
     it('should display the jobs fields', () => {
       cy.get('[data-test="field-number_new_jobs"]').should('exist')
-      cy.get('[data-test="field-average_salary"]').should('exist')
+      cy.get('[data-test="field-actual_average_salary"]').should('exist')
       cy.get('[data-test="field-number_safeguarded_jobs"]').should('exist')
     })
 
@@ -634,7 +636,7 @@ describe('Edit the value details of a project', () => {
         .its('request.body')
         .should('include', {
           number_new_jobs: nonCapitalOnlyFDIProject.number_new_jobs,
-          average_salary: `${nonCapitalOnlyFDIProject.average_salary.id}`,
+          actual_average_salary: 54321,
           number_safeguarded_jobs: `${nonCapitalOnlyFDIProject.number_safeguarded_jobs}`,
         })
     })
@@ -832,11 +834,11 @@ describe('Edit the value details of a project', () => {
       })
 
       it('should display the average salary field', () => {
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
+        cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+          assertFieldInput({
             element,
             label: 'Average salary of new jobs (required)',
-            optionsCount: 3,
+            value: '',
           })
         })
       })
@@ -1029,12 +1031,10 @@ describe('Edit the value details of a project', () => {
     })
 
     it('should display the average salary field', () => {
-      cy.get('[data-test="field-average_salary"]').then((element) => {
-        assertFieldRadios({
+      cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+        assertFieldInput({
           element,
           label: 'Average salary of new jobs (required)',
-          optionsCount: 3,
-          value: labourIntensiveProjectWithValue.average_salary.name,
         })
       })
     })
@@ -1044,7 +1044,6 @@ describe('Edit the value details of a project', () => {
         assertFieldInput({
           element,
           label: 'Number of safeguarded jobs (required)',
-          value: labourIntensiveProjectWithValue.number_safeguarded_jobs,
         })
       })
     })
@@ -1356,58 +1355,58 @@ describe('Edit the value details of a project', () => {
     })
   })
 
-  context(
-    'When viewing a project created before a salary range is disabled',
-    () => {
-      it('should display the salary range for £25,000 - £29,000 when the project was created before the disable date', () => {
-        const project = setupProjectFaker({ created_on: '2016-02-05' })
-        setup(project)
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
-            element,
-            label: 'Average salary of new jobs (required)',
-            optionsCount: 4,
-          })
-        })
-      })
-    }
-  )
+  // context(
+  //   'When viewing a project created before a salary range is disabled',
+  //   () => {
+  //     it('should display the salary range for £25,000 - £29,000 when the project was created before the disable date', () => {
+  //       const project = setupProjectFaker({ created_on: '2016-02-05' })
+  //       setup(project)
+  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+  //         assertFieldInput({
+  //           element,
+  //           label: 'Average salary of new jobs (required)',
+  //           value: '54,321',
+  //         })
+  //       })
+  //     })
+  //   }
+  // )
 
-  context(
-    'When viewing a project created on the same day a salary range is disabled',
-    () => {
-      it('should not display the salary range for £25,000 – £29,000', () => {
-        const project = setupProjectFaker({
-          created_on: '2016-03-05T12:00:00Z',
-        })
-        setup(project)
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
-            element,
-            label: 'Average salary of new jobs (required)',
-            optionsCount: 3,
-          })
-        })
-      })
-    }
-  )
+  // context(
+  //   'When viewing a project created on the same day a salary range is disabled',
+  //   () => {
+  //     it('should not display the salary range for £25,000 – £29,000', () => {
+  //       const project = setupProjectFaker({
+  //         created_on: '2016-03-05T12:00:00Z',
+  //       })
+  //       setup(project)
+  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+  //         assertFieldInput({
+  //           element,
+  //           label: 'Average salary of new jobs (required)',
+  //           value: '54,321',
+  //         })
+  //       })
+  //     })
+  //   }
+  // )
 
-  context(
-    'When viewing a project created after a salary range is disabled',
-    () => {
-      it('should not display the salary range for £25,000 – £29,000', () => {
-        const project = setupProjectFaker({ created_on: '2016-04-02' })
-        setup(project)
-        cy.get('[data-test="field-average_salary"]').then((element) => {
-          assertFieldRadios({
-            element,
-            label: 'Average salary of new jobs (required)',
-            optionsCount: 3,
-          })
-        })
-      })
-    }
-  )
+  // context(
+  //   'When viewing a project created after a salary range is disabled',
+  //   () => {
+  //     it('should not display the salary range for £25,000 – £29,000', () => {
+  //       const project = setupProjectFaker({ created_on: '2016-04-02' })
+  //       setup(project)
+  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
+  //         assertFieldInput({
+  //           element,
+  //           label: 'Average salary of new jobs (required)',
+  //           value: '54,321',
+  //         })
+  //       })
+  //     })
+  //   }
+  // )
 
   context('Requirement and validation of job-related fields', () => {
     const fillNonJobFields = () => {
@@ -1450,7 +1449,7 @@ describe('Edit the value details of a project', () => {
             false
           )
           assertJobFieldLabel(
-            '[data-test="field-average_salary"]',
+            'label[for="actual_average_salary"]',
             'Average salary of new jobs',
             false
           )
@@ -1495,7 +1494,7 @@ describe('Edit the value details of a project', () => {
           'Number of new jobs (required)'
         )
         assertJobFieldLabel(
-          '[data-test="field-average_salary"]',
+          'label[for="actual_average_salary"]',
           'Average salary of new jobs',
           true
         )
@@ -1516,7 +1515,7 @@ describe('Edit the value details of a project', () => {
         cy.get('[data-test="number-new-jobs-input"]').type(0)
 
         // Fill in other job fields to satisfy requirements
-        cy.get('[data-test="average-salary-below-25-000"]').click()
+        cy.get('[data-test="actual-average-salary-input"]').type('123')
         cy.get('[data-test="number-safeguarded-jobs-input"]').type(0)
 
         cy.get('[data-test="submit-button"]').click()
@@ -1529,7 +1528,7 @@ describe('Edit the value details of a project', () => {
 
         // Fill in job related fields
         cy.get('[data-test="number-new-jobs-input"]').type(1)
-        cy.get('[data-test="average-salary-below-25-000"]').click()
+        cy.get('[data-test="actual-average-salary-input"]').type('123')
         cy.get('[data-test="number-safeguarded-jobs-input"]').type(0)
 
         cy.get('[data-test="submit-button"]').click()
@@ -1562,7 +1561,7 @@ describe('Edit the value details of a project', () => {
           true
         )
         assertJobFieldLabel(
-          '[data-test="field-average_salary"]',
+          'label[for="actual_average_salary"]',
           'Average salary of new jobs',
           false
         )

--- a/test/functional/cypress/specs/investments/project-edit-value-spec.js
+++ b/test/functional/cypress/specs/investments/project-edit-value-spec.js
@@ -1355,59 +1355,6 @@ describe('Edit the value details of a project', () => {
     })
   })
 
-  // context(
-  //   'When viewing a project created before a salary range is disabled',
-  //   () => {
-  //     it('should display the salary range for £25,000 - £29,000 when the project was created before the disable date', () => {
-  //       const project = setupProjectFaker({ created_on: '2016-02-05' })
-  //       setup(project)
-  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
-  //         assertFieldInput({
-  //           element,
-  //           label: 'Average salary of new jobs (required)',
-  //           value: '54,321',
-  //         })
-  //       })
-  //     })
-  //   }
-  // )
-
-  // context(
-  //   'When viewing a project created on the same day a salary range is disabled',
-  //   () => {
-  //     it('should not display the salary range for £25,000 – £29,000', () => {
-  //       const project = setupProjectFaker({
-  //         created_on: '2016-03-05T12:00:00Z',
-  //       })
-  //       setup(project)
-  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
-  //         assertFieldInput({
-  //           element,
-  //           label: 'Average salary of new jobs (required)',
-  //           value: '54,321',
-  //         })
-  //       })
-  //     })
-  //   }
-  // )
-
-  // context(
-  //   'When viewing a project created after a salary range is disabled',
-  //   () => {
-  //     it('should not display the salary range for £25,000 – £29,000', () => {
-  //       const project = setupProjectFaker({ created_on: '2016-04-02' })
-  //       setup(project)
-  //       cy.get('[data-test="field-actual_average_salary"]').then((element) => {
-  //         assertFieldInput({
-  //           element,
-  //           label: 'Average salary of new jobs (required)',
-  //           value: '54,321',
-  //         })
-  //       })
-  //     })
-  //   }
-  // )
-
   context('Requirement and validation of job-related fields', () => {
     const fillNonJobFields = () => {
       cy.get('[data-test="client-cannot-provide-total-investment-yes"]').click()

--- a/test/functional/cypress/support/assertions.js
+++ b/test/functional/cypress/support/assertions.js
@@ -536,36 +536,18 @@ const assertFieldInputWithLegend = ({
         value && cy.wrap($el).should('have.attr', 'value', String(value) || '')
     )
 
-const assertFieldInput = ({
-  element,
-  label,
-  hint = undefined,
-  value = undefined,
-  ignoreHint = false,
-}) =>
-  cy
-    .wrap(element)
-    .find('label')
-    .should('have.text', label)
-    .parent()
-    .next()
-    .then(
-      ($el) =>
-        hint &&
-        cy
-          .wrap($el)
-          .should('have.text', hint || '')
-          .next()
-    )
-    .then(
-      //in the scenario where we don't need to validate what the hint is, but a hint is still
-      //being rendered, skip over the hint without validating it to get to the next element
-      ($el) => (ignoreHint && value ? cy.wrap($el).next() : undefined)
-    )
-    .find('input')
-    .then(($el) => {
-      value && cy.wrap($el).should('have.attr', 'value', String(value) || '')
-    })
+const assertFieldInput = ({ element, label, hint, value }) =>
+  cy.wrap(element).within(() => {
+    cy.get('label').should('have.text', label)
+
+    if (typeof hint === 'string' || hint) {
+      cy.get('[data-test="hint-text"]').should('have.text', hint)
+    }
+
+    if (typeof value === 'string' || value) {
+      cy.get('input').should('have.attr', 'value', value)
+    }
+  })
 
 const assertFieldInputNoLabel = ({ element, value = undefined }) =>
   cy

--- a/test/sandbox/fixtures/v3/investment/projects.json
+++ b/test/sandbox/fixtures/v3/investment/projects.json
@@ -5165,6 +5165,7 @@
       "some_new_jobs": null,
       "number_new_jobs": 0,
       "will_new_jobs_last_two_years": null,
+      "actual_average_salary": 54321,
       "average_salary": {
         "name": "Below £25,000",
         "id": "2943bf3d-32dd-43be-8ad4-969b006dee7b"


### PR DESCRIPTION
## Description of change

This PR
* Replaces the `average_salary` radio group with `actual_average_salary` number input in the `/investments/projects/{id}/edit-value` form
* Displays the `actual_average_salary` in `/investments/projects/{id}/details` and falls back to `average_salary` if `actual_average_salary` has no value yet

## Test instructions

1. Find a project which has `average_salary` but no `actual_average_salary` and grab its ID (for example [this one](https://dev.datahub.uktrade.digital/investments/projects/4b42da35-d62a-4b2a-a202-a7cd0ad27b4f/details))
2. Navigate to `/investments/projects/{id}/details`
3. Under _Average salary of new jobs_ you should see the value from `average_salary`, e.g. "Below £25,000"
4. Click the _Edit value_ button or navigate to `/investments/projects/{id}/edit-value`
5. The _Average salary of new jobs_ field should be a currency input instead of the previous radio group
6. Enter some value into the field e.g. `54321` and submit the form, which should take you back to `/investments/projects/{id}/details`
7. Under _Average salary of new jobs_ you should now see the value from `actual_average_salary`, e.g. "£54,321" instead of the `average_salary`

## Screenshots

### Before

<img width="764" alt="Screenshot 2025-05-23 at 11 52 16" src="https://github.com/user-attachments/assets/d68b024d-e1b2-4306-a7d3-800d22337934" />
<img width="764" alt="Screenshot 2025-05-23 at 11 53 11" src="https://github.com/user-attachments/assets/75fc576d-eb83-4d16-aac8-cd3be91fb7d6" />

### After

<img width="764" alt="Screenshot 2025-05-23 at 11 51 01" src="https://github.com/user-attachments/assets/d86fb2d1-0b45-4d53-b7e7-6fcb606875d3" />
<img width="764" alt="Screenshot 2025-05-23 at 11 53 35" src="https://github.com/user-attachments/assets/085fb637-c2f3-4801-91e3-77703f3ae535" />

