### PR TITLE
Fix a bug when company name was [object Object] in create similar task

### DIFF
--- a/src/client/modules/Tasks/TaskForm/TaskFormAdd.jsx
+++ b/src/client/modules/Tasks/TaskForm/TaskFormAdd.jsx
@@ -34,7 +34,7 @@ const getTitle = (task) => {
     return `Add task for ${task.interaction.subject}`
   }
   if (task.company) {
-    return `Add task for ${task.company}`
+    return `Add task for ${task.company.label}`
   }
   return `Add task`
 }

--- a/test/functional/cypress/specs/tasks/create-similar-task-spec.js
+++ b/test/functional/cypress/specs/tasks/create-similar-task-spec.js
@@ -48,6 +48,10 @@ describe('Copy task from task with company', () => {
     })
 
     it('should save the task with the expected values', () => {
+      cy.get('h1').should(
+        'have.text',
+        `Add task for ${taskWithCompany.company.name}`
+      )
       assertTaskForm(taskWithCompany, taskWithCompany.company.id)
     })
   })


### PR DESCRIPTION
## Description of change

Fixes a bug when company name was `[object Object]` in the _create similar task_ form.

## Test instructions

1. Navigate to `/tasks/create` and create a task linked with a company (select a company in the typeahead field on the very bottom)
2. Open the newly created task
3. On the task details page click on the _Create similar task_ button
4. The page heading should read "Add task for {company-name}" instead of "Add task for [object Object]" as it was before this PR

## Screenshots

### Before
<img width="762" alt="Screenshot 2025-05-29 at 11 15 02" src="https://github.com/user-attachments/assets/1dbfb5b1-73f5-40bf-b4dd-cfd3bec1be22" />

### After
<img width="762" alt="Screenshot 2025-05-29 at 11 14 42" src="https://github.com/user-attachments/assets/33ad6b78-f949-4373-89d3-9fb37cac40e4" />
