### PR TITLE
Update investment status card to use new table styling

### DIFF
--- a/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
@@ -65,7 +65,7 @@ const InvestmentStatusCard = ({
             caption="Investment status"
             data-test="investmentsStatusContainer"
           >
-            <SummaryTableHighlight.Row heading="Last Project won">
+            <SummaryTableHighlight.Row heading="Last project won">
               {summary?.won?.last_won_project?.id != null ? (
                 <AccessibleLink
                   href={urls.investments.projects.details(

--- a/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/InvestmentStatusCard.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 
-import { SummaryTable } from '../../../../components'
+import { SummaryTableHighlight } from '../../../../components'
 import {
   TASK_GET_PROJECT_WON_COUNT,
   OVERVIEW_COMPANY_PROJECTS_LIST_ID,
@@ -11,12 +11,7 @@ import {
 import { OVERVIEW__COMPANY_INVESTMENT_WON_COUNT } from '../../../../actions'
 import urls from '../../../../../lib/urls'
 import Task from '../../../../components/Task'
-import {
-  StyledLastTableCell,
-  StyledSpan,
-  StyledSummaryTable,
-  StyledTableRow,
-} from './components'
+import { StyledAccessibleLink, StyledSpan } from './components'
 import AccessibleLink from '../../../../components/Link'
 
 const {
@@ -34,7 +29,7 @@ const buildProjectCountCell = (
   companyId,
   dataTest
 ) => (
-  <SummaryTable.Row heading={heading}>
+  <SummaryTableHighlight.Row heading={heading}>
     {list ? (
       <AccessibleLink
         href={buildProjectStatusUrl(companyId, urlParam)}
@@ -45,7 +40,7 @@ const buildProjectCountCell = (
     ) : (
       '0'
     )}
-  </SummaryTable.Row>
+  </SummaryTableHighlight.Row>
 )
 
 const InvestmentStatusCard = ({
@@ -65,74 +60,72 @@ const InvestmentStatusCard = ({
       }}
     >
       {() => (
-        <StyledSummaryTable
-          caption="Investment status"
-          data-test="investmentsStatusContainer"
-        >
-          <SummaryTable.Row heading="Last Project won">
-            {summary?.won?.last_won_project?.id != null ? (
-              <AccessibleLink
-                href={urls.investments.projects.details(
-                  summary.won.last_won_project.id
-                )}
-                data-test="latest-won-project-link"
-              >
-                {`${formatDate(summary.won.last_won_project.last_changed, DATE_FORMAT_COMPACT)} - ${
-                  summary.won.last_won_project.name
-                }`}
-              </AccessibleLink>
-            ) : (
-              <StyledSpan>None</StyledSpan>
+        <>
+          <SummaryTableHighlight
+            caption="Investment status"
+            data-test="investmentsStatusContainer"
+          >
+            <SummaryTableHighlight.Row heading="Last Project won">
+              {summary?.won?.last_won_project?.id != null ? (
+                <AccessibleLink
+                  href={urls.investments.projects.details(
+                    summary.won.last_won_project.id
+                  )}
+                  data-test="latest-won-project-link"
+                >
+                  {`${formatDate(summary.won.last_won_project.last_changed, DATE_FORMAT_COMPACT)} - ${
+                    summary.won.last_won_project.name
+                  }`}
+                </AccessibleLink>
+              ) : (
+                <StyledSpan>None</StyledSpan>
+              )}
+            </SummaryTableHighlight.Row>
+            {buildProjectCountCell(
+              statusList?.won,
+              'Total projects won',
+              '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
+              companyId,
+              'total-project-won'
             )}
-          </SummaryTable.Row>
-          {buildProjectCountCell(
-            statusList?.won,
-            'Total projects won',
-            '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=945ea6d1-eee3-4f5b-9144-84a75b71b8e6',
-            companyId,
-            'total-project-won'
-          )}
-          {buildProjectCountCell(
-            stageList?.active,
-            'Active projects',
-            '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=7606cc19-20da-4b74-aba1-2cec0d753ad8',
-            companyId,
-            'total-active-projects'
-          )}
-          {buildProjectCountCell(
-            stageList?.prospect,
-            'Prospect projects',
-            '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=8a320cc9-ae2e-443e-9d26-2f36452c2ced',
-            companyId,
-            'total-prospect-projects'
-          )}
-          {buildProjectCountCell(
-            stageList?.verifyWin,
-            'Verify win projects',
-            '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=49b8f6f3-0c50-4150-a965-2c974f3149e3',
-            companyId,
-            'total-verify-win-projects'
-          )}
-          {buildProjectCountCell(
-            statusList?.abandoned,
-            'Abandoned projects',
-            '?page=1&sortby=created_on%3Adesc&status%5B0%5D=abandoned',
-            companyId,
-            'total-abandoned-projects'
-          )}
-          <StyledTableRow>
-            <StyledLastTableCell colSpan={2}>
-              <AccessibleLink
-                href={urls.companies.investments.companyInvestmentProjectsWithSearch(
-                  companyId
-                )}
-                data-test="investment-page-link"
-              >
-                View all investments
-              </AccessibleLink>
-            </StyledLastTableCell>
-          </StyledTableRow>
-        </StyledSummaryTable>
+            {buildProjectCountCell(
+              stageList?.active,
+              'Active projects',
+              '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=7606cc19-20da-4b74-aba1-2cec0d753ad8',
+              companyId,
+              'total-active-projects'
+            )}
+            {buildProjectCountCell(
+              stageList?.prospect,
+              'Prospect projects',
+              '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=8a320cc9-ae2e-443e-9d26-2f36452c2ced',
+              companyId,
+              'total-prospect-projects'
+            )}
+            {buildProjectCountCell(
+              stageList?.verifyWin,
+              'Verify win projects',
+              '?page=1&sortby=created_on%3Adesc&stage%5B0%5D=49b8f6f3-0c50-4150-a965-2c974f3149e3',
+              companyId,
+              'total-verify-win-projects'
+            )}
+            {buildProjectCountCell(
+              statusList?.abandoned,
+              'Abandoned projects',
+              '?page=1&sortby=created_on%3Adesc&status%5B0%5D=abandoned',
+              companyId,
+              'total-abandoned-projects'
+            )}
+          </SummaryTableHighlight>
+          <StyledAccessibleLink
+            href={urls.companies.investments.companyInvestmentProjectsWithSearch(
+              companyId
+            )}
+            data-test="investment-page-link"
+          >
+            View all investments
+          </StyledAccessibleLink>
+        </>
       )}
     </Task.Status>
   </>

--- a/src/client/modules/Companies/CompanyOverview/TableCards/components.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/components.jsx
@@ -4,9 +4,11 @@
 
 import styled from 'styled-components'
 import { Table } from 'govuk-react'
+import { FONT_SIZE } from '@govuk-react/constants'
 
 import { SummaryTable } from '../../../../components'
 import { GREY_1 } from '../../../../utils/colours'
+import AccessibleLink from '../../../../components/Link'
 
 export const StyledTableCell = styled(Table.Cell)`
   border: 0;
@@ -17,6 +19,10 @@ export const StyledTableCell = styled(Table.Cell)`
 export const StyledLastTableCell = styled(Table.Cell)`
   border: 0;
   padding-bottom: 0;
+`
+
+export const StyledAccessibleLink = styled(AccessibleLink)`
+  font-size: ${FONT_SIZE.SIZE_16};
 `
 
 export const StyledSummaryTable = styled(SummaryTable)`

--- a/test/functional/cypress/specs/companies/overview-spec.js
+++ b/test/functional/cypress/specs/companies/overview-spec.js
@@ -143,7 +143,7 @@ describe('Company overview page', () => {
           .next()
           .children()
         cy.get('th')
-          .contains('Last Project won')
+          .contains('Last project won')
           .siblings()
           .contains('td', '07 Jun 2022')
         cy.get('[data-test="latest-won-project-link"]').click()


### PR DESCRIPTION
## Description of change

Updates the existing card to match the new table styling using CSS grid and supports a text "highlight".

See design and figma files here: https://uktrade.atlassian.net/browse/TET-1024

## Test instructions

Everything the same as before but different layout/styling.

## Screenshots

### Before
<img width="474" alt="Screenshot 2025-05-27 at 15 18 34" src="https://github.com/user-attachments/assets/d1287a09-195d-45a4-9213-07cdd9f43ffc" />

### After
<img width="480" alt="Screenshot 2025-05-27 at 15 17 57" src="https://github.com/user-attachments/assets/d946120e-d047-47b0-8a7c-f1e5b68d0d0b" />

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
