### PR TITLE
Update accolades card for new summary table layout

### DIFF
--- a/src/client/modules/Companies/CompanyOverview/TableCards/AccoladesCard.jsx
+++ b/src/client/modules/Companies/CompanyOverview/TableCards/AccoladesCard.jsx
@@ -2,11 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 
-import { FONT_SIZE } from '@govuk-react/constants'
-
-import { SummaryTable } from '../../../../components'
+import { SummaryTableHighlight } from '../../../../components'
 import { buildCellContents } from './transformers'
-import { StyledSummaryTable } from './components'
 import { CompanyKingsAwardsResource } from '../../../../components/Resource'
 
 const CardContainer = styled('div')`
@@ -15,66 +12,56 @@ const CardContainer = styled('div')`
   margin-bottom: 20px;
 `
 
-const StyledKingsAwardTable = styled(SummaryTable)`
-  margin: 0;
-  margin-top: 20px;
-  & > tbody th {
-    width: 50%;
-  }
-  caption {
-    font-size: ${FONT_SIZE.SIZE_20};
-  }
-`
-
 const AccoladesCard = ({ companyId }) => {
   return (
     <CompanyKingsAwardsResource id={companyId}>
       {(kingsAwards) =>
         kingsAwards && kingsAwards.length ? (
           <CardContainer>
-            <StyledSummaryTable
+            <SummaryTableHighlight
               caption="Accolades"
               data-test="accolades-container"
             >
-              <SummaryTable.Row
+              <SummaryTableHighlight.HighlightRow
+                isHalf={false}
                 heading="Number of accolades"
                 children={kingsAwards.length}
               />
-            </StyledSummaryTable>
+            </SummaryTableHighlight>
             {kingsAwards.map((award) => (
-              <StyledKingsAwardTable
+              <SummaryTableHighlight
                 caption="The King’s Award for Enterprise"
                 data-test="kings-award-container"
               >
-                <SummaryTable.Row
+                <SummaryTableHighlight.Row
                   heading="Year awarded"
                   children={buildCellContents(
                     award.yearAwarded,
                     <span>{award.yearAwarded}</span>
                   )}
                 />
-                <SummaryTable.Row
+                <SummaryTableHighlight.Row
                   heading="Award category"
                   children={buildCellContents(
                     award.category,
                     <span>{award.category}</span>
                   )}
                 />
-                <SummaryTable.Row
+                <SummaryTableHighlight.Row
                   heading="Reason"
                   children={buildCellContents(
                     award.citation,
                     <span>{award.citation}</span>
                   )}
                 />
-                <SummaryTable.Row
+                <SummaryTableHighlight.Row
                   heading="Award expiry year"
                   children={buildCellContents(
                     award.yearExpired,
                     <span>{award.yearExpired}</span>
                   )}
                 />
-              </StyledKingsAwardTable>
+              </SummaryTableHighlight>
             ))}
           </CardContainer>
         ) : null


### PR DESCRIPTION
## Description of change

Styling changes for the accolades table for new layout with CSS grid and "highlights".

See design and figma files here: https://uktrade.atlassian.net/browse/TET-1024

## Test instructions

Just CSS/layout changes.

## Screenshots

### Before
<img width="476" alt="Screenshot 2025-05-27 at 15 54 00" src="https://github.com/user-attachments/assets/7faf2019-84cf-4e4d-bd81-9aa78ecd708e" />

### After
<img width="475" alt="Screenshot 2025-05-27 at 15 53 48" src="https://github.com/user-attachments/assets/c7468f94-edf9-4b79-b8c2-b687bf111fd4" />

## Checklist
- [x] Has the branch been rebased to main?
- [x] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [x] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
