### PR TITLE
Tet 1033 new interaction domestic

### DIFF
--- a/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionDetails.jsx
@@ -68,6 +68,10 @@ const getServiceContext = (theme, kind, investmentProject) => {
       [KINDS.INTERACTION]: SERVICE_CONTEXTS.OTHER_INTERACTION,
       [KINDS.SERVICE_DELIVERY]: SERVICE_CONTEXTS.OTHER_SERVICE_DELIVERY,
     },
+    [THEMES.DOMESTIC]: {
+      [KINDS.INTERACTION]: SERVICE_CONTEXTS.OTHER_INTERACTION,
+      [KINDS.SERVICE_DELIVERY]: SERVICE_CONTEXTS.OTHER_SERVICE_DELIVERY,
+    },
   }
   return kind && mapping[theme][kind] ? mapping[theme][kind] : mapping[theme]
 }

--- a/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
+++ b/src/apps/interactions/apps/details-form/client/StepInteractionType.jsx
@@ -88,6 +88,30 @@ const StepInteractionType = () => {
             value: THEMES.TRADE_AGREEMENT,
           },
           {
+            label: 'Domestic',
+            value: THEMES.DOMESTIC,
+            children: (
+              <FieldRadios
+                label="What would you like to record?"
+                name="kind"
+                dataTestPrefix="domestic"
+                required="Select interaction type"
+                options={[
+                  {
+                    label: 'A standard interaction',
+                    hint: 'For example, an email, phone call or meeting',
+                    value: KINDS.INTERACTION,
+                  },
+                  {
+                    label: 'A service you have provided',
+                    hint: 'For example, a significant assist or event',
+                    value: KINDS.SERVICE_DELIVERY,
+                  },
+                ]}
+              />
+            ),
+          },
+          {
             label: 'Other',
             value: THEMES.OTHER,
             children: (

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -137,6 +137,9 @@ const transformInteractionToValues = (
   const exportCountries = get(interaction, 'export_countries') || []
   const groupExportCountries =
     transformExportCountriesToGroupStatus(exportCountries)
+  if (interaction.theme == THEMES.DOMESTIC) {
+    interaction.theme = THEMES.OTHER
+  }
 
   return {
     theme: interaction.theme || THEMES.OTHER,

--- a/src/apps/interactions/apps/details-form/client/tasks.js
+++ b/src/apps/interactions/apps/details-form/client/tasks.js
@@ -137,9 +137,6 @@ const transformInteractionToValues = (
   const exportCountries = get(interaction, 'export_countries') || []
   const groupExportCountries =
     transformExportCountriesToGroupStatus(exportCountries)
-  if (interaction.theme == THEMES.DOMESTIC) {
-    interaction.theme = THEMES.OTHER
-  }
 
   return {
     theme: interaction.theme || THEMES.OTHER,

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -50,7 +50,7 @@ const THEMES = {
   EXPORT: 'export',
   INVESTMENT: 'investment',
   TRADE_AGREEMENT: 'trade_agreement',
-  DOMESTIC: 'other',
+  DOMESTIC: 'domestic',
   OTHER: 'other',
 }
 

--- a/src/apps/interactions/constants.js
+++ b/src/apps/interactions/constants.js
@@ -50,6 +50,7 @@ const THEMES = {
   EXPORT: 'export',
   INVESTMENT: 'investment',
   TRADE_AGREEMENT: 'trade_agreement',
+  DOMESTIC: 'other',
   OTHER: 'other',
 }
 

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -947,6 +947,100 @@ describe('Trade Agreement theme', () => {
   })
 })
 
+describe('Domestic theme - standard interaction', () => {
+  context('when viewing the form', () => {
+    beforeEach(() => {
+      spyOnRequest()
+      cy.visit(urls.companies.interactions.create(company.id))
+    })
+
+    testBreadcrumbs({
+      Home: urls.dashboard.index(),
+      Companies: urls.companies.index(),
+      [company.name]: urls.companies.detail(company.id),
+      ['Add interaction']: null,
+    })
+  })
+
+  context('when creating an domestic interaction', () => {
+    beforeEach(() => {
+      spyOnRequest()
+      cy.visit(urls.companies.interactions.create(company.id))
+
+      cy.contains('label', 'Domestic').click()
+      cy.contains('label', 'A standard interaction').click()
+      cy.contains('button', 'Continue').click()
+    })
+
+    it('should render all form fields', () => {
+      assertFormFields(cy.get('#interaction-details-form form'), [
+        ELEMENT_SERVICE_HEADER,
+        ELEMENT_SERVICE,
+        ELEMENT_SERVICE,
+        ELEMENT_RELATED_TRADE_AGREEMENT,
+        ELEMENT_PARTICIPANTS_HEADER,
+        ELEMENT_CONTACT,
+        ELEMENT_ADD_CONTACT_LINK,
+        ELEMENT_CONTACT_INFO_DETAILS,
+        ELEMENT_ADVISER,
+        ELEMENT_DETAILS_HEADER,
+        ELEMENT_DATE,
+        ELEMENT_COMMUNICATION_CHANNEL,
+        ELEMENT_SUMMARY,
+        ELEMENT_NOTES,
+        ELEMENT_BUSINESS_INTELLIGENCE_INFO,
+        ELEMENT_FEEDBACK_POLICY,
+        ELEMENT_COUNTRIES,
+        ELEMENT_STEP2_BUTTONS,
+      ])
+    })
+
+    const domestic_standard_theme_error_messages = [
+      'Select a service',
+      'Select at least one contact',
+      'Select a communication channel',
+      'Enter a summary',
+      'Select if the contact provided business intelligence',
+    ]
+
+    it('should validate the form', () => {
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(domestic_standard_theme_error_messages)
+    })
+
+    it('should validate the second tier service form field', () => {
+      fillSelect('[data-test=field-service]', 'Account management')
+      cy.contains('button', 'Add interaction').click()
+      assertErrorSummary(domestic_standard_theme_error_messages)
+    })
+
+    it('should save the interaction', () => {
+      submitForm(KINDS.INTERACTION, THEMES.DOMESTIC, {
+        service: 'Account management',
+        subservice: 'General',
+      })
+    })
+
+    it('should not persist form fields after navigating back', () => {
+      cy.url().should('include', '?step=interaction_details')
+      cy.contains(ELEMENT_SUMMARY.label)
+        .parent()
+        .next()
+        .find('input')
+        .type('Persisting summary')
+      cy.go('back')
+      cy.url().should('include', '?step=interaction_type')
+      cy.contains('button', 'Continue').click()
+      cy.url().should('include', '?step=interaction_details')
+      cy.contains(ELEMENT_SUMMARY.label)
+        .parent()
+        .next()
+        .find('input')
+        .should('have.attr', 'value', '')
+    })
+  })
+})
+
 describe('Contact loop', () => {
   context('when a contact does not exist and user wants to add one', () => {
     beforeEach(() => {

--- a/test/functional/cypress/specs/interaction/details-form-spec.js
+++ b/test/functional/cypress/specs/interaction/details-form-spec.js
@@ -1194,6 +1194,34 @@ describe('Filtering services based on theme & kind', () => {
       ].join('')
     )
   })
+  it('should show filtered services for Domestic => Interaction', () => {
+    selectInteractionType('Domestic', 'A standard interaction')
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'Account management',
+        'Enquiry or referral',
+        'Other advice and information',
+        'Other introductions',
+        'Specific service',
+      ].join('')
+    )
+  })
+
+  it('should show filtered services for Domestic => Service delivery', () => {
+    selectInteractionType('Domestic', 'A service you have provided')
+
+    cy.get('#field-service').should(
+      'have.text',
+      [
+        '-- Select service --',
+        'Account management',
+        'Events',
+        'Specific service',
+      ].join('')
+    )
+  })
 })
 
 describe('Editing an interaction without a theme', () => {


### PR DESCRIPTION
## Description of change

Add new interaction for domestic interaction
Same form layout as Other


## Test instructions

- Go to a company
- Add new interaction
- Select Domestic
- Select a standard interaction or a service you provide
- Fill in interaction form and save

## Screenshots

### Before
<img width="714" alt="image" src="https://github.com/user-attachments/assets/bbec62fa-8428-492b-bf30-959d2ffd9d11" />

### After
<img width="714" alt="image" src="https://github.com/user-attachments/assets/637584e3-a394-4d07-8c7a-a91175924bb6" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
