### PR TITLE
New EW questionnaire rejected review - thank you layout

### DIFF
--- a/src/client/modules/ExportWins/Review/ThankYou.jsx
+++ b/src/client/modules/ExportWins/Review/ThankYou.jsx
@@ -33,7 +33,7 @@ const ThankYou = () => {
             Thank you for taking time to review this export win.
           </StyledStatusMessage>
         ) : (
-          <StyledStatusMessage>
+          <StyledStatusMessage colour={GREEN}>
             <p>Thank you for reviewing this export win.</p>
             <p>
               As you have asked for some changes to be made, we will review your


### PR DESCRIPTION
## Description of change

A revised customer questionnaire journey recently iterates and reviewed. The thank you screen after rejecting the Wins was modified.

## Test instructions

- From company overview profile, `Add export win` and fill-in the necessary information(Note: make it sure has an access the company contact being selected).
- Upon receiving a wins email confirmation, click `Review wins` link from email content.
- From `Review export win` summary page, select one of the radio button `Some of this information needs revising`.

   Scenarios:
     - `Some of this information...` then continue button, it takes you into mandatory comment questionnaires to fill-in.
     - Then `Submit and continue` button 
     - Export win reviewed and changes are need - Thank you screen message will appear.
     

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/98b3f2aa-bae0-436d-bbbe-433a59d094e8)

![image](https://github.com/user-attachments/assets/daec2c21-0544-4587-a1e7-606278337c3a)


### After

![image](https://github.com/user-attachments/assets/36184a3b-ea47-485c-8b2e-68c383503279)

## Checklist

[//]: # 'When submitting a PR make sure the code review guidelines have been satisfied.
https://github.com/uktrade/data-hub-frontend/blob/main/docs/Code%20review%20guidelines.md'

- [x] Has the branch been rebased to main?
- [X] Automated tests (Any of the following when applicable: Unit, Functional or End-to-End)
- [X] Manual compatibility testing (Browsers: Chrome, Firefox, Edge, Safari)
