### PR TITLE
Convert account summary card to table with highlights

### DIFF
--- a/src/client/modules/Companies/CompanyOverview/TableCards/AccountManagementCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/AccountManagementCard.jsx
@@ -3,15 +3,12 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import pluralize from 'pluralize'
 
-import { SummaryTable } from '../../../../components'
+import { FONT_SIZE } from '@govuk-react/constants'
+
+import { SummaryTableHighlight } from '../../../../components'
 import { isItaTierDAccount } from '../../utils'
 import urls from '../../../../../lib/urls'
 import { buildCellContents } from './transformers'
-import {
-  StyledLastTableCell,
-  StyledSummaryTable,
-  StyledTableRow,
-} from './components'
 import AccessibleLink from '../../../../components/Link'
 
 const Button = styled('button')`
@@ -24,6 +21,10 @@ const Button = styled('button')`
   color: #069;
   text-decoration: underline;
   cursor: pointer;
+`
+
+const StyledAccessibleLink = styled(AccessibleLink)`
+  font-size: ${FONT_SIZE.SIZE_16};
 `
 
 const StyledAddressList = styled('ol')`
@@ -57,75 +58,73 @@ const AccountManagementCard = ({ company }) => {
     )
 
   return (
-    <StyledSummaryTable
-      caption="Account management"
-      data-test="account-management-container"
-    >
-      <SummaryTable.Row heading="DBT Region">
-        {buildCellContents(
-          company?.ukRegion,
-          <span>{company.ukRegion?.name}</span>
-        )}
-      </SummaryTable.Row>
-      <SummaryTable.Row
-        heading={
-          isItaTierDAccount(company.oneListGroupTier)
-            ? 'Lead ITA'
-            : 'Account Manager'
-        }
+    <>
+      <SummaryTableHighlight
+        caption="Account management"
+        data-test="account-management-container"
       >
-        {buildCellContents(
-          company?.oneListGroupGlobalAccountManager,
-          <AccessibleLink
-            data-test="account-manager-link"
-            href={urls.companies.accountManagement.index(company.id)}
-          >
-            {company.oneListGroupGlobalAccountManager?.name}
-          </AccessibleLink>
-        )}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="One List">
-        {buildCellContents(
-          company?.oneListGroupTier?.name,
-          <span>{company.oneListGroupTier?.name}</span>
-        )}
-      </SummaryTable.Row>
-      <SummaryTable.Row heading="Primary Contact(s)">
-        {buildCellContents(
-          viewablePrimaryContacts.length > 0,
-          <StyledAddressList>
-            {viewablePrimaryContacts.map((contact, index) => (
-              <li key={`${contact.id}-${index}`}>
-                <AccessibleLink
-                  data-test={`contact-${contact.id}-link`}
-                  href={urls.contacts.details(contact.id)}
-                >
-                  {contact.name}
-                </AccessibleLink>
-              </li>
-            ))}
-          </StyledAddressList>
-        )}
-        {viewablePrimaryContacts.length < maxNumberOfContacts && (
-          <Button onClick={onViewMore}>
-            <span>
-              View {hiddenContactCount} more{' '}
-              {pluralize('contact', hiddenContactCount)}
-            </span>
-          </Button>
-        )}
-      </SummaryTable.Row>
-      <StyledTableRow>
-        <StyledLastTableCell colSpan={2}>
-          <AccessibleLink
-            href={urls.companies.accountManagement.index(company.id)}
-            data-test="account-management-page-link"
-          >
-            View full account management
-          </AccessibleLink>
-        </StyledLastTableCell>
-      </StyledTableRow>
-    </StyledSummaryTable>
+        <SummaryTableHighlight.HighlightRow heading="DBT region" isHalf={false}>
+          {buildCellContents(
+            company?.ukRegion,
+            <span>{company.ukRegion?.name}</span>
+          )}
+        </SummaryTableHighlight.HighlightRow>
+        <SummaryTableHighlight.Row
+          heading={
+            isItaTierDAccount(company.oneListGroupTier)
+              ? 'Lead ITA'
+              : 'Account manager'
+          }
+        >
+          {buildCellContents(
+            company?.oneListGroupGlobalAccountManager,
+            <AccessibleLink
+              data-test="account-manager-link"
+              href={urls.companies.accountManagement.index(company.id)}
+            >
+              {company.oneListGroupGlobalAccountManager?.name}
+            </AccessibleLink>
+          )}
+        </SummaryTableHighlight.Row>
+        <SummaryTableHighlight.Row heading="Primary contact(s)">
+          {buildCellContents(
+            viewablePrimaryContacts.length > 0,
+            <StyledAddressList>
+              {viewablePrimaryContacts.map((contact, index) => (
+                <li key={`${contact.id}-${index}`}>
+                  <AccessibleLink
+                    data-test={`contact-${contact.id}-link`}
+                    href={urls.contacts.details(contact.id)}
+                  >
+                    {contact.name}
+                  </AccessibleLink>
+                </li>
+              ))}
+            </StyledAddressList>
+          )}
+          {viewablePrimaryContacts.length < maxNumberOfContacts && (
+            <Button onClick={onViewMore}>
+              <span>
+                View {hiddenContactCount} more{' '}
+                {pluralize('contact', hiddenContactCount)}
+              </span>
+            </Button>
+          )}
+        </SummaryTableHighlight.Row>
+        <SummaryTableHighlight.Row heading="One list">
+          {buildCellContents(
+            company?.oneListGroupTier?.name,
+            <span>{company.oneListGroupTier?.name}</span>
+          )}
+        </SummaryTableHighlight.Row>
+      </SummaryTableHighlight>
+      <StyledAccessibleLink
+        href={urls.companies.accountManagement.index(company.id)}
+        data-test="account-management-page-link"
+      >
+        View full account management
+      </StyledAccessibleLink>
+    </>
   )
 }
 

--- a/test/component/cypress/specs/Companies/CompanyOverview/AccountManagementCard.cy.jsx
+++ b/test/component/cypress/specs/Companies/CompanyOverview/AccountManagementCard.cy.jsx
@@ -24,14 +24,14 @@ describe('AccountManagementCard', () => {
       assertSummaryTable({
         dataTest: 'account-management-container',
         content: {
-          'DBT Region': companyGlobalUltimateAllDetails.ukRegion.name,
-          'Account Manager':
+          'DBT region': companyGlobalUltimateAllDetails.ukRegion.name,
+          'Account manager':
             companyGlobalUltimateAllDetails.oneListGroupGlobalAccountManager
               .name,
-          'One List': companyGlobalUltimateAllDetails.oneListGroupTier.name,
-          'Primary Contact(s)':
+          'Primary contact(s)':
             companyGlobalUltimateAllDetails.contacts[0].name +
             companyGlobalUltimateAllDetails.contacts[1].name,
+          'One list': companyGlobalUltimateAllDetails.oneListGroupTier.name,
         },
       })
     })
@@ -68,14 +68,14 @@ describe('AccountManagementCard', () => {
       assertSummaryTable({
         dataTest: 'account-management-container',
         content: {
-          'DBT Region': companyNoGlobalUltimateAllDetails.ukRegion.name,
+          'DBT region': companyNoGlobalUltimateAllDetails.ukRegion.name,
           'Lead ITA':
             companyNoGlobalUltimateAllDetails.oneListGroupGlobalAccountManager
               .name,
-          'One List': companyNoGlobalUltimateAllDetails.oneListGroupTier.name,
-          'Primary Contact(s)':
+          'Primary contact(s)':
             companyNoGlobalUltimateAllDetails.contacts[0].name +
             companyNoGlobalUltimateAllDetails.contacts[1].name,
+          'One list': companyNoGlobalUltimateAllDetails.oneListGroupTier.name,
         },
       })
     })
@@ -112,10 +112,10 @@ describe('AccountManagementCard', () => {
       assertSummaryTable({
         dataTest: 'account-management-container',
         content: {
-          'DBT Region': 'Not set',
-          'Account Manager': 'Not set',
-          'One List': 'Not set',
-          'Primary Contact(s)': 'Not set',
+          'DBT region': 'Not set',
+          'Account manager': 'Not set',
+          'Primary contact(s)': 'Not set',
+          'One list': 'Not set',
         },
       })
     })


### PR DESCRIPTION
## Description of change

Convert account summary card to table with highlights

## Test instructions

Everything same as before but a differently styled card and sentence case instead of title case.

## Screenshots

### Before
<img width="475" alt="Screenshot 2025-05-27 at 14 10 08" src="https://github.com/user-attachments/assets/ae30dd4c-0d70-492a-bc7f-6ed0d10aa7ed" />

### After
<img width="480" alt="Screenshot 2025-05-27 at 14 09 50" src="https://github.com/user-attachments/assets/14417980-f13f-432c-a8b5-03c8e0ca6b44" />

## Checklist
- [x] Has the branch been rebased to main?
- [ ] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
